### PR TITLE
feat: cache backfill on flush and compaction

### DIFF
--- a/docs/superpowers/plans/2026-06-05-reduce-key-cloning-plan.md
+++ b/docs/superpowers/plans/2026-06-05-reduce-key-cloning-plan.md
@@ -1,0 +1,446 @@
+# Reduce key cloning in `SsTableBuilder::add_inner` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Eliminate the per-entry full-key clone in `SsTableBuilder::add_inner` and the per-block first-key clone in `BlockBuilder::add` by tracking positions inside already-encoded block data.
+
+**Architecture:** Replace `BlockBuilder.first_key: KeyVec` with offset/len into `self.data`. Replace `SsTableBuilder.first_key/last_key: KeyVec` with a `has_data` flag and derive first/last meta keys from the `BlockBuilder` only at block boundaries (rare) via a new `BlockBuilder::key_at` helper.
+
+**Tech Stack:** Rust 2024, `bytes`, `cargo nextest`, existing `KeyVec`/`KeyBytes`/`KeySlice` types.
+
+---
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `kv-engine/src/block/builder.rs` | `BlockBuilder` structure and `add()` logic; new `key_at()` helper. |
+| `kv-engine/src/table/builder.rs` | `SsTableBuilder` structure and `add_inner()` / `build()` logic. |
+| `kv-engine/src/tests/block.rs` | Unit tests for the new `key_at()` helper. |
+
+---
+
+### Task 1: Update `BlockBuilder` to avoid the first-key `KeyVec`
+
+**Files:**
+- Modify: `kv-engine/src/block/builder.rs`
+
+**Why:** The first key of a block is already stored in `self.data` at the first entry's suffix. We only need its offset and length to compute overlap for later entries.
+
+- [x] **Step 1: Change `BlockBuilder` fields**
+
+Replace:
+
+```rust
+    /// The first key in the block
+    first_key: KeyVec,
+```
+
+with:
+
+```rust
+    /// Offset in `self.data` where the first key's suffix begins.
+    first_key_offset: usize,
+    /// Length of the first key in bytes.
+    first_key_len: u16,
+    /// Whether the first key has been recorded. Required to disambiguate an
+    /// empty first key from the initial zero state.
+    has_first_key: bool,
+```
+
+- [x] **Step 2: Update `BlockBuilder::new`**
+
+Initialize the new fields:
+
+```rust
+            block_size,
+            first_key_offset: 0,
+            first_key_len: 0,
+            has_first_key: false,
+```
+
+- [x] **Step 3: Update `overlap_len` to read from `self.data`**
+
+Replace the body with:
+
+```rust
+    fn overlap_len(&self, key: &[u8]) -> usize {
+        let first_key = &self.data[self.first_key_offset
+            ..self.first_key_offset + self.first_key_len as usize];
+        let chunk_size = 128;
+        let offset = std::iter::zip(
+            first_key.chunks_exact(chunk_size),
+            key.chunks_exact(chunk_size),
+        )
+        .take_while(|(a, b)| a == b)
+        .count()
+            * chunk_size;
+
+        offset
+            + std::iter::zip(&first_key[offset..], &key[offset..])
+                .take_while(|(a, b)| a == b)
+                .count()
+    }
+```
+
+- [x] **Step 4: Update `BlockBuilder::add` to record the first-key position**
+
+After pushing the entry data, record where the first key lives:
+
+```rust
+    pub fn add(&mut self, key: KeySlice, value: &[u8]) -> bool {
+        if !self.is_empty()
+            && self.current_size() + key.len() + value.len() + 3 * SIZE_OF_U16 >= self.block_size
+        {
+            return false;
+        }
+
+        let entry_start = self.data.len();
+        self.offsets.push(self.data.len() as u16);
+
+        let overlap = if self.is_empty() {
+            0
+        } else {
+            self.overlap_len(key.raw_ref())
+        };
+        self.data.put_u16(overlap as u16);
+        self.data.put_u16((key.len() - overlap) as u16);
+        self.data.put(&key.raw_ref()[overlap..]);
+
+        self.data.put_u16(value.len() as u16);
+        self.data.put(value);
+
+        if self.first_key_len == 0 {
+            // First entry always has overlap == 0, so the suffix is the full key.
+            self.first_key_offset = entry_start + 2 * SIZE_OF_U16;
+            self.first_key_len = key.len() as u16;
+        }
+
+        true
+    }
+```
+
+- [x] **Step 5: Add `BlockBuilder::key_at` helper**
+
+Add this `pub(crate)` method after `add`:
+
+```rust
+    /// Return the full key bytes of the `idx`-th entry.
+    /// Used at block boundaries to produce `BlockMeta` first/last keys without
+    /// maintaining a live clone of the latest key.
+    pub(crate) fn key_at(&self, idx: usize) -> bytes::Bytes {
+        use bytes::Bytes;
+        assert!(idx < self.offsets.len(), "key_at index out of bounds");
+
+        let off = self.offsets[idx] as usize;
+        let overlap = u16::from_be_bytes([self.data[off], self.data[off + 1]]) as usize;
+        let suffix_len = u16::from_be_bytes([
+            self.data[off + SIZE_OF_U16],
+            self.data[off + SIZE_OF_U16 + 1],
+        ]) as usize;
+        let suffix_start = off + 2 * SIZE_OF_U16;
+        let suffix = &self.data[suffix_start..suffix_start + suffix_len];
+
+        if overlap == 0 {
+            shared_bytes_from_slice(suffix)
+        } else {
+            let first_key =
+                &self.data[self.first_key_offset..self.first_key_offset + self.first_key_len as usize];
+            let mut out = Vec::with_capacity(overlap + suffix_len + 1);
+            out.extend_from_slice(&first_key[..overlap]);
+            out.extend_from_slice(suffix);
+            Bytes::from(out)
+        }
+    }
+```
+
+- [x] **Step 6: Add a local `shared_bytes_from_slice` helper at the top of the file**
+
+At the top of `kv-engine/src/block/builder.rs`, add:
+
+```rust
+fn shared_bytes_from_slice(src: &[u8]) -> bytes::Bytes {
+    if src.is_empty() {
+        return bytes::Bytes::new();
+    }
+    let mut vec = Vec::with_capacity(src.len() + 1);
+    vec.extend_from_slice(src);
+    bytes::Bytes::from(vec)
+}
+```
+
+- [x] **Step 7: Import `bytes::Bytes` if not already imported**
+
+The file already imports `bytes::{BufMut, Bytes}`. If `Bytes` is present, no change is needed.
+
+- [x] **Step 8: Run block unit tests to catch format regressions early**
+
+```bash
+cargo nextest run --package kv-engine --lib block
+```
+
+Expected: all block tests pass.
+
+---
+
+### Task 2: Update `SsTableBuilder` to avoid live first/last `KeyVec` clones
+
+**Files:**
+- Modify: `kv-engine/src/table/builder.rs`
+
+**Why:** `self.last_key.set_from_slice(key)` copied the full key on every entry. We now derive first/last keys only when sealing a block or finishing the SST.
+
+- [x] **Step 1: Change `SsTableBuilder` fields**
+
+Remove:
+
+```rust
+    first_key: KeyVec,
+    last_key: KeyVec,
+```
+
+Add:
+
+```rust
+    has_data: bool,
+```
+
+- [x] **Step 2: Update `SsTableBuilder::new` and `new_with_vlog`**
+
+In both constructors, replace:
+
+```rust
+            first_key: KeyVec::new(),
+            last_key: KeyVec::new(),
+```
+
+with:
+
+```rust
+            has_data: false,
+```
+
+- [x] **Step 3: Update `is_empty`**
+
+Replace the body with:
+
+```rust
+    pub fn is_empty(&self) -> bool {
+        !self.has_data
+    }
+```
+
+- [x] **Step 4: Rewrite `add_inner`**
+
+Replace the entire method with:
+
+```rust
+    fn add_inner(&mut self, key: KeySlice, value: &[u8]) -> Result<()> {
+        if !self.has_data {
+            self.has_data = true;
+        }
+
+        if !self.builder.add(key, value) {
+            let old_builder = mem::replace(&mut self.builder, BlockBuilder::new(self.block_size));
+            let first_key = KeyBytes::from_bytes(old_builder.key_at(0));
+            let last_idx = old_builder.offsets.len().saturating_sub(1);
+            let last_key = KeyBytes::from_bytes(old_builder.key_at(last_idx));
+            let data = old_builder.build().encode();
+
+            let meta = BlockMeta {
+                offset: self.data.len(),
+                first_key,
+                last_key,
+            };
+            self.meta.push(meta);
+            self.data.extend(data);
+
+            let _ = self.builder.add(key, value);
+        }
+
+        self.key_hashes.push(super::bloom::hash_key(key.raw_ref()));
+        Ok(())
+    }
+```
+
+- [x] **Step 5: Update `SsTableBuilder::build` final-block handling**
+
+Replace the final meta creation block:
+
+```rust
+        let meta = BlockMeta {
+            offset: self.data.len(),
+            first_key: std::mem::take(&mut self.first_key).into_key_bytes(),
+            last_key: std::mem::take(&mut self.last_key).into_key_bytes(),
+        };
+```
+
+with:
+
+```rust
+        let (first_key, last_key) = if self.has_data {
+            let last_idx = self.builder.offsets.len().saturating_sub(1);
+            (
+                KeyBytes::from_bytes(self.builder.key_at(0)),
+                KeyBytes::from_bytes(self.builder.key_at(last_idx)),
+            )
+        } else {
+            (
+                KeyBytes::from_bytes(bytes::Bytes::new()),
+                KeyBytes::from_bytes(bytes::Bytes::new()),
+            )
+        };
+        let meta = BlockMeta {
+            offset: self.data.len(),
+            first_key,
+            last_key,
+        };
+```
+
+- [x] **Step 6: Update imports in `kv-engine/src/table/builder.rs`**
+
+The file currently imports:
+
+```rust
+use bytes::BufMut;
+```
+
+Change it to:
+
+```rust
+use bytes::{BufMut, Bytes};
+```
+
+And update the crate import:
+
+```rust
+use crate::{
+    block::BlockBuilder,
+    key::{KeySlice, KeyVec},
+    ...
+};
+```
+
+Change it to:
+
+```rust
+use crate::{
+    block::BlockBuilder,
+    key::{KeyBytes, KeySlice, KeyVec},
+    ...
+};
+```
+
+- [x] **Step 7: Run SST unit tests**
+
+```bash
+cargo nextest run --package kv-engine --lib sst
+```
+
+Expected: all SST tests pass.
+
+---
+
+### Task 3: Add a focused unit test for `BlockBuilder::key_at`
+
+**Files:**
+- Modify: `kv-engine/src/tests/block.rs`
+
+**Why:** We are now parsing raw block bytes to reconstruct keys. A dedicated test guards against format drift.
+
+- [x] **Step 1: Append the test at the end of the file**
+
+```rust
+#[test]
+fn test_block_builder_key_at() {
+    let mut builder = BlockBuilder::new(10000);
+    let keys: Vec<Vec<u8>> = (0..100)
+        .map(|i| format!("key_{:03}", i * 5).into_bytes())
+        .collect();
+    for key in &keys {
+        assert!(builder.add(
+            KeySlice::for_testing_from_slice_no_ts(key),
+            &format!("value_{:010}", key.len()).into_bytes(),
+        ));
+    }
+
+    for (i, expected) in keys.iter().enumerate() {
+        let actual = builder.key_at(i);
+        assert_eq!(actual.as_ref(), expected.as_slice(), "key_at({i}) mismatch");
+    }
+}
+```
+
+- [x] **Step 2: Run the new test**
+
+```bash
+cargo nextest run --package kv-engine --lib block::test_block_builder_key_at
+```
+
+Expected: PASS.
+
+---
+
+### Task 4: Run the full test matrix and checks
+
+- [x] **Step 1: Library + integration tests**
+
+```bash
+cargo nextest run --workspace --all-features --all-targets
+```
+
+Expected: all tests pass.
+
+- [x] **Step 2: Clippy**
+
+```bash
+cargo clippy --package kv-engine --all-features -- -D warnings
+```
+
+Expected: clean.
+
+- [x] **Step 3: Format**
+
+```bash
+cargo fmt --all -- --check
+```
+
+Expected: clean.
+
+---
+
+### Task 5: Optional benchmark validation
+
+- [x] **Step 1: Run the write-heavy benchmark subset**
+
+```bash
+cargo run --release --bin write-perf -- --only fillseq fillrandom overwrite
+```
+
+If the `write-perf` binary does not accept `--only`, run the full binary and compare the three workloads against a baseline recorded before the change.
+
+Expected: `fillseq`, `fillrandom`, and `overwrite` throughput improves by ~3–5% (variance permitting).
+
+---
+
+## Spec coverage check
+
+| Spec requirement | Task |
+|---|---|
+| Remove `BlockBuilder.first_key: KeyVec` | Task 1, Steps 1–5 |
+| `overlap_len` reads first key from `self.data` | Task 1, Step 3 |
+| Remove `SsTableBuilder.first_key/last_key: KeyVec` | Task 2, Steps 1–3 |
+| Derive meta first/last keys at block boundaries | Task 2, Steps 4–5 |
+| Preserve SST format and all tests | Tasks 2–4 |
+| Add unit test for key extraction | Task 3 |
+| Verify with benchmarks | Task 5 |
+
+## Placeholder scan
+
+No placeholders, TBDs, or vague steps. Every code block contains the actual change; every command has an expected outcome.
+
+## Type consistency check
+
+- `BlockBuilder::key_at` returns `bytes::Bytes` (explicitly qualified to avoid shadowing).
+- `SsTableBuilder` uses `KeyBytes::from_bytes(...)` to wrap the returned `Bytes`.
+- `has_data: bool` replaces `first_key.is_empty()` checks consistently.

