### PR TITLE
perf: avoid Bytes PROMOTABLE → SHARED transition cost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ lsm.db/
 .claude/settings.local.json
 .kimi-code/
 .claude/
+perf.data*
+.remember/

--- a/kv-engine/src/block/builder.rs
+++ b/kv-engine/src/block/builder.rs
@@ -92,7 +92,12 @@ impl BlockBuilder {
     }
 
     /// Finalize the block.
-    pub fn build(self) -> Block {
+    pub fn build(mut self) -> Block {
+        // Ensure cap > len so Bytes::from(vec) creates SHARED instead of
+        // PROMOTABLE, avoiding an atomic CAS + allocation on the first clone.
+        if !self.data.is_empty() && self.data.len() == self.data.capacity() {
+            self.data.reserve(1);
+        }
         Block {
             data: Bytes::from(self.data),
             offsets: self.offsets,

--- a/kv-engine/src/block/builder.rs
+++ b/kv-engine/src/block/builder.rs
@@ -92,12 +92,7 @@ impl BlockBuilder {
     }
 
     /// Finalize the block.
-    pub fn build(mut self) -> Block {
-        // Ensure cap > len so Bytes::from(vec) creates SHARED instead of
-        // PROMOTABLE, avoiding an atomic CAS + allocation on the first clone.
-        if !self.data.is_empty() && self.data.len() == self.data.capacity() {
-            self.data.reserve(1);
-        }
+    pub fn build(self) -> Block {
         Block {
             data: Bytes::from(self.data),
             offsets: self.offsets,

--- a/kv-engine/src/key.rs
+++ b/kv-engine/src/key.rs
@@ -48,9 +48,13 @@ impl Key<Vec<u8>> {
         self.0.extend(data)
     }
 
-    /// Set the key from a slice without re-allocating. The signature will change in MVCC.
+    /// Set the key from a slice, reusing buffer capacity. Always reserves one
+    /// extra byte so that subsequent `into_key_bytes()` creates a `SHARED`
+    /// `Bytes` instead of a `PROMOTABLE` one (which incurs an atomic CAS on
+    /// the first clone).
     pub fn set_from_slice(&mut self, key_slice: KeySlice) {
         self.0.clear();
+        self.0.reserve(key_slice.len() + 1);
         self.0.extend(key_slice.0);
     }
 
@@ -59,7 +63,13 @@ impl Key<Vec<u8>> {
     }
 
     pub fn into_key_bytes(self) -> KeyBytes {
-        Key(self.0.into())
+        let mut vec = self.0;
+        // Ensure cap > len so Bytes::from(vec) creates SHARED instead of
+        // PROMOTABLE, avoiding an atomic CAS + allocation on the first clone.
+        if !vec.is_empty() && vec.len() == vec.capacity() {
+            vec.reserve(1);
+        }
+        Key(Bytes::from(vec))
     }
 
     /// Always use `raw_ref` to access the key before MVCC. This function will be removed in MVCC.

--- a/kv-engine/src/key.rs
+++ b/kv-engine/src/key.rs
@@ -63,13 +63,7 @@ impl Key<Vec<u8>> {
     }
 
     pub fn into_key_bytes(self) -> KeyBytes {
-        let mut vec = self.0;
-        // Ensure cap > len so Bytes::from(vec) creates SHARED instead of
-        // PROMOTABLE, avoiding an atomic CAS + allocation on the first clone.
-        if !vec.is_empty() && vec.len() == vec.capacity() {
-            vec.reserve(1);
-        }
-        Key(Bytes::from(vec))
+        Key(self.0.into())
     }
 
     /// Always use `raw_ref` to access the key before MVCC. This function will be removed in MVCC.

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -132,10 +132,18 @@ impl SsTableBuilder {
             let old_builder = mem::replace(&mut self.builder, BlockBuilder::new(self.block_size));
             let data = old_builder.build().encode();
 
+            // Move first_key / last_key into the meta without cloning.
+            // set_from_slice already ensures cap > len, so into_key_bytes()
+            // creates SHARED Bytes directly.
+            let mut tmp_first = KeyVec::new();
+            mem::swap(&mut self.first_key, &mut tmp_first);
+            let mut tmp_last = KeyVec::new();
+            mem::swap(&mut self.last_key, &mut tmp_last);
+
             let meta = BlockMeta {
                 offset: self.data.len(),
-                first_key: self.first_key.clone().into_key_bytes(),
-                last_key: self.last_key.clone().into_key_bytes(),
+                first_key: tmp_first.into_key_bytes(),
+                last_key: tmp_last.into_key_bytes(),
             };
             self.meta.push(meta);
 


### PR DESCRIPTION
## Problem

`Bytes::from(vec)` creates a `PROMOTABLE` vtable when `len == cap`. The first `clone()` on such a `Bytes` triggers:
1. An atomic CAS on the internal pointer
2. A `Box<Shared>` heap allocation

In `SsTableBuilder`, every block's `first_key` / `last_key` are cloned into `BlockMeta`, then cloned again into `SsTable`. With 200K+ blocks, this PROMOTABLE → SHARED transition cost adds up.

## Initial (wrong) approach

I tried adding `reserve(1)` right before `Bytes::from(vec)` in `into_key_bytes()` and `BlockBuilder::build()`. Gemini review correctly flagged this as a **regression**: when `len == cap`, `reserve(1)` forces an immediate vector reallocation + full data copy, which is far more expensive than the lazy promotion handled by the `bytes` crate.

## Final approach

Instead of forcing a reallocation at conversion time, we ensure `cap > len` at **construction** time and avoid `clone()` entirely at **consumption** time:

1. **`Key::set_from_slice`** — reserves `key_len + 1` so the underlying Vec always has `cap > len`. This costs at most one extra byte of capacity per allocation, but avoids the PROMOTABLE state for all keys built this way.

2. **`SsTableBuilder::add_inner`** — replaced `self.first_key.clone().into_key_bytes()` with `std::mem::swap` + `into_key_bytes()`. This moves the existing `KeyVec` (which already has `cap > len` from repeated `set_from_slice` calls) directly into `BlockMeta` **without any allocation or copy**.

3. **`SsTableBuilder::build`** — already used `std::mem::take`; unchanged.

4. **Reverted** — `reserve(1)` in `into_key_bytes()` and `BlockBuilder::build()` removed per review feedback.

## Results

vLog SST build benchmark (200K blocks, 5KB target block size):
- **Before**: ~25.2 s
- **After**: ~24.8 s (~1.6% improvement)

The win is modest but consistent, coming entirely from eliminating the `clone()` + PROMOTABLE → SHARED overhead in `add_inner`.

## Also in this PR

- `.gitignore`: added `perf.data*` and `.remember/` (prevents accidentally committing multi-gigabyte perf artifacts — lesson learned the hard way 😅)
