### PR TITLE
docs: update all docs to reflect current codebase state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,9 @@ A toy LSM-tree-based key-value storage engine written in Rust. This is an educat
 
 Key dependencies:
 - `crossbeam-skiplist` — lock-free memtable
+- `arc-swap` — lock-free state snapshot (replaces RwLock for reads)
 - `parking_lot` — synchronization primitives
-- `tinyufo` — block cache and vLog reader cache
+- `tinyufo` — block cache and vLog reader cache (lock-free S3-FIFO)
 - `bytes` — zero-copy byte buffers
 - `crc32fast` — checksums
 - `ahash` — bloom filter hashing (AES-NI accelerated)
@@ -32,9 +33,14 @@ Key dependencies:
 ├── .typos.toml             # Spell-check allowlist
 ├── lsan-suppressions.txt   # LeakSanitizer suppressions
 ├── docs/
-│   └── bench-report-vlog.md
+│   ├── bench-report-vlog.md
+│   ├── io-uring-bench.md
+│   └── perf-profile.md
 ├── rfcs/
-│   └── 001-key-value-separation.md
+│   ├── 001-key-value-separation.md
+│   ├── 002-io-uring-disk-writes.md
+│   ├── 003-thread-per-core-compio.md
+│   └── 004-cache-backfill.md
 └── kv-engine/
     ├── Cargo.toml
     ├── README.md
@@ -45,6 +51,7 @@ Key dependencies:
         ├── bin/
         │   ├── kv-engine-cli.rs       # Interactive REPL CLI
         │   ├── compaction-simulator.rs
+        │   ├── write-perf.rs          # Benchmark binary (19 workloads)
         │   └── wrapper.rs
         ├── block.rs                   # SST block format
         ├── block/
@@ -79,11 +86,14 @@ Key dependencies:
         │   ├── mod.rs
         │   ├── builder.rs
         │   ├── reader.rs
-        │   └── gc.rs
+        │   ├── gc.rs
+        │   └── index.rs               # Per-file .vidx companion index for GC
+        ├── cache.rs                   # Block cache (TinyUFO, lock-free)
         ├── debug.rs
         └── tests/                     # Integration tests
             ├── block.rs
             ├── bloom_compression.rs
+            ├── cache_backfill.rs
             ├── compaction.rs
             ├── compaction_integration.rs
             ├── compaction_integration_2.rs
@@ -214,6 +224,7 @@ Run `cargo fmt --all` before committing. CI enforces `cargo fmt --check`.
 - `tests::memtable` — memtable operations
 - `tests::compaction` / `compaction_integration*` / `*compaction` — compaction strategies
 - `tests::bloom_compression` — bloom filter false-positive rates
+- `tests::cache_backfill` — cache backfill on flush and compaction
 - `tests::harness` — shared test utilities
 
 ## Security Considerations
@@ -236,6 +247,7 @@ Note: Miri is disabled because `crossbeam-skiplist` uses epoch-based GC incompat
 ### Runtime Safety
 
 - The engine uses `crossbeam-epoch` for lock-free data structures.
+- `arc-swap` provides lock-free atomic state snapshots for reads.
 - `parking_lot` is used for mutexes/rwlocks instead of `std::sync`.
 - CRC32 checksums protect SST blocks and vLog entries.
 - vLog entries include key validation on read to detect stale/corrupted pointers.
@@ -251,7 +263,7 @@ Note: Miri is disabled because `crossbeam-skiplist` uses epoch-based GC incompat
 - `levels` — L1+ tiers or levels
 - `sstables` — map of SST ID → `Arc<SsTable>`
 
-State mutations follow a copy-on-write pattern: the state is behind `Arc<RwLock<Arc<...>>>` so readers get snapshots while background tasks (flush, compaction) produce new state versions under a separate `state_lock`.
+State mutations follow a copy-on-write pattern: the state is behind `ArcSwap<LsmStorageState>` so readers get lock-free snapshots via atomic load. Background tasks (flush, compaction) produce new state versions under a `state_lock` mutex. An `active_memtable_lock: RwLock<()>` prevents write-loss during memtable freeze.
 
 ### Key-Value Separation (vLog)
 
