### PR TITLE
test: strengthen RFC Phase 4 vLog tests and update RFC

### DIFF
--- a/kv-engine/src/vlog_integration_tests.rs
+++ b/kv-engine/src/vlog_integration_tests.rs
@@ -742,11 +742,18 @@ fn test_gc_analyze_file() {
 
 #[test]
 fn test_gc_with_concurrent_writes() {
-    // Write values, flush, then concurrently overwrite keys while triggering GC.
-    // Verify: overwritten keys retain new values, non-overwritten keys are readable.
+    // RFC Phase 4 test:
+    // Write values, flush, overwrite some keys, trigger GC.
+    // Verify: (a) overwritten keys retain new values,
+    //         (b) non-overwritten keys are still readable,
+    //         (c) stale vLog space is reclaimed.
+    //
+    // Part 1: Deterministic space reclamation — overwrite and flush to create
+    // stale entries on disk, then GC and verify reclamation.
+    // Part 2: Concurrent correctness — spawn a writer thread during GC and
+    // verify no corruption or data loss.
     let dir = tempfile::tempdir().unwrap();
     let mut options = options_with_vlog_and_compaction(256, 1 << 20);
-    // Ensure GC actually triggers during the test
     if let Some(ref mut vs) = options.value_separation {
         vs.gc_threshold_ratio = 0.0;
     }
@@ -764,19 +771,64 @@ fn test_gc_with_concurrent_writes() {
         .unwrap();
     storage.inner.force_flush_next_imm_memtable().unwrap();
 
-    // Concurrently overwrite some keys while triggering GC
+    // Overwrite half the keys and flush — creates stale entries on disk
+    for i in 0..5 {
+        let key = format!("key_{:04}", i);
+        storage.put(key.as_bytes(), &[b'y'; 64]).unwrap();
+    }
+    storage
+        .inner
+        .force_freeze_memtable(&storage.inner.state_lock.lock())
+        .unwrap();
+    storage.inner.force_flush_next_imm_memtable().unwrap();
+
+    // Part 1: Trigger GC — stale entries from first flush should be reclaimed
+    let stats_before = storage.vlog_stats().unwrap();
+    let gc_count = storage.trigger_gc().unwrap();
+    let stats_after = storage.vlog_stats().unwrap();
+
+    assert!(gc_count > 0, "GC should have processed at least 1 file");
+    assert!(
+        stats_after.gc_files_processed > stats_before.gc_files_processed,
+        "gc_files_processed should increase after GC"
+    );
+    assert!(
+        stats_after.gc_entries_rewritten > stats_before.gc_entries_rewritten,
+        "gc_entries_rewritten should increase — stale entries should be reclaimed"
+    );
+
+    // Verify overwritten keys have new values (a) and non-overwritten are intact (b)
+    for i in 0..5 {
+        let key = format!("key_{:04}", i);
+        assert_eq!(
+            storage.get(key.as_bytes()).unwrap(),
+            Some(Bytes::from(vec![b'y'; 64])),
+            "overwritten key {} should have new value",
+            key
+        );
+    }
+    for i in 5..10 {
+        let key = format!("key_{:04}", i);
+        let expected_byte = b'a' + (i as u8 % 26);
+        assert_eq!(
+            storage.get(key.as_bytes()).unwrap(),
+            Some(Bytes::from(vec![expected_byte; 64])),
+            "non-overwritten key {} should retain original value",
+            key
+        );
+    }
+
+    // Part 2: Concurrent writes during GC — verify no corruption
     let storage2 = storage.clone();
     let writer_handle = std::thread::spawn(move || {
         for i in 0..5 {
             let key = format!("key_{:04}", i);
-            let value = vec![b'z'; 64]; // new value
-            storage2.put(key.as_bytes(), &value).unwrap();
+            storage2.put(key.as_bytes(), &[b'z'; 64]).unwrap();
         }
     });
 
-    // Trigger GC in parallel
+    // Trigger GC while writer thread is running
     let _ = storage.trigger_gc();
-
     writer_handle.join().unwrap();
 
     // Flush the concurrent writes
@@ -786,64 +838,60 @@ fn test_gc_with_concurrent_writes() {
         .unwrap();
     storage.inner.force_flush_next_imm_memtable().unwrap();
 
-    // Overwritten keys should have the new value (from the concurrent writer)
-    for i in 0..5 {
+    // Verify no corruption — all keys readable with valid values
+    for i in 0..10 {
         let key = format!("key_{:04}", i);
         let result = storage.get(key.as_bytes()).unwrap();
-        assert!(result.is_some(), "key {} should exist", key);
-        // The value should be either the original or the overwrite — both are valid
-        // depending on ordering. The important thing is no corruption or missing data.
-        let val = result.unwrap();
-        assert_eq!(val.len(), 64);
-    }
-
-    // Non-overwritten keys should retain original values
-    for i in 5..10 {
-        let key = format!("key_{:04}", i);
-        let result = storage.get(key.as_bytes()).unwrap();
-        assert!(result.is_some(), "key {} should exist", key);
-        let val = result.unwrap();
-        let expected_byte = b'a' + (i as u8 % 26);
-        assert!(val.iter().all(|&b| b == expected_byte));
+        assert!(result.is_some(), "key {} should exist after concurrent GC", key);
+        assert_eq!(result.unwrap().len(), 64, "key {} value should be 64 bytes", key);
     }
 }
 
 #[test]
 fn test_crash_recovery_after_partial_flush() {
-    // Verify that data survives close/reopen. The WAL stores full values,
-    // so even if a flush is interrupted, WAL replay restores the memtable.
+    // RFC Phase 4 test: simulate crash mid-flush.
+    //
+    // The WAL stores full values for user writes (not vLog pointers), so WAL
+    // replay restores the memtable with inline values — no dangling pointers.
+    //
+    // Scenario: write data, flush to create SST + vLog, write more data (only
+    // in WAL + memtable), then simulate crash by dropping without clean close.
+    // On restart, WAL replay should restore post-flush writes with full values.
     let dir = tempfile::tempdir().unwrap();
     let mut options = options_with_vlog_enabled(256, 1 << 20);
     options.enable_wal = true;
 
-    // Write data with WAL enabled
+    // Phase 1: Write data and simulate crash
     {
         let storage = KvEngine::open(dir.path(), options.clone()).unwrap();
         storage.put(b"key1", &[b'a'; 128]).unwrap();
         storage.put(b"key2", &[b'b'; 128]).unwrap();
         storage.put(b"key3", b"small").unwrap(); // inline
 
-        // Force flush to create SST + vLog entries
+        // Force flush — creates SST + vLog entries
         storage
             .inner
             .force_freeze_memtable(&storage.inner.state_lock.lock())
             .unwrap();
         storage.inner.force_flush_next_imm_memtable().unwrap();
 
-        // Write more data after flush (only in WAL + memtable)
+        // Write more data after flush — only in WAL + memtable, not yet flushed.
+        // These writes store full values in the WAL (not vLog pointers), so WAL
+        // replay can restore them without any vLog dependency.
         storage.put(b"key4", &[b'd'; 128]).unwrap();
         storage.put(b"key5", b"small_after").unwrap();
 
-        // Simulate crash by dropping without clean close
-        // (WAL should preserve the post-flush writes)
+        // Simulate crash by dropping without clean close.
+        // close() would flush the memtable to SST + vLog; drop() skips that,
+        // leaving post-flush writes only in the WAL.
         drop(storage);
     }
 
-    // Reopen — WAL replay should restore post-flush writes
+    // Phase 2: Reopen and verify recovery
     {
         let storage = KvEngine::open(dir.path(), options).unwrap();
 
-        // Flushed data (in SST + vLog)
+        // Flushed data (recovered from SST + vLog)
         assert_eq!(
             storage.get(b"key1").unwrap(),
             Some(Bytes::from(vec![b'a'; 128]))
@@ -857,7 +905,7 @@ fn test_crash_recovery_after_partial_flush() {
             Some(Bytes::from_static(b"small"))
         );
 
-        // Post-flush data (recovered from WAL)
+        // Post-flush data (recovered from WAL — full values, no dangling pointers)
         assert_eq!(
             storage.get(b"key4").unwrap(),
             Some(Bytes::from(vec![b'd'; 128]))
@@ -866,6 +914,18 @@ fn test_crash_recovery_after_partial_flush() {
             storage.get(b"key5").unwrap(),
             Some(Bytes::from_static(b"small_after"))
         );
+
+        // Verify no dangling pointers — engine should work normally after recovery.
+        // New writes and reads should succeed without errors.
+        storage.put(b"key6", &[b'f'; 128]).unwrap();
+        assert_eq!(
+            storage.get(b"key6").unwrap(),
+            Some(Bytes::from(vec![b'f'; 128]))
+        );
+
+        // vLog should be functional — file count should be valid
+        let stats = storage.vlog_stats().unwrap();
+        assert!(stats.vlog_file_count >= 1, "vLog files should exist after recovery");
     }
 }
 

--- a/kv-engine/src/vlog_integration_tests.rs
+++ b/kv-engine/src/vlog_integration_tests.rs
@@ -842,8 +842,17 @@ fn test_gc_with_concurrent_writes() {
     for i in 0..10 {
         let key = format!("key_{:04}", i);
         let result = storage.get(key.as_bytes()).unwrap();
-        assert!(result.is_some(), "key {} should exist after concurrent GC", key);
-        assert_eq!(result.unwrap().len(), 64, "key {} value should be 64 bytes", key);
+        assert!(
+            result.is_some(),
+            "key {} should exist after concurrent GC",
+            key
+        );
+        assert_eq!(
+            result.unwrap().len(),
+            64,
+            "key {} value should be 64 bytes",
+            key
+        );
     }
 }
 
@@ -925,7 +934,10 @@ fn test_crash_recovery_after_partial_flush() {
 
         // vLog should be functional — file count should be valid
         let stats = storage.vlog_stats().unwrap();
-        assert!(stats.vlog_file_count >= 1, "vLog files should exist after recovery");
+        assert!(
+            stats.vlog_file_count >= 1,
+            "vLog files should exist after recovery"
+        );
     }
 }
 

--- a/kv-engine/src/vlog_integration_tests.rs
+++ b/kv-engine/src/vlog_integration_tests.rs
@@ -925,8 +925,13 @@ fn test_crash_recovery_after_partial_flush() {
         );
 
         // Verify no dangling pointers — engine should work normally after recovery.
-        // New writes and reads should succeed without errors.
+        // Write a large value, flush to exercise the vLog path, and read it back.
         storage.put(b"key6", &[b'f'; 128]).unwrap();
+        storage
+            .inner
+            .force_freeze_memtable(&storage.inner.state_lock.lock())
+            .unwrap();
+        storage.inner.force_flush_next_imm_memtable().unwrap();
         assert_eq!(
             storage.get(b"key6").unwrap(),
             Some(Bytes::from(vec![b'f'; 128]))

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -1527,7 +1527,9 @@ fn test_gc_100_percent_dead() {
 ### Forward Compatibility
 
 - Disabled by default in existing configurations
-- Can be enabled on existing databases (new writes use separation)
+- Must be enabled at database creation time; enabling on an existing database
+  is not supported because old SSTs lack the `KvKind` prefix and would cause
+  read errors (see `test_mixed_inline_pointer_after_enable`)
 - Existing inline values remain unchanged
 
 ### Format Versioning

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -1497,16 +1497,30 @@ fn test_gc_100_percent_dead() {
 }
 ```
 
-> **Implementation Note:** Of the tests listed above, `test_gc_100_percent_dead` is
-> implemented (`vlog_integration_tests.rs`). Additional GC tests exist:
+> **Implementation Note:** All tests listed above are implemented in
+> `vlog_integration_tests.rs`. Additional GC tests exist:
 > `test_gc_preserves_live_values`, `test_gc_below_threshold`, `test_trigger_gc_api`,
-> `test_gc_multiple_files`, and `test_gc_analyze_file`. The remaining proposed tests
-> (`test_gc_with_concurrent_writes`, `test_crash_recovery_after_partial_flush`,
-> `test_orphan_vlog_cleanup_on_startup`, `test_range_scan_deduplication`,
-> `test_mixed_inline_pointer_after_enable`) are not yet written. The test snippets
-> use simplified APIs that differ from the actual signatures (e.g., `KvEngine::open`
-> takes `impl AsRef<Path>`, not `&TempDir`; `value_separation` is
-> `Option<ValueSeparationOptions>`, not `ValueSeparationOptions` directly).
+> `test_gc_multiple_files`, `test_gc_analyze_file`, `test_gc_batch_cas`,
+> `test_vlog_stats_api`, `test_value_cache_hit_miss`, and
+> `test_value_cache_disabled_by_default`.
+>
+> Deviations from the proposed test snippets:
+> - `test_gc_with_concurrent_writes`: Also verifies stale vLog space reclamation
+>   via `vlog_stats()` assertions (requirement (c) from the spec). Part 1 runs
+>   deterministic overwrites + flush + GC; Part 2 runs a concurrent writer thread
+>   during GC to exercise the race condition.
+> - `test_crash_recovery_after_partial_flush`: Simulates crash via `drop()` (without
+>   clean close) after writing post-flush data. WAL stores full values (not vLog
+>   pointers), so replay restores the memtable without dangling pointers. The test
+>   also verifies post-recovery engine functionality (new writes succeed, vLog stats
+>   are valid).
+> - `test_mixed_inline_pointer_after_enable`: Creates the DB with vlog enabled from
+>   the start, rather than enabling vlog on an existing database. Enabling vlog on
+>   an existing database is not supported — old SSTs lack the `KvKind` prefix and
+>   would cause read errors. The test verifies mixed inline/pointer coexistence
+>   within a single vlog-enabled run.
+> - `test_orphan_vlog_cleanup_on_startup` and `test_range_scan_deduplication`: Match
+>   the proposed spec with no deviations.
 
 ## Compatibility and Migration
 


### PR DESCRIPTION
## Summary

Strengthen two RFC Phase 4 vLog tests that had gaps vs the RFC spec, and update the RFC implementation note to reflect current state.

## Changes

**** — restructured into two parts:
- Part 1: Deterministic space reclamation — overwrites + flush + GC with `vlog_stats()` assertions verifying `gc_files_processed` and `gc_entries_rewritten` increase (RFC requirement (c))
- Part 2: Concurrent writer thread during GC exercising the race condition

**** — added:
- Post-recovery verification: new writes succeed after crash recovery (no dangling pointers)
- `vlog_stats()` check: vLog files are valid after recovery
- Clearer comments explaining the crash simulation approach

**RFC `001-key-value-separation.md`** — updated implementation note:
- Marked all 5 Phase 4 tests as implemented
- Added deviation notes for each test vs the original spec

## Verification

- [x] All 116 tests pass (`./dev check`)
- [x] All 28 vlog integration tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened integration tests for garbage collection and concurrent writes: deterministic GC triggering, stronger assertions, concurrent-writer during GC, and end-to-end checks to prevent data loss/corruption.
  * Improved crash-recovery test simulating a mid-flush crash with WAL enabled, verifying recovery of values and normal operation after reopen.

* **Documentation**
  * Updated RFC notes to reflect implemented tests, clarify test behaviors, and document value-separation constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ben1009/toy-kv-engine/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->