--- a/docs/superpowers/specs/2026-06-05-reduce-key-cloning-design.md
+++ b/docs/superpowers/specs/2026-06-05-reduce-key-cloning-design.md
@@ -1,0 +1,165 @@
+# Design: Reduce key cloning in `SsTableBuilder::add_inner`
+
+**Date:** 2026-06-05  
+**Author:** kimi  
+**Status:** Approved (Option A)
+
+## Summary
+
+`SsTableBuilder::add_inner` is the current #1 CPU consumer in write-heavy workloads
+(~25% of total CPU). A large part of that cost is full-key cloning:
+
+- `self.last_key.set_from_slice(key)` copies the full key on **every** entry.
+- `BlockBuilder` copies the first key of each block into `self.first_key: KeyVec`.
+- At block boundaries `self.first_key` / `self.last_key` are refreshed with another
+copy of the current key.
+
+This design eliminates almost all of those copies by tracking **positions** inside
+the already-encoded block data instead of keeping parallel `Vec<u8>` copies of keys.
+
+## Goals
+
+- Remove the per-entry full-key clone in `SsTableBuilder::add_inner`.
+- Remove the per-block first-key clone in `BlockBuilder::add`.
+- Preserve exact SST format and all existing tests.
+- Target 3–5% reduction in `add_inner` CPU (more on small-key workloads).
+
+## Non-goals
+
+- Change the SST on-disk format.
+- Change public `SsTableBuilder::add` / `add_raw` signatures.
+- Optimize value copying or block encoding beyond key storage.
+
+## Design
+
+### 1. `BlockBuilder`: remove `first_key: KeyVec`
+
+The first entry of a block is always encoded with `overlap=0` and a suffix that
+equals the full first key. Therefore the first key is already present in
+`self.data` at `offsets[0]`.
+
+Replace:
+
+```rust
+first_key: KeyVec,
+```
+
+with:
+
+```rust
+first_key_offset: usize,
+first_key_len:    u16,
+has_first_key:    bool,
+```
+
+- On the very first `add`, set `has_first_key = true` and record the offset and
+  suffix length of the first entry. The explicit boolean sentinel correctly
+  handles an empty (`""`) first key, which would otherwise be ambiguous with the
+  initial `first_key_len == 0` state.
+- `overlap_len(key)` reads the first key from `self.data[first_key_offset ..
+  first_key_offset + first_key_len]` instead of from a separate `Vec`.
+
+This removes `key.to_key_vec()` from the hot path entirely.
+
+### 2. `SsTableBuilder`: derive first/last keys from encoded block data
+
+Remove:
+
+```rust
+first_key: KeyVec,
+last_key:  KeyVec,
+```
+
+Add:
+
+```rust
+has_data: bool,
+```
+
+`is_empty()` becomes `!self.has_data`.
+
+When a block fills up and is sealed:
+
+1. `old_builder.build().encode()` returns a `Bytes` buffer containing the encoded
+   block. This buffer already holds every full key (the first entry stores the
+   full first key; subsequent entries store `overlap + suffix`, which together
+   reconstruct the full key).
+2. A small helper parses the first and last entries from that `Bytes` and
+   returns the full key bytes for each.
+3. Those key bytes are copied into small dedicated `KeyBytes` buffers (one per
+   meta key). Because this only happens at block boundaries (~1/1000 entries for
+   the default 4 KB block / 1 KB value configuration), the copy cost is
+   negligible compared to the per-entry clone we are removing.
+4. The encoded block `Bytes` is then appended to `self.data` (a `Vec<u8>`). The
+   meta keys do not retain references to the encoded block buffer, so there is
+   no long-term memory overhead per SST.
+
+For the trailing partial block at final `build()`, the same helper extracts the
+first and last keys from the final encoded block.
+
+### 3. Key-extraction helper
+
+A new private helper on `Block` (or a standalone utility) decodes a single entry
+header from raw block bytes:
+
+```rust
+fn read_entry_key(buf: &Bytes, offset: usize, first_key: &[u8]) -> Bytes
+```
+
+Given the entry offset and the first key bytes, it reads `(overlap, suffix_len)`,
+slices `suffix` from the buffer, and returns:
+
+```rust
+if overlap == 0 {
+    suffix.clone()
+} else {
+    let mut out = BytesMut::with_capacity(overlap + suffix_len);
+    out.extend_from_slice(&first_key[..overlap]);
+    out.extend_from_slice(&suffix);
+    out.freeze()
+}
+```
+
+At block-seal time we call it twice: once for entry 0 (which ignores
+`first_key` because `overlap == 0`) and once for the last entry.
+
+### 4. Block format invariants used
+
+- Entry layout is fixed: `[overlap: u16][suffix_len: u16][suffix][value_len: u16][value]`.
+- The first entry always has `overlap == 0`, therefore `suffix == full key`.
+- All offsets are recorded in `BlockBuilder::offsets`, so entry boundaries are
+  known without scanning.
+
+These invariants are already guaranteed by the existing block builder and are
+covered by existing block tests.
+
+## Testing plan
+
+1. **Existing tests must pass unchanged:**
+   - `tests::block::*`
+   - `tests::sst::*`
+   - `tests::compaction::*`
+   - `tests::vlog_integration_tests::sst_builder`
+   - All harness-based integration tests.
+
+2. **Add focused tests for the new helper:**
+   - Build a block with keys that share long prefixes.
+   - Use the helper to extract first and last keys and assert they match the
+     original keys.
+
+3. **Benchmark validation:**
+   - Run `cargo bench --package kv-engine --bench vlog_benchmarks` or the
+     write-perf suite and compare `fillseq` / `fillrandom` / `overwrite`
+     throughput before/after.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Parsing raw block bytes incorrectly corrupts `BlockMeta` | Covered by existing SST decode tests plus a new unit test for the helper. |
+| Copying key bytes at block boundary reintroduces a small cost | Boundary copies are ~1/1000 of entries; still far cheaper than the old per-entry clone. |
+| Performance regression on tiny blocks where boundary copies were already cheap | The overhead of parsing two entries per block is tiny compared to eliminating a memcpy per entry. |
+
+## Open questions
+
+None. Approved for implementation as Option A.

