### PR TITLE
feat: promote value caching to first-class feature

### DIFF
--- a/kv-engine/benches/vlog_benchmarks.rs
+++ b/kv-engine/benches/vlog_benchmarks.rs
@@ -34,6 +34,7 @@ fn make_options(vlog_enabled: bool, min_value_size: usize) -> LsmStorageOptions 
             None
         },
         manifest_snapshot_threshold_bytes: 0,
+        block_cache_capacity: 1024,
     }
 }
 
@@ -61,6 +62,7 @@ fn make_options_with_compaction(vlog_enabled: bool, min_value_size: usize) -> Ls
             None
         },
         manifest_snapshot_threshold_bytes: 0,
+        block_cache_capacity: 1024,
     }
 }
 
@@ -114,6 +116,7 @@ fn make_options_with_cache(min_value_size: usize, cache_bytes: u64) -> LsmStorag
             ..Default::default()
         }),
         manifest_snapshot_threshold_bytes: 0,
+        block_cache_capacity: 1024,
     }
 }
 

--- a/kv-engine/benches/vlog_benchmarks.rs
+++ b/kv-engine/benches/vlog_benchmarks.rs
@@ -28,6 +28,7 @@ fn make_options(vlog_enabled: bool, min_value_size: usize) -> LsmStorageOptions 
             Some(ValueSeparationOptions {
                 enabled: true,
                 min_value_size,
+                value_cache_capacity_bytes: 0, // uncached baseline
                 ..Default::default()
             })
         } else {
@@ -56,6 +57,7 @@ fn make_options_with_compaction(vlog_enabled: bool, min_value_size: usize) -> Ls
             Some(ValueSeparationOptions {
                 enabled: true,
                 min_value_size,
+                value_cache_capacity_bytes: 0, // uncached baseline
                 ..Default::default()
             })
         } else {

--- a/kv-engine/src/bin/kv-engine-cli.rs
+++ b/kv-engine/src/bin/kv-engine-cli.rs
@@ -35,6 +35,8 @@ struct Args {
     enable_wal: bool,
     #[arg(long)]
     serializable: bool,
+    #[arg(long, default_value = "1024")]
+    block_cache_capacity: u64,
 }
 
 struct ReplHandler {
@@ -126,6 +128,23 @@ impl ReplHandler {
                 self.lsm.close()?;
                 std::process::exit(0);
             }
+            Command::Stats => {
+                let cs = self.lsm.cache_stats();
+                println!("Block cache:");
+                println!("  entries:    {}", cs.block_cache_entry_count);
+                if cs.value_cache_hit_count > 0 || cs.value_cache_miss_count > 0 {
+                    println!("Value cache:");
+                    println!("  hits:       {}", cs.value_cache_hit_count);
+                    println!("  misses:     {}", cs.value_cache_miss_count);
+                    let vc_total = cs.value_cache_hit_count + cs.value_cache_miss_count;
+                    println!(
+                        "  hit rate:   {:.1}%",
+                        cs.value_cache_hit_count as f64 / vc_total as f64 * 100.0
+                    );
+                } else {
+                    println!("Value cache: disabled or no activity");
+                }
+            }
         };
 
         self.epoch += 1;
@@ -156,6 +175,7 @@ enum Command {
     FullCompaction,
     Quit,
     Close,
+    Stats,
 }
 
 impl Command {
@@ -226,6 +246,7 @@ impl Command {
                 map(tag_no_case("full_compaction"), |_| Command::FullCompaction),
                 map(tag_no_case("quit"), |_| Command::Quit),
                 map(tag_no_case("close"), |_| Command::Close),
+                map(tag_no_case("stats"), |_| Command::Stats),
             ))(i)
         };
 
@@ -347,6 +368,7 @@ fn main() -> Result<()> {
             serializable: args.serializable,
             value_separation: None,
             manifest_snapshot_threshold_bytes: 4 << 20, // 4MB
+            block_cache_capacity: args.block_cache_capacity,
         },
     )?;
 

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -104,6 +104,9 @@ pub struct LsmStorageOptions {
     /// exceeds this size, a snapshot of the current state is written to MANIFEST_SNAPSHOT
     /// and the manifest is truncated. Set to 0 to disable. Defaults to 4MB.
     pub manifest_snapshot_threshold_bytes: u64,
+    /// Maximum number of entries in the block cache. Set to 0 to disable.
+    /// Defaults to 1024.
+    pub block_cache_capacity: u64,
 }
 
 impl LsmStorageOptions {
@@ -117,6 +120,7 @@ impl LsmStorageOptions {
             serializable: false,
             value_separation: None,
             manifest_snapshot_threshold_bytes: 0, // disabled by default in tests
+            block_cache_capacity: 1024,
         }
     }
 
@@ -130,6 +134,7 @@ impl LsmStorageOptions {
             serializable: false,
             value_separation: None,
             manifest_snapshot_threshold_bytes: 0,
+            block_cache_capacity: 1024,
         }
     }
 