@@ -283,6 +295,18 @@ Enable via `LsmStorageOptions::value_separation`.
 ### WAL
 
 Write-ahead logging is optional (`enable_wal: bool`). When enabled, each memtable has an associated WAL file for crash recovery.
+
+### Block Cache
+
+`cache.rs` implements a lock-free block cache using Cloudflare's `TinyUFO` (S3-FIFO + TinyLFU). Configurable capacity via `block_cache_capacity` (default 1792 blocks). Per-key single-flight coalesces concurrent cache-miss I/O for the same block.
+
+### Cache Backfill
+
+On flush and compaction, newly produced SST blocks are inserted into the block cache via `force_put` (bypasses TinyUFO admission). Flush backfill captures blocks from `SsTableBuilder` in-memory (zero extra I/O). Compaction backfill covers L0/L1/L2 tiered compactions. See [RFC 004](rfcs/004-cache-backfill.md).
+
+### vLog Index
+
+`vlog/index.rs` maintains per-file `.vidx` companion files that map keys to their vLog entry locations. This optimizes GC liveness analysis by avoiding full header scans. Indices are loaded lazily on first GC access and persisted after each flush.
 
 ## Development Workflow
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A toy LSM-tree-based key-value storage engine written in Rust. This is an educat
 - **Compaction Strategies**: Simple leveled, leveled, and tiered compaction
 - **Key-Value Separation**: WiscKey-style vLog for large values to reduce write amplification
 - **Block Cache**: Lock-free `TinyUFO` (S3-FIFO + TinyLFU) with cache backfill on flush and compaction
-- **Value Cache**: Dedicated weighted LRU cache for vLog values (configurable, default 64MB)
+- **Value Cache**: TinyUFO-based weighted cache for vLog values (configurable, default 64MB)
 - **vLog Index**: Per-file `.vidx` companion files for GC liveness optimization
 - **Bloom Filters**: ahash-based (AES-NI accelerated) key membership tests
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ A toy LSM-tree-based key-value storage engine written in Rust. This is an educat
 - **WAL**: Optional write-ahead logging for crash recovery
 - **Compaction Strategies**: Simple leveled, leveled, and tiered compaction
 - **Key-Value Separation**: WiscKey-style vLog for large values to reduce write amplification
-- **Block Cache**: Configurable caching with `TinyUFO`
-- **Bloom Filters**: Space-efficient key membership tests
+- **Block Cache**: Lock-free `TinyUFO` (S3-FIFO + TinyLFU) with cache backfill on flush and compaction
+- **Value Cache**: Dedicated weighted LRU cache for vLog values (configurable, default 64MB)
+- **vLog Index**: Per-file `.vidx` companion files for GC liveness optimization
+- **Bloom Filters**: ahash-based (AES-NI accelerated) key membership tests
 
 ## Quick Start
 
@@ -43,18 +45,22 @@ cargo run --bin kv-engine-cli -- --path /tmp/lsm.db --compaction leveled
 ## Project Structure
 
 - `kv-engine/src/lsm_storage.rs` — Core engine state and operations
-- `kv-engine/src/mem_table.rs` — Lock-free skip-list memtable
+- `kv-engine/src/mem_table.rs` — Lock-free skip-list memtable with bloom filter
 - `kv-engine/src/block.rs`, `kv-engine/src/table.rs` — SST block and table formats
 - `kv-engine/src/compact.rs` — Compaction orchestration
 - `kv-engine/src/mvcc.rs` — MVCC transaction support
 - `kv-engine/src/wal.rs` — Write-ahead log
-- `kv-engine/src/vlog/` — Key-value separation
-- `kv-engine/src/bin/` — CLI and compaction simulator
+- `kv-engine/src/vlog/` — Key-value separation (builder, reader, GC, index)
+- `kv-engine/src/cache.rs` — Block cache (TinyUFO)
+- `kv-engine/src/manifest.rs` — SST/vLog manifest tracking
+- `kv-engine/src/bin/` — CLI, compaction simulator, and benchmark binary
 
 ## Documentation
 
 - [vLog Benchmark Report](docs/bench-report-vlog.md)
+- [Performance Profiling Report](docs/perf-profile.md)
 - [Key-Value Separation RFC](rfcs/001-key-value-separation.md)
+- [Cache Backfill RFC](rfcs/004-cache-backfill.md)
 
 ## License
 

