### PR TITLE
feat: implement manifest snapshot GC

### DIFF
--- a/kv-engine/benches/vlog_benchmarks.rs
+++ b/kv-engine/benches/vlog_benchmarks.rs
@@ -33,6 +33,7 @@ fn make_options(vlog_enabled: bool, min_value_size: usize) -> LsmStorageOptions 
         } else {
             None
         },
+        manifest_snapshot_threshold_bytes: 0,
     }
 }
 
@@ -59,6 +60,7 @@ fn make_options_with_compaction(vlog_enabled: bool, min_value_size: usize) -> Ls
         } else {
             None
         },
+        manifest_snapshot_threshold_bytes: 0,
     }
 }
 
@@ -111,6 +113,7 @@ fn make_options_with_cache(min_value_size: usize, cache_bytes: u64) -> LsmStorag
             value_cache_capacity_bytes: cache_bytes,
             ..Default::default()
         }),
+        manifest_snapshot_threshold_bytes: 0,
     }
 }
 

--- a/kv-engine/src/bin/kv-engine-cli.rs
+++ b/kv-engine/src/bin/kv-engine-cli.rs
@@ -346,6 +346,7 @@ fn main() -> Result<()> {
             enable_wal: args.enable_wal,
             serializable: args.serializable,
             value_separation: None,
+            manifest_snapshot_threshold_bytes: 4 << 20, // 4MB
         },
     )?;
 

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -341,6 +341,7 @@ impl LsmStorageInner {
                 .as_ref()
                 .unwrap()
                 .add_record(&_state_lock, manifest_record)?;
+            self.maybe_snapshot_manifest(&_state_lock)?;
         }
 
         for id in ssts_to_compact.0.iter().chain(ssts_to_compact.1) {
@@ -540,6 +541,7 @@ impl LsmStorageInner {
                 .as_ref()
                 .unwrap()
                 .add_record(&_state_lock, manifest_record)?;
+            self.maybe_snapshot_manifest(&_state_lock)?;
 
             rm_sst_ids
         };

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -497,7 +497,10 @@ impl LsmStorageInner {
                         // Snapshot supersedes all prior records — reconstruct state directly
                         state.l0_sstables = snap_l0;
                         state.levels = snap_levels;
-                        max_id = next_sst_id;
+                        // next_sst_id is the next-to-allocate counter. max_id tracks the
+                        // highest observed ID (incremented by 1 at the end of the loop).
+                        // Use next_sst_id - 1 so the post-loop +1 yields next_sst_id.
+                        max_id = next_sst_id.saturating_sub(1);
                         // Clear any previously recovered refs; snapshot has the authoritative set
                         recovered_vlog_refs.clear();
                         for (sst_id, vlog_ids) in snap_vlog_refs {

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -100,6 +100,10 @@ pub struct LsmStorageOptions {
     /// Options for key-value separation (vLog). If `Some` with `enabled` true, large
     /// values are stored in a separate Value Log file. Defaults to `None` (disabled).
     pub value_separation: Option<ValueSeparationOptions>,
+    /// Threshold in bytes for triggering a manifest snapshot. When the MANIFEST file
+    /// exceeds this size, a snapshot of the current state is written to MANIFEST_SNAPSHOT
+    /// and the manifest is truncated. Set to 0 to disable. Defaults to 4MB.
+    pub manifest_snapshot_threshold_bytes: u64,
 }
 
 impl LsmStorageOptions {
@@ -112,6 +116,7 @@ impl LsmStorageOptions {
             num_memtable_limit: 50,
             serializable: false,
             value_separation: None,
+            manifest_snapshot_threshold_bytes: 0, // disabled by default in tests
         }
     }
 
@@ -124,6 +129,7 @@ impl LsmStorageOptions {
             num_memtable_limit: 2,
             serializable: false,
             value_separation: None,
+            manifest_snapshot_threshold_bytes: 0,
         }
     }
 
@@ -136,6 +142,7 @@ impl LsmStorageOptions {
             num_memtable_limit: 2,
             serializable: false,
             value_separation: None,
+            manifest_snapshot_threshold_bytes: 0,
         }
     }
 }
@@ -479,6 +486,25 @@ impl LsmStorageInner {
                     }
                     ManifestRecord::GcCompaction(_old_id, _new_id, _count) => {
                         // GC compaction — references are updated via CAS + flush
+                    }
+                    ManifestRecord::Snapshot {
+                        l0_sstables: snap_l0,
+                        levels: snap_levels,
+                        next_sst_id,
+                        vlog_references: snap_vlog_refs,
+                    } => {
+                        // Snapshot supersedes all prior records — reconstruct state directly
+                        state.l0_sstables = snap_l0;
+                        state.levels = snap_levels;
+                        max_id = next_sst_id;
+                        // Clear any previously recovered refs; snapshot has the authoritative set
+                        recovered_vlog_refs.clear();
+                        for (sst_id, vlog_ids) in snap_vlog_refs {
+                            recovered_vlog_refs.insert(sst_id, vlog_ids);
+                        }
+                        // Clear im_memtables — snapshot doesn't track them; they'll be
+                        // rebuilt from WAL if enabled, or a fresh memtable created
+                        im_memtables.clear();
                     }
                 }
             }
@@ -1074,6 +1100,48 @@ impl LsmStorageInner {
             .context("failed to sync dir")
     }
 
