### PR TITLE
perf: batch manifest records to reduce fsyncs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ lsm.db/
 .claude/
 perf.data*
 .remember/
+moka

--- a/docs/perf-profile.md
+++ b/docs/perf-profile.md
@@ -158,7 +158,7 @@ SST deletion reduced housekeeper from 63% → 9.5% in write-heavy workloads.
 | Increase block cache (1024→8192) | 10-20% read throughput | Low | ✅ Done |
 | Investigate moka housekeeper CPU cost | 10-20% overall CPU | Medium | ✅ Done (invalidation on compaction) |
 | Coalesced buffer write for vLog entries | 2-3x vLog throughput | Low | ✅ Done |
-| Manifest batching with `std::fs` | Reduces manifest fsyncs | Low (10 lines) | Open |
+| Manifest batching with `std::fs` | Reduces manifest fsyncs | Low (10 lines) | ✅ Done (PR #48) |
 | Scan path optimization (iterator overhead) | 2x seekrandom | High | Open |
 | Block encode: consume self, eliminate copy | ~2-3% write CPU | Low | ✅ Done (PR #43) |
 
@@ -403,6 +403,46 @@ or `tinyufo` would eliminate this, but requires more invasive changes.
 
 ---
 
+## Manifest Batching (2026-06-04, PR #48)
+
+**Date:** 2026-06-04
+**Branch:** `perf/manifest-batching`
+**Commit:** `e2bbb31`
+
+### Problem
+
+The GC loop wrote one `ManifestRecord::GcCompaction` at a time, calling `fsync` after each
+record. With multiple GC results, this produced N fsyncs per GC run.
+
+### Fix
+
+- `Manifest::add_records()` — batch N records into a single buffer, one `write_all`, one `fsync`
+- Serialize records into a `Vec` **before** acquiring the file lock to reduce contention
+- Hold `state_lock` across both `add_records()` and `maybe_snapshot_manifest()` for consistency
+
+### Benchmarks (isolated runs, `write-perf` vLog GC section)
+
+| Round | main (baseline) | PR #48 (batched) | Change |
+|-------|-----------------|------------------|--------|
+| GC 2 files | 205.8 µs | 146.2 µs | **−29%** |
+| GC 3 files | 282.0 µs | 208.4 µs | **−26%** |
+| GC 4 files | 353.7 µs | 272.5 µs | **−23%** |
+
+### vLog Concurrent R/W + GC (5s)
+
+| Metric | main | PR #48 | Change |
+|--------|------|--------|--------|
+| Writes | 1.78M (355k/s) | 2.03M (406k/s) | **+14%** |
+| Reads | 9.23M (1.85M/s) | 10.1M (2.02M/s) | **+9%** |
+| GC rounds | 10 | 10 | — |
+
+### Key Insight
+
+Batching manifest records eliminates redundant fsyncs and reduces lock hold time.
+The GC thread finishes faster, freeing CPU for foreground reads/writes.
+
+---
+
 ## Full Benchmark Suite (2026-06-03)
 
 **Date:** 2026-06-03
@@ -557,7 +597,7 @@ is not called between start and elapsed).
 | Reduce key cloning in `add_inner` | ~3-5% write CPU (3x `to_key_vec` per entry) | Medium | Open |
 | Avoid intermediate allocation in block encode | ~2-3% write CPU (`build().encode()` double-alloc) | Low | ✅ Done (PR #43) |
 | Replace RwLock with arc-swap for state | Eliminate read lock contention | Low | ✅ Done (PR #44) |
-| Manifest batching with `std::fs` | Reduces manifest fsyncs | Low (10 lines) | Open |
+| Manifest batching with `std::fs` | Reduces manifest fsyncs | Low (10 lines) | ✅ Done (PR #48) |
 | Scan path optimization | 2x seekrandom | High | Open |
 | Reverse iteration support | Eliminates forward-only scan workaround | Medium | Open |
 

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -364,16 +364,16 @@ impl KvEngine {
         let count = results.len();
 
         // Batch manifest records for GC operations into a single fsync.
-        if let Some(ref manifest) = self.inner.manifest {
+        if let Some(ref manifest) = self.inner.manifest
+            && !results.is_empty()
+        {
             let records: Vec<ManifestRecord> = results
                 .iter()
                 .map(|r| {
                     ManifestRecord::GcCompaction(r.old_file_id, r.new_file_id, r.keys_rewritten)
                 })
                 .collect();
-            if !records.is_empty() {
-                manifest.add_records(&self.inner.state_lock.lock(), &records)?;
-            }
+            manifest.add_records(&self.inner.state_lock.lock(), &records)?;
         }
 
         // Attempt to reclaim vLog files that are no longer referenced by any SST.

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -373,7 +373,9 @@ impl KvEngine {
                     ManifestRecord::GcCompaction(r.old_file_id, r.new_file_id, r.keys_rewritten)
                 })
                 .collect();
-            manifest.add_records(&self.inner.state_lock.lock(), &records)?;
+            let state_lock = self.inner.state_lock.lock();
+            manifest.add_records(&state_lock, &records)?;
+            self.inner.maybe_snapshot_manifest(&state_lock)?;
         }
 
         // Attempt to reclaim vLog files that are no longer referenced by any SST.

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -363,17 +363,16 @@ impl KvEngine {
         let results = gc.gc_all()?;
         let count = results.len();
 
-        // Write manifest records for GC operations
-        for result in &results {
-            if let Some(ref manifest) = self.inner.manifest {
-                manifest.add_record(
-                    &self.inner.state_lock.lock(),
-                    ManifestRecord::GcCompaction(
-                        result.old_file_id,
-                        result.new_file_id,
-                        result.keys_rewritten,
-                    ),
-                )?;
+        // Batch manifest records for GC operations into a single fsync.
+        if let Some(ref manifest) = self.inner.manifest {
+            let records: Vec<ManifestRecord> = results
+                .iter()
+                .map(|r| {
+                    ManifestRecord::GcCompaction(r.old_file_id, r.new_file_id, r.keys_rewritten)
+                })
+                .collect();
+            if !records.is_empty() {
+                manifest.add_records(&self.inner.state_lock.lock(), &records)?;
             }
         }
 

--- a/kv-engine/src/manifest.rs
+++ b/kv-engine/src/manifest.rs
@@ -217,11 +217,26 @@ impl Manifest {
         self.add_record_when_init(record)
     }
 
-    pub fn add_record_when_init(&self, record: ManifestRecord) -> Result<()> {
-        let mut file = self.file.lock();
-        let buf = serde_json::to_vec(&record)?;
-        file.write_all(buf.as_slice())?;
+    /// Batch multiple manifest records with a single fsync.
+    pub fn add_records(
+        &self,
+        _state_lock_observer: &MutexGuard<()>,
+        records: &[ManifestRecord],
+    ) -> Result<()> {
+        self.add_records_when_init(records)
+    }
 
+    pub fn add_record_when_init(&self, record: ManifestRecord) -> Result<()> {
+        self.add_records_when_init(std::slice::from_ref(&record))
+    }
+
+    /// Batch multiple manifest records into a single fsync.
+    pub fn add_records_when_init(&self, records: &[ManifestRecord]) -> Result<()> {
+        let mut file = self.file.lock();
+        for record in records {
+            let buf = serde_json::to_vec(record)?;
+            file.write_all(buf.as_slice())?;
+        }
         file.sync_all().context("failed to sync manifest")
     }
 }

--- a/kv-engine/src/manifest.rs
+++ b/kv-engine/src/manifest.rs
@@ -231,12 +231,18 @@ impl Manifest {
     }
 
     /// Batch multiple manifest records into a single fsync.
+    /// Records are serialized into a buffer before acquiring the lock
+    /// to reduce contention and ensure atomic write.
     pub fn add_records_when_init(&self, records: &[ManifestRecord]) -> Result<()> {
-        let mut file = self.file.lock();
-        for record in records {
-            let buf = serde_json::to_vec(record)?;
-            file.write_all(buf.as_slice())?;
+        if records.is_empty() {
+            return Ok(());
         }
+        let mut buf = Vec::new();
+        for record in records {
+            serde_json::to_writer(&mut buf, record)?;
+        }
+        let mut file = self.file.lock();
+        file.write_all(&buf)?;
         file.sync_all().context("failed to sync manifest")
     }
 }


### PR DESCRIPTION
Batches multiple manifest records into a single write + fsync in the GC loop.

### Changes
- `Manifest::add_records()` — new method to batch N records with 1 fsync
- `Manifest::add_record()` — now delegates to `add_records()` with a single-element slice
- GC loop in `trigger_gc()` — collects all `GcCompaction` results into a Vec, then writes them in one batch
- Serialize records into a buffer **before** acquiring the file lock (reduces contention, avoids partial-write corruption)
- Bind `state_lock` to a local variable and hold it across both `add_records()` and `maybe_snapshot_manifest()` for consistency

### Safety
Old SST files are deleted only after the manifest fsync returns. If we crash before fsync, the old SSTs still exist and recovery replays the old manifest state. No data loss.

### Perf Impact

vLog GC benchmark (isolated runs, `write-perf`):

| Round | main (baseline) | PR #48 (batched) | Change |
|-------|-----------------|------------------|--------|
| GC 2 files | 205.8 µs | 146.2 µs | **−29%** |
| GC 3 files | 282.0 µs | 208.4 µs | **−26%** |
| GC 4 files | 353.7 µs | 272.5 µs | **−23%** |

vLog concurrent R/W + GC (5s):

| Metric | main | PR #48 | Change |
|--------|------|--------|--------|
| Writes | 1.78M (355k/s) | 2.03M (406k/s) | **+14%** |
| Reads | 9.23M (1.85M/s) | 10.1M (2.02M/s) | **+9%** |

Also updated `docs/perf-profile.md` with the new section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Batched manifest updates during garbage collection into a single write-and-sync per GC run, reducing I/O, improving durability of GC metadata, and increasing overall write throughput.

* **Documentation**
  * Updated performance profiling docs with a new "Manifest Batching" section, benchmark results, and marked the manifest-batching optimization as done.

* **Chores**
  * Added a .gitignore entry to ignore a `moka` item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->