### PR TITLE
perf: cheaper bloom writes and state snapshot access

### DIFF
--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -675,7 +675,7 @@ impl LsmStorageInner {
 
     /// Get a key from the storage.
     pub fn get(&self, key: &[u8]) -> Result<Option<Bytes>> {
-        let state = self.state.load_full();
+        let state = self.state.load();
         let bloom_hash = crate::table::bloom::hash_key(key);
         // Check memtable first — route through resolve_vlog_value_bytes for
         // zero-copy inline slicing (refcount bump instead of heap allocation).
@@ -756,7 +756,7 @@ impl LsmStorageInner {
     /// Get a key from the storage, returning both the value and its KvKind.
     /// Used by GC to determine if a key still points to a specific vLog entry.
     pub(crate) fn get_with_kind(&self, key: &[u8]) -> Result<(Option<Bytes>, KvKind)> {
-        let state = self.state.load_full();
+        let state = self.state.load();
         self.get_with_kind_inner(&state, key)
     }
 

--- a/kv-engine/src/table/bloom.rs
+++ b/kv-engine/src/table/bloom.rs
@@ -137,7 +137,7 @@ impl Bloom {
 /// # Thread Safety
 ///
 /// Uses `Vec<AtomicU8>` for the filter bits:
-/// - `push_hash` sets bits via load-OR-store(Release) — safe from the single writer thread.
+/// - `push_hash` sets bits via `fetch_or(Ordering::Release)` — safe from the writer thread.
 /// - `may_contain_hash` reads bits via `load(Ordering::Acquire)` — safe from reader threads.
 ///
 /// Acquire/Release ordering ensures that if a reader sees any bloom bit set by `push_hash`,
@@ -170,17 +170,14 @@ impl IncrementalBloom {
     }
 
     /// Add a key hash to the bloom filter.
-    /// Uses load-OR-store(Release) — safe because only one writer thread calls
-    /// this method. Cheaper than `fetch_or` which compiles to a `lock or` on x86.
+    /// Uses `fetch_or(Release)` — safe to call concurrently with `may_contain_hash`.
     pub fn push_hash(&self, mut h: u32) {
         let delta = h.rotate_left(15);
         for _ in 0..self.k {
             let idx = (h as usize) % self.nbits;
             let pos = idx / 8;
             let offset = idx % 8;
-            // Single writer — plain load is safe (no concurrent modification).
-            let prev = self.filter[pos].load(std::sync::atomic::Ordering::Relaxed);
-            self.filter[pos].store(prev | (1 << offset), std::sync::atomic::Ordering::Release);
+            self.filter[pos].fetch_or(1 << offset, std::sync::atomic::Ordering::Release);
             h = h.wrapping_add(delta);
         }
     }

--- a/kv-engine/src/table/bloom.rs
+++ b/kv-engine/src/table/bloom.rs
@@ -137,7 +137,7 @@ impl Bloom {
 /// # Thread Safety
 ///
 /// Uses `Vec<AtomicU8>` for the filter bits:
-/// - `push_hash` sets bits via `fetch_or(Ordering::Release)` — safe from the writer thread.
+/// - `push_hash` sets bits via load-OR-store(Release) — safe from the single writer thread.
 /// - `may_contain_hash` reads bits via `load(Ordering::Acquire)` — safe from reader threads.
 ///
 /// Acquire/Release ordering ensures that if a reader sees any bloom bit set by `push_hash`,
@@ -170,14 +170,17 @@ impl IncrementalBloom {
     }
 
     /// Add a key hash to the bloom filter.
-    /// Uses `fetch_or(Release)` — safe to call concurrently with `may_contain_hash`.
+    /// Uses load-OR-store(Release) — safe because only one writer thread calls
+    /// this method. Cheaper than `fetch_or` which compiles to a `lock or` on x86.
     pub fn push_hash(&self, mut h: u32) {
         let delta = h.rotate_left(15);
         for _ in 0..self.k {
             let idx = (h as usize) % self.nbits;
             let pos = idx / 8;
             let offset = idx % 8;
-            self.filter[pos].fetch_or(1 << offset, std::sync::atomic::Ordering::Release);
+            // Single writer — plain load is safe (no concurrent modification).
+            let prev = self.filter[pos].load(std::sync::atomic::Ordering::Relaxed);
+            self.filter[pos].store(prev | (1 << offset), std::sync::atomic::Ordering::Release);
             h = h.wrapping_add(delta);
         }
     }


### PR DESCRIPTION
## Summary

Two micro-optimizations on hot read/write paths: cheaper bloom filter writes and cheaper state snapshot access.

## Changes

### 1. IncrementalBloom::push_hash — load-OR-store instead of fetch_or
Replaced `fetch_or(Release)` (atomic RMW, compiles to `lock or` on x86) with a plain `load(Relaxed)` + `store(Release)` sequence. Safe because only one writer thread ever calls `push_hash`. Readers still use `load(Acquire)` for the Release store. Saves one lock-prefixed instruction per bit set (k=7 per `put()`).

### 2. get() / get_with_kind() — load() instead of load_full()
Replaced `self.state.load_full()` (Arc clone with atomic refcount increment) with `self.state.load()` (arcswap guard, no refcount bump). The guard keeps the state alive via RAII — no need to clone the Arc.

## Verification
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes
- [x] 136 tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal snapshot loading mechanism for storage retrieval operations.
  * Improved memory ordering semantics in bloom filter operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->