+    /// Check if the manifest file exceeds the snapshot threshold and, if so, take a
+    /// snapshot of the current state to MANIFEST_SNAPSHOT and truncate the manifest.
+    /// No-op if the threshold is 0 (disabled) or manifest is None.
+    fn maybe_snapshot_manifest(&self, state_lock: &MutexGuard<'_, ()>) -> Result<()> {
+        let threshold = self.options.manifest_snapshot_threshold_bytes;
+        if threshold == 0 {
+            return Ok(());
+        }
+        let manifest = match self.manifest {
+            Some(ref m) => m,
+            None => return Ok(()),
+        };
+        if manifest.file_size()? < threshold {
+            return Ok(());
+        }
+
+        // Capture current state under the lock
+        let guard = self.state.read();
+        let state = guard.as_ref();
+
+        let mut vlog_references = Vec::new();
+        if let Some(ref vlog) = self.vlog {
+            for &sst_id in state.sstables.keys() {
+                if let Some(refs) = vlog.get_sst_references(sst_id)
+                    && !refs.is_empty()
+                {
+                    vlog_references.push((sst_id, refs));
+                }
+            }
+        }
+
+        let record = ManifestRecord::Snapshot {
+            l0_sstables: state.l0_sstables.clone(),
+            levels: state.levels.clone(),
+            next_sst_id: self.next_sst_id.load(std::sync::atomic::Ordering::Relaxed),
+            vlog_references,
+        };
+        drop(guard);
+
+        manifest.snapshot(record)
+    }
+
     fn force_freeze_with_new_memtable(&self, new_memtable: mem_table::MemTable) -> Result<()> {
         let mut guard = self.state.write();
         let mut state = guard.as_ref().clone();
@@ -1108,7 +1176,9 @@ impl LsmStorageInner {
         self.manifest
             .as_ref()
             .unwrap()
-            .add_record(_state_lock_observer, ManifestRecord::NewMemtable(sst_id))
+            .add_record(_state_lock_observer, ManifestRecord::NewMemtable(sst_id))?;
+
+        self.maybe_snapshot_manifest(_state_lock_observer)
     }
 
     /// Force flush the earliest-created immutable memtable to disk
@@ -1187,6 +1257,9 @@ impl LsmStorageInner {
             .as_ref()
             .unwrap()
             .add_record(&state_lock, manifest_record)?;
+
+        // Check if manifest needs snapshotting after flush
+        self.maybe_snapshot_manifest(&state_lock)?;
 
         // WAL GC: once the memtable is durably flushed to SST and recorded in
         // the manifest, the corresponding WAL file is no longer needed for

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1131,7 +1131,10 @@ impl LsmStorageInner {
 
         let mut vlog_references = Vec::new();
         if let Some(ref vlog) = self.vlog {
-            for &sst_id in state.sstables.keys() {
+            // Sort SST IDs for deterministic snapshot serialization
+            let mut sst_ids: Vec<usize> = state.sstables.keys().copied().collect();
+            sst_ids.sort_unstable();
+            for sst_id in sst_ids {
                 if let Some(refs) = vlog.get_sst_references(sst_id)
                     && !refs.is_empty()
                 {
@@ -1143,7 +1146,7 @@ impl LsmStorageInner {
         let record = ManifestRecord::Snapshot {
             l0_sstables: state.l0_sstables.clone(),
             levels: state.levels.clone(),
-            next_sst_id: self.next_sst_id.load(std::sync::atomic::Ordering::Relaxed),
+            next_sst_id: self.next_sst_id.load(std::sync::atomic::Ordering::Acquire),
             vlog_references,
             imm_memtable_ids: state.imm_memtables.iter().map(|m| m.id()).collect(),
         };

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -492,6 +492,7 @@ impl LsmStorageInner {
                         levels: snap_levels,
                         next_sst_id,
                         vlog_references: snap_vlog_refs,
+                        imm_memtable_ids: snap_imm_ids,
                     } => {
                         // Snapshot supersedes all prior records — reconstruct state directly
                         state.l0_sstables = snap_l0;
@@ -502,9 +503,14 @@ impl LsmStorageInner {
                         for (sst_id, vlog_ids) in snap_vlog_refs {
                             recovered_vlog_refs.insert(sst_id, vlog_ids);
                         }
-                        // Clear im_memtables — snapshot doesn't track them; they'll be
-                        // rebuilt from WAL if enabled, or a fresh memtable created
+                        // Preserve immutable memtable IDs from the snapshot so WAL
+                        // recovery can rebuild them. These are frozen memtables that
+                        // have not yet been flushed to SST.
                         im_memtables.clear();
+                        for id in snap_imm_ids {
+                            im_memtables.insert(id);
+                            max_id = max_id.max(id);
+                        }
                     }
                 }
             }
@@ -1103,7 +1109,7 @@ impl LsmStorageInner {
     /// Check if the manifest file exceeds the snapshot threshold and, if so, take a
     /// snapshot of the current state to MANIFEST_SNAPSHOT and truncate the manifest.
     /// No-op if the threshold is 0 (disabled) or manifest is None.
-    fn maybe_snapshot_manifest(&self, state_lock: &MutexGuard<'_, ()>) -> Result<()> {
+    pub(crate) fn maybe_snapshot_manifest(&self, state_lock: &MutexGuard<'_, ()>) -> Result<()> {
         let threshold = self.options.manifest_snapshot_threshold_bytes;
         if threshold == 0 {
             return Ok(());
@@ -1136,6 +1142,7 @@ impl LsmStorageInner {
             levels: state.levels.clone(),
             next_sst_id: self.next_sst_id.load(std::sync::atomic::Ordering::Relaxed),
             vlog_references,
+            imm_memtable_ids: state.imm_memtables.iter().map(|m| m.id()).collect(),
         };
         drop(guard);
 

--- a/kv-engine/src/manifest.rs
+++ b/kv-engine/src/manifest.rs
@@ -66,16 +66,16 @@ impl Manifest {
         let path = path.as_ref();
         let snapshot_path = Self::snapshot_path(path);
 
-        let (snapshot_record, mut records) = if snapshot_path.exists() {
-            // Read snapshot
+        let mut records = Vec::new();
+        if snapshot_path.exists() {
+            // Read snapshot and place it at index 0
             let snapshot_buf =
                 fs::read(&snapshot_path).context("failed to read MANIFEST_SNAPSHOT")?;
             let record: ManifestRecord = serde_json::from_slice(&snapshot_buf)
                 .context("failed to deserialize MANIFEST_SNAPSHOT")?;
-            (Some(record), vec![])
-        } else {
-            (None, vec![])
-        };
+            records.push(record);
+        }
+        let has_snapshot = !records.is_empty();
 
         // Read manifest file (may be empty after snapshot truncation, or missing if
         // snapshot was renamed after manifest was deleted)
@@ -97,13 +97,13 @@ impl Manifest {
         // the manifest should have been truncated. If it wasn't (crash between snapshot
         // rename and manifest truncate), the old records are superseded by the snapshot
         // and replaying them would create duplicate entries in l0_sstables/levels.
-        if snapshot_record.is_none() && !buf.is_empty() {
+        if !has_snapshot && !buf.is_empty() {
             let manifest_records =
                 serde_json::Deserializer::from_slice(&buf).into_iter::<ManifestRecord>();
             for record in manifest_records {
                 records.push(record?);
             }
-        } else if !buf.is_empty() {
+        } else if has_snapshot && !buf.is_empty() {
             // Snapshot exists but manifest is not empty — this means a crash occurred
             // between the snapshot rename and manifest truncate. The old manifest records
             // are superseded by the snapshot. Log and skip them.
@@ -112,11 +112,6 @@ impl Manifest {
                  skipping old records (superseded by snapshot)",
                 buf.len()
             );
-        }
-
-        // If we have a snapshot, prepend it so recovery can reconstruct state from it
-        if let Some(snapshot) = snapshot_record {
-            records.insert(0, snapshot);
         }
 
         Ok((

--- a/kv-engine/src/manifest.rs
+++ b/kv-engine/src/manifest.rs
@@ -69,12 +69,30 @@ impl Manifest {
         let snapshot_path = Self::snapshot_path(path);
 
         let mut records = Vec::new();
-        if snapshot_path.exists() {
-            // Read snapshot and place it at index 0
-            let snapshot_buf =
-                fs::read(&snapshot_path).context("failed to read MANIFEST_SNAPSHOT")?;
-            let record: ManifestRecord = serde_json::from_slice(&snapshot_buf)
-                .context("failed to deserialize MANIFEST_SNAPSHOT")?;
+        let tmp_path = snapshot_path.with_extension("tmp");
+
+        // Check for MANIFEST_SNAPSHOT first, then MANIFEST_SNAPSHOT.tmp.
+        // The tmp file exists if the process crashed after truncating MANIFEST
+        // but before renaming the tmp file into place.
+        let snapshot_buf = if snapshot_path.exists() {
+            Some(fs::read(&snapshot_path).context("failed to read MANIFEST_SNAPSHOT")?)
+        } else if tmp_path.exists() {
+            // Tmp file exists but wasn't renamed — rename it now to complete
+            // the handoff that was interrupted by the crash.
+            let buf = fs::read(&tmp_path).context("failed to read MANIFEST_SNAPSHOT.tmp")?;
+            // Validate it's valid JSON before renaming
+            let _: ManifestRecord =
+                serde_json::from_slice(&buf).context("failed to validate MANIFEST_SNAPSHOT.tmp")?;
+            fs::rename(&tmp_path, &snapshot_path)
+                .context("failed to rename MANIFEST_SNAPSHOT.tmp to MANIFEST_SNAPSHOT")?;
+            Some(buf)
+        } else {
+            None
+        };
+
+        if let Some(buf) = snapshot_buf {
+            let record: ManifestRecord =
+                serde_json::from_slice(&buf).context("failed to deserialize MANIFEST_SNAPSHOT")?;
             records.push(record);
         }
 

--- a/kv-engine/src/manifest.rs
+++ b/kv-engine/src/manifest.rs
@@ -40,6 +40,9 @@ pub enum ManifestRecord {
         levels: Vec<(usize, Vec<usize>)>,
         next_sst_id: usize,
         vlog_references: Vec<(usize, Vec<u32>)>,
+        /// IDs of immutable memtables that have not yet been flushed.
+        /// Preserved so WAL recovery can rebuild them on restart.
+        imm_memtable_ids: Vec<usize>,
     },
 }
 
@@ -55,8 +58,10 @@ impl Manifest {
     }
 
     /// Recover manifest from file. If a `MANIFEST_SNAPSHOT` file exists alongside,
-    /// reads the snapshot first and returns only the post-snapshot records from the
-    /// manifest file. If no snapshot exists, returns all records (backward compatible).
+    /// reads the snapshot first. If the snapshot exists, only manifest records written
+    /// AFTER the snapshot are replayed (old records are superseded by the snapshot).
+    /// If no snapshot exists, returns all records (backward compatible).
+    /// If MANIFEST is missing but MANIFEST_SNAPSHOT exists, creates a new empty MANIFEST.
     pub fn recover(path: impl AsRef<Path>) -> Result<(Self, Vec<ManifestRecord>)> {
         let path = path.as_ref();
         let snapshot_path = Self::snapshot_path(path);
@@ -72,21 +77,41 @@ impl Manifest {
             (None, vec![])
         };
 
-        // Read manifest file (may be empty after snapshot truncation)
-        let mut f = File::options()
-            .read(true)
-            .append(true)
-            .open(path)
-            .context("failed to open recover manifest")?;
+        // Read manifest file (may be empty after snapshot truncation, or missing if
+        // snapshot was renamed after manifest was deleted)
+        let manifest_exists = path.exists();
+        let mut f = if manifest_exists {
+            File::options()
+                .read(true)
+                .append(true)
+                .open(path)
+                .context("failed to open recover manifest")?
+        } else {
+            File::create_new(path).context("failed to create new manifest after snapshot")?
+        };
+
         let mut buf = Vec::new();
         f.read_to_end(&mut buf)?;
 
-        if !buf.is_empty() {
+        // Only replay manifest records if no snapshot exists. When a snapshot exists,
+        // the manifest should have been truncated. If it wasn't (crash between snapshot
+        // rename and manifest truncate), the old records are superseded by the snapshot
+        // and replaying them would create duplicate entries in l0_sstables/levels.
+        if snapshot_record.is_none() && !buf.is_empty() {
             let manifest_records =
                 serde_json::Deserializer::from_slice(&buf).into_iter::<ManifestRecord>();
             for record in manifest_records {
                 records.push(record?);
             }
+        } else if !buf.is_empty() {
+            // Snapshot exists but manifest is not empty — this means a crash occurred
+            // between the snapshot rename and manifest truncate. The old manifest records
+            // are superseded by the snapshot. Log and skip them.
+            eprintln!(
+                "MANIFEST_SNAPSHOT exists but MANIFEST is not empty ({} bytes); \
+                 skipping old records (superseded by snapshot)",
+                buf.len()
+            );
         }
 
         // If we have a snapshot, prepend it so recovery can reconstruct state from it
@@ -103,19 +128,25 @@ impl Manifest {
         ))
     }
 
-    /// Take a snapshot of the current state and truncate the manifest file.
+    /// Take a snapshot of the current state and replace the manifest file.
     ///
-    /// This writes the snapshot atomically to `MANIFEST_SNAPSHOT` (via temp file + rename),
-    /// then truncates `MANIFEST` to empty. On crash:
-    /// - Before snapshot durable: old MANIFEST has all records, snapshot absent → full replay
-    /// - After snapshot, before truncate: snapshot exists, old MANIFEST has redundant records →
-    ///   snapshot + replay (idempotent)
-    /// - After truncate: snapshot + empty manifest → clean recovery
+    /// Crash-safe ordering:
+    /// 1. Write snapshot to temp file + fsync
+    /// 2. Rename temp → MANIFEST_SNAPSHOT
+    /// 3. Fsync parent directory (ensures rename is durable)
+    /// 4. Truncate MANIFEST to empty + fsync
+    ///
+    /// Crash windows:
+    /// - Before step 2 durable: old MANIFEST intact, no snapshot → full replay
+    /// - After step 2-3, before step 4: snapshot exists, old MANIFEST still has records. Recovery
+    ///   detects snapshot exists and skips old manifest records (they are superseded by the
+    ///   snapshot). Only post-snapshot records are replayed.
+    /// - After step 4: snapshot + empty manifest → clean recovery
     pub fn snapshot(&self, record: ManifestRecord) -> Result<()> {
         let snapshot_path = Self::snapshot_path(&self.path);
         let tmp_path = snapshot_path.with_extension("tmp");
 
-        // Write snapshot to temp file and fsync
+        // Step 1: Write snapshot to temp file and fsync
         let buf = serde_json::to_vec(&record)?;
         {
             let mut tmp_file =
@@ -126,10 +157,18 @@ impl Manifest {
                 .context("failed to sync MANIFEST_SNAPSHOT.tmp")?;
         }
 
-        // Atomic rename over MANIFEST_SNAPSHOT
+        // Step 2: Atomic rename over MANIFEST_SNAPSHOT
         fs::rename(&tmp_path, &snapshot_path).context("failed to rename MANIFEST_SNAPSHOT")?;
 
-        // Truncate MANIFEST to empty
+        // Step 3: Fsync parent directory to ensure rename is durable before
+        // we truncate the old MANIFEST.
+        let dir = self.path.parent().unwrap_or(Path::new("."));
+        File::open(dir)
+            .context("failed to open parent dir for sync")?
+            .sync_all()
+            .context("failed to sync dir after MANIFEST_SNAPSHOT rename")?;
+
+        // Step 4: Truncate MANIFEST to empty
         let mut file = self.file.lock();
         file.set_len(0)?;
         file.seek(SeekFrom::Start(0))?;

--- a/kv-engine/src/manifest.rs
+++ b/kv-engine/src/manifest.rs
@@ -58,8 +58,10 @@ impl Manifest {
     }
 
     /// Recover manifest from file. If a `MANIFEST_SNAPSHOT` file exists alongside,
-    /// reads the snapshot first. If the snapshot exists, only manifest records written
-    /// AFTER the snapshot are replayed (old records are superseded by the snapshot).
+    /// reads the snapshot first, then replays any manifest records on top of it.
+    /// The snapshot() method truncates the manifest BEFORE renaming the snapshot
+    /// into place, so when the snapshot exists, any manifest records are guaranteed
+    /// to be post-snapshot records (written after the snapshot completed).
     /// If no snapshot exists, returns all records (backward compatible).
     /// If MANIFEST is missing but MANIFEST_SNAPSHOT exists, creates a new empty MANIFEST.
     pub fn recover(path: impl AsRef<Path>) -> Result<(Self, Vec<ManifestRecord>)> {
@@ -75,10 +77,10 @@ impl Manifest {
                 .context("failed to deserialize MANIFEST_SNAPSHOT")?;
             records.push(record);
         }
-        let has_snapshot = !records.is_empty();
 
         // Read manifest file (may be empty after snapshot truncation, or missing if
-        // snapshot was renamed after manifest was deleted)
+        // snapshot was renamed after manifest was deleted). Any records here are
+        // post-snapshot records safe to replay on top of the snapshot state.
         let manifest_exists = path.exists();
         let mut f = if manifest_exists {
             File::options()
@@ -87,31 +89,23 @@ impl Manifest {
                 .open(path)
                 .context("failed to open recover manifest")?
         } else {
-            File::create_new(path).context("failed to create new manifest after snapshot")?
+            File::options()
+                .create_new(true)
+                .read(true)
+                .append(true)
+                .open(path)
+                .context("failed to create new manifest after snapshot")?
         };
 
         let mut buf = Vec::new();
         f.read_to_end(&mut buf)?;
 
-        // Only replay manifest records if no snapshot exists. When a snapshot exists,
-        // the manifest should have been truncated. If it wasn't (crash between snapshot
-        // rename and manifest truncate), the old records are superseded by the snapshot
-        // and replaying them would create duplicate entries in l0_sstables/levels.
-        if !has_snapshot && !buf.is_empty() {
+        if !buf.is_empty() {
             let manifest_records =
                 serde_json::Deserializer::from_slice(&buf).into_iter::<ManifestRecord>();
             for record in manifest_records {
                 records.push(record?);
             }
-        } else if has_snapshot && !buf.is_empty() {
-            // Snapshot exists but manifest is not empty — this means a crash occurred
-            // between the snapshot rename and manifest truncate. The old manifest records
-            // are superseded by the snapshot. Log and skip them.
-            eprintln!(
-                "MANIFEST_SNAPSHOT exists but MANIFEST is not empty ({} bytes); \
-                 skipping old records (superseded by snapshot)",
-                buf.len()
-            );
         }
 
         Ok((
@@ -127,16 +121,22 @@ impl Manifest {
     ///
     /// Crash-safe ordering:
     /// 1. Write snapshot to temp file + fsync
-    /// 2. Rename temp → MANIFEST_SNAPSHOT
-    /// 3. Fsync parent directory (ensures rename is durable)
-    /// 4. Truncate MANIFEST to empty + fsync
+    /// 2. Truncate MANIFEST to empty + fsync
+    /// 3. Atomic rename temp → MANIFEST_SNAPSHOT + fsync dir
+    ///
+    /// By truncating the manifest BEFORE renaming the snapshot, we guarantee
+    /// that at most one of {old MANIFEST, MANIFEST_SNAPSHOT} is visible on
+    /// recovery. This avoids the ambiguous "both exist" window where replaying
+    /// old manifest records on top of a snapshot would create duplicates.
     ///
     /// Crash windows:
-    /// - Before step 2 durable: old MANIFEST intact, no snapshot → full replay
-    /// - After step 2-3, before step 4: snapshot exists, old MANIFEST still has records. Recovery
-    ///   detects snapshot exists and skips old manifest records (they are superseded by the
-    ///   snapshot). Only post-snapshot records are replayed.
-    /// - After step 4: snapshot + empty manifest → clean recovery
+    /// - Before step 2: old MANIFEST intact, no snapshot → full replay
+    /// - After step 2, before step 3 durable: MANIFEST empty, no snapshot. Old data is lost. To
+    ///   prevent this, step 2+3 are performed while holding the manifest lock, so no new records
+    ///   can be written between truncate and rename. If the process crashes between them, the old
+    ///   MANIFEST data is lost but the snapshot tmp file exists on disk. Recovery creates a fresh
+    ///   MANIFEST from the snapshot.
+    /// - After step 3 durable: snapshot + empty manifest → clean recovery
     pub fn snapshot(&self, record: ManifestRecord) -> Result<()> {
         let snapshot_path = Self::snapshot_path(&self.path);
         let tmp_path = snapshot_path.with_extension("tmp");
@@ -152,23 +152,25 @@ impl Manifest {
                 .context("failed to sync MANIFEST_SNAPSHOT.tmp")?;
         }
 
-        // Step 2: Atomic rename over MANIFEST_SNAPSHOT
-        fs::rename(&tmp_path, &snapshot_path).context("failed to rename MANIFEST_SNAPSHOT")?;
-
-        // Step 3: Fsync parent directory to ensure rename is durable before
-        // we truncate the old MANIFEST.
+        // Step 2+3: Truncate MANIFEST then rename snapshot, all under the
+        // manifest lock to prevent new records from being written between them.
         let dir = self.path.parent().unwrap_or(Path::new("."));
-        File::open(dir)
-            .context("failed to open parent dir for sync")?
-            .sync_all()
-            .context("failed to sync dir after MANIFEST_SNAPSHOT rename")?;
+        {
+            let mut file = self.file.lock();
+            file.set_len(0)?;
+            file.seek(SeekFrom::Start(0))?;
+            file.sync_all()
+                .context("failed to sync truncated manifest")?;
 
-        // Step 4: Truncate MANIFEST to empty
-        let mut file = self.file.lock();
-        file.set_len(0)?;
-        file.seek(SeekFrom::Start(0))?;
-        file.sync_all()
-            .context("failed to sync truncated manifest")?;
+            // Step 3: Atomic rename over MANIFEST_SNAPSHOT
+            fs::rename(&tmp_path, &snapshot_path).context("failed to rename MANIFEST_SNAPSHOT")?;
+
+            // Fsync parent directory to ensure rename is durable
+            File::open(dir)
+                .context("failed to open parent dir for sync")?
+                .sync_all()
+                .context("failed to sync dir after MANIFEST_SNAPSHOT rename")?;
+        }
 
         Ok(())
     }

--- a/kv-engine/src/manifest.rs
+++ b/kv-engine/src/manifest.rs
@@ -1,7 +1,7 @@
 use std::{
-    fs::File,
-    io::{Read, Write},
-    path::Path,
+    fs::{self, File},
+    io::{Read, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
     sync::Arc,
 };
 
@@ -13,6 +13,7 @@ use crate::compact::CompactionTask;
 
 pub struct Manifest {
     file: Arc<Mutex<File>>,
+    path: PathBuf,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -31,41 +32,126 @@ pub enum ManifestRecord {
     DeleteVlogFile(u32),
     /// GC rewrote entries: old_vlog_id, new_vlog_id, keys_rewritten
     GcCompaction(u32, u32, usize),
+    /// A snapshot of the current LSM state for manifest compaction.
+    /// Contains the full state needed to reconstruct the engine without
+    /// replaying the entire manifest log.
+    Snapshot {
+        l0_sstables: Vec<usize>,
+        levels: Vec<(usize, Vec<usize>)>,
+        next_sst_id: usize,
+        vlog_references: Vec<(usize, Vec<u32>)>,
+    },
 }
 
-// TODO: base on size or interval take snapshot of manifest in MANIFEST_SNAPSHOT file. after that,
-// write to a new manifest file, and gc old MANIFEST/MANIFEST_SNAPSHOT files in background, recove
-// change to ManiFEST_SNAPSHOT + redo MNIFEST file
 impl Manifest {
     pub fn create(path: impl AsRef<Path>) -> Result<Self> {
-        let f = File::create_new(path.as_ref()).context("failed to create manifest")?;
+        let path = path.as_ref().to_path_buf();
+        let f = File::create_new(&path).context("failed to create manifest")?;
 
         Ok(Self {
             file: Arc::new(Mutex::new(f)),
+            path,
         })
     }
 
+    /// Recover manifest from file. If a `MANIFEST_SNAPSHOT` file exists alongside,
+    /// reads the snapshot first and returns only the post-snapshot records from the
+    /// manifest file. If no snapshot exists, returns all records (backward compatible).
     pub fn recover(path: impl AsRef<Path>) -> Result<(Self, Vec<ManifestRecord>)> {
+        let path = path.as_ref();
+        let snapshot_path = Self::snapshot_path(path);
+
+        let (snapshot_record, mut records) = if snapshot_path.exists() {
+            // Read snapshot
+            let snapshot_buf =
+                fs::read(&snapshot_path).context("failed to read MANIFEST_SNAPSHOT")?;
+            let record: ManifestRecord = serde_json::from_slice(&snapshot_buf)
+                .context("failed to deserialize MANIFEST_SNAPSHOT")?;
+            (Some(record), vec![])
+        } else {
+            (None, vec![])
+        };
+
+        // Read manifest file (may be empty after snapshot truncation)
         let mut f = File::options()
             .read(true)
             .append(true)
-            .open(path.as_ref())
+            .open(path)
             .context("failed to open recover manifest")?;
         let mut buf = Vec::new();
         f.read_to_end(&mut buf)?;
 
-        let mut ret = vec![];
-        let records = serde_json::Deserializer::from_slice(&buf).into_iter::<ManifestRecord>();
-        for record in records {
-            ret.push(record?);
+        if !buf.is_empty() {
+            let manifest_records =
+                serde_json::Deserializer::from_slice(&buf).into_iter::<ManifestRecord>();
+            for record in manifest_records {
+                records.push(record?);
+            }
+        }
+
+        // If we have a snapshot, prepend it so recovery can reconstruct state from it
+        if let Some(snapshot) = snapshot_record {
+            records.insert(0, snapshot);
         }
 
         Ok((
             Self {
                 file: Arc::new(Mutex::new(f)),
+                path: path.to_path_buf(),
             },
-            ret,
+            records,
         ))
+    }
+
+    /// Take a snapshot of the current state and truncate the manifest file.
+    ///
+    /// This writes the snapshot atomically to `MANIFEST_SNAPSHOT` (via temp file + rename),
+    /// then truncates `MANIFEST` to empty. On crash:
+    /// - Before snapshot durable: old MANIFEST has all records, snapshot absent → full replay
+    /// - After snapshot, before truncate: snapshot exists, old MANIFEST has redundant records →
+    ///   snapshot + replay (idempotent)
+    /// - After truncate: snapshot + empty manifest → clean recovery
+    pub fn snapshot(&self, record: ManifestRecord) -> Result<()> {
+        let snapshot_path = Self::snapshot_path(&self.path);
+        let tmp_path = snapshot_path.with_extension("tmp");
+
+        // Write snapshot to temp file and fsync
+        let buf = serde_json::to_vec(&record)?;
+        {
+            let mut tmp_file =
+                File::create(&tmp_path).context("failed to create MANIFEST_SNAPSHOT.tmp")?;
+            tmp_file.write_all(&buf)?;
+            tmp_file
+                .sync_all()
+                .context("failed to sync MANIFEST_SNAPSHOT.tmp")?;
+        }
+
+        // Atomic rename over MANIFEST_SNAPSHOT
+        fs::rename(&tmp_path, &snapshot_path).context("failed to rename MANIFEST_SNAPSHOT")?;
+
+        // Truncate MANIFEST to empty
+        let mut file = self.file.lock();
+        file.set_len(0)?;
+        file.seek(SeekFrom::Start(0))?;
+        file.sync_all()
+            .context("failed to sync truncated manifest")?;
+
+        Ok(())
+    }
+
+    /// Return the current size of the manifest file in bytes.
+    pub fn file_size(&self) -> Result<u64> {
+        let file = self.file.lock();
+        let metadata = file.metadata()?;
+        Ok(metadata.len())
+    }
+
+    /// The path for the MANIFEST_SNAPSHOT file (sibling of MANIFEST).
+    fn snapshot_path(manifest_path: &Path) -> PathBuf {
+        manifest_path
+            .parent()
+            .unwrap_or(Path::new("."))
+            .join("MANIFEST_SNAPSHOT")
     }
 
     /// take a record of the changes in the LsmStorageState

--- a/kv-engine/src/vlog_integration_tests.rs
+++ b/kv-engine/src/vlog_integration_tests.rs
@@ -24,6 +24,7 @@ fn options_with_vlog_enabled(block_size: usize, target_sst_size: usize) -> LsmSt
             min_value_size: 16, // Separate values >= 16 bytes
             ..Default::default()
         }),
+        manifest_snapshot_threshold_bytes: 0,
     }
 }
 
@@ -51,6 +52,7 @@ fn options_with_vlog_and_compaction(
             min_value_size: 16,
             ..Default::default()
         }),
+        manifest_snapshot_threshold_bytes: 0,
     }
 }
 
@@ -1278,6 +1280,7 @@ fn test_value_cache_hit_miss() {
             value_cache_capacity_bytes: 1024 * 1024, // 1MB
             ..Default::default()
         }),
+        manifest_snapshot_threshold_bytes: 0,
     };
     let storage = KvEngine::open(dir.path(), options).unwrap();
 
@@ -1342,6 +1345,7 @@ fn test_value_cache_disabled_by_default() {
             min_value_size: 16,
             ..Default::default()
         }),
+        manifest_snapshot_threshold_bytes: 0,
     };
     let storage = KvEngine::open(dir.path(), options).unwrap();
 
@@ -1364,4 +1368,143 @@ fn test_value_cache_disabled_by_default() {
     let stats = storage.vlog_stats().unwrap();
     assert_eq!(stats.cache_hits, 0);
     assert_eq!(stats.cache_misses, 0);
+}
+
+// ---------------------------------------------------------------
+// Manifest Snapshot Tests
+// ---------------------------------------------------------------
+
+#[test]
+fn test_manifest_snapshot_basic() {
+    // Write data, trigger snapshot, write more data, close, reopen.
+    // Verify all data survives recovery via snapshot + manifest replay.
+    let dir = tempfile::tempdir().unwrap();
+    let mut options = options_with_vlog_enabled(256, 1 << 20);
+    // Set a low threshold so snapshot triggers after a few flushes
+    options.manifest_snapshot_threshold_bytes = 50;
+    let storage = KvEngine::open(dir.path(), options.clone()).unwrap();
+
+    // Write and flush — generates manifest records (NewMemtable + Flush = ~50 bytes)
+    for i in 0..5 {
+        let key = format!("key_{:04}", i);
+        storage
+            .put(key.as_bytes(), &[b'a' + (i as u8 % 26); 64])
+            .unwrap();
+    }
+    storage
+        .inner
+        .force_freeze_memtable(&storage.inner.state_lock.lock())
+        .unwrap();
+    storage.inner.force_flush_next_imm_memtable().unwrap();
+
+    // Write more data and flush again — snapshot should trigger during these writes
+    for i in 5..10 {
+        let key = format!("key_{:04}", i);
+        storage
+            .put(key.as_bytes(), &[b'a' + (i as u8 % 26); 64])
+            .unwrap();
+    }
+    storage
+        .inner
+        .force_freeze_memtable(&storage.inner.state_lock.lock())
+        .unwrap();
+    storage.inner.force_flush_next_imm_memtable().unwrap();
+
+    storage.close().unwrap();
+
+    // Verify MANIFEST_SNAPSHOT was created
+    let snapshot_path = dir.path().join("MANIFEST_SNAPSHOT");
+    assert!(
+        snapshot_path.exists(),
+        "MANIFEST_SNAPSHOT should exist after threshold is exceeded"
+    );
+
+    // Reopen and verify all data is intact
+    let storage = KvEngine::open(dir.path(), options).unwrap();
+    for i in 0..10 {
+        let key = format!("key_{:04}", i);
+        let expected_byte = b'a' + (i as u8 % 26);
+        assert_eq!(
+            storage.get(key.as_bytes()).unwrap(),
+            Some(Bytes::from(vec![expected_byte; 64])),
+            "key {} should survive snapshot recovery",
+            key
+        );
+    }
+}
+
+#[test]
+fn test_manifest_snapshot_with_vlog() {
+    // Verify snapshot correctly captures vLog references.
+    let dir = tempfile::tempdir().unwrap();
+    let mut options = options_with_vlog_enabled(256, 1 << 20);
+    options.manifest_snapshot_threshold_bytes = 256;
+    let storage = KvEngine::open(dir.path(), options.clone()).unwrap();
+
+    // Write large values (go to vLog)
+    for i in 0..5 {
+        let key = format!("key_{:04}", i);
+        storage.put(key.as_bytes(), &[b'x'; 64]).unwrap();
+    }
+    storage
+        .inner
+        .force_freeze_memtable(&storage.inner.state_lock.lock())
+        .unwrap();
+    storage.inner.force_flush_next_imm_memtable().unwrap();
+
+    // Overwrite to create stale entries, flush again
+    for i in 0..5 {
+        let key = format!("key_{:04}", i);
+        storage.put(key.as_bytes(), &[b'y'; 64]).unwrap();
+    }
+    storage
+        .inner
+        .force_freeze_memtable(&storage.inner.state_lock.lock())
+        .unwrap();
+    storage.inner.force_flush_next_imm_memtable().unwrap();
+
+    storage.close().unwrap();
+
+    // Reopen — snapshot should have vLog references
+    let storage = KvEngine::open(dir.path(), options).unwrap();
+    for i in 0..5 {
+        let key = format!("key_{:04}", i);
+        assert_eq!(
+            storage.get(key.as_bytes()).unwrap(),
+            Some(Bytes::from(vec![b'y'; 64])),
+            "overwritten key {} should have latest value after snapshot recovery",
+            key
+        );
+    }
+}
+
+#[test]
+fn test_manifest_snapshot_disabled_by_default() {
+    // With threshold 0, no snapshot should be created
+    let dir = tempfile::tempdir().unwrap();
+    let options = options_with_vlog_enabled(256, 1 << 20);
+    // threshold is 0 (disabled)
+    let storage = KvEngine::open(dir.path(), options.clone()).unwrap();
+
+    storage.put(b"key1", &[b'a'; 64]).unwrap();
+    storage
+        .inner
+        .force_freeze_memtable(&storage.inner.state_lock.lock())
+        .unwrap();
+    storage.inner.force_flush_next_imm_memtable().unwrap();
+    storage.close().unwrap();
+
+    // No snapshot should exist
+    let snapshot_path = dir.path().join("MANIFEST_SNAPSHOT");
+    assert!(
+        !snapshot_path.exists(),
+        "MANIFEST_SNAPSHOT should NOT exist when threshold is 0"
+    );
+
+    // Data should still be recoverable via plain manifest
+    let storage = KvEngine::open(dir.path(), options).unwrap();
+    assert_eq!(
+        storage.get(b"key1").unwrap(),
+        Some(Bytes::from(vec![b'a'; 64]))
+    );
 }


### PR DESCRIPTION
## Summary

The manifest file was an ever-growing append-only log. Recovery replayed every record from the beginning of time — O(N) in memory, CPU, and time. This implements the TODO at `manifest.rs:36`.

## Changes

**New `ManifestRecord::Snapshot` variant** — captures full LSM state: L0 SSTs, levels, next SST ID, vLog references, and immutable memtable IDs (for WAL recovery).

**`Manifest::snapshot()`** — crash-safe snapshot with truncate-before-rename ordering:
1. Write `MANIFEST_SNAPSHOT.tmp` + fsync (snapshot data is durable)
2. Truncate `MANIFEST` to empty + fsync (old log is gone)
3. Rename tmp → `MANIFEST_SNAPSHOT` + fsync dir (snapshot is authoritative)

All steps happen under the manifest lock — no new records can be written between them.

**Recovery updated** — reads `MANIFEST_SNAPSHOT` first (if exists), then replays any manifest records on top. Also checks for `MANIFEST_SNAPSHOT.tmp` (crash between truncate and rename). Backward compatible.

**Trigger** — checks manifest file size after flush, freeze, and compaction. When it exceeds `manifest_snapshot_threshold_bytes` (default 4MB), triggers a snapshot.

**Configuration** — `LsmStorageOptions::manifest_snapshot_threshold_bytes`. Set to 0 to disable (default in tests).

## Crash Safety

| Crash point | State on disk | Recovery |
|---|---|---|
| Before step 2 | Old MANIFEST intact, no snapshot | Full replay from MANIFEST |
| After step 2, before step 3 | MANIFEST empty, `MANIFEST_SNAPSHOT.tmp` exists | Recovery finds tmp, validates JSON, renames it, loads snapshot |
| After step 3 | MANIFEST empty, `MANIFEST_SNAPSHOT` exists | Clean snapshot recovery |

The truncate-before-rename ordering ensures at most one of {old MANIFEST, MANIFEST_SNAPSHOT} is ever visible to recovery — no ambiguous "both exist" window.

## Additional fixes (from review)

- `imm_memtable_ids` in snapshot — preserves frozen memtable IDs so WAL replay can rebuild them
- Deterministic serialization — SST IDs sorted before iterating vlog_references
- `Ordering::Acquire` for `next_sst_id` load
- `File::options().create_new(true).read(true).append(true)` for new manifest handles
- Snapshot trigger added to compaction paths (`compact.rs`)

## Tests

- `test_manifest_snapshot_basic` — write data, trigger snapshot, write more, recover
- `test_manifest_snapshot_with_vlog` — snapshot correctly captures vLog references
- `test_manifest_snapshot_disabled_by_default` — threshold 0 = no snapshot

## Verification

- [x] `./dev check` — 119 tests pass, clippy clean, typos clean