--- a/docs/bench-report-vlog.md
+++ b/docs/bench-report-vlog.md
@@ -110,7 +110,7 @@ SST lookup + cache hash probe.
 
 Mitigations:
 - **Value cache** (new): LRU cache keyed by `(file_id, offset)`, configurable via `value_cache_capacity_bytes`
-- vLog reader cache (moka) avoids re-opening files
+- vLog reader cache (TinyUFO) avoids re-opening files
 - Sequential vLog layout benefits from OS readahead
 
 ### 4. Full Scan Throughput

--- a/docs/bench-report-vlog.md
+++ b/docs/bench-report-vlog.md
@@ -109,7 +109,7 @@ to the same keys are served from memory — 99.2% hit rate reduces latency from
 SST lookup + cache hash probe.
 
 Mitigations:
-- **Value cache** (new): LRU cache keyed by `(file_id, offset)`, configurable via `value_cache_capacity_bytes`
+- **Value cache** (new): TinyUFO-based weighted cache keyed by `(file_id, offset)`, configurable via `value_cache_capacity_bytes`
 - vLog reader cache (TinyUFO) avoids re-opening files
 - Sequential vLog layout benefits from OS readahead
 

--- a/docs/perf-profile.md
+++ b/docs/perf-profile.md
@@ -150,7 +150,7 @@ reverse index Mutex ~1%. Total ~1.4%.
 
 3. **Reads were expensive — now optimized.** Before: mixed 50/50 r/w dropped to 319k ops/sec. After: 1.40M ops/sec. The skiplist `try_pin_loop` + epoch pin overhead was eliminated via memtable bloom filter, direct point_get, and ahash.
 
-4. **moka housekeeper was a CPU hog — now mitigated.** Was 63% in write-only, 18% in mixed. After invalidating stale block cache entries on compaction (commit `1803040` follow-up): 9.5% in write-heavy workloads. Remaining cost is mostly `BucketArray::rehash` (4.5%), which would need a different cache library to eliminate.
+4. **moka housekeeper was a CPU hog — now eliminated.** Was 63% in write-only, 18% in mixed. After invalidating stale block cache entries on compaction (commit `1803040` follow-up): 9.5% in write-heavy workloads. Fully eliminated by switching to TinyUFO (PR #55) — no background thread, lock-free S3-FIFO eviction inline during `put()`.
 
 5. **Concurrent writes scale.** 4 threads achieve 1.7x throughput over 1 thread. The lock-free skiplist enables this.
 
@@ -425,11 +425,11 @@ Per-thread breakdown (cpu_atom):
 | rehash | 6.1% | 4.5% | -26% |
 | sync | 1.4% | 1.0% | -29% |
 
-### Remaining Housekeeper Cost
+### Remaining Housekeeper Cost (resolved)
 
-The remaining 9.5% is dominated by `BucketArray::rehash` (4.5%) — moka's internal hash table
-resizing. This is inherent to moka's concurrent hash table design. Switching to `quick-cache`
-or `tinyufo` would eliminate this, but requires more invasive changes.
+The 9.5% was dominated by `BucketArray::rehash` (4.5%) — moka's internal hash table
+resizing. This was resolved by switching to TinyUFO (PR #55), which eliminated the
+housekeeper thread entirely. Cache-related CPU is now ~1.4%.
 
 ---
 
@@ -606,7 +606,7 @@ is not called between start and elapsed).
 | **Write path** | ~15% | `add_inner` (key clone, block encode, mem copy), `put_raw_batch`, `put` | fillseq, fillrandom, overwrite |
 | **Read path (skiplist)** | ~19% | `try_pin_loop`, `get_with_hash`, `RefEntry`, `lookup_memtable` | readrandom, readmissing, mixed |
 | **Read path (allocation)** | ~2% | `promotable_even_clone`, `cfree` | All read workloads |
-| **moka cache** | ~13% | `BucketArray::rehash` (6.1%), `Inner::sync` (2.2%) | All workloads |
+| **TinyUFO cache** | ~1.4% | `tinyufo::estimation::incr_no_overflow`, flurry hash | All workloads |
 | **Epoch GC** | ~3% | `try_advance` | All workloads |
 | **Other** | ~3% | `SkipList`, `try_freeze_memtable` | Mixed |
 
@@ -616,15 +616,18 @@ is not called between start and elapsed).
 - **Read-heavy** (readrandom, readmissing): `crossbeam_skiplist::try_pin_loop` + `MemTable::get_with_hash` — epoch pin + skiplist search
 - **Mixed** (readwhilewriting, readrandomwriterandom): Both paths compete; skiplist reads are the limiting factor
 - **Seek** (seekrandom, seekrandomwhilewriting): Iterator path — merge iterator + block cache lookup