--- a/kv-engine/benches/vlog_benchmarks.rs
+++ b/kv-engine/benches/vlog_benchmarks.rs
@@ -36,6 +36,7 @@ fn make_options(vlog_enabled: bool, min_value_size: usize) -> LsmStorageOptions 
         },
         manifest_snapshot_threshold_bytes: 0,
         block_cache_capacity: 1024,
+        enable_cache_backfill: true,
     }
 }
 
@@ -65,6 +66,7 @@ fn make_options_with_compaction(vlog_enabled: bool, min_value_size: usize) -> Ls
         },
         manifest_snapshot_threshold_bytes: 0,
         block_cache_capacity: 1024,
+        enable_cache_backfill: true,
     }
 }
 
@@ -119,6 +121,7 @@ fn make_options_with_cache(min_value_size: usize, cache_bytes: u64) -> LsmStorag
         }),
         manifest_snapshot_threshold_bytes: 0,
         block_cache_capacity: 1024,
+        enable_cache_backfill: true,
     }
 }
 
@@ -447,6 +450,7 @@ fn bench_cold_point_get(c: &mut Criterion) {
             },
             manifest_snapshot_threshold_bytes: 0,
             block_cache_capacity: 4, // tiny — forces disk reads
+            enable_cache_backfill: true,
         }
     };
 
@@ -518,6 +522,7 @@ fn bench_flush_throughput(c: &mut Criterion) {
                         },
                         manifest_snapshot_threshold_bytes: 0,
                         block_cache_capacity: 1024,
+                        enable_cache_backfill: true,
                     };
                     let lsm = KvEngine::open(dir.path(), options).unwrap();
                     (dir, lsm, 0usize)
@@ -582,6 +587,7 @@ fn bench_cold_scan(c: &mut Criterion) {
             },
             manifest_snapshot_threshold_bytes: 0,
             block_cache_capacity: 4, // tiny — every block read hits disk
+            enable_cache_backfill: true,
         }
     };
 

--- a/kv-engine/src/bin/kv-engine-cli.rs
+++ b/kv-engine/src/bin/kv-engine-cli.rs
@@ -369,6 +369,7 @@ fn main() -> Result<()> {
             value_separation: None,
             manifest_snapshot_threshold_bytes: 4 << 20, // 4MB
             block_cache_capacity: args.block_cache_capacity,
+            enable_cache_backfill: true,
         },
     )?;
 

--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -46,6 +46,7 @@ fn make_options(vlog: bool, wal: bool) -> LsmStorageOptions {
         },
         manifest_snapshot_threshold_bytes: 4 << 20,
         block_cache_capacity: 8192,
+        enable_cache_backfill: true,
     }
 }
 

--- a/kv-engine/src/block.rs
+++ b/kv-engine/src/block.rs
@@ -31,6 +31,20 @@ impl Block {
         buf.freeze()
     }
 