@@ -143,8 +148,20 @@ impl LsmStorageOptions {
             serializable: false,
             value_separation: None,
             manifest_snapshot_threshold_bytes: 0,
+            block_cache_capacity: 1024,
         }
     }
+}
+
+/// Aggregated cache statistics for the storage engine.
+#[derive(Clone, Debug)]
+pub struct CacheStats {
+    /// Number of entries currently in the block cache.
+    pub block_cache_entry_count: u64,
+    /// Number of value cache hits (only available when value separation is enabled).
+    pub value_cache_hit_count: u64,
+    /// Number of value cache misses (only available when value separation is enabled).
+    pub value_cache_miss_count: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -355,6 +372,20 @@ impl KvEngine {
         };
         vlog.stats()
     }
+
+    /// Get aggregated cache statistics for both block and value caches.
+    pub fn cache_stats(&self) -> CacheStats {
+        let (vc_hits, vc_misses) = self
+            .inner
+            .vlog
+            .as_ref()
+            .map_or((0, 0), |vlog| vlog.cache_hit_miss_counts());
+        CacheStats {
+            block_cache_entry_count: self.inner.block_cache.entry_count(),
+            value_cache_hit_count: vc_hits,
+            value_cache_miss_count: vc_misses,
+        }
+    }
 }
 
 impl LsmStorageInner {
@@ -373,7 +404,7 @@ impl LsmStorageInner {
         let mut state = LsmStorageState::create(&options, vlog_enabled);
         // seems the cache is not cleaned forever ? just let lru do the gc job.
         // better refill the cache somehow after compaction
-        let block_cache = Arc::new(BlockCache::new(1024));
+        let block_cache = Arc::new(BlockCache::new(options.block_cache_capacity));
         let compaction_controller = match &options.compaction_options {
             CompactionOptions::Leveled(options) => {
                 CompactionController::Leveled(LeveledCompactionController::new(options.clone()))

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -104,7 +104,7 @@ pub struct LsmStorageOptions {
     /// exceeds this size, a snapshot of the current state is written to MANIFEST_SNAPSHOT
     /// and the manifest is truncated. Set to 0 to disable. Defaults to 4MB.
     pub manifest_snapshot_threshold_bytes: u64,
-    /// Maximum number of entries in the block cache. Set to 0 to disable.
+    /// Maximum number of entries in the block cache. Minimum 1 (moka panics on 0).
     /// Defaults to 1024.
     pub block_cache_capacity: u64,
 }
@@ -404,7 +404,8 @@ impl LsmStorageInner {
         let mut state = LsmStorageState::create(&options, vlog_enabled);
         // seems the cache is not cleaned forever ? just let lru do the gc job.
         // better refill the cache somehow after compaction
-        let block_cache = Arc::new(BlockCache::new(options.block_cache_capacity));
+        // moka panics on zero capacity; clamp to 1 minimum.
+        let block_cache = Arc::new(BlockCache::new(options.block_cache_capacity.max(1)));
         let compaction_controller = match &options.compaction_options {
             CompactionOptions::Leveled(options) => {
                 CompactionController::Leveled(LeveledCompactionController::new(options.clone()))

--- a/kv-engine/src/tests/vlog_integration_tests/cache.rs
+++ b/kv-engine/src/tests/vlog_integration_tests/cache.rs
@@ -17,6 +17,7 @@ fn test_value_cache_hit_miss() {
             ..Default::default()
         }),
         manifest_snapshot_threshold_bytes: 0,
+        block_cache_capacity: 1024,
     };
     let storage = KvEngine::open(dir.path(), options).unwrap();
 
@@ -75,9 +76,11 @@ fn test_value_cache_disabled_by_default() {
         value_separation: Some(ValueSeparationOptions {
             enabled: true,
             min_value_size: 16,
+            value_cache_capacity_bytes: 0, // explicitly disabled
             ..Default::default()
         }),
         manifest_snapshot_threshold_bytes: 0,
+        block_cache_capacity: 1024,
     };
     let storage = KvEngine::open(dir.path(), options).unwrap();
 
@@ -96,4 +99,47 @@ fn test_value_cache_disabled_by_default() {
     let stats = storage.vlog_stats().unwrap();
     assert_eq!(stats.cache_hits, 0);
     assert_eq!(stats.cache_misses, 0);
+}
+
+#[test]
+fn test_value_cache_enabled_by_default() {
+    let dir = tempfile::tempdir().unwrap();
+    // Use default ValueSeparationOptions — value_cache_capacity_bytes defaults to 64MB
+    let options = LsmStorageOptions {
+        block_size: 256,
+        target_sst_size: 1 << 20,
+        num_memtable_limit: 2,
+        compaction_options: CompactionOptions::NoCompaction,
+        enable_wal: false,
+        serializable: false,
+        value_separation: Some(ValueSeparationOptions {
+            enabled: true,
+            min_value_size: 16,
+            ..Default::default()
+        }),
+        manifest_snapshot_threshold_bytes: 0,
+        block_cache_capacity: 1024,
+    };
+    let storage = KvEngine::open(dir.path(), options).unwrap();
+
+    storage.put(b"key1", &[b'a'; 64]).unwrap();
+    force_flush(&storage.inner);
+
+    // First read: cache miss
+    assert_eq!(
+        storage.get(b"key1").unwrap(),
+        Some(Bytes::from(vec![b'a'; 64]))
+    );
+    let stats = storage.vlog_stats().unwrap();
+    assert_eq!(stats.cache_misses, 1);
+    assert_eq!(stats.cache_hits, 0);
+
+    // Second read: cache hit (default 64MB cache is active)
+    assert_eq!(
+        storage.get(b"key1").unwrap(),
+        Some(Bytes::from(vec![b'a'; 64]))
+    );
+    let stats = storage.vlog_stats().unwrap();
+    assert_eq!(stats.cache_misses, 1);
+    assert_eq!(stats.cache_hits, 1);
 }

--- a/kv-engine/src/tests/vlog_integration_tests/mod.rs
+++ b/kv-engine/src/tests/vlog_integration_tests/mod.rs
@@ -32,6 +32,7 @@ fn options_with_vlog_enabled(block_size: usize, target_sst_size: usize) -> LsmSt
             ..Default::default()
         }),
         manifest_snapshot_threshold_bytes: 0,
+        block_cache_capacity: 1024,
     }
 }
 
@@ -60,6 +61,7 @@ fn options_with_vlog_and_compaction(
             ..Default::default()
         }),
         manifest_snapshot_threshold_bytes: 0,
