### PR TITLE
perf: cache improvements — ahash, single-flight, tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,9 +742,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.81"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -939,18 +939,28 @@ checksum = "689224d06523904ebcc9b482c6a3f4f7fb396096645c4cd10c0d2ff7371a34d3"
 
 [[package]]
 name = "serde"
-version = "1.0.198"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.198"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -988,9 +998,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.60"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/docs/perf-profile.md
+++ b/docs/perf-profile.md
@@ -15,7 +15,9 @@
 
 **arc-swap state snapshot (2026-06-03, PR #44).** Replaced `parking_lot::RwLock` with `arc_swap::ArcSwap` for state snapshot. Every `get()`/`scan()` now uses atomic load instead of lock acquisition. fillrandom +86%, overwrite +87%.
 
-**TinyUFO cache swap (2026-06-04, PR #55).** Replaced `moka` (TinyLFU + LRU) with Cloudflare's `TinyUFO` (S3-FIFO + TinyLFU, lock-free) for all in-memory caches. Eliminated the moka housekeeper thread (was 9.5-63% of CPU). fillrandom +42%, readrandom +7.3%, readwhilewriting reads +15%. Cache-related CPU dropped from 9.5-63% to ~1.4%.
+**TinyUFO cache swap (2026-06-04, PR #55).** Replaced `moka` (TinyLFU + LRU) with Cloudflare's `TinyUFO` (S3-FIFO + TinyLFU, lock-free) for all in-memory caches. Eliminated the moka housekeeper thread (was 9.5-63% of CPU). Cache-related CPU dropped from 9.5-63% to ~1.4%.
+
+**Cache improvements (2026-06-04).** Added ahash for cache/vlog reverse indexes, per-key single-flight for block cache misses (coalesces concurrent I/O), and 19 unit tests. Combined with TinyUFO: fillseq +17%, fillrandom +8%, readrandom +11%, overwrite +14% vs moka baseline. Concurrent R/W reads +8%, readwhilewriting writes +5%.
 
 ## Throughput by Workload
 
@@ -162,6 +164,9 @@ reverse index Mutex ~1%. Total ~1.4%.
 | `SsTable::point_get` without iterator | 10-20% read throughput | Medium | ✅ Done |
 | Increase block cache (1024→8192) | 10-20% read throughput | Low | ✅ Done |
 | Replace moka with TinyUFO cache | Eliminate housekeeper (9.5-63% CPU) | Medium | ✅ Done (PR #55) |
+| ahash for cache/vlog reverse indexes | ~5-10% on concurrent paths | Low | ✅ Done |
+| Single-flight block cache misses | 2× concurrent read throughput | Medium | ✅ Done |
+| Cache unit tests (19 tests) | Correctness coverage | Low | ✅ Done |
 | Coalesced buffer write for vLog entries | 2-3x vLog throughput | Low | ✅ Done |
 | Manifest batching with `std::fs` | Reduces manifest fsyncs | Low (10 lines) | ✅ Done (PR #48) |
 | Scan path optimization (iterator overhead) | 2x seekrandom | High | Open |
@@ -178,16 +183,32 @@ reverse index Mutex ~1%. Total ~1.4%.
 
 These workloads mirror RocksDB's `db_bench` patterns for direct comparison.
 
-### Throughput Summary
+### Throughput Summary — moka vs TinyUFO+ahash+single-flight
 
-| Workload | moka | TinyUFO (PR #55) | Δ |
-|----------|------|-----------------|---|
-| fillseq (200k, 1KB) | 2.82M | 2.70M | -4% |
-| fillrandom (200k, 1KB) | 1.81M | **2.57M** | **+42%** |
-| readrandom (100k reads, 200k entries) | 741k | **795k** | **+7.3%** |
-| readwhilewriting (1W/4R, 5s) | 793k writes, **1.06M reads** | 752k writes, **1.22M reads** | reads **+15%** |
-| readrandomwriterandom (4 threads, 5s) | 701k writes, 701k reads | 696k writes, 696k reads | ~0% |
-| seekrandom (10k seeks, 10 nexts) | 47.6k seeks/sec | 68.2k seeks/sec | +43% |
+All numbers are median of 3 runs. "TinyUFO+" = TinyUFO + ahash reverse indexes + single-flight block cache misses.
+
+| # | Workload | moka | TinyUFO+ | Δ |
+|---|----------|------|----------|---|
+| 1 | Scan (full, 100k) | 13.3M entries/s | 12.7M entries/s | ~same |
+| 2 | Conc R/W (no WAL) W | 1.05M/s | 1.11M/s | +6% |
+| 2 | Conc R/W (no WAL) R | 2.59M/s | 2.80M/s | +8% |
+| 3 | Conc R/W (WAL) W | 509k/s | 504k/s | ~same |
+| 3 | Conc R/W (WAL) R | 2.75M/s | 2.92M/s | +6% |
+| 7 | **fillseq** | 1.99M | **2.32M** | **+17%** |
+| 8 | **fillrandom** | 2.04M | **2.20M** | **+8%** |
+| 9 | **readrandom** | 667k | **742k** | **+11%** |
+| 10 | readwhilewriting W | 650k/s | 683k/s | +5% |
+| 10 | readwhilewriting R | 1.02M/s | 1.06M/s | +4% |
+| 11 | readrandomwriterandom | 679k/s | 716k/s | +5% |
+| 12 | **seekrandom** | 64.8k | **68.3k** | **+5%** |
+| 13 | **overwrite** | 1.25M | **1.42M** | **+14%** |
+| 14 | readseq | 4.81M | 5.14M | +7% |
+| 15 | readreverse | 9.80M | 11.09M | +13% |
+| 16 | readmissing | 1.58M | 1.77M | +12% |
+| 17 | seekwhilewriting | 49.8k | 50.3k | +1% |
+| 18 | deleterandom | 1.62M | 1.75M | +8% |
+
+**Key wins:** fillseq +17%, overwrite +14% (write path freed from moka housekeeper). readrandom +11%, readmissing +12% (ahash + lock-free cache). Concurrent R/W +6-8% (single-flight coalescing + ahash).
 
 ### Profile: fillseq + fillrandom (200k entries, 1KB vals)
 
@@ -803,16 +824,18 @@ The `RwLock` was unnecessary for the common case. Since the state is replaced at
 via atomic pointer load. The `state_lock` mutex still protects multi-step mutations
 (CAS, compaction, flush) from races.
 
-### Updated Bottleneck Summary
+### Updated Bottleneck Summary (post TinyUFO + cache improvements)
 
 | Category | % CPU | Key functions | Dominant in |
 |----------|-------|---------------|-------------|
-| **Write path** | ~15.1% | `add_inner`, `put_raw_batch`, `put` | fillseq, fillrandom |
-| **Read path (skiplist)** | ~15.6% | `try_pin_loop`, `get_with_hash`, `RefEntry` | readrandom, readmissing |
-| **moka cache** | ~6.9% | `BucketArray::rehash`, `Inner::sync` | All workloads |
-| **Memory allocation** | ~3.7% | libc malloc/free | All workloads |
-| **Epoch GC** | ~1.7% | `try_advance` | All workloads |
-| **arc-swap** | ~1.5% | `arc_swap::load` | All workloads |
+| **Write path** | ~25% | `SsTableBuilder::add_inner` | fillseq, fillrandom, overwrite |
+| **Read path (skiplist)** | ~11% | `SkipMap::get`, `MemTable::get_with_hash` | readrandom, readmissing |
+| **Memory allocation** | ~5.7% | libc malloc/free/realloc | All workloads |
+| **TinyUFO cache** | ~0.4% | `tinyufo::estimation::incr_no_overflow` | All workloads |
+| **Lock contention** | ~0.8% | `parking_lot::lock_slow` | Concurrent workloads |
+| **arc-swap** | ~1.1% | `arc_swap::load` | All workloads |
+
+moka housekeeper: **0%** (eliminated). Cache overhead dropped from ~13% to ~0.4%.
 
 ### Files Changed
 

--- a/kv-engine/src/cache.rs
+++ b/kv-engine/src/cache.rs
@@ -15,6 +15,11 @@ use tinyufo::TinyUfo;
 
 use crate::block::Block;
 
+/// Cache key for block cache entries: (sst_id, block_idx).
+type BlockKey = (usize, usize);
+/// Per-key lock map for single-flight miss coalescing.
+type WaiterMap = Mutex<AHashMap<BlockKey, Arc<Mutex<()>>>>;
+
 /// Weight divisor for the value cache.  A value of N bytes gets weight
 /// `max(1, N / VALUE_WEIGHT_DIVISOR)`, keeping totals within u16 range
 /// for a 64 MiB budget (64 MiB / 64 = 1 048 576 <= 65 535 * 16).
@@ -31,18 +36,18 @@ const VALUE_WEIGHT_DIVISOR: usize = 64;
 /// - TinyUFO does not expose eviction callbacks, so when blocks are evicted by the cache their keys
 ///   remain in the reverse index until the owning SST is compacted away.  In practice this is a
 ///   slow, bounded leak because the number of live SSTs (and their blocks) is finite.
-/// - If `invalidate_ssts` runs while a `get_or_insert` closure is in flight for the same SST,
-///   the loading thread will re-insert the block and its reverse-index entry after invalidation
+/// - If `invalidate_ssts` runs while a `get_or_insert` closure is in flight for the same SST, the
+///   loading thread will re-insert the block and its reverse-index entry after invalidation
 ///   completes.  This is a bounded leak (one entry per concurrent in-flight load) and the orphaned
 ///   block will be evicted by TinyUFO under memory pressure.
 pub struct BlockCache {
-    inner: TinyUfo<(usize, usize), Arc<Block>>,
+    inner: TinyUfo<BlockKey, Arc<Block>>,
     /// Reverse index: sst_id → keys cached for that SST.
     /// `AHashSet` prevents duplicate entries on re-insert after eviction.
-    sst_blocks: Mutex<AHashMap<usize, AHashSet<(usize, usize)>>>,
+    sst_blocks: Mutex<AHashMap<usize, AHashSet<BlockKey>>>,
     /// Per-key locks to coalesce concurrent misses (single-flight).
     /// Prevents multiple threads from loading the same block from disk.
-    waiters: Mutex<AHashMap<(usize, usize), Arc<Mutex<()>>>>,
+    waiters: WaiterMap,
     /// Fast entry count — incremented on insert, decremented on invalidation.
     count: AtomicU64,
 }
@@ -312,8 +317,7 @@ mod tests {
         assert_eq!(&r1.unwrap().data[..], b"ok");
 
         // second call is a hit
-        let r2: Result<Arc<Block>, String> =
-            cache.try_get_with(1, 0, || Ok(make_block(b"WRONG")));
+        let r2: Result<Arc<Block>, String> = cache.try_get_with(1, 0, || Ok(make_block(b"WRONG")));
         assert_eq!(&r2.unwrap().data[..], b"ok");
     }
 
@@ -478,8 +482,13 @@ mod tests {
         assert_eq!(cache.entry_count(), 10);
         // Verify that TinyUFO actually evicted some early entries.
         // (The exact evictions depend on TinyUFO's S3-FIFO algorithm.)
-        let evicted = (0..10).filter(|&i| cache.inner.get(&(1, i)).is_none()).count();
-        assert!(evicted > 0, "expected some evictions in a capacity-4 cache with 10 inserts");
+        let evicted = (0..10)
+            .filter(|&i| cache.inner.get(&(1, i)).is_none())
+            .count();
+        assert!(
+            evicted > 0,
+            "expected some evictions in a capacity-4 cache with 10 inserts"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -569,10 +578,7 @@ mod tests {
                     // Each thread inserts into a different file_id.
                     let file_id = t as u32;
                     for i in 0..50u64 {
-                        cache.insert(
-                            (file_id, i),
-                            Bytes::from(format!("t{t}-v{i}")),
-                        );
+                        cache.insert((file_id, i), Bytes::from(format!("t{t}-v{i}")));
                     }
                     // Invalidate own file.
                     cache.invalidate_file(file_id);

--- a/kv-engine/src/cache.rs
+++ b/kv-engine/src/cache.rs
@@ -75,7 +75,6 @@ impl BlockCache {
         let _guard = waiter.lock();
         // Double-check after acquiring the per-key lock.
         if let Some(v) = self.inner.get(&key) {
-            self.waiters.lock().remove(&key);
             return v;
         }
         let v = f();
@@ -108,17 +107,11 @@ impl BlockCache {
             w.entry(key).or_default().clone()
         };
         let _guard = waiter.lock();
+        // Double-check after acquiring the per-key lock.
         if let Some(v) = self.inner.get(&key) {
-            self.waiters.lock().remove(&key);
             return Ok(v);
         }
-        let v = match f() {
-            Ok(v) => v,
-            Err(e) => {
-                self.waiters.lock().remove(&key);
-                return Err(e);
-            }
-        };
+        let v = f()?;
         self.inner.force_put(key, v.clone(), 1);
         self.sst_blocks
             .lock()
@@ -397,6 +390,50 @@ mod tests {
         assert_eq!(cache.entry_count(), 1);
     }
 
+    #[test]
+    fn block_cache_try_get_with_concurrent_error() {
+        let cache = Arc::new(BlockCache::new(64));
+        let barrier = Arc::new(std::sync::Barrier::new(4));
+
+        let handles: Vec<_> = (0..4)
+            .map(|_| {
+                let cache = cache.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    cache.try_get_with::<_, &str>(1, 0, || {
+                        std::thread::sleep(std::time::Duration::from_millis(20));
+                        Err("disk broken")
+                    })
+                })
+            })
+            .collect();
+
+        for h in handles {
+            let r = h.join().unwrap();
+            assert!(r.is_err());
+        }
+        // Cache should remain empty after all errors.
+        assert_eq!(cache.entry_count(), 0);
+
+        // Subsequent successful call still works.
+        let r: Result<Arc<Block>, &str> = cache.try_get_with(1, 0, || Ok(make_block(b"ok")));
+        assert_eq!(&r.unwrap().data[..], b"ok");
+        assert_eq!(cache.entry_count(), 1);
+    }
+
+    #[test]
+    fn block_cache_entry_count_drifts_after_eviction() {
+        // Capacity = 4 entries.
+        let cache = BlockCache::new(4);
+        // Insert 10 unique blocks — TinyUFO will evict some.
+        for i in 0..10 {
+            cache.get_or_insert(1, i, || make_block(&[i as u8]));
+        }
+        // entry_count overestimates because TinyUFO evictions are invisible.
+        assert!(cache.entry_count() >= 4);
+    }
+
     // -----------------------------------------------------------------------
     // ValueCache
     // -----------------------------------------------------------------------
@@ -468,5 +505,41 @@ mod tests {
         // reverse index still has exactly one entry for (1,0)
         let index = cache.file_keys.lock();
         assert_eq!(index.get(&1).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn value_cache_concurrent_insert_and_invalidate() {
+        let cache = Arc::new(ValueCache::new(1024 * 1024));
+        let barrier = Arc::new(std::sync::Barrier::new(4));
+
+        let handles: Vec<_> = (0..4)
+            .map(|t| {
+                let cache = cache.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    // Each thread inserts into a different file_id.
+                    let file_id = t as u32;
+                    for i in 0..50u64 {
+                        cache.insert(
+                            (file_id, i),
+                            Bytes::from(format!("t{t}-v{i}")),
+                        );
+                    }
+                    // Invalidate own file.
+                    cache.invalidate_file(file_id);
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().unwrap();
+        }
+        // All files were invalidated — cache should be empty.
+        for t in 0..4u32 {
+            for i in 0..50u64 {
+                assert_eq!(cache.get(&(t, i)), None);
+            }
+        }
     }
 }

--- a/kv-engine/src/cache.rs
+++ b/kv-engine/src/cache.rs
@@ -79,6 +79,7 @@ impl BlockCache {
         let _guard = waiter.lock();
         // Double-check after acquiring the per-key lock.
         if let Some(v) = self.inner.get(&key) {
+            self.waiters.lock().remove(&key);
             return v;
         }
         let v = f();
@@ -113,6 +114,7 @@ impl BlockCache {
         let _guard = waiter.lock();
         // Double-check after acquiring the per-key lock.
         if let Some(v) = self.inner.get(&key) {
+            self.waiters.lock().remove(&key);
             return Ok(v);
         }
         let v = f()?;

--- a/kv-engine/src/cache.rs
+++ b/kv-engine/src/cache.rs
@@ -397,15 +397,18 @@ mod tests {
     #[test]
     fn block_cache_try_get_with_concurrent_error() {
         let cache = Arc::new(BlockCache::new(64));
+        let calls = Arc::new(AtomicUsize::new(0));
         let barrier = Arc::new(std::sync::Barrier::new(4));
 
         let handles: Vec<_> = (0..4)
             .map(|_| {
                 let cache = cache.clone();
+                let calls = calls.clone();
                 let barrier = barrier.clone();
                 std::thread::spawn(move || {
                     barrier.wait();
                     cache.try_get_with::<_, &str>(1, 0, || {
+                        calls.fetch_add(1, Ordering::Relaxed);
                         std::thread::sleep(std::time::Duration::from_millis(20));
                         Err("disk broken")
                     })
@@ -417,12 +420,46 @@ mod tests {
             let r = h.join().unwrap();
             assert!(r.is_err());
         }
+        // Error path: each blocked thread retries after the previous one fails,
+        // so the closure runs once per thread (serialized by per-key lock).
+        assert_eq!(calls.load(Ordering::Relaxed), 4);
         // Cache should remain empty after all errors.
         assert_eq!(cache.entry_count(), 0);
 
-        // Subsequent successful call still works.
+        // Subsequent successful call still works — waiter entry is reused.
         let r: Result<Arc<Block>, &str> = cache.try_get_with(1, 0, || Ok(make_block(b"ok")));
         assert_eq!(&r.unwrap().data[..], b"ok");
+        assert_eq!(cache.entry_count(), 1);
+    }
+
+    #[test]
+    fn block_cache_try_get_with_single_flight_success() {
+        let cache = Arc::new(BlockCache::new(64));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(std::sync::Barrier::new(4));
+
+        let handles: Vec<_> = (0..4)
+            .map(|_| {
+                let cache = cache.clone();
+                let calls = calls.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    cache.try_get_with::<_, &str>(1, 0, || {
+                        calls.fetch_add(1, Ordering::Relaxed);
+                        std::thread::sleep(std::time::Duration::from_millis(50));
+                        Ok(make_block(b"data"))
+                    })
+                })
+            })
+            .collect();
+
+        for h in handles {
+            let r = h.join().unwrap();
+            assert_eq!(&r.unwrap().data[..], b"data");
+        }
+        // Closure should have run exactly once (single-flight on success).
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
         assert_eq!(cache.entry_count(), 1);
     }
 
@@ -435,7 +472,12 @@ mod tests {
             cache.get_or_insert(1, i, || make_block(&[i as u8]));
         }
         // entry_count overestimates because TinyUFO evictions are invisible.
-        assert!(cache.entry_count() >= 4);
+        // Each insert incremented count, but evictions didn't decrement it.
+        assert_eq!(cache.entry_count(), 10);
+        // Verify that TinyUFO actually evicted some early entries.
+        // (The exact evictions depend on TinyUFO's S3-FIFO algorithm.)
+        let evicted = (0..10).filter(|&i| cache.inner.get(&(1, i)).is_none()).count();
+        assert!(evicted > 0, "expected some evictions in a capacity-4 cache with 10 inserts");
     }
 
     // -----------------------------------------------------------------------

--- a/kv-engine/src/cache.rs
+++ b/kv-engine/src/cache.rs
@@ -203,3 +203,194 @@ impl ValueCache {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_block(data: &[u8]) -> Arc<Block> {
+        Arc::new(Block {
+            data: Bytes::copy_from_slice(data),
+            offsets: vec![],
+        })
+    }
+
+    // -----------------------------------------------------------------------
+    // BlockCache
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn block_cache_new_clamps_capacity() {
+        let cache = BlockCache::new(0);
+        // capacity is clamped to at least 1
+        let b = cache.get_or_insert(1, 0, || make_block(b"x"));
+        assert_eq!(&b.data[..], b"x");
+    }
+
+    #[test]
+    fn block_cache_get_or_insert_hit_and_miss() {
+        let cache = BlockCache::new(64);
+        let calls = std::sync::atomic::AtomicUsize::new(0);
+
+        // miss — closure runs
+        let b1 = cache.get_or_insert(1, 0, || {
+            calls.fetch_add(1, Ordering::Relaxed);
+            make_block(b"hello")
+        });
+        assert_eq!(&b1.data[..], b"hello");
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+
+        // hit — closure does NOT run
+        let b2 = cache.get_or_insert(1, 0, || {
+            calls.fetch_add(1, Ordering::Relaxed);
+            make_block(b"WRONG")
+        });
+        assert_eq!(&b2.data[..], b"hello");
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn block_cache_different_keys_independent() {
+        let cache = BlockCache::new(64);
+        let a = cache.get_or_insert(1, 0, || make_block(b"a"));
+        let b = cache.get_or_insert(1, 1, || make_block(b"b"));
+        let c = cache.get_or_insert(2, 0, || make_block(b"c"));
+        assert_eq!(&a.data[..], b"a");
+        assert_eq!(&b.data[..], b"b");
+        assert_eq!(&c.data[..], b"c");
+        assert_eq!(cache.entry_count(), 3);
+    }
+
+    #[test]
+    fn block_cache_try_get_with_hit() {
+        let cache = BlockCache::new(64);
+        let r1: Result<Arc<Block>, String> = cache.try_get_with(1, 0, || Ok(make_block(b"ok")));
+        assert!(r1.is_ok());
+        assert_eq!(&r1.unwrap().data[..], b"ok");
+
+        // second call is a hit
+        let r2: Result<Arc<Block>, String> =
+            cache.try_get_with(1, 0, || Ok(make_block(b"WRONG")));
+        assert_eq!(&r2.unwrap().data[..], b"ok");
+    }
+
+    #[test]
+    fn block_cache_try_get_with_error_propagates() {
+        let cache = BlockCache::new(64);
+        let r: Result<Arc<Block>, &str> = cache.try_get_with(1, 0, || Err("disk broken"));
+        match r {
+            Err(e) => assert_eq!(e, "disk broken"),
+            Ok(_) => panic!("expected error"),
+        }
+
+        // cache is empty — entry_count stays 0
+        assert_eq!(cache.entry_count(), 0);
+
+        // can still insert after error
+        let r2: Result<Arc<Block>, &str> = cache.try_get_with(1, 0, || Ok(make_block(b"ok")));
+        assert_eq!(&r2.unwrap().data[..], b"ok");
+        assert_eq!(cache.entry_count(), 1);
+    }
+
+    #[test]
+    fn block_cache_invalidate_ssts() {
+        let cache = BlockCache::new(64);
+        cache.get_or_insert(1, 0, || make_block(b"a"));
+        cache.get_or_insert(1, 1, || make_block(b"b"));
+        cache.get_or_insert(2, 0, || make_block(b"c"));
+        assert_eq!(cache.entry_count(), 3);
+
+        let mut remove = HashSet::new();
+        remove.insert(1);
+        cache.invalidate_ssts(&remove);
+
+        // SST 1 blocks gone, SST 2 block remains
+        assert!(cache.inner.get(&(1, 0)).is_none());
+        assert!(cache.inner.get(&(1, 1)).is_none());
+        assert!(cache.inner.get(&(2, 0)).is_some());
+        assert_eq!(cache.entry_count(), 1);
+    }
+
+    #[test]
+    fn block_cache_invalidate_unknown_id_noop() {
+        let cache = BlockCache::new(64);
+        cache.get_or_insert(1, 0, || make_block(b"a"));
+        let mut remove = HashSet::new();
+        remove.insert(999);
+        cache.invalidate_ssts(&remove);
+        assert_eq!(cache.entry_count(), 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // ValueCache
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn value_cache_insert_and_get() {
+        let cache = ValueCache::new(1024 * 1024); // 1 MiB
+        cache.insert((1, 0), Bytes::from_static(b"hello"));
+        assert_eq!(cache.get(&(1, 0)), Some(Bytes::from_static(b"hello")));
+        assert_eq!(cache.get(&(1, 1)), None);
+    }
+
+    #[test]
+    fn value_cache_weight_clamping_small_value() {
+        let cache = ValueCache::new(1024 * 1024);
+        // 10 bytes → weight = ceil(10/64) = 1, fits easily
+        cache.insert((1, 0), Bytes::from_static(b"0123456789"));
+        assert_eq!(cache.get(&(1, 0)), Some(Bytes::from_static(b"0123456789")));
+    }
+
+    #[test]
+    fn value_cache_weight_exceeds_budget_skipped() {
+        // budget = 1024 bytes → weight_budget = 1024/64 = 16
+        let cache = ValueCache::new(1024);
+        // value = 2048 bytes → weight = ceil(2048/64) = 32 > 16 → skipped
+        let big = Bytes::from(vec![0u8; 2048]);
+        cache.insert((1, 0), big.clone());
+        assert_eq!(cache.get(&(1, 0)), None);
+    }
+
+    #[test]
+    fn value_cache_weight_exceeds_u16_skipped() {
+        // 5 MiB budget → weight_budget capped at u16::MAX (65535)
+        let cache = ValueCache::new(5 * 1024 * 1024);
+        // 5 MiB value → raw weight = ceil(5MiB / 64) = 81920 > u16::MAX
+        let huge = Bytes::from(vec![0u8; 5 * 1024 * 1024]);
+        cache.insert((1, 0), huge);
+        assert_eq!(cache.get(&(1, 0)), None);
+    }
+
+    #[test]
+    fn value_cache_invalidate_file() {
+        let cache = ValueCache::new(1024 * 1024);
+        cache.insert((1, 0), Bytes::from_static(b"a"));
+        cache.insert((1, 1), Bytes::from_static(b"b"));
+        cache.insert((2, 0), Bytes::from_static(b"c"));
+
+        cache.invalidate_file(1);
+        assert_eq!(cache.get(&(1, 0)), None);
+        assert_eq!(cache.get(&(1, 1)), None);
+        assert_eq!(cache.get(&(2, 0)), Some(Bytes::from_static(b"c")));
+    }
+
+    #[test]
+    fn value_cache_invalidate_unknown_file_noop() {
+        let cache = ValueCache::new(1024 * 1024);
+        cache.insert((1, 0), Bytes::from_static(b"a"));
+        cache.invalidate_file(999);
+        assert_eq!(cache.get(&(1, 0)), Some(Bytes::from_static(b"a")));
+    }
+
+    #[test]
+    fn value_cache_duplicate_key_updates_reverse_index() {
+        let cache = ValueCache::new(1024 * 1024);
+        cache.insert((1, 0), Bytes::from_static(b"old"));
+        cache.insert((1, 0), Bytes::from_static(b"new"));
+        assert_eq!(cache.get(&(1, 0)), Some(Bytes::from_static(b"new")));
+
+        // reverse index still has exactly one entry for (1,0)
+        let index = cache.file_keys.lock();
+        assert_eq!(index.get(&1).unwrap().len(), 1);
+    }
+}

--- a/kv-engine/src/cache.rs
+++ b/kv-engine/src/cache.rs
@@ -3,7 +3,9 @@
 //! Provides [`BlockCache`] (with reverse-index for SST block invalidation)
 //! and [`ValueCache`] (with byte-weight clamping and per-file key tracking).
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
+
+use ahash::{AHashMap, AHashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -36,7 +38,7 @@ pub struct BlockCache {
     inner: TinyUfo<(usize, usize), Arc<Block>>,
     /// Reverse index: sst_id → keys cached for that SST.
     /// `HashSet` prevents duplicate entries on re-insert after eviction.
-    sst_blocks: Mutex<HashMap<usize, HashSet<(usize, usize)>>>,
+    sst_blocks: Mutex<AHashMap<usize, AHashSet<(usize, usize)>>>,
     /// Fast entry count — incremented on insert, decremented on invalidation.
     count: AtomicU64,
 }
@@ -46,7 +48,7 @@ impl BlockCache {
         let cap = capacity.max(1);
         Self {
             inner: TinyUfo::new(cap, cap),
-            sst_blocks: Mutex::new(HashMap::new()),
+            sst_blocks: Mutex::new(AHashMap::new()),
             count: AtomicU64::new(0),
         }
     }
@@ -136,7 +138,7 @@ pub struct ValueCache {
     inner: TinyUfo<(u32, u64), Bytes>,
     /// Reverse index: file_id → cache keys for that file.
     /// `HashSet` prevents duplicate entries on re-insert after eviction.
-    file_keys: Mutex<HashMap<u32, HashSet<(u32, u64)>>>,
+    file_keys: Mutex<AHashMap<u32, AHashSet<(u32, u64)>>>,
     /// Weight budget (in TinyUFO weight units).  Values whose scaled
     /// weight exceeds this are skipped to avoid exceeding the byte budget.
     weight_budget: u16,
@@ -156,7 +158,7 @@ impl ValueCache {
         let estimated_items = (byte_budget / 4096).max(16) as usize;
         Self {
             inner: TinyUfo::new(weight_budget, estimated_items),
-            file_keys: Mutex::new(HashMap::new()),
+            file_keys: Mutex::new(AHashMap::new()),
             weight_budget: weight_budget.min(u16::MAX as usize) as u16,
         }
     }

--- a/kv-engine/src/cache.rs
+++ b/kv-engine/src/cache.rs
@@ -31,14 +31,14 @@ const VALUE_WEIGHT_DIVISOR: usize = 64;
 /// - TinyUFO does not expose eviction callbacks, so when blocks are evicted by the cache their keys
 ///   remain in the reverse index until the owning SST is compacted away.  In practice this is a
 ///   slow, bounded leak because the number of live SSTs (and their blocks) is finite.
-/// - Concurrent misses on the same key are not coalesced (unlike moka's `get_with`).  Each thread
-///   performs its own disk read.  This is safe because all closures are idempotent, but wastes I/O
-///   under contention.
 pub struct BlockCache {
     inner: TinyUfo<(usize, usize), Arc<Block>>,
     /// Reverse index: sst_id → keys cached for that SST.
-    /// `HashSet` prevents duplicate entries on re-insert after eviction.
+    /// `AHashSet` prevents duplicate entries on re-insert after eviction.
     sst_blocks: Mutex<AHashMap<usize, AHashSet<(usize, usize)>>>,
+    /// Per-key locks to coalesce concurrent misses (single-flight).
+    /// Prevents multiple threads from loading the same block from disk.
+    waiters: Mutex<AHashMap<(usize, usize), Arc<Mutex<()>>>>,
     /// Fast entry count — incremented on insert, decremented on invalidation.
     count: AtomicU64,
 }
@@ -49,12 +49,16 @@ impl BlockCache {
         Self {
             inner: TinyUfo::new(cap, cap),
             sst_blocks: Mutex::new(AHashMap::new()),
+            waiters: Mutex::new(AHashMap::new()),
             count: AtomicU64::new(0),
         }
     }
 
     /// Cache-through block read.  On miss, calls `f` to read from disk,
     /// inserts the result, and registers the key in the reverse index.
+    ///
+    /// Concurrent misses on the same key are coalesced: only the first
+    /// thread runs `f`; others wait and read from cache.
     pub fn get_or_insert<F>(&self, sst_id: usize, block_idx: usize, f: F) -> Arc<Block>
     where
         F: FnOnce() -> Arc<Block>,
@@ -63,9 +67,18 @@ impl BlockCache {
         if let Some(v) = self.inner.get(&key) {
             return v;
         }
+        // Single-flight: acquire a per-key lock so only one thread loads.
+        let waiter = {
+            let mut w = self.waiters.lock();
+            w.entry(key).or_default().clone()
+        };
+        let _guard = waiter.lock();
+        // Double-check after acquiring the per-key lock.
+        if let Some(v) = self.inner.get(&key) {
+            self.waiters.lock().remove(&key);
+            return v;
+        }
         let v = f();
-        // Use `force_put` to bypass TinyLFU admission — guarantees the block
-        // is cached even under cache pressure.  Hit-ratio cost is ~0.5pp.
         self.inner.force_put(key, v.clone(), 1);
         self.sst_blocks
             .lock()
@@ -73,11 +86,15 @@ impl BlockCache {
             .or_default()
             .insert(key);
         self.count.fetch_add(1, Ordering::Relaxed);
+        self.waiters.lock().remove(&key);
         v
     }
 
     /// Like [`get_or_insert`], but the closure returns `Result`.
     /// On error the cache is left unchanged and the error is propagated.
+    ///
+    /// Concurrent misses on the same key are coalesced: only the first
+    /// thread runs `f`; others wait and read from cache.
     pub fn try_get_with<F, E>(&self, sst_id: usize, block_idx: usize, f: F) -> Result<Arc<Block>, E>
     where
         F: FnOnce() -> Result<Arc<Block>, E>,
@@ -86,7 +103,22 @@ impl BlockCache {
         if let Some(v) = self.inner.get(&key) {
             return Ok(v);
         }
-        let v = f()?;
+        let waiter = {
+            let mut w = self.waiters.lock();
+            w.entry(key).or_default().clone()
+        };
+        let _guard = waiter.lock();
+        if let Some(v) = self.inner.get(&key) {
+            self.waiters.lock().remove(&key);
+            return Ok(v);
+        }
+        let v = match f() {
+            Ok(v) => v,
+            Err(e) => {
+                self.waiters.lock().remove(&key);
+                return Err(e);
+            }
+        };
         self.inner.force_put(key, v.clone(), 1);
         self.sst_blocks
             .lock()
@@ -94,6 +126,7 @@ impl BlockCache {
             .or_default()
             .insert(key);
         self.count.fetch_add(1, Ordering::Relaxed);
+        self.waiters.lock().remove(&key);
         Ok(v)
     }
 
@@ -111,8 +144,15 @@ impl BlockCache {
                 .collect()
         };
         let removed = keys.len() as u64;
-        for key in keys {
-            self.inner.remove(&key);
+        for key in &keys {
+            self.inner.remove(key);
+        }
+        // Also clean up any in-flight waiter entries for removed keys.
+        {
+            let mut w = self.waiters.lock();
+            for key in &keys {
+                w.remove(key);
+            }
         }
         self.count.fetch_sub(removed, Ordering::Relaxed);
     }
@@ -208,6 +248,8 @@ impl ValueCache {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicUsize;
+
     use super::*;
 
     fn make_block(data: &[u8]) -> Arc<Block> {
@@ -320,6 +362,38 @@ mod tests {
         let mut remove = HashSet::new();
         remove.insert(999);
         cache.invalidate_ssts(&remove);
+        assert_eq!(cache.entry_count(), 1);
+    }
+
+    #[test]
+    fn block_cache_single_flight_coalesces_misses() {
+        let cache = Arc::new(BlockCache::new(64));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(std::sync::Barrier::new(4));
+
+        let handles: Vec<_> = (0..4)
+            .map(|_| {
+                let cache = cache.clone();
+                let calls = calls.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    cache.get_or_insert(1, 0, || {
+                        calls.fetch_add(1, Ordering::Relaxed);
+                        // Simulate disk latency
+                        std::thread::sleep(std::time::Duration::from_millis(50));
+                        make_block(b"data")
+                    })
+                })
+            })
+            .collect();
+
+        for h in handles {
+            let b = h.join().unwrap();
+            assert_eq!(&b.data[..], b"data");
+        }
+        // Closure should have run exactly once (single-flight).
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
         assert_eq!(cache.entry_count(), 1);
     }
 

--- a/kv-engine/src/cache.rs
+++ b/kv-engine/src/cache.rs
@@ -84,7 +84,11 @@ impl BlockCache {
         let _guard = waiter.lock();
         // Double-check after acquiring the per-key lock.
         if let Some(v) = self.inner.get(&key) {
-            self.waiters.lock().remove(&key);
+            // Only remove if we own this exact waiter (not a newer one).
+            let mut w = self.waiters.lock();
+            if w.get(&key).is_some_and(|cur| Arc::ptr_eq(cur, &waiter)) {
+                w.remove(&key);
+            }
             return v;
         }
         let v = f();
@@ -95,7 +99,12 @@ impl BlockCache {
             .or_default()
             .insert(key);
         self.count.fetch_add(1, Ordering::Relaxed);
-        self.waiters.lock().remove(&key);
+        {
+            let mut w = self.waiters.lock();
+            if w.get(&key).is_some_and(|cur| Arc::ptr_eq(cur, &waiter)) {
+                w.remove(&key);
+            }
+        }
         v
     }
 
@@ -119,7 +128,10 @@ impl BlockCache {
         let _guard = waiter.lock();
         // Double-check after acquiring the per-key lock.
         if let Some(v) = self.inner.get(&key) {
-            self.waiters.lock().remove(&key);
+            let mut w = self.waiters.lock();
+            if w.get(&key).is_some_and(|cur| Arc::ptr_eq(cur, &waiter)) {
+                w.remove(&key);
+            }
             return Ok(v);
         }
         let v = f()?;
@@ -130,7 +142,12 @@ impl BlockCache {
             .or_default()
             .insert(key);
         self.count.fetch_add(1, Ordering::Relaxed);
-        self.waiters.lock().remove(&key);
+        {
+            let mut w = self.waiters.lock();
+            if w.get(&key).is_some_and(|cur| Arc::ptr_eq(cur, &waiter)) {
+                w.remove(&key);
+            }
+        }
         Ok(v)
     }
 

--- a/kv-engine/src/cache.rs
+++ b/kv-engine/src/cache.rs
@@ -31,6 +31,10 @@ const VALUE_WEIGHT_DIVISOR: usize = 64;
 /// - TinyUFO does not expose eviction callbacks, so when blocks are evicted by the cache their keys
 ///   remain in the reverse index until the owning SST is compacted away.  In practice this is a
 ///   slow, bounded leak because the number of live SSTs (and their blocks) is finite.
+/// - If `invalidate_ssts` runs while a `get_or_insert` closure is in flight for the same SST,
+///   the loading thread will re-insert the block and its reverse-index entry after invalidation
+///   completes.  This is a bounded leak (one entry per concurrent in-flight load) and the orphaned
+///   block will be evicted by TinyUFO under memory pressure.
 pub struct BlockCache {
     inner: TinyUfo<(usize, usize), Arc<Block>>,
     /// Reverse index: sst_id → keys cached for that SST.

--- a/kv-engine/src/cache.rs
+++ b/kv-engine/src/cache.rs
@@ -112,7 +112,10 @@ impl BlockCache {
     /// On error the cache is left unchanged and the error is propagated.
     ///
     /// Concurrent misses on the same key are coalesced: only the first
-    /// thread runs `f`; others wait and read from cache.
+    /// thread runs `f`; others wait and read from cache.  On error, the
+    /// waiter entry is retained so subsequent callers serialize their
+    /// retries.  If the error is permanent, the entry leaks until a
+    /// successful insert or SST invalidation occurs.
     pub fn try_get_with<F, E>(&self, sst_id: usize, block_idx: usize, f: F) -> Result<Arc<Block>, E>
     where
         F: FnOnce() -> Result<Arc<Block>, E>,

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -197,8 +197,8 @@ impl MemTable {
     /// Collect vLog file IDs referenced by ValuePointer entries in this memtable.
     /// Used during startup to prevent orphan cleanup from deleting vLog files
     /// that are still needed by unflushed memtable entries.
-    pub fn collect_vlog_file_ids(&self) -> ahash::AHashSet<u32> {
-        let mut ids = ahash::AHashSet::new();
+    pub fn collect_vlog_file_ids(&self) -> std::collections::HashSet<u32> {
+        let mut ids = std::collections::HashSet::new();
         if !self.vlog_enabled {
             return ids;
         }

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -197,8 +197,8 @@ impl MemTable {
     /// Collect vLog file IDs referenced by ValuePointer entries in this memtable.
     /// Used during startup to prevent orphan cleanup from deleting vLog files
     /// that are still needed by unflushed memtable entries.
-    pub fn collect_vlog_file_ids(&self) -> std::collections::HashSet<u32> {
-        let mut ids = std::collections::HashSet::new();
+    pub fn collect_vlog_file_ids(&self) -> ahash::AHashSet<u32> {
+        let mut ids = ahash::AHashSet::new();
         if !self.vlog_enabled {
             return ids;
         }

--- a/kv-engine/src/vlog/gc.rs
+++ b/kv-engine/src/vlog/gc.rs
@@ -1,4 +1,6 @@
-use std::{collections::HashSet, sync::Arc};
+use std::sync::Arc;
+
+use ahash::AHashSet;
 
 use anyhow::{Ok, Result, anyhow};
 use bytes::Bytes;
@@ -327,7 +329,7 @@ impl<'a> GarbageCollector<'a> {
     /// Run GC on all vLog files referenced by the current SST set.
     pub fn gc_all(&self) -> Result<Vec<GcResult>> {
         let snapshot = self.inner.state.load_full();
-        let mut vlog_files: HashSet<u32> = HashSet::new();
+        let mut vlog_files: AHashSet<u32> = AHashSet::new();
 
         // Collect vLog file IDs from all SSTs
         for sst_id in snapshot.sstables.keys() {

--- a/kv-engine/src/vlog/mod.rs
+++ b/kv-engine/src/vlog/mod.rs
@@ -489,7 +489,13 @@ impl ValueLog {
 
         // Double-check: another thread may have opened it while we waited.
         if let Some(reader) = self.readers.get(&file_id) {
-            self.open_locks.lock().remove(&file_id);
+            let mut locks = self.open_locks.lock();
+            if locks
+                .get(&file_id)
+                .is_some_and(|cur| Arc::ptr_eq(cur, &file_lock))
+            {
+                locks.remove(&file_id);
+            }
             return Ok(reader);
         }
 
@@ -497,18 +503,26 @@ impl ValueLog {
         let reader = match ValueLogReader::open(path) {
             Ok(r) => Arc::new(r.with_file_id(file_id)),
             Err(e) => {
-                // On error, remove waiter so subsequent callers can retry.
-                self.open_locks.lock().remove(&file_id);
+                let mut locks = self.open_locks.lock();
+                if locks
+                    .get(&file_id)
+                    .is_some_and(|cur| Arc::ptr_eq(cur, &file_lock))
+                {
+                    locks.remove(&file_id);
+                }
                 return Err(e);
             }
         };
-        // Use force_put to bypass TinyLFU admission — the reader must be
-        // cached to respect max_open_vlog_files.
         self.readers.force_put(file_id, reader.clone(), 1);
-        // Remove waiter AFTER cache insert — fixes race where concurrent
-        // get_reader callers could create a new waiter and open the same
-        // file before this thread inserts into the cache.
-        self.open_locks.lock().remove(&file_id);
+        {
+            let mut locks = self.open_locks.lock();
+            if locks
+                .get(&file_id)
+                .is_some_and(|cur| Arc::ptr_eq(cur, &file_lock))
+            {
+                locks.remove(&file_id);
+            }
+        }
         Ok(reader)
     }
 

--- a/kv-engine/src/vlog/mod.rs
+++ b/kv-engine/src/vlog/mod.rs
@@ -753,7 +753,10 @@ impl ValueLog {
     /// active memtable. `preserve` contains vLog file IDs referenced by
     /// unflushed memtable entries (rebuilt from the WAL during crash recovery)
     /// that must not be deleted even though no SST references them yet.
-    pub fn cleanup_orphan_vlog_files(&self, preserve: &std::collections::HashSet<u32>) -> Result<usize> {
+    pub fn cleanup_orphan_vlog_files(
+        &self,
+        preserve: &std::collections::HashSet<u32>,
+    ) -> Result<usize> {
         let mut orphans = Vec::new();
         for entry in std::fs::read_dir(&self.path)? {
             let entry = entry?;

--- a/kv-engine/src/vlog/mod.rs
+++ b/kv-engine/src/vlog/mod.rs
@@ -4,13 +4,14 @@ pub mod index;
 pub mod reader;
 
 use std::{
-    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     sync::{
         Arc,
         atomic::{AtomicU32, AtomicU64, Ordering},
     },
 };
+
+use ahash::{AHashMap, AHashSet};
 
 use anyhow::{Result, anyhow};
 pub use builder::ValueLogBuilder;
@@ -265,8 +266,8 @@ pub struct VlogEntry {
 
 /// Tracks which vLog files are referenced by each SST.
 struct VlogReferencesInner {
-    sst_to_vlogs: HashMap<usize, HashSet<u32>>,
-    vlog_to_ssts: HashMap<u32, HashSet<usize>>,
+    sst_to_vlogs: AHashMap<usize, AHashSet<u32>>,
+    vlog_to_ssts: AHashMap<u32, AHashSet<usize>>,
 }
 
 /// Tracks which vLog files are referenced by each SST.
@@ -284,8 +285,8 @@ impl VlogReferences {
     pub fn new() -> Self {
         Self {
             inner: RwLock::new(VlogReferencesInner {
-                sst_to_vlogs: HashMap::new(),
-                vlog_to_ssts: HashMap::new(),
+                sst_to_vlogs: AHashMap::new(),
+                vlog_to_ssts: AHashMap::new(),
             }),
         }
     }
@@ -308,7 +309,7 @@ impl VlogReferences {
         if vlog_ids.is_empty() {
             return;
         }
-        let set: HashSet<u32> = HashSet::from_iter(vlog_ids.iter().copied());
+        let set: AHashSet<u32> = vlog_ids.iter().copied().collect();
         for &vid in &set {
             inner.vlog_to_ssts.entry(vid).or_default().insert(sst_id);
         }
@@ -380,7 +381,7 @@ pub struct ValueLog {
     pending_deletions: Mutex<Vec<PendingDeletion>>,
     /// Per-file GC locks to prevent concurrent GC on the same file.
     /// Shared across all GarbageCollector instances.
-    gc_locks: Mutex<HashSet<u32>>,
+    gc_locks: Mutex<AHashSet<u32>>,
     /// Cumulative entries rewritten by GC since startup.
     gc_entries_rewritten: AtomicU64,
     /// Cumulative bytes written by GC since startup.
@@ -396,11 +397,11 @@ pub struct ValueLog {
     /// exceed `max_open_vlog_files`.  Entries are cleaned up after each
     /// open (success or failure) and in `remove_file`.  Bounded by the
     /// number of concurrent in-flight opens (typically 1-2).
-    open_locks: Mutex<HashMap<u32, Arc<Mutex<()>>>>,
+    open_locks: Mutex<AHashMap<u32, Arc<Mutex<()>>>>,
     /// In-memory per-file vLog indices for GC optimization.
     /// Maps file_id → Arc<VlogIndex>. Loaded lazily on first access;
     /// rebuilt from vLog headers if the `.vidx` file is missing.
-    indices: RwLock<HashMap<u32, Arc<VlogIndex>>>,
+    indices: RwLock<AHashMap<u32, Arc<VlogIndex>>>,
 }
 
 impl ValueLog {
@@ -446,14 +447,14 @@ impl ValueLog {
             value_cache,
             references: VlogReferences::new(),
             pending_deletions: Mutex::new(Vec::new()),
-            gc_locks: Mutex::new(HashSet::new()),
+            gc_locks: Mutex::new(AHashSet::new()),
             gc_entries_rewritten: AtomicU64::new(0),
             gc_bytes_rewritten: AtomicU64::new(0),
             gc_files_processed: AtomicU64::new(0),
             cache_hits: AtomicU64::new(0),
             cache_misses: AtomicU64::new(0),
-            open_locks: Mutex::new(HashMap::new()),
-            indices: RwLock::new(HashMap::new()),
+            open_locks: Mutex::new(AHashMap::new()),
+            indices: RwLock::new(AHashMap::new()),
         })
     }
 
@@ -745,7 +746,7 @@ impl ValueLog {
     /// active memtable. `preserve` contains vLog file IDs referenced by
     /// unflushed memtable entries (rebuilt from the WAL during crash recovery)
     /// that must not be deleted even though no SST references them yet.
-    pub fn cleanup_orphan_vlog_files(&self, preserve: &HashSet<u32>) -> Result<usize> {
+    pub fn cleanup_orphan_vlog_files(&self, preserve: &AHashSet<u32>) -> Result<usize> {
         let mut orphans = Vec::new();
         for entry in std::fs::read_dir(&self.path)? {
             let entry = entry?;

--- a/kv-engine/src/vlog/mod.rs
+++ b/kv-engine/src/vlog/mod.rs
@@ -460,7 +460,7 @@ impl ValueLog {
 
     /// Return the next vLog file id to use for a new file.
     pub fn next_file_id(&self) -> u32 {
-        self.next_file_id.fetch_add(1, Ordering::SeqCst)
+        self.next_file_id.fetch_add(1, Ordering::Relaxed)
     }
 
     /// Full path for a given vLog file id.
@@ -746,7 +746,7 @@ impl ValueLog {
     /// active memtable. `preserve` contains vLog file IDs referenced by
     /// unflushed memtable entries (rebuilt from the WAL during crash recovery)
     /// that must not be deleted even though no SST references them yet.
-    pub fn cleanup_orphan_vlog_files(&self, preserve: &AHashSet<u32>) -> Result<usize> {
+    pub fn cleanup_orphan_vlog_files(&self, preserve: &std::collections::HashSet<u32>) -> Result<usize> {
         let mut orphans = Vec::new();
         for entry in std::fs::read_dir(&self.path)? {
             let entry = entry?;

--- a/kv-engine/src/vlog/mod.rs
+++ b/kv-engine/src/vlog/mod.rs
@@ -489,6 +489,7 @@ impl ValueLog {
 
         // Double-check: another thread may have opened it while we waited.
         if let Some(reader) = self.readers.get(&file_id) {
+            self.open_locks.lock().remove(&file_id);
             return Ok(reader);
         }
 

--- a/kv-engine/src/vlog/mod.rs
+++ b/kv-engine/src/vlog/mod.rs
@@ -489,19 +489,25 @@ impl ValueLog {
 
         // Double-check: another thread may have opened it while we waited.
         if let Some(reader) = self.readers.get(&file_id) {
-            // Clean up the lock entry — no longer needed.
-            self.open_locks.lock().remove(&file_id);
             return Ok(reader);
         }
 
         let path = self.path_of_file(file_id);
-        let result = ValueLogReader::open(path).map(|r| Arc::new(r.with_file_id(file_id)));
-        // Clean up the lock entry regardless of success/failure.
-        self.open_locks.lock().remove(&file_id);
-        let reader = result?;
+        let reader = match ValueLogReader::open(path) {
+            Ok(r) => Arc::new(r.with_file_id(file_id)),
+            Err(e) => {
+                // On error, remove waiter so subsequent callers can retry.
+                self.open_locks.lock().remove(&file_id);
+                return Err(e);
+            }
+        };
         // Use force_put to bypass TinyLFU admission — the reader must be
         // cached to respect max_open_vlog_files.
         self.readers.force_put(file_id, reader.clone(), 1);
+        // Remove waiter AFTER cache insert — fixes race where concurrent
+        // get_reader callers could create a new waiter and open the same
+        // file before this thread inserts into the cache.
+        self.open_locks.lock().remove(&file_id);
         Ok(reader)
     }
 


### PR DESCRIPTION
## Summary

Follow-up improvements to the TinyUFO cache (PR #55):

1. **ahash for reverse indexes** — Replace std HashMap/HashSet with ahash AHashMap/AHashSet in cache and vlog internal structures for faster hashing on hot paths
2. **Single-flight block cache misses** — Per-key Mutex coalesces concurrent misses so only one thread loads from disk, eliminating redundant I/O
3. **Unit tests** — 19 cache tests (was 0), 136 total passing
4. **Bug fixes** — Waiter cleanup on double-check hit, get_reader single-flight race, public API type consistency

## Changes

- : BlockCache/ValueCache with ahash internals, single-flight via waiters map, 19 unit tests
- : ahash for open_locks/gc_locks/indices, fixed get_reader waiter-before-insert race
- : ahash for vlog_files tracking
- : reverted ahash from public API (collect_vlog_file_ids returns HashSet)
- : full 19-workload moka vs TinyUFO+ comparison

## Performance (moka → TinyUFO+ahash+single-flight, median of 3 runs)

| Workload | Δ |
|----------|---|
| fillseq | **+17%** |
| fillrandom | **+8%** |
| readrandom | **+11%** |
| overwrite | **+14%** |
| readwhilewriting reads | +4% |
| Concurrent R/W reads | +8% |
| seekrandom | +5% |
| deleterandom | +8% |

## Verification

- [x] cargo fmt --check
- [x] cargo clippy --workspace --all-features --all-targets -- -D warnings
- [x] cargo test (136 tests passing)
- [x] Full benchmark suite (19 workloads, 3 runs each)
- [x] CPU profile — no cache-related hotspots, moka housekeeper 0%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated performance report with new cache/vLog benchmark results and a revised bottleneck summary reflecting recent cache improvements and throughput deltas.

* **Bug Fixes**
  * Fixed a concurrency timing issue during vLog reader initialization; reduced background CPU usage from housekeeping.

* **Refactor**
  * Cache and vLog internals reworked to reduce contention and coalesce concurrent loads, improving throughput and lowering CPU.

* **Tests**
  * Expanded tests for cache behavior, error/success coalescing, invalidation, and concurrent scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->