-- **moka housekeeper** (12% across all): `BucketArray::rehash` is the remaining irreducible cost of moka's concurrent hash table
+- **TinyUFO cache** (~1.4% across all): lock-free S3-FIFO eviction, no background thread (moka housekeeper eliminated in PR #55)
 
 ### Remaining Optimization Opportunities
 
 | Optimization | Expected Impact | Effort | Status |
 |-------------|----------------|--------|--------|
-| Replace moka with quick-cache/lru | Eliminate 12% housekeeper+rehash CPU | High | Open |
+| Replace moka with TinyUFO cache | Eliminate housekeeper (9.5-63% CPU) | Medium | ✅ Done (PR #55) |
+| ahash for cache/vlog reverse indexes | ~5-10% on concurrent paths | Low | ✅ Done |
+| Single-flight block cache misses | 2× concurrent read throughput | Medium | ✅ Done |
+| Cache backfill on flush/compaction | Eliminate flush cliff | Medium | ✅ Done (RFC 004) |
 | Zero-allocation reads | ~2% CPU (eliminate `promotable_even_clone`) | Low | Open |
-| Reduce key cloning in `add_inner` | ~3-5% write CPU (3x `to_key_vec` per entry) | Medium | Open |
+| Reduce key cloning in `add_inner` | ~3-5% write CPU (3x `to_key_vec` per entry) | Low | ✅ Done |
 | Avoid intermediate allocation in block encode | ~2-3% write CPU (`build().encode()` double-alloc) | Low | ✅ Done (PR #43) |
 | Replace RwLock with arc-swap for state | Eliminate read lock contention | Low | ✅ Done (PR #44) |
 | Manifest batching with `std::fs` | Reduces manifest fsyncs | Low (10 lines) | ✅ Done (PR #48) |

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -1841,8 +1841,8 @@ This section documents intentional deviations between the original RFC design an
    file. Used by GC to skip header reads during liveness analysis. Rebuilt
    automatically from vLog headers if the index file is missing. See
    `kv-engine/src/vlog/index.rs`.
-5. ~~**Value Caching**~~: Done. Dedicated weighted LRU cache for vLog values
-   using moka, with configurable capacity (default 64MB, set to 0 to disable).
+5. ~~**Value Caching**~~: Done. TinyUFO-based weighted cache for vLog values
+   with configurable capacity (default 64MB, set to 0 to disable).
    Block cache is also now configurable via `LsmStorageOptions::block_cache_capacity`
    (default 1024 entries). `KvEngine::cache_stats()` API exposes hit/miss rates.
    CLI `stats` command prints cache info.


### PR DESCRIPTION
## Summary

Update all documentation to reflect recent changes: TinyUFO cache swap, arc-swap state snapshot, cache backfill (RFC 004), vLog index, value cache, and key-cloning optimization.

## Changes

- **README.md**: add value cache, vLog index, cache backfill features; update project structure and doc links
- **AGENTS.md**: add `cache.rs`, `vlog/index.rs`, `write-perf.rs`, `cache_backfill.rs` to tree; add block cache, cache backfill, vLog index architecture notes; update LSM state to `ArcSwap`; add `arc-swap` dependency
- **docs/perf-profile.md**: mark moka→TinyUFO, ahash, single-flight, cache backfill, key cloning as done; update stale moka conclusions
- **docs/bench-report-vlog.md**: fix stale moka reference for vLog reader cache

## Verification

- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes
- [x] Doc-only changes, no code modified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture and component documentation with clearer descriptions of cache mechanisms and vLog storage features.
  * Enhanced project structure documentation with additional internal modules and benchmark details.
  * Refreshed performance profiling documentation reflecting updated cache implementation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->