+        block_cache_capacity: 1024,
     }
 }
 

--- a/kv-engine/src/vlog/mod.rs
+++ b/kv-engine/src/vlog/mod.rs
@@ -141,7 +141,7 @@ impl Default for ValueSeparationOptions {
             max_vlog_file_size: 64 << 20,
             gc_threshold_ratio: 0.5,
             max_open_vlog_files: 64,
-            value_cache_capacity_bytes: 0,
+            value_cache_capacity_bytes: 64 << 20, // 64MB
         }
     }
 }
@@ -479,6 +479,15 @@ impl ValueLog {
         if let Some(ref cache) = self.value_cache {
             cache.insert((ptr.file_id, ptr.offset), value);
         }
+    }
+
+    /// Return cache hit and miss counts without scanning the directory.
+    pub fn cache_hit_miss_counts(&self) -> (u64, u64) {
+        use std::sync::atomic::Ordering;
+        (
+            self.cache_hits.load(Ordering::Relaxed),
+            self.cache_misses.load(Ordering::Relaxed),
+        )
     }
 
     /// Read the value at `ptr`, verifying that the stored key matches

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -1841,9 +1841,11 @@ This section documents intentional deviations between the original RFC design an
    file. Used by GC to skip header reads during liveness analysis. Rebuilt
    automatically from vLog headers if the index file is missing. See
    `kv-engine/src/vlog/index.rs`.
-5. **Value Caching**: Dedicated cache for hot values. A separate LRU cache for
-   vLog values (distinct from the block cache). Useful when point-get latency is
-   dominated by vLog seeks.
+5. ~~**Value Caching**~~: Done. Dedicated weighted LRU cache for vLog values
+   using moka, with configurable capacity (default 64MB, set to 0 to disable).
+   Block cache is also now configurable via `LsmStorageOptions::block_cache_capacity`
+   (default 1024 entries). `KvEngine::cache_stats()` API exposes hit/miss rates.
+   CLI `stats` command prints cache info.
 
 ### Concrete (near-term)
 


### PR DESCRIPTION
## Summary

Promotes the existing value cache from a hidden, disabled-by-default feature to a first-class, configurable feature with CLI visibility.

## Changes

- **LsmStorageOptions**: Add `block_cache_capacity` field (default 1024) — block cache size is now configurable instead of hardcoded
- **ValueSeparationOptions**: Change `value_cache_capacity_bytes` default from 0 (disabled) to 64MB
- **CacheStats + KvEngine::cache_stats()**: Programmatic API exposing block cache entry count and value cache hit/miss counts
- **CLI `stats` command**: Prints block cache entries, value cache hits/misses/hit-rate
- **CLI `--block-cache-capacity` flag**: Configure block cache from the command line
- **New test**: `test_value_cache_enabled_by_default` verifies the 64MB default works
- **RFC**: Mark Value Caching as done in Future Work

## Verification

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -D warnings` passes
- [x] `cargo test` — 116 tests pass (including new cache test)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `stats` REPL command showing block-cache entries, value-cache hits/misses, and hit rate
  * CLI option to configure block cache capacity (default 1024)
  * Public API to retrieve cache metrics

* **Improvements**
  * Value caching enabled by default (64 MB) with ability to disable for uncached baseline

* **Tests**
  * Updated integration tests for value-cache hit/miss behavior and defaults

* **Documentation**
  * RFC updated to mark value caching implemented and configurable
<!-- end of auto-generated comment: release notes by coderabbit.ai -->