+    /// Encode without consuming self. Slightly less efficient than [`encode`]`
+    /// (copies `data` instead of moving it), but avoids cloning the block when
+    /// the caller needs to keep the original for cache backfill.
+    pub fn encode_ref(&self) -> Bytes {
+        let mut buf =
+            BytesMut::with_capacity(self.data.len() + (self.offsets.len() + 1) * SIZE_OF_U16);
+        buf.put_slice(&self.data);
+        for o in &self.offsets {
+            buf.put_u16(*o);
+        }
+        buf.put_u16(self.offsets.len() as u16);
+        buf.freeze()
+    }
+
     /// Decode from the data layout, transform the input `data` to a single `Block`
     pub fn decode(data: &[u8]) -> Self {
         assert!(

--- a/kv-engine/src/block.rs
+++ b/kv-engine/src/block.rs
@@ -22,20 +22,29 @@ pub struct Block {
 impl Block {
     /// Encode the internal data to the data layout defined in the block layout.
     /// Consumes self to reuse the `data` buffer — avoids an intermediate allocation.
-    pub fn encode(self) -> Bytes {
+    ///
+    /// Returns an error if the block contains more than 65535 offsets.
+    pub fn encode(self) -> Result<Bytes> {
         let mut buf =
             BytesMut::with_capacity(self.data.len() + (self.offsets.len() + 1) * SIZE_OF_U16);
         buf.put(self.data);
         for o in &self.offsets {
             buf.put_u16(*o);
         }
-        buf.put_u16(self.offsets.len() as u16);
-        buf.freeze()
+        let offsets_len: u16 = self
+            .offsets
+            .len()
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("too many offsets: {}", self.offsets.len()))?;
+        buf.put_u16(offsets_len);
+        Ok(buf.freeze())
     }
 
-    /// Encode without consuming self. Slightly less efficient than [`encode`]`
+    /// Encode without consuming self. Slightly less efficient than [`encode`]
     /// (copies `data` instead of moving it), but avoids cloning the block when
     /// the caller needs to keep the original for cache backfill.
+    ///
+    /// Returns an error if the block contains more than 65535 offsets.
     pub fn encode_ref(&self) -> Result<Bytes> {
         let mut buf =
             BytesMut::with_capacity(self.data.len() + (self.offsets.len() + 1) * SIZE_OF_U16);

--- a/kv-engine/src/block.rs
+++ b/kv-engine/src/block.rs
@@ -3,6 +3,8 @@ mod iterator;
 
 use std::mem;
 
+use anyhow::Result;
+
 pub use builder::BlockBuilder;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 pub use iterator::BlockIterator;
@@ -34,15 +36,20 @@ impl Block {
     /// Encode without consuming self. Slightly less efficient than [`encode`]`
     /// (copies `data` instead of moving it), but avoids cloning the block when
     /// the caller needs to keep the original for cache backfill.
-    pub fn encode_ref(&self) -> Bytes {
+    pub fn encode_ref(&self) -> Result<Bytes> {
         let mut buf =
             BytesMut::with_capacity(self.data.len() + (self.offsets.len() + 1) * SIZE_OF_U16);
         buf.put_slice(&self.data);
         for o in &self.offsets {
             buf.put_u16(*o);
         }
-        buf.put_u16(self.offsets.len() as u16);
-        buf.freeze()
+        let offsets_len: u16 = self
+            .offsets
+            .len()
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("too many offsets: {}", self.offsets.len()))?;
+        buf.put_u16(offsets_len);
+        Ok(buf.freeze())
     }
 
     /// Decode from the data layout, transform the input `data` to a single `Block`

--- a/kv-engine/src/cache.rs
+++ b/kv-engine/src/cache.rs
@@ -182,6 +182,12 @@ impl BlockCache {
     }
 
     /// Approximate number of cached entries.  O(1), lock-free.
+    ///
+    /// **Drift:** This counter is incremented on insert but only decremented on
+    /// [`invalidate_ssts`], not on TinyUFO eviction.  With cache backfill enabled
+    /// (inserting many blocks per flush/compaction), the drift can grow faster
+    /// because `force_put` evictions are invisible.  Treat the return value as an
+    /// upper bound, not an exact count.
     pub fn entry_count(&self) -> u64 {
         self.count.load(Ordering::Relaxed)
     }

--- a/kv-engine/src/cache.rs
+++ b/kv-engine/src/cache.rs
@@ -185,6 +185,30 @@ impl BlockCache {
     pub fn entry_count(&self) -> u64 {
         self.count.load(Ordering::Relaxed)
     }
+
+    /// Insert a batch of blocks for a newly created SST into the cache.
+    ///
+    /// Used by flush and compaction threads to warm the cache with newly
+    /// produced blocks.  Bypasses single-flight miss coalescing (there are
+    /// no concurrent misses for brand-new blocks) and updates the reverse
+    /// index in one batch.
+    pub fn backfill(&self, sst_id: usize, blocks: Vec<Arc<Block>>) {
+        if blocks.is_empty() {
+            return;
+        }
+        let num_blocks = blocks.len();
+        // Insert into cache outside the sst_blocks lock to avoid blocking
+        // concurrent readers during force_put (which may trigger eviction).
+        let mut keys = Vec::with_capacity(num_blocks);
+        for (idx, block) in blocks.into_iter().enumerate() {
+            let key = (sst_id, idx);
+            self.inner.force_put(key, block, 1);
+            keys.push(key);
+        }
+        self.count.fetch_add(num_blocks as u64, Ordering::Relaxed);
+        let mut index = self.sst_blocks.lock();
+        index.entry(sst_id).or_default().extend(keys);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -487,6 +511,33 @@ mod tests {
         // Closure should have run exactly once (single-flight on success).
         assert_eq!(calls.load(Ordering::Relaxed), 1);
         assert_eq!(cache.entry_count(), 1);
+    }
+
+    #[test]
+    fn block_cache_backfill_inserts_blocks() {
+        let cache = BlockCache::new(64);
+        let blocks: Vec<Arc<Block>> = (0..3).map(|i| make_block(&[i as u8; 4])).collect();
+
+        cache.backfill(1, blocks);
+
+        // All 3 blocks should be cached.
+        assert_eq!(cache.entry_count(), 3);
+        for i in 0..3 {
+            let b = cache.inner.get(&(1, i));
+            assert!(b.is_some(), "block {i} should be in cache");
+            assert_eq!(&b.unwrap().data[..], &[i as u8; 4]);
+        }
+
+        // Reverse index should have all 3 keys.
+        let index = cache.sst_blocks.lock();
+        assert_eq!(index.get(&1).unwrap().len(), 3);
+    }
+
+    #[test]
+    fn block_cache_backfill_empty_is_noop() {
+        let cache = BlockCache::new(64);
+        cache.backfill(1, vec![]);
+        assert_eq!(cache.entry_count(), 0);
     }
 
     #[test]

--- a/kv-engine/src/cache.rs
+++ b/kv-engine/src/cache.rs
@@ -213,7 +213,10 @@ impl BlockCache {
         }
         self.count.fetch_add(num_blocks as u64, Ordering::Relaxed);
         let mut index = self.sst_blocks.lock();
-        index.entry(sst_id).or_default().extend(keys);
+        index
+            .entry(sst_id)
+            .or_insert_with(|| AHashSet::with_capacity(num_blocks))
+            .extend(keys);
     }
 }
 

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -123,18 +123,21 @@ impl LsmStorageInner {
         let mut ret = vec![];
         let mut all_vlog_ids = vec![];
         let mut builder = SsTableBuilder::new(self.options.block_size);
+        builder.set_collect_blocks(self.options.enable_cache_backfill);
 
         while iter.is_valid() {
             if builder.estimated_size() >= self.options.target_sst_size {
                 all_vlog_ids.extend_from_slice(builder.vlog_file_ids());
                 let sst_id = self.next_sst_id();
-                let sst = builder.build(
+                let (sst, blocks) = builder.build_with_backfill(
                     sst_id,
                     Some(self.block_cache.clone()),
                     self.path_of_sst(sst_id),
                 )?;
+                self.block_cache.backfill(sst_id, blocks);
                 ret.push(Arc::new(sst));
                 builder = SsTableBuilder::new(self.options.block_size);
+                builder.set_collect_blocks(self.options.enable_cache_backfill);
             }
 
             // Detect tombstones: non-vlog mode uses empty values, vlog mode uses [KvKind::Inline:1]
@@ -150,11 +153,12 @@ impl LsmStorageInner {
         if !builder.is_empty() {
             all_vlog_ids.extend_from_slice(builder.vlog_file_ids());
             let sst_id = self.next_sst_id();
-            let sst = builder.build(
+            let (sst, blocks) = builder.build_with_backfill(
                 sst_id,
                 Some(self.block_cache.clone()),
                 self.path_of_sst(sst_id),
             )?;
+            self.block_cache.backfill(sst_id, blocks);
             ret.push(Arc::new(sst));
         }
 

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -176,6 +176,12 @@ impl LsmStorageInner {
         // Batch-backfill after all SSTs are produced to keep the compaction
         // loop tight. Cache warming latency is the same total work but no
         // longer interrupts the compaction pipeline between SSTs.
+        //
+        // NOTE: `backfill_queue` temporarily holds all output blocks in memory
+        // until compaction finishes. For a large compaction this can spike RSS
+        // by roughly the output SST size. This is bounded by
+        // `target_sst_size * num_output_ssts` and is released once backfill
+        // completes.
         for (sst_id, blocks) in backfill_queue {
             self.block_cache.backfill(sst_id, blocks);
         }

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -13,7 +13,6 @@ pub use simple_leveled::{
 pub use tiered::{TieredCompactionController, TieredCompactionOptions, TieredCompactionTask};
 
 use crate::{
-    block::Block,
     iterators::{
         StorageIterator, concat_iterator::SstConcatIterator, merge_iterator::MergeIterator,
         two_merge_iterator::TwoMergeIterator,
@@ -128,7 +127,6 @@ impl LsmStorageInner {
 
         let mut ret = vec![];
         let mut all_vlog_ids = vec![];
-        let mut backfill_queue: Vec<(usize, Vec<Arc<Block>>)> = Vec::new();
         let mut builder = SsTableBuilder::new(self.options.block_size);
         builder.set_collect_blocks(should_backfill);
 
@@ -142,7 +140,7 @@ impl LsmStorageInner {
                     self.path_of_sst(sst_id),
                 )?;
                 if should_backfill {
-                    backfill_queue.push((sst_id, blocks));
+                    self.block_cache.backfill(sst_id, blocks);
                 }
                 ret.push(Arc::new(sst));
                 builder = SsTableBuilder::new(self.options.block_size);
@@ -168,22 +166,9 @@ impl LsmStorageInner {
                 self.path_of_sst(sst_id),
             )?;
             if should_backfill {
-                backfill_queue.push((sst_id, blocks));
+                self.block_cache.backfill(sst_id, blocks);
             }
             ret.push(Arc::new(sst));
-        }
-
-        // Batch-backfill after all SSTs are produced to keep the compaction
-        // loop tight. Cache warming latency is the same total work but no
-        // longer interrupts the compaction pipeline between SSTs.
-        //
-        // NOTE: `backfill_queue` temporarily holds all output blocks in memory
-        // until compaction finishes. For a large compaction this can spike RSS
-        // by roughly the output SST size. This is bounded by
-        // `target_sst_size * num_output_ssts` and is released once backfill
-        // completes.
-        for (sst_id, blocks) in backfill_queue {
-            self.block_cache.backfill(sst_id, blocks);
         }
 
         all_vlog_ids.sort_unstable();

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -13,6 +13,7 @@ pub use simple_leveled::{
 pub use tiered::{TieredCompactionController, TieredCompactionOptions, TieredCompactionTask};
 
 use crate::{
+    block::Block,
     iterators::{
         StorageIterator, concat_iterator::SstConcatIterator, merge_iterator::MergeIterator,
         two_merge_iterator::TwoMergeIterator,
@@ -120,10 +121,16 @@ impl LsmStorageInner {
         mut iter: impl for<'a> StorageIterator<KeyType<'a> = KeySlice<'a>> + 'static,
         compact_to_bottom_level: bool,
     ) -> Result<(Vec<Arc<SsTable>>, Vec<u32>)> {
+        // Only backfill upper-level compactions (e.g. L0→L1). Deep-level
+        // compactions operate on cold data — backfilling them would evict
+        // hotter blocks via force_put before invalidate_ssts frees capacity.
+        let should_backfill = self.options.enable_cache_backfill && !compact_to_bottom_level;
+
         let mut ret = vec![];
         let mut all_vlog_ids = vec![];
+        let mut backfill_queue: Vec<(usize, Vec<Arc<Block>>)> = Vec::new();
         let mut builder = SsTableBuilder::new(self.options.block_size);
-        builder.set_collect_blocks(self.options.enable_cache_backfill);
+        builder.set_collect_blocks(should_backfill);
 
         while iter.is_valid() {
             if builder.estimated_size() >= self.options.target_sst_size {
@@ -134,10 +141,12 @@ impl LsmStorageInner {
                     Some(self.block_cache.clone()),
                     self.path_of_sst(sst_id),
                 )?;
-                self.block_cache.backfill(sst_id, blocks);
+                if should_backfill {
+                    backfill_queue.push((sst_id, blocks));
+                }
                 ret.push(Arc::new(sst));
                 builder = SsTableBuilder::new(self.options.block_size);
-                builder.set_collect_blocks(self.options.enable_cache_backfill);
+                builder.set_collect_blocks(should_backfill);
             }
 
             // Detect tombstones: non-vlog mode uses empty values, vlog mode uses [KvKind::Inline:1]
@@ -158,8 +167,17 @@ impl LsmStorageInner {
                 Some(self.block_cache.clone()),
                 self.path_of_sst(sst_id),
             )?;
-            self.block_cache.backfill(sst_id, blocks);
+            if should_backfill {
+                backfill_queue.push((sst_id, blocks));
+            }
             ret.push(Arc::new(sst));
+        }
+
+        // Batch-backfill after all SSTs are produced to keep the compaction
+        // loop tight. Cache warming latency is the same total work but no
+        // longer interrupts the compaction pipeline between SSTs.
+        for (sst_id, blocks) in backfill_queue {
+            self.block_cache.backfill(sst_id, blocks);
         }
 
         all_vlog_ids.sort_unstable();

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -107,6 +107,10 @@ pub struct LsmStorageOptions {
     /// Maximum number of entries in the block cache. Minimum 1.
     /// Defaults to 8192 (~32MB with 4KB blocks). Use 1024 for tests.
     pub block_cache_capacity: u64,
+    /// Whether to backfill the block cache with newly produced blocks during
+    /// flush and compaction. When enabled, recently flushed data stays warm in
+    /// cache, eliminating the cache-miss cliff. Defaults to `true`.
+    pub enable_cache_backfill: bool,
 }
 
 impl LsmStorageOptions {
@@ -121,6 +125,7 @@ impl LsmStorageOptions {
             value_separation: None,
             manifest_snapshot_threshold_bytes: 0, // disabled by default in tests
             block_cache_capacity: 1024,
+            enable_cache_backfill: true,
         }
     }
 
@@ -135,6 +140,7 @@ impl LsmStorageOptions {
             value_separation: None,
             manifest_snapshot_threshold_bytes: 0,
             block_cache_capacity: 1024,
+            enable_cache_backfill: true,
         }
     }
 
@@ -149,6 +155,7 @@ impl LsmStorageOptions {
             value_separation: None,
             manifest_snapshot_threshold_bytes: 0,
             block_cache_capacity: 1024,
+            enable_cache_backfill: true,
         }
     }
 }
@@ -1178,15 +1185,17 @@ impl LsmStorageInner {
             )?;
             let mut builder =
                 SsTableBuilder::new_with_vlog(self.options.block_size, vlog_builder, vs_opts);
+            builder.set_collect_blocks(self.options.enable_cache_backfill);
             memtable_to_flush.flush(&mut builder)?;
             let vlog_ids = builder.vlog_file_ids().to_vec();
-            // Extract vLog index entries before build() consumes the builder
+            // Extract vLog index entries before build_with_backfill() consumes the builder
             let vlog_index_entries = builder.take_vlog_entries();
-            let sst = builder.build(
+            let (sst, blocks) = builder.build_with_backfill(
                 sst_id,
                 Some(self.block_cache.clone()),
                 self.path_of_sst(sst_id),
             )?;
+            self.block_cache.backfill(sst_id, blocks);
             // Register vLog references
             if !vlog_ids.is_empty() {
                 vlog.register_sst_references(sst_id, &vlog_ids);
@@ -1209,12 +1218,14 @@ impl LsmStorageInner {
             (sst, vlog_ids)
         } else {
             let mut builder = SsTableBuilder::new(self.options.block_size);
+            builder.set_collect_blocks(self.options.enable_cache_backfill);
             memtable_to_flush.flush(&mut builder)?;
-            let sst = builder.build(
+            let (sst, blocks) = builder.build_with_backfill(
                 sst_id,
                 Some(self.block_cache.clone()),
                 self.path_of_sst(sst_id),
             )?;
+            self.block_cache.backfill(sst_id, blocks);
             (sst, vec![])
         };
 

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -8,7 +8,7 @@ use super::{
     bloom::{self, Bloom},
 };
 use crate::{
-    block::BlockBuilder,
+    block::{Block, BlockBuilder},
     key::{KeyBytes, KeySlice},
     lsm_storage::BlockCache,
     vlog::{KvKind, ValueLogBuilder, ValuePointer, ValueSeparationOptions, index::VlogIndexEntry},
@@ -27,6 +27,11 @@ pub struct SsTableBuilder {
     /// Whether any entry has been added. Used by `is_empty()` and `build()`
     /// to guard against calling `key_at()` on an empty builder.
     has_data: bool,
+    /// Collected blocks for cache backfill. Only populated when
+    /// `collect_blocks` is true (e.g., during flush and compaction).
+    collected_blocks: Vec<Arc<Block>>,
+    /// Whether to collect blocks during build for cache backfill.
+    collect_blocks: bool,
 }
 
 impl SsTableBuilder {
@@ -42,6 +47,8 @@ impl SsTableBuilder {
             vlog_options: ValueSeparationOptions::default(),
             referenced_vlog_ids: Vec::new(),
             has_data: false,
+            collected_blocks: Vec::new(),
+            collect_blocks: false,
         }
     }
 
@@ -62,7 +69,15 @@ impl SsTableBuilder {
             vlog_options,
             referenced_vlog_ids: vec![file_id],
             has_data: false,
+            collected_blocks: Vec::new(),
+            collect_blocks: false,
         }
+    }
+
+    /// Enable or disable block collection for cache backfill.
+    /// When enabled, `build_with_backfill()` will return the collected blocks.
+    pub fn set_collect_blocks(&mut self, collect: bool) {
+        self.collect_blocks = collect;
     }
 
     pub fn is_empty(&self) -> bool {
@@ -131,7 +146,11 @@ impl SsTableBuilder {
             let first_key = KeyBytes::from_bytes(old_builder.key_at(0));
             let last_idx = old_builder.num_entries().saturating_sub(1);
             let last_key = KeyBytes::from_bytes(old_builder.key_at(last_idx));
-            let data = old_builder.build().encode();
+            let block = old_builder.build();
+            if self.collect_blocks {
+                self.collected_blocks.push(Arc::new(block.clone()));
+            }
+            let data = block.encode();
 
             let meta = BlockMeta {
                 offset: self.data.len(),
@@ -182,12 +201,29 @@ impl SsTableBuilder {
 
     /// Builds the SSTable and writes it to the given path. Use the `FileObject` structure to
     /// manipulate the disk objects.
+    ///
+    /// Delegates to [`build_with_backfill`] and discards the collected blocks.
     pub fn build(
-        mut self,
+        self,
         id: usize,
         block_cache: Option<Arc<BlockCache>>,
         path: impl AsRef<Path>,
     ) -> Result<SsTable> {
+        let (sst, _blocks) = self.build_with_backfill(id, block_cache, path)?;
+        Ok(sst)
+    }
+
+    /// Builds the SSTable, writes it to the given path, and returns both the
+    /// SST and the collected blocks (if `collect_blocks` was enabled).
+    ///
+    /// The returned blocks can be inserted into the block cache via
+    /// [`BlockCache::backfill`] to warm the cache after flush or compaction.
+    pub fn build_with_backfill(
+        mut self,
+        id: usize,
+        block_cache: Option<Arc<BlockCache>>,
+        path: impl AsRef<Path>,
+    ) -> Result<(SsTable, Vec<Arc<Block>>)> {
         // Close the vLog builder (fsync) before writing the SST.
         if let Some(vlog) = self.vlog_builder.take() {
             vlog.close()?;
@@ -212,7 +248,11 @@ impl SsTableBuilder {
         };
         self.meta.push(meta);
 
-        let data = self.builder.build().encode();
+        let final_block = self.builder.build();
+        if self.collect_blocks {
+            self.collected_blocks.push(Arc::new(final_block.clone()));
+        }
+        let data = final_block.encode();
         self.data.extend(data);
         let mut buf = self.data;
 
@@ -228,7 +268,7 @@ impl SsTableBuilder {
 
         let file = FileObject::create(path.as_ref(), buf)?;
 
-        Ok(SsTable {
+        let sst = SsTable {
             file,
             block_meta: self.meta.clone(),
             block_meta_offset: meta_offset,
@@ -238,7 +278,8 @@ impl SsTableBuilder {
             last_key: self.meta[self.meta.len() - 1].last_key.clone(),
             bloom: Some(bloom),
             max_ts: 0,
-        })
+        };
+        Ok((sst, self.collected_blocks))
     }
 
     #[cfg(test)]

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -152,7 +152,7 @@ impl SsTableBuilder {
                 self.collected_blocks.push(Arc::new(block));
                 data
             } else {
-                block.encode()
+                block.encode()?
             };
 
             let meta = BlockMeta {
@@ -257,7 +257,7 @@ impl SsTableBuilder {
             self.collected_blocks.push(Arc::new(final_block));
             data
         } else {
-            final_block.encode()
+            final_block.encode()?
         };
         self.data.extend(data);
         let mut buf = self.data;

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -148,7 +148,7 @@ impl SsTableBuilder {
             let last_key = KeyBytes::from_bytes(old_builder.key_at(last_idx));
             let block = old_builder.build();
             let data = if self.collect_blocks {
-                let data = block.encode_ref();
+                let data = block.encode_ref()?;
                 self.collected_blocks.push(Arc::new(block));
                 data
             } else {
@@ -253,7 +253,7 @@ impl SsTableBuilder {
 
         let final_block = self.builder.build();
         let data = if self.collect_blocks && self.has_data {
-            let data = final_block.encode_ref();
+            let data = final_block.encode_ref()?;
             self.collected_blocks.push(Arc::new(final_block));
             data
         } else {

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -147,10 +147,13 @@ impl SsTableBuilder {
             let last_idx = old_builder.num_entries().saturating_sub(1);
             let last_key = KeyBytes::from_bytes(old_builder.key_at(last_idx));
             let block = old_builder.build();
-            if self.collect_blocks {
-                self.collected_blocks.push(Arc::new(block.clone()));
-            }
-            let data = block.encode();
+            let data = if self.collect_blocks {
+                let data = block.encode_ref();
+                self.collected_blocks.push(Arc::new(block));
+                data
+            } else {
+                block.encode()
+            };
 
             let meta = BlockMeta {
                 offset: self.data.len(),
@@ -249,10 +252,13 @@ impl SsTableBuilder {
         self.meta.push(meta);
 
         let final_block = self.builder.build();
-        if self.collect_blocks {
-            self.collected_blocks.push(Arc::new(final_block.clone()));
-        }
-        let data = final_block.encode();
+        let data = if self.collect_blocks && self.has_data {
+            let data = final_block.encode_ref();
+            self.collected_blocks.push(Arc::new(final_block));
+            data
+        } else {
+            final_block.encode()
+        };
         self.data.extend(data);
         let mut buf = self.data;
 
@@ -268,14 +274,28 @@ impl SsTableBuilder {
 
         let file = FileObject::create(path.as_ref(), buf)?;
 
+        if self.collect_blocks && self.has_data {
+            debug_assert_eq!(
+                self.collected_blocks.len(),
+                self.meta.len(),
+                "backfill block count mismatch: collected {} but SST has {} meta entries",
+                self.collected_blocks.len(),
+                self.meta.len()
+            );
+        }
+
+        let meta = mem::take(&mut self.meta);
+        let first_key = meta[0].first_key.clone();
+        let last_key = meta[meta.len() - 1].last_key.clone();
+
         let sst = SsTable {
             file,
-            block_meta: self.meta.clone(),
+            block_meta: meta,
             block_meta_offset: meta_offset,
             id,
             block_cache,
-            first_key: self.meta[0].first_key.clone(),
-            last_key: self.meta[self.meta.len() - 1].last_key.clone(),
+            first_key,
+            last_key,
             bloom: Some(bloom),
             max_ts: 0,
         };

--- a/kv-engine/src/tests.rs
+++ b/kv-engine/src/tests.rs
@@ -1,5 +1,6 @@
 mod block;
 mod bloom_compression;
+mod cache_backfill;
 mod compaction;
 mod compaction_integration;
 mod compaction_integration_2;

--- a/kv-engine/src/tests/block.rs
+++ b/kv-engine/src/tests/block.rs
@@ -96,7 +96,7 @@ fn test_block_build_all() {
 #[test]
 fn test_block_encode() {
     let block = generate_block();
-    block.encode();
+    block.encode().unwrap();
 }
 
 #[test]
@@ -104,7 +104,7 @@ fn test_block_decode() {
     let block = generate_block();
     let expected_offsets = block.offsets.clone();
     let expected_data = block.data.clone();
-    let encoded = block.encode();
+    let encoded = block.encode().unwrap();
     let decoded_block = Block::decode(&encoded);
     assert_eq!(expected_offsets, decoded_block.offsets);
     assert_eq!(expected_data, decoded_block.data);
@@ -176,7 +176,7 @@ fn test_block_builder_key_at_empty_first_key() {
     // preserve the entry data. (BlockIterator treats an empty key as "invalid" by
     // existing design, so we verify the decoded layout directly.)
     let block = builder.build();
-    let encoded = block.encode();
+    let encoded = block.encode().unwrap();
     let decoded = Block::decode(&encoded);
     assert_eq!(decoded.offsets.len(), 3);
     assert!(!decoded.data.is_empty());

--- a/kv-engine/src/tests/cache_backfill.rs
+++ b/kv-engine/src/tests/cache_backfill.rs
@@ -1,0 +1,103 @@
+//! Integration tests for cache backfill on flush and compaction.
+
+use tempfile::tempdir;
+
+use crate::{
+    lsm_storage::{KvEngine, LsmStorageOptions},
+    tests::harness::sync,
+};
+
+/// After a flush with backfill enabled, the block cache should contain
+/// entries for the newly flushed SST.
+#[test]
+fn test_backfill_warms_cache_after_flush() {
+    let dir = tempdir().unwrap();
+    let options = LsmStorageOptions {
+        enable_cache_backfill: true,
+        block_cache_capacity: 1024,
+        ..LsmStorageOptions::default_for_test()
+    };
+    let engine = KvEngine::open(&dir, options).unwrap();
+
+    // Write enough data to produce at least one block.
+    for i in 0..100 {
+        let key = format!("key{:04}", i);
+        let val = format!("val{:04}", i);
+        engine.put(key.as_bytes(), val.as_bytes()).unwrap();
+    }
+    sync(&engine.inner);
+
+    // Blocks should have been backfilled into the cache.
+    let count = engine.inner.block_cache.entry_count();
+    assert!(
+        count > 0,
+        "expected backfilled blocks in cache, got entry_count={count}"
+    );
+}
+
+/// With backfill disabled, flush should NOT insert blocks into the cache.
+#[test]
+fn test_backfill_disabled_no_cache_entries() {
+    let dir = tempdir().unwrap();
+    let options = LsmStorageOptions {
+        enable_cache_backfill: false,
+        block_cache_capacity: 1024,
+        ..LsmStorageOptions::default_for_test()
+    };
+    let engine = KvEngine::open(&dir, options).unwrap();
+
+    for i in 0..100 {
+        let key = format!("key{:04}", i);
+        let val = format!("val{:04}", i);
+        engine.put(key.as_bytes(), val.as_bytes()).unwrap();
+    }
+    sync(&engine.inner);
+
+    // No blocks should be in the cache.
+    assert_eq!(
+        engine.inner.block_cache.entry_count(),
+        0,
+        "backfill disabled: cache should be empty after flush"
+    );
+}
+
+/// After compaction, the engine should remain functional and the cache
+/// should contain entries from backfilled compaction output.
+#[test]
+fn test_backfill_after_compaction() {
+    let dir = tempdir().unwrap();
+    let options = LsmStorageOptions {
+        enable_cache_backfill: true,
+        block_cache_capacity: 4096,
+        ..LsmStorageOptions::default_for_scan_flush_test()
+    };
+    let engine = KvEngine::open(&dir, options).unwrap();
+
+    // Write data and flush twice to create L0 SSTs.
+    for i in 0..100 {
+        let key = format!("key{:04}", i);
+        let val = format!("val{:04}", i);
+        engine.put(key.as_bytes(), val.as_bytes()).unwrap();
+    }
+    sync(&engine.inner);
+    for i in 100..200 {
+        let key = format!("key{:04}", i);
+        let val = format!("val{:04}", i);
+        engine.put(key.as_bytes(), val.as_bytes()).unwrap();
+    }
+    sync(&engine.inner);
+
+    // Cache should have entries from flush backfill.
+    let count = engine.inner.block_cache.entry_count();
+    assert!(
+        count > 0,
+        "expected backfilled blocks after flush, got entry_count={count}"
+    );
+
+    // Verify data is still readable.
+    for i in 0..200 {
+        let key = format!("key{:04}", i);
+        let val = engine.get(key.as_bytes()).unwrap();
+        assert!(val.is_some(), "key{i:04} should exist");
+    }
+}

--- a/kv-engine/src/tests/cache_backfill.rs
+++ b/kv-engine/src/tests/cache_backfill.rs
@@ -3,6 +3,7 @@
 use tempfile::tempdir;
 
 use crate::{
+    compact::{CompactionOptions, LeveledCompactionOptions},
     lsm_storage::{KvEngine, LsmStorageOptions},
     tests::harness::sync,
 };
@@ -62,42 +63,47 @@ fn test_backfill_disabled_no_cache_entries() {
 }
 
 /// After compaction, the engine should remain functional and the cache
-/// should contain entries from backfilled compaction output.
+/// should still contain entries from flush backfill. Note:
+/// `force_full_compaction` compacts to the bottom level, which skips
+/// backfill (by design — only upper-level compactions backfill).
 #[test]
 fn test_backfill_after_compaction() {
     let dir = tempdir().unwrap();
     let options = LsmStorageOptions {
         enable_cache_backfill: true,
         block_cache_capacity: 4096,
-        ..LsmStorageOptions::default_for_scan_flush_test()
+        ..LsmStorageOptions::default_for_test()
     };
     let engine = KvEngine::open(&dir, options).unwrap();
 
-    // Write data and flush twice to create L0 SSTs.
-    for i in 0..100 {
-        let key = format!("key{:04}", i);
-        let val = format!("val{:04}", i);
-        engine.put(key.as_bytes(), val.as_bytes()).unwrap();
+    // Write data and flush to populate the cache via backfill.
+    for batch in 0..3 {
+        for i in 0..100 {
+            let key = format!("key{:06}", batch * 100 + i);
+            let val = format!("val{:06}", batch * 100 + i);
+            engine.put(key.as_bytes(), val.as_bytes()).unwrap();
+        }
+        sync(&engine.inner);
     }
-    sync(&engine.inner);
-    for i in 100..200 {
-        let key = format!("key{:04}", i);
-        let val = format!("val{:04}", i);
-        engine.put(key.as_bytes(), val.as_bytes()).unwrap();
-    }
-    sync(&engine.inner);
 
     // Cache should have entries from flush backfill.
-    let count = engine.inner.block_cache.entry_count();
+    let count_before = engine.inner.block_cache.entry_count();
     assert!(
-        count > 0,
-        "expected backfilled blocks after flush, got entry_count={count}"
+        count_before > 0,
+        "expected backfilled blocks after flush, got entry_count={count_before}"
     );
 
-    // Verify data is still readable.
-    for i in 0..200 {
-        let key = format!("key{:04}", i);
-        let val = engine.get(key.as_bytes()).unwrap();
-        assert!(val.is_some(), "key{i:04} should exist");
+    // Force compaction. This compacts to bottom level so backfill is skipped,
+    // but the engine should remain functional and existing cache entries
+    // for non-compacted SSTs should survive.
+    engine.force_full_compaction().unwrap();
+
+    // Verify data is still readable after compaction.
+    for batch in 0..3 {
+        for i in 0..100 {
+            let key = format!("key{:06}", batch * 100 + i);
+            let val = engine.get(key.as_bytes()).unwrap();
+            assert!(val.is_some(), "{key} should exist after compaction");
+        }
     }
 }

--- a/kv-engine/src/tests/cache_backfill.rs
+++ b/kv-engine/src/tests/cache_backfill.rs
@@ -3,7 +3,6 @@
 use tempfile::tempdir;
 
 use crate::{
-    compact::{CompactionOptions, LeveledCompactionOptions},
     lsm_storage::{KvEngine, LsmStorageOptions},
     tests::harness::sync,
 };

--- a/kv-engine/src/tests/vlog_integration_tests/cache.rs
+++ b/kv-engine/src/tests/vlog_integration_tests/cache.rs
@@ -18,6 +18,7 @@ fn test_value_cache_hit_miss() {
         }),
         manifest_snapshot_threshold_bytes: 0,
         block_cache_capacity: 1024,
+        enable_cache_backfill: true,
     };
     let storage = KvEngine::open(dir.path(), options).unwrap();
 
@@ -81,6 +82,7 @@ fn test_value_cache_disabled_by_default() {
         }),
         manifest_snapshot_threshold_bytes: 0,
         block_cache_capacity: 1024,
+        enable_cache_backfill: true,
     };
     let storage = KvEngine::open(dir.path(), options).unwrap();
 
@@ -119,6 +121,7 @@ fn test_value_cache_enabled_by_default() {
         }),
         manifest_snapshot_threshold_bytes: 0,
         block_cache_capacity: 1024,
+        enable_cache_backfill: true,
     };
     let storage = KvEngine::open(dir.path(), options).unwrap();
 

--- a/kv-engine/src/tests/vlog_integration_tests/mod.rs
+++ b/kv-engine/src/tests/vlog_integration_tests/mod.rs
@@ -33,6 +33,7 @@ fn options_with_vlog_enabled(block_size: usize, target_sst_size: usize) -> LsmSt
         }),
         manifest_snapshot_threshold_bytes: 0,
         block_cache_capacity: 1024,
+        enable_cache_backfill: true,
     }
 }
 
@@ -62,6 +63,7 @@ fn options_with_vlog_and_compaction(
         }),
         manifest_snapshot_threshold_bytes: 0,
         block_cache_capacity: 1024,
+        enable_cache_backfill: true,
     }
 }
 


### PR DESCRIPTION
## Summary

Implements RFC 004: cache backfill on flush and compaction to eliminate the cache-miss cliff after SST production.

## Changes

### Core
- **`BlockCache::backfill(sst_id, blocks)`** — batch insert blocks into cache with force-put, bypassing TinyLFU admission
- **`Block::encode_ref(&self)`** — non-consuming encode returning `Result<Bytes>` with safe `try_into()` conversion
- **`Block::encode(self)`** — consuming encode returning `Result<Bytes>` with safe `try_into()` conversion
- **`SsTableBuilder`** — `collected_blocks` field + `build_with_backfill()` returning `(SsTable, Vec<Arc<Block>>)`
- **Flush path** — backfills after memtable flush (both vLog and non-vLog branches)
- **Compaction** — L0-only heuristic (`compact_to_bottom_level=false`), inline backfill per SST

### Configuration
- `LsmStorageOptions::enable_cache_backfill` (default: true)

### Tests
- `test_backfill_warms_cache_after_flush` — verifies cache entries exist after flush
- `test_backfill_disabled_no_cache_entries` — verifies opt-out works
- `test_backfill_after_compaction` — verifies data integrity after compaction with backfill

## Review Fixes

| Issue | Source | Fix |
|-------|--------|-----|
| Phantom block for empty SST | Kimi | Guard final block collection with `has_data` |
| Block clone overhead | Kimi | Added `encode_ref(&self)` non-consuming encode |
| `self.meta` Vec clone on build | Kimi | `mem::take` to move instead of clone |
| `debug_assert` fires when `collect_blocks=false` | Kimi | Guard with `collect_blocks && has_data` |
| `entry_count` drift documentation | Kimi | Documented in doc comment |
| L0-only heuristic | Kimi | Skip backfill for `compact_to_bottom_level` |
| Batch backfill memory spike | Kimi | Removed `backfill_queue`, inline backfill per SST |
| AHashSet default capacity | Gemini | Pre-allocate with `num_blocks` capacity |
| `as u16` truncation in `encode_ref` | Gemini | Use `try_into()` with error propagation |
| backfill_queue RSS spike | Gemini | Inline backfill, removed queue entirely |
| `as u16` truncation in `encode()` | CodeRabbit | Use `try_into()` with error propagation |
| `encode_ref` doc missing fallibility | CodeRabbit | Updated doc comments for both encode methods |
| Unused imports in tests | CodeRabbit | Removed `CompactionOptions`, `LeveledCompactionOptions` |