### PR TITLE
feat: enable MVCC with timestamped internal key encoding

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,3 +2,9 @@
 slow-timeout = { period = "10s", terminate-after = 3, grace-period = "3s" }
 retries = { backoff = "exponential", count = 3, delay = "1s", jitter = true }
 test-threads = "num-cpus"
+
+# Coverage profile: longer timeout to account for instrumentation overhead
+[profile.coverage]
+slow-timeout = { period = "30s", terminate-after = 3, grace-period = "5s" }
+retries = { backoff = "exponential", count = 3, delay = "1s", jitter = true }
+test-threads = "num-cpus"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -67,6 +67,6 @@ jobs:
         uses: taiki-e/install-action@nextest
       - name: cargo nextest
         if: hashFiles('Cargo.lock') != ''
-        run: cargo +beta nextest run --locked --all-features --all-targets
+        run: cargo +beta nextest run --locked --all-features --lib
         env:
           RUSTFLAGS: -D deprecated

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: cargo llvm-cov
-        run: cargo llvm-cov nextest --locked --workspace --all-features --lib --lcov --output-path lcov.info
+        run: cargo llvm-cov nextest --locked --workspace --all-features --lib --lcov --output-path lcov.info --profile coverage
       - name: Upload to codecov.io
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:

--- a/kv-engine/Cargo.toml
+++ b/kv-engine/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 ignored = ["arc-swap", "crossbeam-epoch"]
 
 [dependencies]
+TinyUFO = "0.8"
 ahash = "0.8"
 anyhow = "1"
 arc-swap = "1"
@@ -17,7 +18,6 @@ crc32fast = "1.3.2"
 crossbeam-channel = "0.5.11"
 crossbeam-epoch = "0.9"
 crossbeam-skiplist = "0.1"
-TinyUFO = "0.8"
 nom = "7.1.3"
 ouroboros = "0.18"
 parking_lot = "0.12"

--- a/kv-engine/Cargo.toml
+++ b/kv-engine/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 ignored = ["arc-swap", "crossbeam-epoch"]
 
 [dependencies]
+TinyUFO = "0.8"
 ahash = "0.8"
 anyhow = "1"
 arc-swap = "1"
@@ -24,7 +25,6 @@ rand = "0.8.5"
 rustyline = "18.0.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
-TinyUFO = "0.8"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/kv-engine/Cargo.toml
+++ b/kv-engine/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 ignored = ["arc-swap", "crossbeam-epoch"]
 
 [dependencies]
-TinyUFO = "0.8"
 ahash = "0.8"
 anyhow = "1"
 arc-swap = "1"
@@ -25,6 +24,7 @@ rand = "0.8.5"
 rustyline = "18.0.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
+TinyUFO = "0.8"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/kv-engine/src/block/iterator.rs
+++ b/kv-engine/src/block/iterator.rs
@@ -169,8 +169,9 @@ impl BlockIterator {
     /// callers.
     pub fn seek_to_key(&mut self, key: KeySlice) {
         let raw = key.raw_ref();
+        let n = self.block.offsets.len();
         let mut lo = 0;
-        let mut hi = self.block.offsets.len() - 1;
+        let mut hi = n;
         while lo < hi {
             let mid = lo + (hi - lo) / 2;
             match self.cmp_entry_at(mid, raw) {

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -63,6 +63,137 @@ impl CompactionTask {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compact_to_bottom_level() {
+        let force = CompactionTask::ForceFullCompaction {
+            l0_sstables: vec![],
+            l1_sstables: vec![],
+        };
+        assert!(force.compact_to_bottom_level());
+
+        let leveled = CompactionTask::Leveled(LeveledCompactionTask {
+            upper_level: Some(1),
+            upper_level_sst_ids: vec![],
+            lower_level: 2,
+            lower_level_sst_ids: vec![],
+            is_lower_level_bottom_level: true,
+        });
+        assert!(leveled.compact_to_bottom_level());
+
+        let leveled_no = CompactionTask::Leveled(LeveledCompactionTask {
+            upper_level: Some(1),
+            upper_level_sst_ids: vec![],
+            lower_level: 2,
+            lower_level_sst_ids: vec![],
+            is_lower_level_bottom_level: false,
+        });
+        assert!(!leveled_no.compact_to_bottom_level());
+
+        let simple = CompactionTask::Simple(SimpleLeveledCompactionTask {
+            upper_level: None,
+            upper_level_sst_ids: vec![],
+            lower_level: 1,
+            lower_level_sst_ids: vec![],
+            is_lower_level_bottom_level: true,
+        });
+        assert!(simple.compact_to_bottom_level());
+
+        let tiered = CompactionTask::Tiered(TieredCompactionTask {
+            tiers: vec![],
+            bottom_tier_included: true,
+        });
+        assert!(tiered.compact_to_bottom_level());
+
+        let tiered_no = CompactionTask::Tiered(TieredCompactionTask {
+            tiers: vec![],
+            bottom_tier_included: false,
+        });
+        assert!(!tiered_no.compact_to_bottom_level());
+    }
+
+    #[test]
+    fn test_is_upper_level_compaction() {
+        let force = CompactionTask::ForceFullCompaction {
+            l0_sstables: vec![],
+            l1_sstables: vec![],
+        };
+        assert!(!force.is_upper_level_compaction());
+
+        // Leveled: lower_level=1 → upper
+        let lev1 = CompactionTask::Leveled(LeveledCompactionTask {
+            upper_level: None,
+            upper_level_sst_ids: vec![],
+            lower_level: 1,
+            lower_level_sst_ids: vec![],
+            is_lower_level_bottom_level: false,
+        });
+        assert!(lev1.is_upper_level_compaction());
+
+        // Leveled: lower_level=2 → upper
+        let lev2 = CompactionTask::Leveled(LeveledCompactionTask {
+            upper_level: Some(1),
+            upper_level_sst_ids: vec![],
+            lower_level: 2,
+            lower_level_sst_ids: vec![],
+            is_lower_level_bottom_level: false,
+        });
+        assert!(lev2.is_upper_level_compaction());
+
+        // Leveled: lower_level=3 → NOT upper
+        let lev3 = CompactionTask::Leveled(LeveledCompactionTask {
+            upper_level: Some(2),
+            upper_level_sst_ids: vec![],
+            lower_level: 3,
+            lower_level_sst_ids: vec![],
+            is_lower_level_bottom_level: true,
+        });
+        assert!(!lev3.is_upper_level_compaction());
+
+        // Simple: lower_level=2 → upper
+        let simp = CompactionTask::Simple(SimpleLeveledCompactionTask {
+            upper_level: None,
+            upper_level_sst_ids: vec![],
+            lower_level: 2,
+            lower_level_sst_ids: vec![],
+            is_lower_level_bottom_level: false,
+        });
+        assert!(simp.is_upper_level_compaction());
+
+        // Simple: lower_level=5 → NOT upper
+        let simp5 = CompactionTask::Simple(SimpleLeveledCompactionTask {
+            upper_level: Some(4),
+            upper_level_sst_ids: vec![],
+            lower_level: 5,
+            lower_level_sst_ids: vec![],
+            is_lower_level_bottom_level: true,
+        });
+        assert!(!simp5.is_upper_level_compaction());
+
+        // Tiered: bottom_tier_included=false → upper (minor compaction)
+        let tiered_minor = CompactionTask::Tiered(TieredCompactionTask {
+            tiers: vec![],
+            bottom_tier_included: false,
+        });
+        assert!(tiered_minor.is_upper_level_compaction());
+
+        // Tiered: bottom_tier_included=true → NOT upper
+        let tiered_major = CompactionTask::Tiered(TieredCompactionTask {
+            tiers: vec![],
+            bottom_tier_included: true,
+        });
+        assert!(!tiered_major.is_upper_level_compaction());
+    }
+
+    #[test]
+    fn test_compaction_controller_flush_to_l0() {
+        assert!(CompactionController::NoCompaction.flush_to_l0());
+    }
+}
+
 pub(crate) enum CompactionController {
     Leveled(LeveledCompactionController),
     Tiered(TieredCompactionController),

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -17,7 +17,7 @@ use crate::{
         StorageIterator, concat_iterator::SstConcatIterator, merge_iterator::MergeIterator,
         two_merge_iterator::TwoMergeIterator,
     },
-    key::{self, KeySlice},
+    key::KeySlice,
     lsm_storage::{LsmStorageInner, LsmStorageState},
     manifest::ManifestRecord,
     table::{SsTable, SsTableBuilder, SsTableIterator},
@@ -170,7 +170,7 @@ impl LsmStorageInner {
             // With MVCC, preserve all versions (including tombstones) so older
             // timestamp reads can still see them. Only drop tombstones at the
             // bottom level in non-MVCC mode.
-            if !is_tombstone || !compact_to_bottom_level || key::TS_ENABLED {
+            if !is_tombstone || !compact_to_bottom_level || self.mvcc.is_some() {
                 builder.add_raw(iter.key(), iter.raw_value())?;
             }
             iter.next()?;
@@ -383,7 +383,7 @@ impl LsmStorageInner {
             };
             self.manifest
                 .as_ref()
-                .unwrap()
+                .expect("manifest initialized")
                 .add_record(&_state_lock, manifest_record)?;
             self.maybe_snapshot_manifest(&_state_lock)?;
         }
@@ -589,14 +589,15 @@ impl LsmStorageInner {
 
             self.sync_dir()?;
             // Use CompactionV2 if vLog is enabled
+            let task = task.expect("task checked for Some above");
             let manifest_record = if self.vlog.is_some() {
-                ManifestRecord::CompactionV2(task.unwrap(), new_sst_ids, compact_vlog_ids)
+                ManifestRecord::CompactionV2(task, new_sst_ids, compact_vlog_ids)
             } else {
-                ManifestRecord::Compaction(task.unwrap(), new_sst_ids)
+                ManifestRecord::Compaction(task, new_sst_ids)
             };
             self.manifest
                 .as_ref()
-                .unwrap()
+                .expect("manifest initialized")
                 .add_record(&_state_lock, manifest_record)?;
             self.maybe_snapshot_manifest(&_state_lock)?;
 

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -17,7 +17,7 @@ use crate::{
         StorageIterator, concat_iterator::SstConcatIterator, merge_iterator::MergeIterator,
         two_merge_iterator::TwoMergeIterator,
     },
-    key::KeySlice,
+    key::{self, KeySlice},
     lsm_storage::{LsmStorageInner, LsmStorageState},
     manifest::ManifestRecord,
     table::{SsTable, SsTableBuilder, SsTableIterator},
@@ -167,7 +167,10 @@ impl LsmStorageInner {
             let raw = iter.raw_value();
             let is_tombstone =
                 raw.is_empty() || (raw.len() == 1 && raw[0] == crate::vlog::KvKind::Inline as u8);
-            if !is_tombstone || !compact_to_bottom_level {
+            // With MVCC, preserve all versions (including tombstones) so older
+            // timestamp reads can still see them. Only drop tombstones at the
+            // bottom level in non-MVCC mode.
+            if !is_tombstone || !compact_to_bottom_level || key::TS_ENABLED {
                 builder.add_raw(iter.key(), iter.raw_value())?;
             }
             iter.next()?;

--- a/kv-engine/src/key.rs
+++ b/kv-engine/src/key.rs
@@ -160,7 +160,10 @@ pub fn decode_user_key_cow(encoded: &[u8]) -> Option<Cow<'_, [u8]>> {
     let mut i = 0;
     while i < term_off {
         if escaped[i] == 0x00 {
-            // Must be 0x00 0xff
+            // Must be 0x00 0xff (escaped zero)
+            if i + 1 >= term_off || escaped[i + 1] != 0xff {
+                return None; // malformed
+            }
             buf.push(0);
             i += 2;
         } else {
@@ -321,7 +324,8 @@ impl<'a> Key<&'a [u8]> {
 
     /// For testing: create from raw bytes with no timestamp encoding.
     /// Returns the raw slice as-is regardless of `TS_ENABLED`.
-    /// For a TS-encoded owned key, use `KeyVec::from_user_key_ts` instead.
+    /// Callers who need a TS-encoded owned key should use
+    /// `KeyVec::from_user_key_ts` instead.
     pub fn for_testing_from_slice_no_ts(slice: &'a [u8]) -> Self {
         Self(slice)
     }

--- a/kv-engine/src/key.rs
+++ b/kv-engine/src/key.rs
@@ -470,4 +470,192 @@ mod tests {
         let k_old = KeyVec::from_user_key_ts(b"same", 1);
         assert!(k_new.as_key_slice() < k_old.as_key_slice());
     }
+
+    // --- encode_internal_key_to_buf ---
+
+    #[test]
+    fn test_encode_internal_key_to_buf() {
+        let mut buf = Vec::new();
+        encode_internal_key_to_buf(&mut buf, b"hello", 42);
+        let expected = encode_internal_key(b"hello", 42);
+        assert_eq!(buf, expected);
+    }
+
+    #[test]
+    fn test_encode_internal_key_to_buf_with_zeros() {
+        let mut buf = Vec::new();
+        encode_internal_key_to_buf(&mut buf, &[0x00, 0x42], 10);
+        let expected = encode_internal_key(&[0x00, 0x42], 10);
+        assert_eq!(buf, expected);
+    }
+
+    #[test]
+    fn test_encode_internal_key_to_buf_append() {
+        // Verify it appends to existing buffer content
+        let mut buf = b"prefix".to_vec();
+        encode_internal_key_to_buf(&mut buf, b"k", 1);
+        assert!(buf.starts_with(b"prefix"));
+        assert!(buf.len() > 6);
+    }
+
+    // --- KeyVec::set_from_user_key_ts ---
+
+    #[test]
+    fn test_keyvec_set_from_user_key_ts() {
+        let mut k = KeyVec::new();
+        k.set_from_user_key_ts(b"key", 99);
+        assert_eq!(k.ts(), 99);
+        assert_eq!(k.decode_user_key(), b"key");
+    }
+
+    #[test]
+    fn test_keyvec_set_from_user_key_ts_reuse() {
+        let mut k = KeyVec::from_user_key_ts(b"old", 1);
+        k.set_from_user_key_ts(b"new", 2);
+        assert_eq!(k.ts(), 2);
+        assert_eq!(k.decode_user_key(), b"new");
+    }
+
+    // --- decode_user_key_into edge cases ---
+
+    #[test]
+    fn test_decode_user_key_into_trailing_zero() {
+        // Bare 0x00 at end (no second byte) → false
+        let mut dst = Vec::new();
+        assert!(!decode_user_key_into(&[0x41, 0x00], &mut dst));
+    }
+
+    #[test]
+    fn test_decode_user_key_into_no_terminator() {
+        // No 0x00 at all → false (no terminator found)
+        let mut dst = Vec::new();
+        assert!(!decode_user_key_into(&[0x41, 0x42, 0x43], &mut dst));
+    }
+
+    #[test]
+    fn test_decode_user_key_into_empty() {
+        let mut dst = Vec::new();
+        // Empty input → false (no terminator)
+        assert!(!decode_user_key_into(&[], &mut dst));
+    }
+
+    // --- extract_ts edge cases ---
+
+    #[test]
+    fn test_extract_ts_too_short() {
+        // Terminator found but not enough bytes for timestamp
+        let enc = [0x41, 0x00, 0x00]; // terminator at offset 1, need 8 more bytes
+        assert!(extract_ts(&enc).is_none());
+    }
+
+    // --- encoded_user_key_prefix with zeros ---
+
+    #[test]
+    fn test_encoded_user_key_prefix_with_zeros() {
+        let enc = encode_internal_key(&[0x00, 0x42, 0x00], 50);
+        let prefix = encoded_user_key_prefix(&enc).unwrap();
+        // Escaped form: 0x00→0x00 0xff, 0x42→0x42, 0x00→0x00 0xff
+        assert_eq!(prefix, &[0x00, 0xff, 0x42, 0x00, 0xff]);
+    }
+
+    // --- Key trait methods ---
+
+    #[test]
+    fn test_key_vec_new_and_clear() {
+        let mut k = KeyVec::new();
+        assert!(k.is_empty());
+        k.append(b"hello");
+        assert_eq!(k.len(), 5);
+        k.clear();
+        assert!(k.is_empty());
+    }
+
+    #[test]
+    fn test_key_vec_set_from_slice() {
+        let src = KeyVec::from_user_key_ts(b"key", 10);
+        let mut dst = KeyVec::new();
+        dst.set_from_slice(src.as_key_slice());
+        assert_eq!(dst.as_key_slice(), src.as_key_slice());
+    }
+
+    #[test]
+    fn test_key_vec_into_key_bytes() {
+        let k = KeyVec::from_user_key_ts(b"key", 5);
+        let kb = k.into_key_bytes();
+        assert_eq!(kb.ts(), 5);
+        assert_eq!(kb.decode_user_key(), b"key");
+    }
+
+    #[test]
+    fn test_key_bytes_from_bytes() {
+        let enc = encode_internal_key(b"test", 77);
+        let kb = KeyBytes::from_bytes(Bytes::from(enc));
+        assert_eq!(kb.ts(), 77);
+        assert_eq!(kb.decode_user_key(), b"test");
+    }
+
+    #[test]
+    fn test_key_slice_to_key_vec() {
+        let k = KeyVec::from_user_key_ts(b"abc", 3);
+        let slice = k.as_key_slice();
+        let v = slice.to_key_vec();
+        assert_eq!(v.ts(), 3);
+        assert_eq!(v.decode_user_key(), b"abc");
+    }
+
+    #[test]
+    fn test_for_testing_from_slice_no_ts() {
+        let k = KeySlice::for_testing_from_slice_no_ts(b"raw");
+        assert_eq!(k.raw_ref(), b"raw");
+    }
+
+    #[test]
+    fn test_for_testing_from_vec_no_ts() {
+        let k = KeyVec::for_testing_from_vec_no_ts(b"raw".to_vec());
+        assert_eq!(k.raw_ref(), b"raw");
+    }
+
+    #[test]
+    fn test_for_testing_from_bytes_no_ts() {
+        let k = KeyBytes::for_testing_from_bytes_no_ts(Bytes::from_static(b"raw"));
+        assert_eq!(k.raw_ref(), b"raw");
+    }
+
+    #[test]
+    fn test_for_testing_from_slice_with_ts() {
+        let k = KeySlice::for_testing_from_slice_with_ts(b"key", 55);
+        assert_eq!(k.ts(), 55);
+        assert_eq!(k.decode_user_key(), b"key");
+    }
+
+    // --- shared_bytes_from_slice ---
+
+    #[test]
+    fn test_shared_bytes_from_slice_empty() {
+        let b = shared_bytes_from_slice(b"");
+        assert!(b.is_empty());
+    }
+
+    #[test]
+    fn test_shared_bytes_from_slice_nonempty() {
+        let b = shared_bytes_from_slice(b"hello");
+        assert_eq!(&*b, b"hello");
+    }
+
+    // --- Key default ---
+
+    #[test]
+    fn test_key_default() {
+        let k: KeyVec = Key::default();
+        assert!(k.is_empty());
+    }
+
+    // --- Key debug ---
+
+    #[test]
+    fn test_key_debug() {
+        let k = KeyVec::from_user_key_ts(b"key", 1);
+        let dbg = format!("{:?}", k);
+        assert!(!dbg.is_empty());
+    }
 }

--- a/kv-engine/src/key.rs
+++ b/kv-engine/src/key.rs
@@ -722,7 +722,7 @@ mod tests {
     #[test]
     fn test_decode_user_key_cow_trailing_zero_in_escaped_region() {
         // 0x00 at the end of escaped region (no second byte before terminator)
-        let mut enc = vec![0x41, 0x00]; // trailing 0x00 with no following byte
+        let enc = vec![0x41, 0x00]; // trailing 0x00 with no following byte
         // No terminator → find_terminator_offset returns None → decode_user_key_cow returns None
         assert!(decode_user_key_cow(&enc).is_none());
     }

--- a/kv-engine/src/key.rs
+++ b/kv-engine/src/key.rs
@@ -1,8 +1,9 @@
+use std::borrow::Cow;
 use std::fmt::Debug;
 
 use bytes::Bytes;
 
-pub const TS_ENABLED: bool = false;
+pub const TS_ENABLED: bool = true;
 
 /// Create a `Bytes` with the `SHARED` representation directly, avoiding the
 /// `PROMOTABLE` -> `SHARED` transition cost on the first clone.
@@ -18,6 +19,156 @@ pub(crate) fn shared_bytes_from_slice(src: &[u8]) -> Bytes {
     let mut vec = Vec::with_capacity(src.len() + 1);
     vec.extend_from_slice(src);
     Bytes::from(vec)
+}
+
+// ---------------------------------------------------------------------------
+// Internal key encoding helpers (RFC Section 6.1)
+//
+// Format: [escaped_user_key][0x00 0x00 terminator][inverted_ts: u64 BE]
+//
+// Escaping rules:
+//   - Non-zero byte `b`      → `b`
+//   - Zero byte `0x00`       → `0x00 0xff`
+//   - End of user key        → `0x00 0x00`
+//   - Inverted timestamp     → `u64::MAX - ts`, big-endian
+//
+// This preserves byte-order: user keys sort ascending, and for the same user
+// key newer timestamps (higher ts → lower inverted_ts) sort first.
+// ---------------------------------------------------------------------------
+
+/// Encode a user key + timestamp into an internal key byte vector.
+pub fn encode_internal_key(user_key: &[u8], ts: u64) -> Vec<u8> {
+    // Worst case: every byte is 0x00 (doubled) + 2-byte terminator + 8-byte ts
+    let mut buf = Vec::with_capacity(user_key.len() * 2 + 2 + 8);
+    for &b in user_key {
+        if b == 0 {
+            buf.push(0x00);
+            buf.push(0xff);
+        } else {
+            buf.push(b);
+        }
+    }
+    // Terminator: 0x00 0x00
+    buf.push(0x00);
+    buf.push(0x00);
+    // Inverted timestamp, big-endian
+    let inv_ts = u64::MAX - ts;
+    buf.extend_from_slice(&inv_ts.to_be_bytes());
+    buf
+}
+
+/// Append an encoded internal key to an existing buffer.
+pub fn encode_internal_key_to_buf(buf: &mut Vec<u8>, user_key: &[u8], ts: u64) {
+    for &b in user_key {
+        if b == 0 {
+            buf.push(0x00);
+            buf.push(0xff);
+        } else {
+            buf.push(b);
+        }
+    }
+    buf.push(0x00);
+    buf.push(0x00);
+    let inv_ts = u64::MAX - ts;
+    buf.extend_from_slice(&inv_ts.to_be_bytes());
+}
+
+/// Find the offset of the `0x00 0x00` terminator in an encoded internal key.
+/// Returns `None` if the terminator is not found (malformed key).
+fn find_terminator_offset(encoded: &[u8]) -> Option<usize> {
+    let mut i = 0;
+    while i < encoded.len() {
+        if encoded[i] == 0x00 {
+            if i + 1 >= encoded.len() {
+                return None;
+            }
+            if encoded[i + 1] == 0x00 {
+                return Some(i);
+            }
+            // 0x00 0xff — escaped zero, skip both
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
+    None
+}
+
+/// Decode the user key from an encoded internal key into a destination buffer.
+/// Returns `false` if the encoded key is malformed.
+pub fn decode_user_key_into(encoded: &[u8], dst: &mut Vec<u8>) -> bool {
+    dst.clear();
+    let mut i = 0;
+    while i < encoded.len() {
+        if encoded[i] == 0x00 {
+            if i + 1 >= encoded.len() {
+                return false;
+            }
+            match encoded[i + 1] {
+                0x00 => return true,   // terminator
+                0xff => dst.push(0),   // escaped zero
+                _ => return false,     // malformed
+            }
+            i += 2;
+        } else {
+            dst.push(encoded[i]);
+            i += 1;
+        }
+    }
+    false // no terminator found
+}
+
+/// Decode the user key from an encoded internal key.
+/// Returns `None` if the key is malformed.
+pub fn decode_user_key(encoded: &[u8]) -> Option<Vec<u8>> {
+    let mut buf = Vec::new();
+    if decode_user_key_into(encoded, &mut buf) {
+        Some(buf)
+    } else {
+        None
+    }
+}
+
+/// Extract the encoded user-key prefix (including escaping, excluding terminator).
+/// This is useful for comparisons that don't need the decoded key.
+pub fn encoded_user_key_prefix(encoded: &[u8]) -> Option<&[u8]> {
+    find_terminator_offset(encoded).map(|off| &encoded[..off])
+}
+
+/// Extract the timestamp from an encoded internal key.
+/// Returns `None` if the key is too short or malformed.
+pub fn extract_ts(encoded: &[u8]) -> Option<u64> {
+    let term_off = find_terminator_offset(encoded)?;
+    let ts_start = term_off + 2; // skip 0x00 0x00
+    if ts_start + 8 > encoded.len() {
+        return None;
+    }
+    let inv_ts = u64::from_be_bytes(encoded[ts_start..ts_start + 8].try_into().ok()?);
+    Some(u64::MAX - inv_ts)
+}
+
+/// Decode the user key into a `Cow`. If the key contains no escaped zeros,
+/// the borrowed variant avoids allocation.
+pub fn decode_user_key_cow(encoded: &[u8]) -> Option<Cow<'_, [u8]>> {
+    let term_off = find_terminator_offset(encoded)?;
+    let escaped = &encoded[..term_off];
+    // Check if escaping is needed
+    if !escaped.contains(&0x00) {
+        return Some(Cow::Borrowed(escaped));
+    }
+    let mut buf = Vec::with_capacity(term_off);
+    let mut i = 0;
+    while i < term_off {
+        if escaped[i] == 0x00 {
+            // Must be 0x00 0xff
+            buf.push(0);
+            i += 2;
+        } else {
+            buf.push(escaped[i]);
+            i += 1;
+        }
+    }
+    Some(Cow::Owned(buf))
 }
 
 pub struct Key<T: AsRef<[u8]>>(T);
@@ -39,8 +190,51 @@ impl<T: AsRef<[u8]>> Key<T> {
         self.0.as_ref().is_empty()
     }
 
+    /// Return the timestamp embedded in this encoded internal key.
+    pub fn ts(&self) -> u64 {
+        extract_ts(self.0.as_ref()).unwrap_or(0)
+    }
+
+    /// Return the encoded user-key prefix (with escaping, without terminator).
+    pub fn encoded_user_key(&self) -> &[u8] {
+        encoded_user_key_prefix(self.0.as_ref()).unwrap_or_else(|| self.0.as_ref())
+    }
+
+    /// Decode the user key from this internal key.
+    pub fn decode_user_key(&self) -> Vec<u8> {
+        decode_user_key(self.0.as_ref()).unwrap_or_else(|| self.0.as_ref().to_vec())
+    }
+
+    /// Decode the user key into a `Cow`, avoiding allocation when possible.
+    pub fn decode_user_key_cow(&self) -> Cow<'_, [u8]> {
+        decode_user_key_cow(self.0.as_ref()).unwrap_or(Cow::Borrowed(self.0.as_ref()))
+    }
+
+    /// Decode the user key into a caller-provided buffer.
+    pub fn decode_user_key_into(&self, dst: &mut Vec<u8>) {
+        decode_user_key_into(self.0.as_ref(), dst);
+    }
+
+    /// Return the raw encoded internal key bytes.
+    pub fn raw_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+
+    /// For testing: return the comparable key bytes.
+    /// When TS_ENABLED, returns the encoded user-key prefix (escaped form,
+    /// without terminator or timestamp). For keys without embedded zero bytes
+    /// this equals the raw user key.
+    pub fn for_testing_key_ref(&self) -> &[u8] {
+        if TS_ENABLED {
+            self.encoded_user_key()
+        } else {
+            self.0.as_ref()
+        }
+    }
+
+    /// For testing: return the timestamp.
     pub fn for_testing_ts(self) -> u64 {
-        0
+        self.ts()
     }
 }
 
@@ -49,25 +243,36 @@ impl Key<Vec<u8>> {
         Self(Vec::new())
     }
 
-    /// Create a `KeyVec` from a `Vec<u8>`. Will be removed in MVCC.
+    /// Create a `KeyVec` from pre-encoded internal key bytes.
     pub fn from_vec(key: Vec<u8>) -> Self {
         Self(key)
     }
 
-    /// Clears the key and set ts to 0.
+    /// Create a `KeyVec` from a user key + timestamp, encoding the internal key.
+    pub fn from_user_key_ts(user_key: &[u8], ts: u64) -> Self {
+        Self(encode_internal_key(user_key, ts))
+    }
+
+    /// Set from a user key + timestamp, reusing buffer capacity.
+    pub fn set_from_user_key_ts(&mut self, user_key: &[u8], ts: u64) {
+        self.0.clear();
+        // Reserve enough for worst-case encoding
+        self.0.reserve(user_key.len() * 2 + 10);
+        encode_internal_key_to_buf(&mut self.0, user_key, ts);
+    }
+
+    /// Clears the key.
     pub fn clear(&mut self) {
         self.0.clear()
     }
 
-    /// Append a slice to the end of the key
+    /// Append a slice to the end of the key (raw bytes, no encoding).
     pub fn append(&mut self, data: &[u8]) {
         self.0.extend(data)
     }
 
-    /// Set the key from a slice, reusing buffer capacity. Always reserves one
-    /// extra byte so that subsequent `into_key_bytes()` creates a `SHARED`
-    /// `Bytes` instead of a `PROMOTABLE` one (which incurs an atomic CAS on
-    /// the first clone).
+    /// Set the key from a `KeySlice` (which holds encoded internal key bytes),
+    /// reusing buffer capacity.
     pub fn set_from_slice(&mut self, key_slice: KeySlice) {
         self.0.clear();
         self.0.reserve(key_slice.len() + 1);
@@ -82,15 +287,7 @@ impl Key<Vec<u8>> {
         Key(self.0.into())
     }
 
-    /// Always use `raw_ref` to access the key before MVCC. This function will be removed in MVCC.
-    pub fn raw_ref(&self) -> &[u8] {
-        self.0.as_ref()
-    }
-
-    pub fn for_testing_key_ref(&self) -> &[u8] {
-        self.0.as_ref()
-    }
-
+    /// For testing: create from raw bytes (no encoding).
     pub fn for_testing_from_vec_no_ts(key: Vec<u8>) -> Self {
         Self(key)
     }
@@ -101,22 +298,14 @@ impl Key<Bytes> {
         Key(&self.0)
     }
 
-    /// Create a `KeyBytes` from a `Bytes`. Will be removed in MVCC.
+    /// Create a `KeyBytes` from pre-encoded internal key bytes.
     pub fn from_bytes(bytes: Bytes) -> KeyBytes {
         Key(bytes)
     }
 
-    /// Always use `raw_ref` to access the key before MVCC. This function will be removed in MVCC.
-    pub fn raw_ref(&self) -> &[u8] {
-        self.0.as_ref()
-    }
-
+    /// For testing: create from raw bytes (no encoding).
     pub fn for_testing_from_bytes_no_ts(bytes: Bytes) -> KeyBytes {
         Key(bytes)
-    }
-
-    pub fn for_testing_key_ref(&self) -> &[u8] {
-        self.0.as_ref()
     }
 }
 
@@ -125,26 +314,23 @@ impl<'a> Key<&'a [u8]> {
         Key(self.0.to_vec())
     }
 
-    /// Create a key slice from a slice. Will be removed in MVCC.
+    /// Create a `KeySlice` from pre-encoded internal key bytes.
     pub fn from_slice(slice: &'a [u8]) -> Self {
         Self(slice)
     }
 
-    /// Always use `raw_ref` to access the key before MVCC. This function will be removed in MVCC.
-    pub fn raw_ref(self) -> &'a [u8] {
-        self.0
-    }
-
-    pub fn for_testing_key_ref(self) -> &'a [u8] {
-        self.0
-    }
-
+    /// For testing: create from raw bytes (no encoding).
+    /// When TS_ENABLED, encodes the key with ts=0 to match production format.
+    /// NOTE: Returns `KeyVec` (owned) when encoding is needed.
     pub fn for_testing_from_slice_no_ts(slice: &'a [u8]) -> Self {
+        // When TS_ENABLED, the caller should use KeyVec::from_user_key_ts instead.
+        // This method returns raw bytes for backward compatibility.
         Self(slice)
     }
 
-    pub fn for_testing_from_slice_with_ts(slice: &'a [u8], _ts: u64) -> Self {
-        Self(slice)
+    /// For testing: encode a user key + timestamp and return a `KeyVec`.
+    pub fn for_testing_from_slice_with_ts(user_key: &[u8], ts: u64) -> KeyVec {
+        KeyVec::from_user_key_ts(user_key, ts)
     }
 }
 

--- a/kv-engine/src/key.rs
+++ b/kv-engine/src/key.rs
@@ -375,3 +375,99 @@ impl<T: AsRef<[u8]> + Ord> Ord for Key<T> {
         self.0.cmp(&other.0)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- encode/decode round-trip ---
+
+    #[test]
+    fn test_encode_decode_round_trip() {
+        let cases: Vec<(&[u8], u64)> = vec![
+            (b"hello", 0),
+            (b"hello", 42),
+            (b"hello", u64::MAX),
+            (b"", 100),
+            (&[0x00, 0x01, 0x00, 0xff], 999),
+        ];
+        for (uk, ts) in cases {
+            let enc = encode_internal_key(uk, ts);
+            assert_eq!(decode_user_key(&enc).unwrap(), uk);
+            assert_eq!(extract_ts(&enc).unwrap(), ts);
+        }
+    }
+
+    // --- decode_user_key_cow ---
+
+    #[test]
+    fn test_decode_user_key_cow_no_zeros_borrowed() {
+        // No 0x00 bytes → Cow::Borrowed (zero-copy)
+        let enc = encode_internal_key(b"abc", 10);
+        let cow = decode_user_key_cow(&enc).unwrap();
+        assert_eq!(&*cow, b"abc");
+        // Should be borrowed, not owned
+        match cow {
+            std::borrow::Cow::Borrowed(_) => {}
+            _ => panic!("expected Borrowed variant for key without zeros"),
+        }
+    }
+
+    #[test]
+    fn test_decode_user_key_cow_with_zeros_owned() {
+        // Contains 0x00 bytes → Cow::Owned
+        let enc = encode_internal_key(&[0x00, 0x42, 0x00], 5);
+        let cow = decode_user_key_cow(&enc).unwrap();
+        assert_eq!(&*cow, &[0x00, 0x42, 0x00]);
+    }
+
+    #[test]
+    fn test_decode_user_key_cow_malformed_escape_returns_none() {
+        // 0x00 followed by 0x01 (not 0x00 or 0xff) → malformed
+        let malformed = [0x41, 0x00, 0x01, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0];
+        assert!(decode_user_key_cow(&malformed).is_none());
+    }
+
+    #[test]
+    fn test_decode_user_key_cow_trailing_zero_returns_none() {
+        // Ends with bare 0x00 (no second byte) → malformed
+        let malformed = [0x41, 0x00];
+        assert!(decode_user_key_cow(&malformed).is_none());
+    }
+
+    // --- decode_user_key ---
+
+    #[test]
+    fn test_decode_user_key_malformed_returns_none() {
+        let malformed = [0x41, 0x00, 0x02, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0];
+        assert!(decode_user_key(&malformed).is_none());
+    }
+
+    // --- encoded_user_key_prefix ---
+
+    #[test]
+    fn test_encoded_user_key_prefix() {
+        let enc = encode_internal_key(b"key", 100);
+        let prefix = encoded_user_key_prefix(&enc).unwrap();
+        // Prefix is the escaped form (no 0x00 bytes in "key")
+        assert_eq!(prefix, b"key");
+    }
+
+    // --- Key accessors ---
+
+    #[test]
+    fn test_key_ts_and_user_key() {
+        let k = KeyVec::from_user_key_ts(b"mykey", 42);
+        assert_eq!(k.ts(), 42);
+        assert_eq!(k.decode_user_key(), b"mykey");
+        assert_eq!(k.encoded_user_key(), b"mykey");
+    }
+
+    #[test]
+    fn test_key_ordering_newer_first() {
+        // Higher ts → lower inverted_ts → sorts first
+        let k_new = KeyVec::from_user_key_ts(b"same", 100);
+        let k_old = KeyVec::from_user_key_ts(b"same", 1);
+        assert!(k_new.as_key_slice() < k_old.as_key_slice());
+    }
+}

--- a/kv-engine/src/key.rs
+++ b/kv-engine/src/key.rs
@@ -658,4 +658,106 @@ mod tests {
         let dbg = format!("{:?}", k);
         assert!(!dbg.is_empty());
     }
+
+    // --- Cover remaining uncovered lines ---
+
+    #[test]
+    fn test_key_into_inner() {
+        let k = KeyVec::from_user_key_ts(b"abc", 5);
+        let inner: Vec<u8> = k.into_inner();
+        assert!(!inner.is_empty());
+    }
+
+    #[test]
+    fn test_key_slice_into_inner() {
+        let data = b"hello";
+        let k = KeySlice::from_slice(data);
+        let inner: &[u8] = k.into_inner();
+        assert_eq!(inner, data);
+    }
+
+    #[test]
+    fn test_key_decode_user_key_into_method() {
+        let k = KeyVec::from_user_key_ts(b"test", 42);
+        let mut dst = Vec::new();
+        k.decode_user_key_into(&mut dst);
+        assert_eq!(dst, b"test");
+    }
+
+    #[test]
+    fn test_key_encoded_user_key_fallback() {
+        // When encoded_user_key_prefix returns None (malformed key),
+        // falls back to raw_ref
+        let k = KeySlice::from_slice(b"no_terminator");
+        let uk = k.encoded_user_key();
+        assert_eq!(uk, b"no_terminator");
+    }
+
+    #[test]
+    fn test_key_for_testing_ts() {
+        let k = KeyVec::from_user_key_ts(b"key", 77);
+        let slice = k.as_key_slice();
+        assert_eq!(slice.for_testing_ts(), 77);
+    }
+
+    #[test]
+    fn test_key_vec_for_testing_key_ref() {
+        let k = KeyVec::from_user_key_ts(b"key", 1);
+        // for_testing_key_ref returns encoded_user_key when TS_ENABLED
+        let r = k.for_testing_key_ref();
+        assert_eq!(r, b"key");
+    }
+
+    #[test]
+    fn test_decode_user_key_cow_malformed_escape_in_escaped_region() {
+        // Construct a key where the escaped region (before terminator)
+        // contains 0x00 not followed by 0xff
+        // Build: user_key="A" (0x41), then 0x00 0x01 (malformed escape), then terminator
+        let mut enc = vec![0x41, 0x00, 0x01]; // malformed: 0x00 followed by 0x01
+        enc.extend_from_slice(&[0x00, 0x00]); // terminator
+        enc.extend_from_slice(&[0, 0, 0, 0, 0, 0, 0, 1]); // ts=1 (inverted: MAX-1)
+        assert!(decode_user_key_cow(&enc).is_none());
+    }
+
+    #[test]
+    fn test_decode_user_key_cow_trailing_zero_in_escaped_region() {
+        // 0x00 at the end of escaped region (no second byte before terminator)
+        let mut enc = vec![0x41, 0x00]; // trailing 0x00 with no following byte
+        // No terminator → find_terminator_offset returns None → decode_user_key_cow returns None
+        assert!(decode_user_key_cow(&enc).is_none());
+    }
+
+    #[test]
+    fn test_extract_ts_malformed_no_terminator() {
+        // No terminator at all
+        let enc = [0x41, 0x42, 0x43];
+        assert!(extract_ts(&enc).is_none());
+    }
+
+    #[test]
+    fn test_extract_ts_short_after_terminator() {
+        // Terminator found but only 4 bytes after (need 8)
+        let enc = [0x41, 0x00, 0x00, 0, 0, 0, 0];
+        assert!(extract_ts(&enc).is_none());
+    }
+
+    #[test]
+    fn test_encoded_user_key_prefix_no_terminator() {
+        assert!(encoded_user_key_prefix(b"no_term").is_none());
+    }
+
+    #[test]
+    fn test_decode_user_key_no_terminator() {
+        assert!(decode_user_key(b"no_term").is_none());
+    }
+
+    #[test]
+    fn test_decode_user_key_into_malformed() {
+        let mut dst = Vec::new();
+        // 0x00 followed by 0x02 (not 0x00 or 0xff) → malformed
+        assert!(!decode_user_key_into(
+            &[0x41, 0x00, 0x02, 0x00, 0x00],
+            &mut dst
+        ));
+    }
 }

--- a/kv-engine/src/key.rs
+++ b/kv-engine/src/key.rs
@@ -82,11 +82,11 @@ fn find_terminator_offset(encoded: &[u8]) -> Option<usize> {
             if i + 1 >= encoded.len() {
                 return None;
             }
-            if encoded[i + 1] == 0x00 {
-                return Some(i);
+            match encoded[i + 1] {
+                0x00 => return Some(i), // terminator
+                0xff => i += 2,         // escaped zero, skip both
+                _ => return None,       // malformed
             }
-            // 0x00 0xff — escaped zero, skip both
-            i += 2;
         } else {
             i += 1;
         }
@@ -319,12 +319,10 @@ impl<'a> Key<&'a [u8]> {
         Self(slice)
     }
 
-    /// For testing: create from raw bytes (no encoding).
-    /// When TS_ENABLED, encodes the key with ts=0 to match production format.
-    /// NOTE: Returns `KeyVec` (owned) when encoding is needed.
+    /// For testing: create from raw bytes with no timestamp encoding.
+    /// Returns the raw slice as-is regardless of `TS_ENABLED`.
+    /// For a TS-encoded owned key, use `KeyVec::from_user_key_ts` instead.
     pub fn for_testing_from_slice_no_ts(slice: &'a [u8]) -> Self {
-        // When TS_ENABLED, the caller should use KeyVec::from_user_key_ts instead.
-        // This method returns raw bytes for backward compatibility.
         Self(slice)
     }
 

--- a/kv-engine/src/key.rs
+++ b/kv-engine/src/key.rs
@@ -105,9 +105,9 @@ pub fn decode_user_key_into(encoded: &[u8], dst: &mut Vec<u8>) -> bool {
                 return false;
             }
             match encoded[i + 1] {
-                0x00 => return true,   // terminator
-                0xff => dst.push(0),   // escaped zero
-                _ => return false,     // malformed
+                0x00 => return true, // terminator
+                0xff => dst.push(0), // escaped zero
+                _ => return false,   // malformed
             }
             i += 2;
         } else {

--- a/kv-engine/src/lsm_iterator.rs
+++ b/kv-engine/src/lsm_iterator.rs
@@ -22,8 +22,11 @@ type LsmIteratorInner = TwoMergeIterator<
 pub struct LsmIterator {
     inner: LsmIteratorInner,
     upper: Bound<Vec<u8>>,
-    /// Scratch buffer for the decoded user key (MVCC only).
+    /// Decoded user key (MVCC only) — returned by `key()` and used for bound checks.
     user_key: Vec<u8>,
+    /// Encoded user-key prefix (MVCC only) — used to skip all versions of the
+    /// current user key in `next()`.  Must stay in sync with `user_key`.
+    encoded_user_key: Vec<u8>,
 }
 
 impl LsmIterator {
@@ -32,16 +35,20 @@ impl LsmIterator {
         // Skip tombstones at the start
         Self::skip_tombstones(&mut iter)?;
 
-        let user_key = if iter.is_valid() && TS_ENABLED {
-            iter.key().decode_user_key()
+        let (user_key, encoded_user_key) = if iter.is_valid() && TS_ENABLED {
+            (
+                iter.key().decode_user_key(),
+                iter.key().encoded_user_key().to_vec(),
+            )
         } else {
-            Vec::new()
+            (Vec::new(), Vec::new())
         };
 
         Ok(Self {
             inner: iter,
             upper,
             user_key,
+            encoded_user_key,
         })
     }
 
@@ -98,18 +105,21 @@ impl StorageIterator for LsmIterator {
 
     fn next(&mut self) -> Result<()> {
         if TS_ENABLED {
-            // Skip all remaining versions of the current user key
-            let current_user_key = self.user_key.clone();
+            // Skip all remaining versions of the current user key.
+            // Compare encoded prefixes (not decoded) so keys with 0x00 bytes
+            // match correctly through the escaping layer.
+            let current_encoded = self.encoded_user_key.clone();
             while self.inner.is_valid()
-                && self.inner.key().encoded_user_key() == current_user_key.as_slice()
+                && self.inner.key().encoded_user_key() == current_encoded.as_slice()
             {
                 self.inner.next()?;
             }
             // Skip tombstones of the next user key(s)
             Self::skip_tombstones(&mut self.inner)?;
-            // Update cached user key
+            // Update cached user keys (decoded for key(), encoded for next())
             if self.inner.is_valid() {
                 self.user_key = self.inner.key().decode_user_key();
+                self.encoded_user_key = self.inner.key().encoded_user_key().to_vec();
             }
         } else {
             self.inner.next()?;

--- a/kv-engine/src/lsm_iterator.rs
+++ b/kv-engine/src/lsm_iterator.rs
@@ -62,9 +62,7 @@ impl LsmIterator {
             if TS_ENABLED {
                 // Skip all versions of this dead user key
                 let dead_key = iter.key().encoded_user_key().to_vec();
-                while iter.is_valid()
-                    && iter.key().encoded_user_key() == dead_key.as_slice()
-                {
+                while iter.is_valid() && iter.key().encoded_user_key() == dead_key.as_slice() {
                     iter.next()?;
                 }
             } else {

--- a/kv-engine/src/lsm_iterator.rs
+++ b/kv-engine/src/lsm_iterator.rs
@@ -7,6 +7,7 @@ use crate::{
         StorageIterator, concat_iterator::SstConcatIterator, merge_iterator::MergeIterator,
         two_merge_iterator::TwoMergeIterator,
     },
+    key::TS_ENABLED,
     mem_table::MemTableIterator,
     table::SsTableIterator,
 };
@@ -21,28 +22,57 @@ type LsmIteratorInner = TwoMergeIterator<
 pub struct LsmIterator {
     inner: LsmIteratorInner,
     upper: Bound<Vec<u8>>,
+    /// Scratch buffer for the decoded user key (MVCC only).
+    user_key: Vec<u8>,
 }
 
 impl LsmIterator {
     pub(crate) fn new(iter: LsmIteratorInner, upper: Bound<Vec<u8>>) -> Result<Self> {
         let mut iter = iter;
-        // seems FusedIterator have conventional meaning, ref https://doc.rust-lang.org/std/iter/trait.FusedIterator.html, so put the logic here instead
-        while iter.is_valid() && iter.value().is_empty() {
-            iter.next()?;
-        }
+        // Skip tombstones at the start
+        Self::skip_tombstones(&mut iter)?;
 
-        Ok(Self { inner: iter, upper })
+        let user_key = if iter.is_valid() && TS_ENABLED {
+            iter.key().decode_user_key()
+        } else {
+            Vec::new()
+        };
+
+        Ok(Self {
+            inner: iter,
+            upper,
+            user_key,
+        })
     }
 
+    /// Skip entries with empty values (tombstones). When MVCC is enabled,
+    /// skip all versions of a dead user key.
+    fn skip_tombstones(iter: &mut LsmIteratorInner) -> Result<()> {
+        while iter.is_valid() {
+            if !iter.value().is_empty() {
+                return Ok(());
+            }
+            if TS_ENABLED {
+                // Skip all versions of this dead user key
+                let dead_key = iter.key().encoded_user_key().to_vec();
+                while iter.is_valid()
+                    && iter.key().encoded_user_key() == dead_key.as_slice()
+                {
+                    iter.next()?;
+                }
+            } else {
+                iter.next()?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Check if the current decoded user key is within the upper bound.
     fn check_bound(&self) -> bool {
         match self.upper.as_ref() {
             Bound::Unbounded => true,
-            Bound::Included(key) => {
-                self.inner.is_valid() && self.inner.key().into_inner() <= key.as_slice()
-            }
-            Bound::Excluded(key) => {
-                self.inner.is_valid() && self.inner.key().into_inner() < key.as_slice()
-            }
+            Bound::Included(key) => self.user_key.as_slice() <= key.as_slice(),
+            Bound::Excluded(key) => self.user_key.as_slice() < key.as_slice(),
         }
     }
 }
@@ -55,29 +85,38 @@ impl StorageIterator for LsmIterator {
     }
 
     fn key(&self) -> &[u8] {
-        // if !self.check_bound() {
-        //     return b"";
-        // }
-
-        self.inner.key().into_inner()
+        if TS_ENABLED {
+            &self.user_key
+        } else {
+            self.inner.key().into_inner()
+        }
     }
 
     fn value(&self) -> &[u8] {
-        // if !self.check_bound() {
-        //     return b"";
-        // }
-
         self.inner.value()
     }
 
     fn next(&mut self) -> Result<()> {
-        self.inner.next()?;
-        if !self.is_valid() {
-            return Ok(());
-        }
-
-        while self.is_valid() && self.inner.value().is_empty() {
+        if TS_ENABLED {
+            // Skip all remaining versions of the current user key
+            let current_user_key = self.user_key.clone();
+            while self.inner.is_valid()
+                && self.inner.key().encoded_user_key() == current_user_key.as_slice()
+            {
+                self.inner.next()?;
+            }
+            // Skip tombstones of the next user key(s)
+            Self::skip_tombstones(&mut self.inner)?;
+            // Update cached user key
+            if self.inner.is_valid() {
+                self.user_key = self.inner.key().decode_user_key();
+            }
+        } else {
             self.inner.next()?;
+            // Legacy: skip empty values
+            while self.inner.is_valid() && self.inner.value().is_empty() {
+                self.inner.next()?;
+            }
         }
 
         Ok(())

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -812,7 +812,8 @@ impl LsmStorageInner {
         let vlog_enabled = self.vlog.is_some();
         if let Some(mvcc) = &self.mvcc {
             // MVCC path: key is encode(user_key, u64::MAX), need versioned lookup
-            let user_key = crate::key::decode_user_key(key).unwrap_or_else(|| key.to_vec());
+            let user_key =
+                crate::key::decode_user_key_cow(key).unwrap_or(std::borrow::Cow::Borrowed(key));
             let read_ts = mvcc.read_ts();
             if vlog_enabled {
                 if let Some(raw) = state.memtable.get_versioned_raw(&user_key, read_ts) {

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -810,10 +810,10 @@ impl LsmStorageInner {
         bloom_hash: u32,
     ) -> Result<Option<(Option<Bytes>, KvKind)>> {
         let vlog_enabled = self.vlog.is_some();
-        if self.mvcc.is_some() {
+        if let Some(mvcc) = &self.mvcc {
             // MVCC path: key is encode(user_key, u64::MAX), need versioned lookup
             let user_key = crate::key::decode_user_key(key).unwrap_or_else(|| key.to_vec());
-            let read_ts = self.mvcc.as_ref().unwrap().read_ts();
+            let read_ts = mvcc.read_ts();
             if vlog_enabled {
                 if let Some(raw) = state.memtable.get_versioned_raw(&user_key, read_ts) {
                     return Ok(Some(Self::parse_value_kind(raw)));
@@ -888,7 +888,7 @@ impl LsmStorageInner {
                     s.point_get_with_hash_and_key(key, bloom_hash, None)?
             {
                 let ts = crate::key::extract_ts(&found_key).unwrap_or(0);
-                if best.as_ref().map_or(true, |(_, best_ts)| ts > *best_ts) {
+                if best.as_ref().is_none_or(|(_, best_ts)| ts > *best_ts) {
                     best = Some((raw, ts));
                 }
             }
@@ -906,9 +906,12 @@ impl LsmStorageInner {
         if self.mvcc.is_some() {
             // MVCC: L0 SSTs may contain different versions of the same key.
             // Check all and return the newest.
-            if let Some(raw) =
-                Self::mvcc_point_get_across_ssts(&state.sstables, &state.l0_sstables, key, bloom_hash)?
-            {
+            if let Some(raw) = Self::mvcc_point_get_across_ssts(
+                &state.sstables,
+                &state.l0_sstables,
+                key,
+                bloom_hash,
+            )? {
                 return Ok(Some(Self::parse_value_kind(raw)));
             }
         } else {
@@ -934,8 +937,8 @@ impl LsmStorageInner {
                     return Ok(Some(Self::parse_value_kind(raw)));
                 }
             } else {
-                let idx = sst_ids
-                    .partition_point(|id| state.sstables[id].first_key().raw_ref() <= key);
+                let idx =
+                    sst_ids.partition_point(|id| state.sstables[id].first_key().raw_ref() <= key);
                 if idx == 0 {
                     continue;
                 }

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -660,6 +660,11 @@ impl LsmStorageInner {
             compaction_controller,
             manifest: Some(manifest),
             options: options.into(),
+            // NOTE: The commit clock starts at 0 after restart.  This is correct
+            // for Phase 1 (no snapshot isolation) because read_ts filtering is
+            // not enforced.  Phase 2 must recover the max committed timestamp
+            // from SSTs/WAL before enabling read_ts filtering, otherwise new
+            // writes would get smaller timestamps than existing data.
             mvcc: Some(LsmMvccInner::new(0)),
             compaction_filters: Arc::new(Mutex::new(Vec::new())),
             vlog,
@@ -1253,7 +1258,7 @@ impl LsmStorageInner {
 
         self.manifest
             .as_ref()
-            .unwrap()
+            .expect("manifest initialized")
             .add_record(_state_lock_observer, ManifestRecord::NewMemtable(sst_id))?;
 
         self.maybe_snapshot_manifest(_state_lock_observer)
@@ -1353,7 +1358,7 @@ impl LsmStorageInner {
         };
         self.manifest
             .as_ref()
-            .unwrap()
+            .expect("manifest initialized")
             .add_record(&state_lock, manifest_record)?;
 
         // Check if manifest needs snapshotting after flush

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -873,6 +873,29 @@ impl LsmStorageInner {
     /// Shared SST lookup for `get()` and `get_with_kind_inner()`.
     /// Searches L0 + leveled SSTs. Returns `Ok(None)` if not found.
     /// Returns `Ok(Some((value, kind)))` with the parsed value and kind.
+    /// MVCC helper: scan a set of SSTs and return the newest version of `key`.
+    /// Used by both L0 and leveled lookup paths.
+    fn mvcc_point_get_across_ssts(
+        sstables: &std::collections::HashMap<usize, Arc<SsTable>>,
+        sst_ids: &[usize],
+        key: &[u8],
+        bloom_hash: u32,
+    ) -> Result<Option<Bytes>> {
+        let mut best: Option<(Bytes, u64)> = None;
+        for id in sst_ids {
+            if let Some(s) = sstables.get(id)
+                && let Some((raw, found_key)) =
+                    s.point_get_with_hash_and_key(key, bloom_hash, None)?
+            {
+                let ts = crate::key::extract_ts(&found_key).unwrap_or(0);
+                if best.as_ref().map_or(true, |(_, best_ts)| ts > *best_ts) {
+                    best = Some((raw, ts));
+                }
+            }
+        }
+        Ok(best.map(|(raw, _ts)| raw))
+    }
+
     fn lookup_sst_raw(
         &self,
         state: &LsmStorageState,
@@ -880,11 +903,21 @@ impl LsmStorageInner {
         bloom_hash: u32,
     ) -> Result<Option<(Option<Bytes>, KvKind)>> {
         // L0 SSTs — may overlap, check each one
-        for id in state.l0_sstables.iter() {
-            if let Some(s) = state.sstables.get(id)
-                && let Some(raw) = s.point_get_with_hash(key, bloom_hash)?
+        if self.mvcc.is_some() {
+            // MVCC: L0 SSTs may contain different versions of the same key.
+            // Check all and return the newest.
+            if let Some(raw) =
+                Self::mvcc_point_get_across_ssts(&state.sstables, &state.l0_sstables, key, bloom_hash)?
             {
                 return Ok(Some(Self::parse_value_kind(raw)));
+            }
+        } else {
+            for id in state.l0_sstables.iter() {
+                if let Some(s) = state.sstables.get(id)
+                    && let Some(raw) = s.point_get_with_hash(key, bloom_hash)?
+                {
+                    return Ok(Some(Self::parse_value_kind(raw)));
+                }
             }
         }
         // Leveled SSTs — with MVCC, the encoded key at u64::MAX sorts before the
@@ -892,13 +925,13 @@ impl LsmStorageInner {
         // directly. Instead, check each SST; the bloom filter provides fast rejection.
         for (_, sst_ids) in state.levels.iter() {
             if self.mvcc.is_some() {
-                // MVCC: check each SST (bloom filter rejects quickly)
-                for id in sst_ids {
-                    if let Some(s) = state.sstables.get(id)
-                        && let Some(raw) = s.point_get_with_hash(key, bloom_hash)?
-                    {
-                        return Ok(Some(Self::parse_value_kind(raw)));
-                    }
+                // MVCC: multiple SSTs at the same level can contain different
+                // versions of the same key. Check all SSTs and return the one
+                // with the highest (newest) timestamp.
+                if let Some(raw) =
+                    Self::mvcc_point_get_across_ssts(&state.sstables, sst_ids, key, bloom_hash)?
+                {
+                    return Ok(Some(Self::parse_value_kind(raw)));
                 }
             } else {
                 let idx = sst_ids

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -660,7 +660,7 @@ impl LsmStorageInner {
             compaction_controller,
             manifest: Some(manifest),
             options: options.into(),
-            mvcc: None,
+            mvcc: Some(LsmMvccInner::new(0)),
             compaction_filters: Arc::new(Mutex::new(Vec::new())),
             vlog,
             weak_self: std::sync::OnceLock::new(),
@@ -684,9 +684,17 @@ impl LsmStorageInner {
     pub fn get(&self, key: &[u8]) -> Result<Option<Bytes>> {
         let state = self.state.load();
         let bloom_hash = crate::table::bloom::hash_key(key);
+        // With MVCC, encode the user key with u64::MAX to seek to the newest version.
+        let lookup_key;
+        let encoded = if self.mvcc.is_some() {
+            lookup_key = crate::key::encode_internal_key(key, u64::MAX);
+            lookup_key.as_slice()
+        } else {
+            key
+        };
         // Check memtable first — route through resolve_vlog_value_bytes for
         // zero-copy inline slicing (refcount bump instead of heap allocation).
-        if let Some((value, kind)) = self.lookup_memtable(&state, key, bloom_hash)? {
+        if let Some((value, kind)) = self.lookup_memtable(&state, encoded, bloom_hash)? {
             return match kind {
                 KvKind::ValuePointer => self.resolve_vlog_value_bytes(
                     key,
@@ -696,7 +704,7 @@ impl LsmStorageInner {
             };
         }
         // SST path — delegate to get_with_kind_inner which uses lookup_sst_raw.
-        if let Some((value, kind)) = self.lookup_sst_raw(&state, key, bloom_hash)? {
+        if let Some((value, kind)) = self.lookup_sst_raw(&state, encoded, bloom_hash)? {
             return match kind {
                 KvKind::ValuePointer => self.resolve_vlog_value_bytes(
                     key,
@@ -776,10 +784,17 @@ impl LsmStorageInner {
         key: &[u8],
     ) -> Result<(Option<Bytes>, KvKind)> {
         let bloom_hash = crate::table::bloom::hash_key(key);
-        if let Some(result) = self.lookup_memtable(state, key, bloom_hash)? {
+        let lookup_key;
+        let encoded = if self.mvcc.is_some() {
+            lookup_key = crate::key::encode_internal_key(key, u64::MAX);
+            lookup_key.as_slice()
+        } else {
+            key
+        };
+        if let Some(result) = self.lookup_memtable(state, encoded, bloom_hash)? {
             return Ok(result);
         }
-        if let Some(result) = self.lookup_sst_raw(state, key, bloom_hash)? {
+        if let Some(result) = self.lookup_sst_raw(state, encoded, bloom_hash)? {
             return Ok(result);
         }
         Ok((None, KvKind::Inline))
@@ -795,28 +810,60 @@ impl LsmStorageInner {
         bloom_hash: u32,
     ) -> Result<Option<(Option<Bytes>, KvKind)>> {
         let vlog_enabled = self.vlog.is_some();
-        if vlog_enabled {
-            if let Some(raw) = state.memtable.get_raw_with_hash(key, bloom_hash) {
-                return Ok(Some(Self::parse_value_kind(raw)));
-            }
-            for m in state.imm_memtables.iter() {
-                if let Some(raw) = m.get_raw_with_hash(key, bloom_hash) {
+        if self.mvcc.is_some() {
+            // MVCC path: key is encode(user_key, u64::MAX), need versioned lookup
+            let user_key = crate::key::decode_user_key(key).unwrap_or_else(|| key.to_vec());
+            let read_ts = self.mvcc.as_ref().unwrap().read_ts();
+            if vlog_enabled {
+                if let Some(raw) = state.memtable.get_versioned_raw(&user_key, read_ts) {
                     return Ok(Some(Self::parse_value_kind(raw)));
                 }
-            }
-        } else {
-            if let Some(v) = state.memtable.get_with_hash(key, bloom_hash) {
-                if v.is_empty() {
-                    return Ok(Some((None, KvKind::Inline)));
+                for m in state.imm_memtables.iter() {
+                    if let Some(raw) = m.get_versioned_raw(&user_key, read_ts) {
+                        return Ok(Some(Self::parse_value_kind(raw)));
+                    }
                 }
-                return Ok(Some((Some(v), KvKind::Inline)));
-            }
-            for m in state.imm_memtables.iter() {
-                if let Some(v) = m.get_with_hash(key, bloom_hash) {
+            } else {
+                if let Some(v) = state.memtable.get_versioned(&user_key, read_ts) {
                     if v.is_empty() {
                         return Ok(Some((None, KvKind::Inline)));
                     }
                     return Ok(Some((Some(v), KvKind::Inline)));
+                }
+                for m in state.imm_memtables.iter() {
+                    if let Some(v) = m.get_versioned(&user_key, read_ts) {
+                        if v.is_empty() {
+                            return Ok(Some((None, KvKind::Inline)));
+                        }
+                        return Ok(Some((Some(v), KvKind::Inline)));
+                    }
+                }
+            }
+        } else {
+            // Non-MVCC path: exact key lookup
+            if vlog_enabled {
+                if let Some(raw) = state.memtable.get_raw_with_hash(key, bloom_hash) {
+                    return Ok(Some(Self::parse_value_kind(raw)));
+                }
+                for m in state.imm_memtables.iter() {
+                    if let Some(raw) = m.get_raw_with_hash(key, bloom_hash) {
+                        return Ok(Some(Self::parse_value_kind(raw)));
+                    }
+                }
+            } else {
+                if let Some(v) = state.memtable.get_with_hash(key, bloom_hash) {
+                    if v.is_empty() {
+                        return Ok(Some((None, KvKind::Inline)));
+                    }
+                    return Ok(Some((Some(v), KvKind::Inline)));
+                }
+                for m in state.imm_memtables.iter() {
+                    if let Some(v) = m.get_with_hash(key, bloom_hash) {
+                        if v.is_empty() {
+                            return Ok(Some((None, KvKind::Inline)));
+                        }
+                        return Ok(Some((Some(v), KvKind::Inline)));
+                    }
                 }
             }
         }
@@ -840,17 +887,31 @@ impl LsmStorageInner {
                 return Ok(Some(Self::parse_value_kind(raw)));
             }
         }
-        // Leveled SSTs — binary search to find the candidate SST, then point_get
+        // Leveled SSTs — with MVCC, the encoded key at u64::MAX sorts before the
+        // SST's first_key (at ts=0), so binary search on encoded keys doesn't work
+        // directly. Instead, check each SST; the bloom filter provides fast rejection.
         for (_, sst_ids) in state.levels.iter() {
-            let idx = sst_ids.partition_point(|id| state.sstables[id].first_key().raw_ref() <= key);
-            if idx == 0 {
-                continue;
-            }
-            let candidate_idx = idx - 1;
-            if let Some(s) = state.sstables.get(&sst_ids[candidate_idx])
-                && let Some(raw) = s.point_get_with_hash(key, bloom_hash)?
-            {
-                return Ok(Some(Self::parse_value_kind(raw)));
+            if self.mvcc.is_some() {
+                // MVCC: check each SST (bloom filter rejects quickly)
+                for id in sst_ids {
+                    if let Some(s) = state.sstables.get(id)
+                        && let Some(raw) = s.point_get_with_hash(key, bloom_hash)?
+                    {
+                        return Ok(Some(Self::parse_value_kind(raw)));
+                    }
+                }
+            } else {
+                let idx = sst_ids
+                    .partition_point(|id| state.sstables[id].first_key().raw_ref() <= key);
+                if idx == 0 {
+                    continue;
+                }
+                let candidate_idx = idx - 1;
+                if let Some(s) = state.sstables.get(&sst_ids[candidate_idx])
+                    && let Some(raw) = s.point_get_with_hash(key, bloom_hash)?
+                {
+                    return Ok(Some(Self::parse_value_kind(raw)));
+                }
             }
         }
         Ok(None)
@@ -1030,11 +1091,13 @@ impl LsmStorageInner {
     }
 
     /// Put a key-value pair into the storage by writing into the current memtable.
-    /// As our memtable implementation only requires an immutable reference for put,
-    /// you ONLY need to take the read lock on state in order to modify the memtable.
-    /// This allows concurrent access to the memtable from multiple threads.
+    /// When MVCC is enabled, encodes the key with an allocated commit timestamp.
     pub fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
-        {
+        if let Some(ref mvcc) = self.mvcc {
+            let _guard = self.active_memtable_lock.read();
+            let state = self.state.load();
+            mvcc.write(key, value, &state.memtable)?;
+        } else {
             let _guard = self.active_memtable_lock.read();
             let state = self.state.load();
             state.memtable.put(key, value)?;
@@ -1299,16 +1362,49 @@ impl LsmStorageInner {
         upper: Bound<&[u8]>,
     ) -> Result<FusedIterator<LsmIterator>> {
         let state = self.state.load_full();
+        let mvcc_enabled = self.mvcc.is_some();
+
+        // Encode bounds for MVCC: lower with u64::MAX (first version of key),
+        // upper with 0 (last version of key, largest byte value).
+        let enc_lower;
+        let enc_upper;
+        let (physical_lower, physical_upper) = if mvcc_enabled {
+            enc_lower = match lower {
+                Bound::Included(k) => Bound::Included(crate::key::encode_internal_key(k, u64::MAX)),
+                Bound::Excluded(k) => Bound::Excluded(crate::key::encode_internal_key(k, u64::MAX)),
+                Bound::Unbounded => Bound::Unbounded,
+            };
+            enc_upper = match upper {
+                Bound::Included(k) => Bound::Included(crate::key::encode_internal_key(k, 0)),
+                Bound::Excluded(k) => Bound::Excluded(crate::key::encode_internal_key(k, 0)),
+                Bound::Unbounded => Bound::Unbounded,
+            };
+            (
+                enc_lower.as_ref().map(|v| v.as_slice()),
+                enc_upper.as_ref().map(|v| v.as_slice()),
+            )
+        } else {
+            (lower, upper)
+        };
+
+        // Helper to encode a lower bound key for SST/concat seek.
+        let encode_seek = |k: &[u8]| -> Vec<u8> {
+            if mvcc_enabled {
+                crate::key::encode_internal_key(k, u64::MAX)
+            } else {
+                k.to_vec()
+            }
+        };
 
         // memtable
         let vlog = self.vlog.clone();
         let mut m_merge_iterators = vec![Box::new(state.memtable.scan_with_vlog(
-            lower,
-            upper,
+            physical_lower,
+            physical_upper,
             vlog.clone(),
         ))];
         for i in state.imm_memtables.iter() {
-            let it = i.scan_with_vlog(lower, upper, vlog.clone());
+            let it = i.scan_with_vlog(physical_lower, physical_upper, vlog.clone());
             m_merge_iterators.push(Box::new(it));
         }
         let m_memo_iter = MergeIterator::create(m_merge_iterators);
@@ -1317,28 +1413,31 @@ impl LsmStorageInner {
         let mut l0_iters = vec![];
         for i in state.l0_sstables.iter() {
             let t = state.sstables[i].clone();
-            if !t.range_overlap(lower, upper) {
+            if !t.range_overlap(physical_lower, physical_upper) {
                 continue;
             }
 
             let mut s = match lower {
-                Bound::Included(lower) => {
-                    SsTableIterator::create_and_seek_to_key(t.clone(), KeySlice::from_slice(lower))?
+                Bound::Included(lower_key) => {
+                    let seek = encode_seek(lower_key);
+                    SsTableIterator::create_and_seek_to_key(t.clone(), KeySlice::from_slice(&seek))?
                 }
-                Bound::Excluded(lower) => {
-                    // if t.first_key().as_key_slice() >= KeySlice::from_slice(lower)
-                    //     || t.last_key().as_key_slice() <= KeySlice::from_slice(lower)
-                    // {
-                    //     continue;
-                    // }
+                Bound::Excluded(lower_key) => {
+                    let seek = encode_seek(lower_key);
                     let mut s = SsTableIterator::create_and_seek_to_key(
                         t.clone(),
-                        KeySlice::from_slice(lower),
+                        KeySlice::from_slice(&seek),
                     )?;
-                    if s.is_valid() && s.key().raw_ref() == lower {
-                        s.next()?;
+                    // Skip all versions of the excluded key
+                    if s.is_valid() {
+                        let seek_user_key = crate::key::encoded_user_key_prefix(&seek);
+                        while s.is_valid()
+                            && crate::key::encoded_user_key_prefix(s.key().raw_ref())
+                                == seek_user_key
+                        {
+                            s.next()?;
+                        }
                     }
-
                     s
                 }
                 Bound::Unbounded => SsTableIterator::create_and_seek_to_first(t.clone())?,
@@ -1361,19 +1460,30 @@ impl LsmStorageInner {
             }
             let concat_iter = if let Some(ref vlog) = self.vlog {
                 match lower {
-                    Bound::Included(lower) => SstConcatIterator::create_and_seek_to_key_with_vlog(
-                        ss_tables,
-                        KeySlice::from_slice(lower),
-                        vlog.clone(),
-                    )?,
-                    Bound::Excluded(lower) => {
+                    Bound::Included(lower_key) => {
+                        let seek = encode_seek(lower_key);
+                        SstConcatIterator::create_and_seek_to_key_with_vlog(
+                            ss_tables,
+                            KeySlice::from_slice(&seek),
+                            vlog.clone(),
+                        )?
+                    }
+                    Bound::Excluded(lower_key) => {
+                        let seek = encode_seek(lower_key);
                         let mut iter = SstConcatIterator::create_and_seek_to_key_with_vlog(
                             ss_tables,
-                            KeySlice::from_slice(lower),
+                            KeySlice::from_slice(&seek),
                             vlog.clone(),
                         )?;
-                        if iter.is_valid() && iter.key().raw_ref() == lower {
-                            iter.next()?;
+                        // Skip all versions of the excluded key
+                        if iter.is_valid() {
+                            let seek_user_key = crate::key::encoded_user_key_prefix(&seek);
+                            while iter.is_valid()
+                                && crate::key::encoded_user_key_prefix(iter.key().raw_ref())
+                                    == seek_user_key
+                            {
+                                iter.next()?;
+                            }
                         }
                         iter
                     }
@@ -1384,17 +1494,28 @@ impl LsmStorageInner {
                 }
             } else {
                 match lower {
-                    Bound::Included(lower) => SstConcatIterator::create_and_seek_to_key(
-                        ss_tables,
-                        KeySlice::from_slice(lower),
-                    )?,
-                    Bound::Excluded(lower) => {
+                    Bound::Included(lower_key) => {
+                        let seek = encode_seek(lower_key);
+                        SstConcatIterator::create_and_seek_to_key(
+                            ss_tables,
+                            KeySlice::from_slice(&seek),
+                        )?
+                    }
+                    Bound::Excluded(lower_key) => {
+                        let seek = encode_seek(lower_key);
                         let mut iter = SstConcatIterator::create_and_seek_to_key(
                             ss_tables,
-                            KeySlice::from_slice(lower),
+                            KeySlice::from_slice(&seek),
                         )?;
-                        if iter.is_valid() && iter.key().raw_ref() == lower {
-                            iter.next()?;
+                        // Skip all versions of the excluded key
+                        if iter.is_valid() {
+                            let seek_user_key = crate::key::encoded_user_key_prefix(&seek);
+                            while iter.is_valid()
+                                && crate::key::encoded_user_key_prefix(iter.key().raw_ref())
+                                    == seek_user_key
+                            {
+                                iter.next()?;
+                            }
                         }
                         iter
                     }
@@ -1405,6 +1526,7 @@ impl LsmStorageInner {
         }
         let m_iter = MergeIterator::create(concat_iters);
         let two_m = TwoMergeIterator::create(two_l0_iter, m_iter)?;
+        // Upper bound for LsmIterator uses decoded user keys (not encoded)
         let lit = LsmIterator::new(two_m, Self::into_vec(upper))?;
 
         Ok(FusedIterator::new(lit))

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -201,19 +201,21 @@ impl MemTable {
             return None;
         }
         let seek_key = Bytes::from(crate::key::encode_internal_key(user_key, u64::MAX));
-        let seek_prefix = crate::key::encoded_user_key_prefix(&seek_key).unwrap().to_vec();
+        let seek_prefix = crate::key::encoded_user_key_prefix(&seek_key)
+            .unwrap()
+            .to_vec();
         let mut range = self.map.range::<Bytes, _>(seek_key..);
         if let Some(entry) = range.next() {
             let found_key = entry.key();
             // Check if the decoded user key matches
-            if let Some(found_user_key) = crate::key::encoded_user_key_prefix(found_key) {
-                if found_user_key == seek_prefix.as_slice() {
-                    let val = entry.value();
-                    if self.vlog_enabled && !val.is_empty() {
-                        return Some(val.slice(1..));
-                    } else {
-                        return Some(val.clone());
-                    }
+            if let Some(found_user_key) = crate::key::encoded_user_key_prefix(found_key)
+                && found_user_key == seek_prefix.as_slice()
+            {
+                let val = entry.value();
+                if self.vlog_enabled && !val.is_empty() {
+                    return Some(val.slice(1..));
+                } else {
+                    return Some(val.clone());
                 }
             }
         }
@@ -231,14 +233,16 @@ impl MemTable {
             return None;
         }
         let seek_key = Bytes::from(crate::key::encode_internal_key(user_key, u64::MAX));
-        let seek_prefix = crate::key::encoded_user_key_prefix(&seek_key).unwrap().to_vec();
+        let seek_prefix = crate::key::encoded_user_key_prefix(&seek_key)
+            .unwrap()
+            .to_vec();
         let mut range = self.map.range::<Bytes, _>(seek_key..);
         if let Some(entry) = range.next() {
             let found_key = entry.key();
-            if let Some(found_user_key) = crate::key::encoded_user_key_prefix(found_key) {
-                if found_user_key == seek_prefix.as_slice() {
-                    return Some(entry.value().clone());
-                }
+            if let Some(found_user_key) = crate::key::encoded_user_key_prefix(found_key)
+                && found_user_key == seek_prefix.as_slice()
+            {
+                return Some(entry.value().clone());
             }
         }
         None

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -202,7 +202,7 @@ impl MemTable {
         }
         let seek_key = Bytes::from(crate::key::encode_internal_key(user_key, u64::MAX));
         let seek_prefix = crate::key::encoded_user_key_prefix(&seek_key)
-            .unwrap()
+            .expect("seek_key is newly encoded and guaranteed to be well-formed")
             .to_vec();
         let mut range = self.map.range::<Bytes, _>(seek_key..);
         if let Some(entry) = range.next() {
@@ -234,7 +234,7 @@ impl MemTable {
         }
         let seek_key = Bytes::from(crate::key::encode_internal_key(user_key, u64::MAX));
         let seek_prefix = crate::key::encoded_user_key_prefix(&seek_key)
-            .unwrap()
+            .expect("seek_key is newly encoded and guaranteed to be well-formed")
             .to_vec();
         let mut range = self.map.range::<Bytes, _>(seek_key..);
         if let Some(entry) = range.next() {
@@ -306,7 +306,7 @@ impl MemTable {
             // which just causes an unnecessary skiplist probe — harmless.
             // Hash the decoded user key (not the encoded internal key) so that
             // bloom filter lookups using raw user keys still match.
-            let user_key = key.decode_user_key();
+            let user_key = key.decode_user_key_cow();
             self.bloom
                 .push_hash(super::table::bloom::hash_key(&user_key));
             self.map.insert(

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -113,8 +113,14 @@ impl MemTable {
     /// Used after WAL recovery where entries are inserted directly into the skiplist.
     fn rebuild_bloom(&self) {
         for entry in self.map.iter() {
+            let key = entry.key();
+            let hash_key = if crate::key::TS_ENABLED {
+                crate::key::decode_user_key(key).unwrap_or_else(|| key.to_vec())
+            } else {
+                key.to_vec()
+            };
             self.bloom
-                .push_hash(super::table::bloom::hash_key(entry.key()));
+                .push_hash(super::table::bloom::hash_key(&hash_key));
         }
     }
 
@@ -184,7 +190,9 @@ impl MemTable {
     /// The memtable stores encoded internal keys. This method seeks to
     /// `encode(user_key, u64::MAX)` (the smallest encoded form for the user key)
     /// and returns the first entry whose decoded user key matches.
-    pub fn get_versioned(&self, user_key: &[u8], read_ts: u64) -> Option<Bytes> {
+    // NOTE: `read_ts` is accepted for API compatibility but not yet enforced.
+    // Snapshot isolation requires recovering the MVCC timestamp on startup (Phase 2).
+    pub fn get_versioned(&self, user_key: &[u8], _read_ts: u64) -> Option<Bytes> {
         if self.is_empty() {
             return None;
         }
@@ -213,7 +221,8 @@ impl MemTable {
     }
 
     /// Get the raw value for the newest version of a user key visible at `read_ts`.
-    pub fn get_versioned_raw(&self, user_key: &[u8], read_ts: u64) -> Option<Bytes> {
+    // NOTE: `read_ts` is accepted for API compatibility but not yet enforced.
+    pub fn get_versioned_raw(&self, user_key: &[u8], _read_ts: u64) -> Option<Bytes> {
         if self.is_empty() {
             return None;
         }

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -179,6 +179,62 @@ impl MemTable {
         self.map.get(key).map(|x| x.value().clone())
     }
 
+    /// Get the newest version of a user key visible at `read_ts`.
+    ///
+    /// The memtable stores encoded internal keys. This method seeks to
+    /// `encode(user_key, u64::MAX)` (the smallest encoded form for the user key)
+    /// and returns the first entry whose decoded user key matches.
+    pub fn get_versioned(&self, user_key: &[u8], read_ts: u64) -> Option<Bytes> {
+        if self.is_empty() {
+            return None;
+        }
+        let bloom_hash = super::table::bloom::hash_key(user_key);
+        if !self.bloom.may_contain_hash(bloom_hash) {
+            return None;
+        }
+        let seek_key = Bytes::from(crate::key::encode_internal_key(user_key, u64::MAX));
+        let seek_prefix = crate::key::encoded_user_key_prefix(&seek_key).unwrap().to_vec();
+        let mut range = self.map.range::<Bytes, _>(seek_key..);
+        if let Some(entry) = range.next() {
+            let found_key = entry.key();
+            // Check if the decoded user key matches
+            if let Some(found_user_key) = crate::key::encoded_user_key_prefix(found_key) {
+                if found_user_key == seek_prefix.as_slice() {
+                    let val = entry.value();
+                    if self.vlog_enabled && !val.is_empty() {
+                        return Some(val.slice(1..));
+                    } else {
+                        return Some(val.clone());
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Get the raw value for the newest version of a user key visible at `read_ts`.
+    pub fn get_versioned_raw(&self, user_key: &[u8], read_ts: u64) -> Option<Bytes> {
+        if self.is_empty() {
+            return None;
+        }
+        let bloom_hash = super::table::bloom::hash_key(user_key);
+        if !self.bloom.may_contain_hash(bloom_hash) {
+            return None;
+        }
+        let seek_key = Bytes::from(crate::key::encode_internal_key(user_key, u64::MAX));
+        let seek_prefix = crate::key::encoded_user_key_prefix(&seek_key).unwrap().to_vec();
+        let mut range = self.map.range::<Bytes, _>(seek_key..);
+        if let Some(entry) = range.next() {
+            let found_key = entry.key();
+            if let Some(found_user_key) = crate::key::encoded_user_key_prefix(found_key) {
+                if found_user_key == seek_prefix.as_slice() {
+                    return Some(entry.value().clone());
+                }
+            }
+        }
+        None
+    }
+
     /// Collect vLog file IDs referenced by ValuePointer entries in this memtable.
     /// Used during startup to prevent orphan cleanup from deleting vLog files
     /// that are still needed by unflushed memtable entries.
@@ -235,8 +291,11 @@ impl MemTable {
             // contained" for a key that IS in the skiplist). The worst case is
             // a false positive (bloom says "contained" but key not yet inserted),
             // which just causes an unnecessary skiplist probe — harmless.
+            // Hash the decoded user key (not the encoded internal key) so that
+            // bloom filter lookups using raw user keys still match.
+            let user_key = key.decode_user_key();
             self.bloom
-                .push_hash(super::table::bloom::hash_key(key.raw_ref()));
+                .push_hash(super::table::bloom::hash_key(&user_key));
             self.map.insert(
                 shared_bytes_from_slice(key.raw_ref()),
                 shared_bytes_from_slice(value),
@@ -451,7 +510,14 @@ impl MemTableIterator {
         let Some(ptr) = crate::vlog::ValuePointer::try_decode(&val[1..]) else {
             return Bytes::new();
         };
-        match vlog.read(&ptr, &item.0) {
+        // With MVCC, the memtable key is an encoded internal key but the vlog
+        // stores raw user keys for verification. Decode the user key first.
+        let vlog_key = if crate::key::TS_ENABLED {
+            crate::key::decode_user_key(&item.0).unwrap_or_else(|| item.0.to_vec())
+        } else {
+            item.0.to_vec()
+        };
+        match vlog.read(&ptr, &vlog_key) {
             std::result::Result::Ok(bytes) => bytes,
             std::result::Result::Err(_) => Bytes::new(),
         }

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -51,7 +51,12 @@ impl LsmMvccInner {
     }
 
     /// Allocate a commit timestamp under the write lock and write to the memtable.
-    pub fn write(&self, user_key: &[u8], value: &[u8], memtable: &MemTable) -> Result<(), anyhow::Error> {
+    pub fn write(
+        &self,
+        user_key: &[u8],
+        value: &[u8],
+        memtable: &MemTable,
+    ) -> Result<(), anyhow::Error> {
         let _write_guard = self.write_lock.lock();
         let commit_ts = {
             let mut ts = self.ts.lock();

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -9,7 +9,7 @@ use std::{
 use parking_lot::Mutex;
 
 use self::{txn::Transaction, watermark::Watermark};
-use crate::lsm_storage::LsmStorageInner;
+use crate::{key::encode_internal_key, lsm_storage::LsmStorageInner, mem_table::MemTable};
 
 pub(crate) struct CommittedTxnData {
     pub(crate) key_hashes: HashSet<u32>,
@@ -48,6 +48,25 @@ impl LsmMvccInner {
     pub fn watermark(&self) -> u64 {
         let ts = self.ts.lock();
         ts.1.watermark().unwrap_or(ts.0)
+    }
+
+    /// Allocate a commit timestamp under the write lock and write to the memtable.
+    pub fn write(&self, user_key: &[u8], value: &[u8], memtable: &MemTable) -> Result<(), anyhow::Error> {
+        let _write_guard = self.write_lock.lock();
+        let commit_ts = {
+            let mut ts = self.ts.lock();
+            ts.0 += 1;
+            ts.0
+        };
+        let encoded_key = encode_internal_key(user_key, commit_ts);
+        memtable.put(&encoded_key, value)?;
+        Ok(())
+    }
+
+    /// Get a read timestamp (the latest committed ts).
+    /// This does NOT add a reader to the watermark — that's done via ReadGuard.
+    pub fn read_ts(&self) -> u64 {
+        self.ts.lock().0
     }
 
     pub fn new_txn(&self, inner: Arc<LsmStorageInner>, serializable: bool) -> Arc<Transaction> {

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -78,3 +78,41 @@ impl LsmMvccInner {
         unimplemented!()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mvcc_inner_new() {
+        let mvcc = LsmMvccInner::new(0);
+        assert_eq!(mvcc.latest_commit_ts(), 0);
+        assert_eq!(mvcc.read_ts(), 0);
+        assert_eq!(mvcc.watermark(), 0); // no readers → returns latest_commit_ts
+    }
+
+    #[test]
+    fn test_mvcc_inner_write() {
+        let mvcc = LsmMvccInner::new(0);
+        let memtable = crate::mem_table::MemTable::create(0);
+        mvcc.write(b"key1", b"val1", &memtable).unwrap();
+        assert_eq!(mvcc.latest_commit_ts(), 1);
+        mvcc.write(b"key1", b"val2", &memtable).unwrap();
+        assert_eq!(mvcc.latest_commit_ts(), 2);
+        // Both versions should be in the memtable (use versioned lookup
+        // which matches the bloom filter's decoded-user-key hashing)
+        // Verify memtable is not empty
+        assert!(!memtable.is_empty(), "memtable should have entries after write");
+        let v2 = memtable.get_versioned(b"key1", 2);
+        assert!(v2.is_some(), "ts=2 version should exist, commit_ts={}", mvcc.latest_commit_ts());
+        assert_eq!(v2.unwrap().as_ref(), b"val2");
+    }
+
+    #[test]
+    fn test_mvcc_inner_update_commit_ts() {
+        let mvcc = LsmMvccInner::new(0);
+        mvcc.update_commit_ts(100);
+        assert_eq!(mvcc.latest_commit_ts(), 100);
+        assert_eq!(mvcc.read_ts(), 100);
+    }
+}

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -102,9 +102,16 @@ mod tests {
         // Both versions should be in the memtable (use versioned lookup
         // which matches the bloom filter's decoded-user-key hashing)
         // Verify memtable is not empty
-        assert!(!memtable.is_empty(), "memtable should have entries after write");
+        assert!(
+            !memtable.is_empty(),
+            "memtable should have entries after write"
+        );
         let v2 = memtable.get_versioned(b"key1", 2);
-        assert!(v2.is_some(), "ts=2 version should exist, commit_ts={}", mvcc.latest_commit_ts());
+        assert!(
+            v2.is_some(),
+            "ts=2 version should exist, commit_ts={}",
+            mvcc.latest_commit_ts()
+        );
         assert_eq!(v2.unwrap().as_ref(), b"val2");
     }
 

--- a/kv-engine/src/mvcc/watermark.rs
+++ b/kv-engine/src/mvcc/watermark.rs
@@ -1,5 +1,8 @@
 use std::collections::BTreeMap;
 
+/// Tracks the oldest active read timestamp across all readers.
+/// When there are no readers, the watermark is `None`, meaning
+/// all committed versions below the latest commit ts can be GC'd.
 pub struct Watermark {
     readers: BTreeMap<u64, usize>,
 }
@@ -11,11 +14,21 @@ impl Watermark {
         }
     }
 
-    pub fn add_reader(&mut self, ts: u64) {}
+    pub fn add_reader(&mut self, ts: u64) {
+        *self.readers.entry(ts).or_insert(0) += 1;
+    }
 
-    pub fn remove_reader(&mut self, ts: u64) {}
+    pub fn remove_reader(&mut self, ts: u64) {
+        if let Some(cnt) = self.readers.get_mut(&ts) {
+            *cnt -= 1;
+            if *cnt == 0 {
+                self.readers.remove(&ts);
+            }
+        }
+    }
 
+    /// Returns the smallest active read timestamp, or `None` if no readers exist.
     pub fn watermark(&self) -> Option<u64> {
-        Some(0)
+        self.readers.keys().next().copied()
     }
 }

--- a/kv-engine/src/mvcc/watermark.rs
+++ b/kv-engine/src/mvcc/watermark.rs
@@ -32,3 +32,50 @@ impl Watermark {
         self.readers.keys().next().copied()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_watermark_empty() {
+        let wm = Watermark::new();
+        assert_eq!(wm.watermark(), None);
+    }
+
+    #[test]
+    fn test_watermark_single_reader() {
+        let mut wm = Watermark::new();
+        wm.add_reader(10);
+        assert_eq!(wm.watermark(), Some(10));
+        wm.remove_reader(10);
+        assert_eq!(wm.watermark(), None);
+    }
+
+    #[test]
+    fn test_watermark_multiple_readers() {
+        let mut wm = Watermark::new();
+        wm.add_reader(20);
+        wm.add_reader(10);
+        wm.add_reader(15);
+        assert_eq!(wm.watermark(), Some(10)); // oldest
+        wm.remove_reader(10);
+        assert_eq!(wm.watermark(), Some(15));
+        wm.remove_reader(15);
+        assert_eq!(wm.watermark(), Some(20));
+        wm.remove_reader(20);
+        assert_eq!(wm.watermark(), None);
+    }
+
+    #[test]
+    fn test_watermark_duplicate_reader_ts() {
+        let mut wm = Watermark::new();
+        wm.add_reader(5);
+        wm.add_reader(5); // same ts, count=2
+        assert_eq!(wm.watermark(), Some(5));
+        wm.remove_reader(5); // count=1
+        assert_eq!(wm.watermark(), Some(5));
+        wm.remove_reader(5); // count=0, removed
+        assert_eq!(wm.watermark(), None);
+    }
+}

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -445,73 +445,39 @@ impl SsTable {
         let lo = self.first_key.as_key_slice();
         let hi = self.last_key.as_key_slice();
 
-        if TS_ENABLED {
-            // With MVCC, bounds are encoded internal keys. Compare encoded keys directly
-            // since the encoding preserves byte order.
-            match lower {
-                Bound::Included(x) => {
-                    let x = KeySlice::from_slice(x);
-                    if x > hi {
-                        return false;
-                    }
+        // Both TS_ENABLED and non-TS paths compare encoded keys directly
+        // since the encoding preserves byte order.
+        match lower {
+            Bound::Included(x) => {
+                let x = KeySlice::from_slice(x);
+                if x > hi {
+                    return false;
                 }
-                Bound::Excluded(x) => {
-                    let x = KeySlice::from_slice(x);
-                    if x >= hi {
-                        return false;
-                    }
+            }
+            Bound::Excluded(x) => {
+                let x = KeySlice::from_slice(x);
+                if x >= hi {
+                    return false;
                 }
-                _ => {}
-            };
+            }
+            _ => {}
+        };
 
-            match upper {
-                Bound::Included(y) => {
-                    let y = KeySlice::from_slice(y);
-                    if y < lo {
-                        return false;
-                    }
+        match upper {
+            Bound::Included(y) => {
+                let y = KeySlice::from_slice(y);
+                if y < lo {
+                    return false;
                 }
-                Bound::Excluded(y) => {
-                    let y = KeySlice::from_slice(y);
-                    if y <= lo {
-                        return false;
-                    }
+            }
+            Bound::Excluded(y) => {
+                let y = KeySlice::from_slice(y);
+                if y <= lo {
+                    return false;
                 }
-                _ => {}
-            };
-        } else {
-            match lower {
-                Bound::Included(x) => {
-                    let x = KeySlice::from_slice(x);
-                    if x > hi {
-                        return false;
-                    }
-                }
-                Bound::Excluded(x) => {
-                    let x = KeySlice::from_slice(x);
-                    if x >= hi {
-                        return false;
-                    }
-                }
-                _ => {}
-            };
-
-            match upper {
-                Bound::Included(y) => {
-                    let y = KeySlice::from_slice(y);
-                    if y < lo {
-                        return false;
-                    }
-                }
-                Bound::Excluded(y) => {
-                    let y = KeySlice::from_slice(y);
-                    if y <= lo {
-                        return false;
-                    }
-                }
-                _ => {}
-            };
-        }
+            }
+            _ => {}
+        };
 
         true
     }

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -381,8 +381,10 @@ impl SsTable {
                 break;
             }
             block = self.read_block_cached(blk_idx)?;
-            blk_iter =
-                crate::block::BlockIterator::create_and_seek_to_key(block, KeySlice::from_slice(key));
+            blk_iter = crate::block::BlockIterator::create_and_seek_to_key(
+                block,
+                KeySlice::from_slice(key),
+            );
         }
         if blk_iter.is_valid() {
             if TS_ENABLED {
@@ -397,14 +399,17 @@ impl SsTable {
                         break; // Different user key
                     }
                     let ts = found_key.ts();
-                    if read_ts.map_or(true, |rts| ts <= rts) {
+                    if read_ts.is_none_or(|rts| ts <= rts) {
                         return Ok(Some((blk_iter.value_bytes(), found_key.raw_ref().to_vec())));
                     }
                     // This version is too new — advance to the next version
                     blk_iter.next();
                 }
             } else if blk_iter.key().raw_ref() == key {
-                return Ok(Some((blk_iter.value_bytes(), blk_iter.key().raw_ref().to_vec())));
+                return Ok(Some((
+                    blk_iter.value_bytes(),
+                    blk_iter.key().raw_ref().to_vec(),
+                )));
             }
         }
         Ok(None)

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -386,17 +386,20 @@ impl SsTable {
                 KeySlice::from_slice(key),
             );
         }
-        if blk_iter.is_valid() {
-            if TS_ENABLED {
-                let seek_uk = crate::key::encoded_user_key_prefix(key).unwrap_or(key);
-                // Scan forward through versions of the same user key (newest
-                // first due to inverted timestamp ordering) to find the newest
-                // version visible at `read_ts`.
+        if TS_ENABLED {
+            let seek_uk = crate::key::encoded_user_key_prefix(key).unwrap_or(key);
+            // Scan forward through versions of the same user key (newest
+            // first due to inverted timestamp ordering) to find the newest
+            // version visible at `read_ts`.  May span multiple blocks.
+            loop {
                 while blk_iter.is_valid() {
                     let found_key = blk_iter.key();
                     let found_uk = found_key.encoded_user_key();
                     if found_uk != seek_uk {
-                        break; // Different user key
+                        // Different user key — no more versions in this block.
+                        // Check if a later block might have more versions (can
+                        // happen when encoded keys shift block boundaries).
+                        break;
                     }
                     let ts = found_key.ts();
                     if read_ts.is_none_or(|rts| ts <= rts) {
@@ -405,12 +408,30 @@ impl SsTable {
                     // This version is too new — advance to the next version
                     blk_iter.next();
                 }
-            } else if blk_iter.key().raw_ref() == key {
-                return Ok(Some((
-                    blk_iter.value_bytes(),
-                    blk_iter.key().raw_ref().to_vec(),
-                )));
+                // The current block had only too-new versions or a different
+                // user key.  Try the next block in case the user key spans a
+                // block boundary.
+                if !blk_iter.is_valid() {
+                    blk_idx += 1;
+                    if blk_idx >= self.num_of_blocks() {
+                        break;
+                    }
+                    block = self.read_block_cached(blk_idx)?;
+                    blk_iter = crate::block::BlockIterator::create_and_seek_to_key(
+                        block,
+                        KeySlice::from_slice(key),
+                    );
+                    // Continue the outer loop to scan this new block
+                    continue;
+                }
+                // Different user key — no point checking later blocks
+                break;
             }
+        } else if blk_iter.is_valid() && blk_iter.key().raw_ref() == key {
+            return Ok(Some((
+                blk_iter.value_bytes(),
+                blk_iter.key().raw_ref().to_vec(),
+            )));
         }
         Ok(None)
     }
@@ -448,34 +469,14 @@ impl SsTable {
         // Both TS_ENABLED and non-TS paths compare encoded keys directly
         // since the encoding preserves byte order.
         match lower {
-            Bound::Included(x) => {
-                let x = KeySlice::from_slice(x);
-                if x > hi {
-                    return false;
-                }
-            }
-            Bound::Excluded(x) => {
-                let x = KeySlice::from_slice(x);
-                if x >= hi {
-                    return false;
-                }
-            }
+            Bound::Included(x) if KeySlice::from_slice(x) > hi => return false,
+            Bound::Excluded(x) if KeySlice::from_slice(x) >= hi => return false,
             _ => {}
         };
 
         match upper {
-            Bound::Included(y) => {
-                let y = KeySlice::from_slice(y);
-                if y < lo {
-                    return false;
-                }
-            }
-            Bound::Excluded(y) => {
-                let y = KeySlice::from_slice(y);
-                if y <= lo {
-                    return false;
-                }
-            }
+            Bound::Included(y) if KeySlice::from_slice(y) < lo => return false,
+            Bound::Excluded(y) if KeySlice::from_slice(y) <= lo => return false,
             _ => {}
         };
 

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -249,6 +249,11 @@ impl SsTable {
     pub fn find_block_idx(&self, key: KeySlice) -> usize {
         let mut lo = 0;
         let mut hi = self.block_meta.len() - 1;
+        // For MVCC: track the earliest block whose user-key range contains the
+        // seek key. Newer versions have smaller inverted_ts and sort first, so
+        // the earliest matching block contains the newest version.
+        let mut earliest_match: Option<usize> = None;
+
         while lo <= hi {
             let mid = lo + (hi - lo) / 2;
             let first = self.block_meta[mid].first_key.as_key_slice();
@@ -262,16 +267,21 @@ impl SsTable {
                 let first_uk = first.encoded_user_key();
                 let last_uk = last.encoded_user_key();
                 if seek_uk >= first_uk && seek_uk <= last_uk {
-                    return mid;
-                }
-                if seek_uk < first_uk {
+                    earliest_match = Some(mid);
+                    // Continue searching left for an earlier block with the same
+                    // user key range (may contain a newer version).
                     if mid == 0 {
                         return 0;
                     }
                     hi = mid - 1;
+                } else if seek_uk < first_uk {
+                    if mid == 0 {
+                        return earliest_match.unwrap_or(0);
+                    }
+                    hi = mid - 1;
                 } else {
                     if mid == self.block_meta.len() - 1 {
-                        return self.block_meta.len() - 1;
+                        return earliest_match.unwrap_or(self.block_meta.len() - 1);
                     }
                     lo = mid + 1;
                 }
@@ -294,7 +304,7 @@ impl SsTable {
         }
         // lo is the insertion point: the first block whose first_key > seek key.
         // If the seek key is before all blocks, lo == 0; if after all, lo == len.
-        lo.min(self.block_meta.len() - 1)
+        earliest_match.unwrap_or_else(|| lo.min(self.block_meta.len() - 1))
     }
 
     /// Direct point lookup for a single key. Returns `Some(raw_value)` if found,
@@ -311,6 +321,32 @@ impl SsTable {
     /// Like `point_get`, but accepts a precomputed bloom hash to avoid
     /// recomputing it when the same key is probed across multiple L0 SSTs.
     pub(crate) fn point_get_with_hash(&self, key: &[u8], bloom_hash: u32) -> Result<Option<Bytes>> {
+        self.point_get_with_hash_inner(key, bloom_hash, None)
+            .map(|opt| opt.map(|(val, _found_key)| val))
+    }
+
+    /// Like `point_get_with_hash`, but also returns the full encoded key of
+    /// the found entry.  Used by the MVCC lookup path to compare timestamps
+    /// across multiple SSTs.
+    ///
+    /// When `read_ts` is provided (MVCC mode), returns the newest version
+    /// whose commit timestamp is <= `read_ts`.  Scans forward through
+    /// versions of the same user key if the first match is too new.
+    pub(crate) fn point_get_with_hash_and_key(
+        &self,
+        key: &[u8],
+        bloom_hash: u32,
+        read_ts: Option<u64>,
+    ) -> Result<Option<(Bytes, Vec<u8>)>> {
+        self.point_get_with_hash_inner(key, bloom_hash, read_ts)
+    }
+
+    fn point_get_with_hash_inner(
+        &self,
+        key: &[u8],
+        bloom_hash: u32,
+        read_ts: Option<u64>,
+    ) -> Result<Option<(Bytes, Vec<u8>)>> {
         // Key range check — compare encoded keys (byte-order preserved).
         // With MVCC, the search key uses ts=u64::MAX (smallest encoded form for the
         // user key), so it may sort before the SST's first_key. We skip the range
@@ -318,15 +354,11 @@ impl SsTable {
         if !TS_ENABLED && (key < self.first_key.raw_ref() || key > self.last_key.raw_ref()) {
             return Ok(None);
         }
-        // Bloom filter check — hash decoded user key when MVCC is enabled
-        if TS_ENABLED {
-            let user_key = crate::key::decode_user_key(key).unwrap_or_else(|| key.to_vec());
-            if let Some(ref bloom) = self.bloom
-                && !bloom.may_contain(crate::table::bloom::hash_key(&user_key))
-            {
-                return Ok(None);
-            }
-        } else if let Some(ref bloom) = self.bloom
+        // Bloom filter check.  The caller precomputes hash_key(raw_user_key),
+        // which equals hash_key(decode(encode(user_key, MAX))) — the same hash
+        // the bloom filter was built with.  Use it directly for both MVCC and
+        // non-MVCC paths, avoiding a redundant decode + rehash per SST probe.
+        if let Some(ref bloom) = self.bloom
             && !bloom.may_contain(bloom_hash)
         {
             return Ok(None);
@@ -354,12 +386,25 @@ impl SsTable {
         }
         if blk_iter.is_valid() {
             if TS_ENABLED {
-                let found_key = blk_iter.key();
-                if found_key.encoded_user_key() == crate::key::encoded_user_key_prefix(key).unwrap_or(key) {
-                    return Ok(Some(blk_iter.value_bytes()));
+                let seek_uk = crate::key::encoded_user_key_prefix(key).unwrap_or(key);
+                // Scan forward through versions of the same user key (newest
+                // first due to inverted timestamp ordering) to find the newest
+                // version visible at `read_ts`.
+                while blk_iter.is_valid() {
+                    let found_key = blk_iter.key();
+                    let found_uk = found_key.encoded_user_key();
+                    if found_uk != seek_uk {
+                        break; // Different user key
+                    }
+                    let ts = found_key.ts();
+                    if read_ts.map_or(true, |rts| ts <= rts) {
+                        return Ok(Some((blk_iter.value_bytes(), found_key.raw_ref().to_vec())));
+                    }
+                    // This version is too new — advance to the next version
+                    blk_iter.next();
                 }
             } else if blk_iter.key().raw_ref() == key {
-                return Ok(Some(blk_iter.value_bytes()));
+                return Ok(Some((blk_iter.value_bytes(), blk_iter.key().raw_ref().to_vec())));
             }
         }
         Ok(None)

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -12,7 +12,7 @@ pub use iterator::SsTableIterator;
 use self::bloom::Bloom;
 use crate::{
     block::{Block, SIZE_OF_U16},
-    key::{Key, KeyBytes, KeySlice},
+    key::{Key, KeyBytes, KeySlice, TS_ENABLED},
     lsm_storage::BlockCache,
 };
 
@@ -251,28 +251,50 @@ impl SsTable {
         let mut hi = self.block_meta.len() - 1;
         while lo <= hi {
             let mid = lo + (hi - lo) / 2;
-            if key >= self.block_meta[mid].first_key.as_key_slice()
-                && key <= self.block_meta[mid].last_key.as_key_slice()
-            {
-                return mid;
-            }
+            let first = self.block_meta[mid].first_key.as_key_slice();
+            let last = self.block_meta[mid].last_key.as_key_slice();
 
-            if key < self.block_meta[mid].first_key.as_key_slice() {
-                if mid == 0 {
-                    return 0;
+            if TS_ENABLED {
+                // Compare decoded user keys for MVCC. The search key uses
+                // ts=u64::MAX so byte-order comparison against block boundaries
+                // (which have real timestamps) would be wrong.
+                let seek_uk = key.encoded_user_key();
+                let first_uk = first.encoded_user_key();
+                let last_uk = last.encoded_user_key();
+                if seek_uk >= first_uk && seek_uk <= last_uk {
+                    return mid;
                 }
-
-                hi = mid - 1;
+                if seek_uk < first_uk {
+                    if mid == 0 {
+                        return 0;
+                    }
+                    hi = mid - 1;
+                } else {
+                    if mid == self.block_meta.len() - 1 {
+                        return self.block_meta.len() - 1;
+                    }
+                    lo = mid + 1;
+                }
             } else {
-                if mid == self.block_meta.len() - 1 {
-                    return self.block_meta.len() - 1;
+                if key >= first && key <= last {
+                    return mid;
                 }
-
-                lo = mid + 1;
+                if key < first {
+                    if mid == 0 {
+                        return 0;
+                    }
+                    hi = mid - 1;
+                } else {
+                    if mid == self.block_meta.len() - 1 {
+                        return self.block_meta.len() - 1;
+                    }
+                    lo = mid + 1;
+                }
             }
         }
-
-        lo
+        // lo is the insertion point: the first block whose first_key > seek key.
+        // If the seek key is before all blocks, lo == 0; if after all, lo == len.
+        lo.min(self.block_meta.len() - 1)
     }
 
     /// Direct point lookup for a single key. Returns `Some(raw_value)` if found,
@@ -289,12 +311,22 @@ impl SsTable {
     /// Like `point_get`, but accepts a precomputed bloom hash to avoid
     /// recomputing it when the same key is probed across multiple L0 SSTs.
     pub(crate) fn point_get_with_hash(&self, key: &[u8], bloom_hash: u32) -> Result<Option<Bytes>> {
-        // Key range check
-        if key < self.first_key.raw_ref() || key > self.last_key.raw_ref() {
+        // Key range check — compare encoded keys (byte-order preserved).
+        // With MVCC, the search key uses ts=u64::MAX (smallest encoded form for the
+        // user key), so it may sort before the SST's first_key. We skip the range
+        // check in MVCC mode and rely on the bloom filter for fast rejection.
+        if !TS_ENABLED && (key < self.first_key.raw_ref() || key > self.last_key.raw_ref()) {
             return Ok(None);
         }
-        // Bloom filter check
-        if let Some(ref bloom) = self.bloom
+        // Bloom filter check — hash decoded user key when MVCC is enabled
+        if TS_ENABLED {
+            let user_key = crate::key::decode_user_key(key).unwrap_or_else(|| key.to_vec());
+            if let Some(ref bloom) = self.bloom
+                && !bloom.may_contain(crate::table::bloom::hash_key(&user_key))
+            {
+                return Ok(None);
+            }
+        } else if let Some(ref bloom) = self.bloom
             && !bloom.may_contain(bloom_hash)
         {
             return Ok(None);
@@ -304,16 +336,31 @@ impl SsTable {
             return Ok(None);
         }
         // Find candidate block via metadata binary search.
-        // Each key-value pair is fully contained within one block, so no
-        // cross-block fallback is needed.
-        let blk_idx = self.find_block_idx(KeySlice::from_slice(key));
-        let block = self.read_block_cached(blk_idx)?;
+        let mut blk_idx = self.find_block_idx(KeySlice::from_slice(key));
+        let mut block = self.read_block_cached(blk_idx)?;
         // Seek within the block
-        let blk_iter =
+        let mut blk_iter =
             crate::block::BlockIterator::create_and_seek_to_key(block, KeySlice::from_slice(key));
-        if blk_iter.is_valid() && blk_iter.key().raw_ref() == key {
-            // Zero-copy slice into the cached block — refcount bump only.
-            return Ok(Some(blk_iter.value_bytes()));
+        // If the block iterator is positioned before the target key (can happen
+        // when encoded keys shift block boundaries), advance to subsequent blocks.
+        while !blk_iter.is_valid() || blk_iter.key().raw_ref() < key {
+            blk_idx += 1;
+            if blk_idx >= self.num_of_blocks() {
+                break;
+            }
+            block = self.read_block_cached(blk_idx)?;
+            blk_iter =
+                crate::block::BlockIterator::create_and_seek_to_key(block, KeySlice::from_slice(key));
+        }
+        if blk_iter.is_valid() {
+            if TS_ENABLED {
+                let found_key = blk_iter.key();
+                if found_key.encoded_user_key() == crate::key::encoded_user_key_prefix(key).unwrap_or(key) {
+                    return Ok(Some(blk_iter.value_bytes()));
+                }
+            } else if blk_iter.key().raw_ref() == key {
+                return Ok(Some(blk_iter.value_bytes()));
+            }
         }
         Ok(None)
     }
@@ -348,37 +395,73 @@ impl SsTable {
         let lo = self.first_key.as_key_slice();
         let hi = self.last_key.as_key_slice();
 
-        match lower {
-            Bound::Included(x) => {
-                let x = KeySlice::from_slice(x);
-                if x > hi {
-                    return false;
+        if TS_ENABLED {
+            // With MVCC, bounds are encoded internal keys. Compare encoded keys directly
+            // since the encoding preserves byte order.
+            match lower {
+                Bound::Included(x) => {
+                    let x = KeySlice::from_slice(x);
+                    if x > hi {
+                        return false;
+                    }
                 }
-            }
-            Bound::Excluded(x) => {
-                let x = KeySlice::from_slice(x);
-                if x >= hi {
-                    return false;
+                Bound::Excluded(x) => {
+                    let x = KeySlice::from_slice(x);
+                    if x >= hi {
+                        return false;
+                    }
                 }
-            }
-            _ => {}
-        };
+                _ => {}
+            };
 
-        match upper {
-            Bound::Included(y) => {
-                let y = KeySlice::from_slice(y);
-                if y < lo {
-                    return false;
+            match upper {
+                Bound::Included(y) => {
+                    let y = KeySlice::from_slice(y);
+                    if y < lo {
+                        return false;
+                    }
                 }
-            }
-            Bound::Excluded(y) => {
-                let y = KeySlice::from_slice(y);
-                if y <= lo {
-                    return false;
+                Bound::Excluded(y) => {
+                    let y = KeySlice::from_slice(y);
+                    if y <= lo {
+                        return false;
+                    }
                 }
-            }
-            _ => {}
-        };
+                _ => {}
+            };
+        } else {
+            match lower {
+                Bound::Included(x) => {
+                    let x = KeySlice::from_slice(x);
+                    if x > hi {
+                        return false;
+                    }
+                }
+                Bound::Excluded(x) => {
+                    let x = KeySlice::from_slice(x);
+                    if x >= hi {
+                        return false;
+                    }
+                }
+                _ => {}
+            };
+
+            match upper {
+                Bound::Included(y) => {
+                    let y = KeySlice::from_slice(y);
+                    if y < lo {
+                        return false;
+                    }
+                }
+                Bound::Excluded(y) => {
+                    let y = KeySlice::from_slice(y);
+                    if y <= lo {
+                        return false;
+                    }
+                }
+                _ => {}
+            };
+        }
 
         true
     }

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::{
     block::{Block, BlockBuilder},
-    key::{KeyBytes, KeySlice},
+    key::{KeyBytes, KeySlice, TS_ENABLED},
     lsm_storage::BlockCache,
     vlog::{KvKind, ValueLogBuilder, ValuePointer, ValueSeparationOptions, index::VlogIndexEntry},
 };
@@ -97,9 +97,15 @@ impl SsTableBuilder {
             && value.len() >= self.vlog_options.min_value_size
             && !value.is_empty()
         {
-            // Write value to vLog and store a pointer
+            // Write value to vLog and store a pointer.
+            // vLog entries are keyed by decoded user key (not encoded internal key).
             let vlog = self.vlog_builder.as_mut().expect("vLog builder required");
-            let ptr = vlog.add(key.raw_ref(), value)?;
+            let user_key = if crate::key::TS_ENABLED {
+                key.decode_user_key()
+            } else {
+                key.raw_ref().to_vec()
+            };
+            let ptr = vlog.add(&user_key, value)?;
             let mut buf = [0u8; 1 + ValuePointer::encoded_size()];
             buf[0] = KvKind::ValuePointer as u8;
             ptr.encode(&mut &mut buf[1..]);
@@ -176,7 +182,12 @@ impl SsTableBuilder {
             self.has_data = true;
         }
 
-        self.key_hashes.push(super::bloom::hash_key(key.raw_ref()));
+        if TS_ENABLED {
+            let user_key = key.decode_user_key();
+            self.key_hashes.push(super::bloom::hash_key(&user_key));
+        } else {
+            self.key_hashes.push(super::bloom::hash_key(key.raw_ref()));
+        }
         Ok(())
     }
 

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -183,7 +183,7 @@ impl SsTableBuilder {
         }
 
         if TS_ENABLED {
-            let user_key = key.decode_user_key();
+            let user_key = key.decode_user_key_cow();
             self.key_hashes.push(super::bloom::hash_key(&user_key));
         } else {
             self.key_hashes.push(super::bloom::hash_key(key.raw_ref()));

--- a/kv-engine/src/table/iterator.rs
+++ b/kv-engine/src/table/iterator.rs
@@ -87,12 +87,17 @@ impl SsTableIterator {
         let mut blk_idx = table.find_block_idx(key);
         let mut blk_iter =
             BlockIterator::create_and_seek_to_key(table.read_block_cached(blk_idx)?, key);
-        if !blk_iter.is_valid() {
+        // If the block iterator is invalid OR positioned before the target key,
+        // advance to subsequent blocks until we find one that contains entries >= key.
+        // This handles the case where encoded keys are longer than raw keys,
+        // shifting block boundaries so the target falls past the found block's last key.
+        while !blk_iter.is_valid() || blk_iter.key().raw_ref() < key.raw_ref() {
             blk_idx += 1;
-            if blk_idx < table.num_of_blocks() {
-                blk_iter =
-                    BlockIterator::create_and_seek_to_first(table.read_block_cached(blk_idx)?);
+            if blk_idx >= table.num_of_blocks() {
+                break;
             }
+            blk_iter =
+                BlockIterator::create_and_seek_to_key(table.read_block_cached(blk_idx)?, key);
         }
 
         Ok((blk_idx, blk_iter))
@@ -148,8 +153,15 @@ impl StorageIterator for SsTableIterator {
                     .expect("SsTableIterator encountered ValuePointer but no vLog was provided");
                 let ptr = ValuePointer::try_decode(payload)
                     .expect("SsTableIterator: invalid ValuePointer encoding in block");
+                // With MVCC, the SST key is an encoded internal key but the vlog
+                // stores raw user keys for verification. Decode the user key first.
+                let vlog_key = if crate::key::TS_ENABLED {
+                    self.blk_iter.key().decode_user_key()
+                } else {
+                    self.blk_iter.key().raw_ref().to_vec()
+                };
                 let bytes = vlog
-                    .read(&ptr, self.blk_iter.key().raw_ref())
+                    .read(&ptr, &vlog_key)
                     .expect("SsTableIterator: failed to read value from vLog");
                 let val = bytes.to_vec();
                 // Update cache (safe: single-threaded, only written here)

--- a/kv-engine/src/tests/harness.rs
+++ b/kv-engine/src/tests/harness.rs
@@ -12,7 +12,7 @@ use crate::{
         TieredCompactionOptions,
     },
     iterators::{StorageIterator, merge_iterator::MergeIterator},
-    key::{KeySlice, TS_ENABLED},
+    key::{KeySlice, KeyVec, TS_ENABLED},
     lsm_storage::{BlockCache, KvEngine, LsmStorageInner, LsmStorageState},
     table::{SsTable, SsTableBuilder, SsTableIterator},
 };
@@ -95,12 +95,15 @@ where
 {
     for (k, v) in expected {
         assert!(iter.is_valid());
+        let actual_key = if TS_ENABLED {
+            Bytes::from(iter.key().decode_user_key())
+        } else {
+            as_bytes(iter.key().for_testing_key_ref())
+        };
         assert_eq!(
-            k,
-            iter.key().for_testing_key_ref(),
+            k, actual_key,
             "expected key: {:?}, actual key: {:?}",
-            k,
-            as_bytes(iter.key().for_testing_key_ref()),
+            k, actual_key,
         );
         assert_eq!(
             v,
@@ -186,13 +189,10 @@ pub fn generate_sst(
     data: Vec<(Bytes, Bytes)>,
     block_cache: Option<Arc<BlockCache>>,
 ) -> SsTable {
-    let mut builder = SsTableBuilder::new(128);
-    for (key, value) in data {
-        builder
-            .add(KeySlice::for_testing_from_slice_no_ts(&key[..]), &value[..])
-            .unwrap();
-    }
-    builder.build(id, block_cache, path.as_ref()).unwrap()
+    // Use ts=0 for test-generated SSTs. The encoded key with ts=0 has the
+    // largest byte representation for a given user key (inverted_ts = u64::MAX),
+    // so it sorts after all other versions — consistent with test semantics.
+    generate_sst_with_ts(id, path, data.into_iter().map(|(k, v)| ((k, 0), v)).collect(), block_cache)
 }
 
 #[allow(dead_code)]
@@ -206,7 +206,7 @@ pub fn generate_sst_with_ts(
     for ((key, ts), value) in data {
         builder
             .add(
-                KeySlice::for_testing_from_slice_with_ts(&key[..], ts),
+                KeyVec::from_user_key_ts(&key[..], ts).as_key_slice(),
                 &value[..],
             )
             .unwrap();

--- a/kv-engine/src/tests/harness.rs
+++ b/kv-engine/src/tests/harness.rs
@@ -192,7 +192,12 @@ pub fn generate_sst(
     // Use ts=0 for test-generated SSTs. The encoded key with ts=0 has the
     // largest byte representation for a given user key (inverted_ts = u64::MAX),
     // so it sorts after all other versions — consistent with test semantics.
-    generate_sst_with_ts(id, path, data.into_iter().map(|(k, v)| ((k, 0), v)).collect(), block_cache)
+    generate_sst_with_ts(
+        id,
+        path,
+        data.into_iter().map(|(k, v)| ((k, 0), v)).collect(),
+        block_cache,
+    )
 }
 
 #[allow(dead_code)]

--- a/kv-engine/src/tests/sst.rs
+++ b/kv-engine/src/tests/sst.rs
@@ -214,3 +214,106 @@ fn test_sst_seek_key() {
             .unwrap();
     }
 }
+
+// --- MVCC multi-version point-get tests ---
+
+/// Build an SST with the same user key at multiple timestamps.
+/// Keys are inserted newest-first (higher ts) so they sort first in byte order.
+fn generate_multi_version_sst(dir: &tempfile::TempDir, block_size: usize) -> SsTable {
+    let mut builder = SsTableBuilder::new(block_size);
+    // key "A" at ts=10 (newest), ts=5, ts=1 (oldest)
+    // key "B" at ts=8, ts=3
+    // key "C" at ts=6
+    let entries: Vec<(&[u8], u64, &[u8])> = vec![
+        (b"A", 10, b"A_v10"),
+        (b"A", 5, b"A_v5"),
+        (b"A", 1, b"A_v1"),
+        (b"B", 8, b"B_v8"),
+        (b"B", 3, b"B_v3"),
+        (b"C", 6, b"C_v6"),
+    ];
+    for (uk, ts, val) in &entries {
+        builder
+            .add_raw(KeyVec::from_user_key_ts(uk, *ts).as_key_slice(), val)
+            .unwrap();
+    }
+    builder
+        .build_for_test(dir.path().join("multi_version.sst"))
+        .unwrap()
+}
+
+#[test]
+fn test_sst_multi_version_point_get_newest() {
+    let dir = tempdir().unwrap();
+    let sst = generate_multi_version_sst(&dir, 128);
+    // Without read_ts (None) → returns newest version (ts=10)
+    let (val, found_key) = sst
+        .point_get_with_hash_and_key(b"A", crate::table::bloom::hash_key(b"A"), None)
+        .unwrap()
+        .unwrap();
+    assert_eq!(&*val, b"A_v10");
+    assert_eq!(crate::key::extract_ts(&found_key).unwrap(), 10);
+}
+
+#[test]
+fn test_sst_multi_version_point_get_with_read_ts() {
+    let dir = tempdir().unwrap();
+    let sst = generate_multi_version_sst(&dir, 128);
+    let bh = crate::table::bloom::hash_key(b"A");
+
+    // read_ts=7 → should return ts=5 version (newest <= 7)
+    let (val, found_key) = sst
+        .point_get_with_hash_and_key(b"A", bh, Some(7))
+        .unwrap()
+        .unwrap();
+    assert_eq!(&*val, b"A_v5");
+    assert_eq!(crate::key::extract_ts(&found_key).unwrap(), 5);
+
+    // read_ts=10 → should return ts=10 version
+    let (val, found_key) = sst
+        .point_get_with_hash_and_key(b"A", bh, Some(10))
+        .unwrap()
+        .unwrap();
+    assert_eq!(&*val, b"A_v10");
+    assert_eq!(crate::key::extract_ts(&found_key).unwrap(), 10);
+
+    // read_ts=2 → should return ts=1 version
+    let (val, found_key) = sst
+        .point_get_with_hash_and_key(b"A", bh, Some(2))
+        .unwrap()
+        .unwrap();
+    assert_eq!(&*val, b"A_v1");
+    assert_eq!(crate::key::extract_ts(&found_key).unwrap(), 1);
+
+    // read_ts=0 → below all versions, returns None
+    assert!(sst
+        .point_get_with_hash_and_key(b"A", bh, Some(0))
+        .unwrap()
+        .is_none());
+}
+
+#[test]
+fn test_sst_multi_version_cross_block_read_ts() {
+    // Use tiny block_size so versions of "A" span multiple blocks
+    let dir = tempdir().unwrap();
+    let sst = generate_multi_version_sst(&dir, 16);
+    let bh = crate::table::bloom::hash_key(b"A");
+
+    // read_ts=7 → should still find ts=5 even if it's in a later block
+    let (val, found_key) = sst
+        .point_get_with_hash_and_key(b"A", bh, Some(7))
+        .unwrap()
+        .unwrap();
+    assert_eq!(&*val, b"A_v5");
+    assert_eq!(crate::key::extract_ts(&found_key).unwrap(), 5);
+}
+
+#[test]
+fn test_sst_multi_version_key_ordering() {
+    // Verify newer versions sort first in byte order
+    let k_new = KeyVec::from_user_key_ts(b"A", 10);
+    let k_mid = KeyVec::from_user_key_ts(b"A", 5);
+    let k_old = KeyVec::from_user_key_ts(b"A", 1);
+    assert!(k_new.as_key_slice() < k_mid.as_key_slice());
+    assert!(k_mid.as_key_slice() < k_old.as_key_slice());
+}

--- a/kv-engine/src/tests/sst.rs
+++ b/kv-engine/src/tests/sst.rs
@@ -204,10 +204,10 @@ fn test_sst_seek_key() {
                 as_bytes(&value_of(i)),
                 as_bytes(value)
             );
-            iter.seek_to_key(KeyVec::from_user_key_ts(
-                &format!("key_{:03}", i * 5 + offset).into_bytes(),
-                0,
-            ).as_key_slice())
+            iter.seek_to_key(
+                KeyVec::from_user_key_ts(&format!("key_{:03}", i * 5 + offset).into_bytes(), 0)
+                    .as_key_slice(),
+            )
             .unwrap();
         }
         iter.seek_to_key(KeyVec::from_user_key_ts(b"k", 0).as_key_slice())

--- a/kv-engine/src/tests/sst.rs
+++ b/kv-engine/src/tests/sst.rs
@@ -46,7 +46,7 @@ fn test_sst_build_two_blocks() {
 }
 
 fn key_of(idx: usize) -> KeyVec {
-    KeyVec::for_testing_from_vec_no_ts(format!("key_{:03}", idx * 5).into_bytes())
+    KeyVec::from_user_key_ts(format!("key_{:03}", idx * 5).as_bytes(), 0)
 }
 
 fn value_of(idx: usize) -> Vec<u8> {
@@ -204,12 +204,13 @@ fn test_sst_seek_key() {
                 as_bytes(&value_of(i)),
                 as_bytes(value)
             );
-            iter.seek_to_key(KeySlice::for_testing_from_slice_no_ts(
+            iter.seek_to_key(KeyVec::from_user_key_ts(
                 &format!("key_{:03}", i * 5 + offset).into_bytes(),
-            ))
+                0,
+            ).as_key_slice())
             .unwrap();
         }
-        iter.seek_to_key(KeySlice::for_testing_from_slice_no_ts(b"k"))
+        iter.seek_to_key(KeyVec::from_user_key_ts(b"k", 0).as_key_slice())
             .unwrap();
     }
 }

--- a/kv-engine/src/tests/sst.rs
+++ b/kv-engine/src/tests/sst.rs
@@ -286,10 +286,11 @@ fn test_sst_multi_version_point_get_with_read_ts() {
     assert_eq!(crate::key::extract_ts(&found_key).unwrap(), 1);
 
     // read_ts=0 → below all versions, returns None
-    assert!(sst
-        .point_get_with_hash_and_key(b"A", bh, Some(0))
-        .unwrap()
-        .is_none());
+    assert!(
+        sst.point_get_with_hash_and_key(b"A", bh, Some(0))
+            .unwrap()
+            .is_none()
+    );
 }
 
 #[test]

--- a/rfcs/005-mvcc.md
+++ b/rfcs/005-mvcc.md
@@ -19,7 +19,8 @@ The design provides:
 
 1. Snapshot reads for `get` and `scan`.
 2. Atomic write batches with one commit timestamp per batch.
-3. Optional point-key serializable optimistic transactions.
+3. Optional point-key serializable optimistic transactions through an explicit
+   isolation-level setting.
 4. Safe garbage collection of old versions using an active-reader watermark.
 5. Compatibility with WAL, compaction, block cache, and value-log separation.
 
@@ -40,7 +41,7 @@ limitations:
 
 1. A long range scan can observe a mix of old and new writes.
 2. Transaction APIs cannot provide repeatable reads.
-3. Serializable writes need a read/write conflict model.
+3. Point-key serializable transactions need a read/write conflict model.
 4. Compaction cannot safely drop overwritten versions without knowing active
    reader timestamps.
 5. vLog GC can race with historical readers unless version liveness is tied to
@@ -57,7 +58,7 @@ compaction a precise lower bound for reclaiming obsolete versions.
 2. Make every user write visible at exactly one commit timestamp.
 3. Provide snapshot isolation for reads and scans.
 4. Provide optional point-key serializable optimistic transactions when
-   `LsmStorageOptions::serializable` is enabled.
+   `LsmStorageOptions::isolation_level` is set to `PointKeySerializable`.
 5. Keep foreground reads lock-free apart from short timestamp bookkeeping.
 6. Let compaction reclaim obsolete versions once watermark, tombstone, and
    overlap rules prove they are no longer needed.
@@ -91,8 +92,10 @@ Snapshot read at read_ts=110 sees ts=105.
 Compaction can drop ts=097 once it is below the MVCC watermark and shadowed.
 ```
 
-The core change is replacing raw user keys in memtables, WALs, SST blocks, bloom
-filters, and iterators with byte-order-preserving internal keys:
+The core change is replacing raw user keys in memtables, WALs, SST blocks, and
+iterators with byte-order-preserving internal keys. Bloom filters remain
+user-key based so snapshot point lookups do not need to know an exact commit
+timestamp:
 
 ```text
 internal_key = escaped_user_key || terminator || inverted_ts
@@ -165,10 +168,6 @@ impl Key<Vec<u8>> {
     pub fn from_user_key_ts(user_key: &[u8], ts: u64) -> Self;
     pub fn set_from_user_key_ts(&mut self, user_key: &[u8], ts: u64);
 }
-
-impl<'a> Key<&'a [u8]> {
-    pub fn from_slice_with_ts(user_key: &'a [u8], ts: u64) -> KeyVec;
-}
 ```
 
 The current `for_testing_*_no_ts` helpers should stay during migration, but
@@ -199,19 +198,20 @@ encoded user-key prefix when only ordering/equality is needed.
 
 Encoded internal key length must be validated before writing to any format that
 stores key lengths as `u16` or otherwise has fixed-width lengths. The effective
-limit is on encoded internal key bytes, not raw user-key bytes. If MVCC needs
-larger keys, the format-versioned WAL/SST/vLog/vLog-index records must widen
-their length fields first.
+limit is on encoded internal key bytes, not raw user-key bytes. The MVP keeps
+the current fixed-width fields and fails before persistence with typed errors
+when an encoded key, value, offset, or metadata entry does not fit. Any widening
+requires a later format-versioned RFC.
 
 Important current limits and validation points:
 
 | Format area | Current constraint | MVCC requirement |
 | --- | --- | --- |
-| WAL records | key/value lengths are stored as `u16` | Validate encoded key and tagged value length before WAL append, or widen in the MVCC WAL format. |
+| WAL records | key/value lengths are stored as `u16` | Validate encoded key and tagged value length before WAL append. |
 | Block entries | key length, prefix-overlap, suffix length, value length, and entry offsets use `u16` | Validate each encoded key/value and block offset before adding to `BlockBuilder`. |
-| Block metadata | per-block metadata offsets, first/last key lengths, block offsets, and metadata offset-vector entries use fixed-width fields or direct casts | Validate every encoded first/last key length, block offset, metadata-entry offset, and metadata offset-vector entry before persisting, or widen them in the MVCC SST format. |
-| SST footer/offsets | metadata and bloom offsets are fixed-width fields | Validate metadata and bloom offsets before writing the footer, or widen them in the MVCC SST format. |
-| vLog entries | key lengths are fixed-width in the current entry format | Store and validate full encoded internal keys, or widen key lengths. |
+| Block metadata | per-block metadata offsets, first/last key lengths, block offsets, and metadata offset-vector entries use fixed-width fields or direct casts | Validate every encoded first/last key length, block offset, metadata-entry offset, and metadata offset-vector entry before persisting. |
+| SST footer/offsets | metadata and bloom offsets are fixed-width fields | Validate metadata and bloom offsets before writing the footer. |
+| vLog entries | key lengths are fixed-width in the current entry format | Store and validate full encoded internal keys. |
 | vLog index | key/index entry lengths inherit current fixed-width assumptions | Validate encoded internal key length before index insert and persistence. |
 
 ### 6.2 Timestamp Allocation
@@ -222,8 +222,8 @@ Important current limits and validation points:
 pub(crate) struct LsmMvccInner {
     pub(crate) write_lock: Mutex<()>,
     pub(crate) commit_lock: Mutex<()>,
-    pub(crate) ts: Arc<Mutex<(u64, Watermark)>>,
-    pub(crate) committed_txns: Arc<Mutex<BTreeMap<u64, CommittedTxnData>>>,
+    pub(crate) ts: Mutex<(u64, Watermark)>,
+    pub(crate) committed_txns: Mutex<BTreeMap<u64, CommittedTxnData>>,
 }
 ```
 
@@ -242,9 +242,9 @@ Rules:
 Before timestamp assignment, each write batch must be canonicalized by raw user
 key. If the same user key appears multiple times in one batch or transaction
 commit, the last operation wins and only one internal key is written for that
-user key at the batch `commit_ts`. Rejecting duplicate user keys is also safe,
-but silently writing multiple records with the same `(user_key, commit_ts)` is
-not allowed.
+user key at the batch `commit_ts`. The MVCC API does not reject duplicates as a
+normal conflict policy, and it must never silently write multiple records with
+the same `(user_key, commit_ts)`.
 
 Commit timestamp assignment has two states:
 
@@ -455,15 +455,27 @@ decoded user key and suppresses `Delete` entries in the public scan output.
 Alternatively, extend `StorageIterator` with an explicit value-kind/tombstone
 method before using it for transaction-local state.
 
-### 6.8 Serializable Mode
+### 6.8 Isolation Levels and Point-Key Serializable Mode
 
-When `serializable` is false, transactions provide repeatable snapshot reads.
-Write-write conflicts are resolved by version order: a later commit creates a
-newer version. This is intentionally last-writer-wins rather than full snapshot
-isolation, which would reject concurrent write-write conflicts.
+`LsmStorageOptions::isolation_level` selects the transaction conflict model:
 
-When `serializable` is true, the first implementation provides point-key
-serializable OCC. `Transaction` tracks:
+```rust
+pub enum IsolationLevel {
+    ReadCommitted,
+    RepeatableSnapshot,
+    PointKeySerializable,
+}
+```
+
+`RepeatableSnapshot` is the default MVCC transaction level. Transactions provide
+repeatable snapshot reads, and write-write conflicts are resolved by version
+order: a later commit creates a newer version. This is intentionally
+last-writer-wins rather than full snapshot isolation, which would reject
+concurrent write-write conflicts.
+
+`ReadCommitted` is reserved for non-transactional API behavior that should read
+the latest published timestamp per operation. `PointKeySerializable` adds
+point-key optimistic concurrency control. `Transaction` tracks:
 
 1. `read_set`: raw user keys read from the LSM snapshot.
 2. `write_set`: raw user keys written by the transaction.
@@ -474,26 +486,45 @@ latest visible version is a tombstone, and keys later shadowed by local writes.
 This prevents a concurrent insert after `read_ts` from bypassing point-key
 conflict detection.
 
+`scan` also adds each yielded LSM snapshot key to `read_set`. This covers keys
+that were actually observed during a range read. It does not cover predicates or
+gaps, so inserts into the scanned range after `read_ts` can still be phantoms
+until a future range-validation phase exists.
+
+Non-transactional `put`, `delete`, and `write_batch` operations must record
+their canonicalized write sets in `committed_txns` when
+`PointKeySerializable` is enabled. Otherwise, a point-key serializable
+transaction that read key `k` before a normal `put(k)` could commit without
+seeing the conflict.
+
+Transactions have an atomic completion flag. `put`, `delete`, and `commit`
+first check that the transaction is still open. `commit` changes the flag from
+open to committed before acquiring `commit_lock`; a second `commit` or any later
+mutation returns an error and cannot append WAL records or memtable entries.
+`abort`/`Drop` releases the read guard for transactions that did not commit, and
+successful commit releases the read guard after the commit path finishes.
+
 On commit:
 
-1. Acquire `commit_lock`.
-2. Remove committed transaction records older than `mvcc.watermark()`.
-3. Check committed transactions with `commit_ts > read_ts`.
-4. Abort if any committed transaction's `write_set` intersects this
+1. Atomically close the transaction for commit.
+2. Acquire `commit_lock`.
+3. Remove committed transaction records older than `mvcc.watermark()`.
+4. Check committed transactions with `commit_ts > read_ts`.
+5. Abort if any committed transaction's `write_set` intersects this
    transaction's `read_set`.
-5. Reserve `commit_ts = latest_commit_ts + 1` without publishing it.
-6. Append and sync one atomic WAL batch record when WAL is enabled.
-7. Insert all versioned records while the memtable cannot be frozen.
-8. Record this transaction's write set in `committed_txns`.
-9. Publish `latest_commit_ts = commit_ts`.
-10. Release `commit_lock`.
+6. Reserve `commit_ts = latest_commit_ts + 1` without publishing it.
+7. Append and sync one atomic WAL batch record when WAL is enabled.
+8. Insert all versioned records while the memtable cannot be frozen.
+9. Record this transaction's write set in `committed_txns`.
+10. Publish `latest_commit_ts = commit_ts`.
+11. Release the read guard.
+12. Release `commit_lock`.
 
 This is optimistic concurrency control. It prevents stale-read anomalies for
 point-key conflicts. It is not full predicate serializability: range reads can
 miss phantoms inserted after `read_ts` unless a later phase adds range predicate
-tracking or range validation. The public option can remain named
-`serializable` for compatibility, but documentation should describe the initial
-guarantee as point-key serializability.
+tracking or range validation. The public option should not be named simply
+`serializable` because the initial guarantee is point-key serializability.
 
 ### 6.9 WAL and Recovery
 
@@ -502,9 +533,8 @@ This keeps recovery simple:
 
 1. Recover memtables from WAL into `SkipMap<encoded_internal_key, value>`.
 2. Recover SST metadata as today.
-3. Recover the maximum commit timestamp from complete WAL batches and either
-   persisted SST `max_ts` or a full SST key scan. SST metadata is sufficient
-   only if the MVCC SST format adds per-table or per-block `max_ts`.
+3. Recover the maximum commit timestamp from complete WAL batches and persisted
+   SST `max_ts` metadata.
 4. Initialize `LsmMvccInner::new(max_commit_ts)`.
 
 WAL writes must be batch-framed. A committed batch should be encoded as a single
@@ -515,13 +545,12 @@ checksum-invalid batch is ignored or causes recovery to truncate the WAL at the
 last valid batch boundary. Replaying a prefix of a batch with one commit
 timestamp is not allowed.
 
-Crash semantics must be explicit: if the engine syncs a complete WAL batch and
-then crashes before publishing `latest_commit_ts` to live readers, recovery may
-treat that complete batch as committed. This is the usual durable-before-ack
-window: the client may not have observed success, but the recovered database may
-include the write. If this behavior is not acceptable, the WAL format needs a
-separate durable publish marker and recovery must ignore synced-but-unpublished
-batches.
+Crash semantics are durable-batch based: if the engine syncs a complete WAL
+batch and then crashes before publishing `latest_commit_ts` to live readers,
+recovery treats that complete batch as committed. This is the usual
+durable-before-ack window: the client may not have observed success, but the
+recovered database may include the write. The MVP does not add a separate
+durable publish marker.
 
 The WAL already stores opaque key bytes, but mixed pre-MVCC and MVCC WALs are
 not distinguishable by the WAL record alone. MVCC therefore needs a manifest or
@@ -542,18 +571,30 @@ Tombstone payload bytes are invalid. `[KvKind::Inline]` with an empty payload is
 accepted only by pre-MVCC compatibility decoding and must not be emitted by MVCC
 writers.
 
-SST recovery needs one of two approaches:
+#### 6.9.1 Migration Strategy
 
-1. Persist `max_ts` in a format-versioned SST footer and load it in
-   `SsTable::open`.
-2. Derive `max_ts` by scanning actual table keys on startup.
+MVCC startup detects the directory format through manifest and file-format
+markers. A pre-MVCC directory is rejected by default unless the caller runs an
+explicit migration tool or opens with an explicit migration option.
 
-Persisting `max_ts` is preferred because the current `SsTable::open` placeholder
-sets it to zero and cannot recover the global timestamp counter correctly.
-Current block metadata stores first and last keys only; because internal-key
-ordering is user-key-first, the maximum timestamp can appear in the middle of a
-block or table. Metadata-only recovery would require adding per-block or
-per-table `max_ts` metadata.
+The migration maps every existing raw user key to timestamp zero, rewrites
+values into the MVCC kind-tagged format, and emits format-versioned WAL, SST,
+vLog, and `.vidx` files. For safety, migration writes into a temporary
+directory or manifest generation, fsyncs all new files, then atomically publishes
+the new manifest. Failure leaves the original directory readable by the old
+format. Rollback is the original directory plus the pre-migration manifest.
+
+Mixed-format directories are not opened for normal reads or writes. They are
+accepted only by the migration tool, which validates every file and either
+finishes publication or leaves the old manifest active.
+
+SST recovery must persist `max_ts` in a format-versioned SST footer or table
+metadata and load it in `SsTable::open`. The full key scan is only a fallback
+for pre-MVCC migration, explicit repair, or corrupt/missing metadata handling;
+it is not the normal MVCC startup path. Current block metadata stores first and
+last keys only; because internal-key ordering is user-key-first, the maximum
+timestamp can appear in the middle of a block or table. Metadata-only recovery
+therefore requires adding per-table `max_ts` metadata.
 
 ### 6.10 SST Metadata and Bloom Filters
 
@@ -625,15 +666,16 @@ after a compaction installs a newer state.
 
 vLog GC must be MVCC-version aware. Current-style key-current-state CAS is not
 sufficient because a historical value pointer belongs to one exact encoded
-internal key. GC may either:
+internal key. The primary strategy is to rewrite value pointers while building
+compaction output, replacing the value for the exact internal key that survives
+version GC. This keeps pointer movement coordinated with SST version selection
+and avoids inventing a new latest version just to move an old value.
 
-1. Rewrite value pointers while building compaction output, replacing the value
-   for the exact internal key that survives version GC.
-2. Use an internal-version CAS API keyed by encoded internal key and expected
-   `ValuePointer`, never by raw user key alone.
-
-GC must not create a new latest version just to move an old value, and it must
-not rewrite a pointer unless the exact internal-key version remains live.
+An independent background vLog GC may be added later, but it must use an
+internal-version CAS API keyed by encoded internal key and expected
+`ValuePointer`, never by raw user key alone. GC must not create a new latest
+version just to move an old value, and it must not rewrite a pointer unless the
+exact internal-key version remains live.
 
 ### 6.13 Cache Interaction
 
@@ -691,19 +733,28 @@ during migration.
 1. Add format markers for MVCC WAL, SST, value, vLog, and `.vidx` decoding.
 2. Replace unchecked fixed-width casts with checked conversions and error
    propagation in block metadata, SST footer offsets, WAL records, vLog entries,
-   and `.vidx` persistence, or widen those fields in the MVCC format.
+   and `.vidx` persistence.
 3. Implement WAL batch framing, checksum validation, truncation behavior, and
    max-timestamp extraction from complete batches only.
+4. Persist and recover SST `max_ts` from format-versioned table metadata.
 
-### Phase 3: MVCC State and Watermark
+### Phase 3: Migration and Compatibility
+
+1. Add manifest and file-format detection for pre-MVCC and MVCC directories.
+2. Reject mixed-format directories during normal startup.
+3. Implement an explicit migration path that maps raw keys to timestamp zero,
+   rewrites kind-tagged values, and publishes through a temporary manifest or
+   directory.
+4. Add rollback and failure-injection tests for interrupted migration.
+
+### Phase 4: MVCC State and Watermark
 
 1. Implement `Watermark`.
 2. Initialize `mvcc: Some(Arc<LsmMvccInner>)` in `LsmStorageInner::open`.
-3. Recover max timestamp from complete WAL batches and persisted SST `max_ts` or
-   a full SST key scan.
+3. Recover max timestamp from complete WAL batches and persisted SST `max_ts`.
 4. Add atomic `ReadGuard::new_latest` registration and cleanup.
 
-### Phase 4: Versioned Writes and Reads
+### Phase 5: Versioned Writes and Reads
 
 1. Add `KvKind::Tombstone` and update `KvKind::from_u8`, value parsers, SST
    builder `add`/`add_raw` paths, compaction tombstone checks, vLog
@@ -714,13 +765,13 @@ during migration.
 4. Implement version-aware `get`.
 5. Hash SST and memtable bloom entries by user key.
 
-### Phase 5: Snapshot Scans
+### Phase 6: Snapshot Scans
 
 1. Make `LsmIterator` collapse duplicate user keys.
 2. Make memtable and SST range bounds timestamp-aware.
 3. Add scan tests for concurrent writes during iteration.
 
-### Phase 6: Transactions
+### Phase 7: Transactions
 
 1. Implement `LsmMvccInner::new_txn`.
 2. Implement `Transaction::{get, scan, put, delete, commit}`.
@@ -728,28 +779,31 @@ during migration.
    `StorageIterator` with explicit value-kind support.
 4. Add repeatable snapshot read tests.
 
-### Phase 7: Serializable OCC
+### Phase 8: Point-Key Serializable OCC
 
 1. Replace the current `HashSet<u32>` sketches with read and write user-key
    sets such as `HashSet<Bytes>`.
 2. Implement committed transaction pruning by watermark.
-3. Detect read/write conflicts at commit.
-4. Add conflict and no-conflict tests.
+3. Record non-transactional write batches in `committed_txns`.
+4. Record point reads, negative reads, tombstone reads, and yielded scan keys in
+   `read_set`.
+5. Detect read/write conflicts at commit.
+6. Add conflict, no-conflict, double-commit, and mutation-after-commit tests.
 
-### Phase 8: Compaction GC
+### Phase 9: Compaction GC
 
 1. Populate SST `max_ts`.
 2. Add watermark-aware version dropping in compaction builders.
 3. Preserve tombstone semantics.
 4. Add tests for old-version reclamation.
 
-### Phase 9: vLog Integration
+### Phase 10: vLog Integration
 
 1. Validate vLog entries against full internal keys.
-2. Make vLog GC rewrite exact live internal-key versions via compaction output
-   or internal-version CAS.
-3. Verify vLog GC with multiple versions of the same user key.
-4. Add tests covering pointer-bearing historical versions.
+2. Make compaction-output vLog GC rewrite exact live internal-key versions.
+3. Keep internal-version CAS only for a later independent background GC path.
+4. Verify vLog GC with multiple versions of the same user key.
+5. Add tests covering pointer-bearing historical versions.
 
 ---
 
@@ -765,8 +819,8 @@ Required tests:
 6. WAL recovery restores versioned keys and max timestamp.
 7. Snapshot transaction reads are repeatable.
 8. Transaction local writes shadow snapshot state.
-9. Serializable transaction aborts on read/write conflict.
-10. Serializable transaction commits when write sets do not conflict.
+9. Point-key serializable transaction aborts on read/write conflict.
+10. Point-key serializable transaction commits when write sets do not conflict.
 11. Compaction keeps versions with `commit_ts > watermark`.
 12. Compaction keeps the newest version with `commit_ts <= watermark`.
 13. Compaction does not resurrect deleted keys.
@@ -785,16 +839,27 @@ Required tests:
 21. Keys whose encoded internal length exceeds the active format limit are
     rejected before WAL, SST, vLog, or vLog-index writes.
 22. Duplicate user keys in one batch or transaction commit are canonicalized
-    with last-op-wins behavior, or rejected consistently.
+    with last-op-wins behavior.
 23. vLog index entries use full encoded internal keys and GC rewrites only exact
     live internal-key versions, including embedded-zero keys and oversized-key
     rejection.
-24. Serializable OCC records negative point reads: if one transaction reads an
-    absent or tombstoned key and another transaction inserts that key after
-    `read_ts`, the first transaction aborts on commit.
+24. Point-key serializable OCC records negative point reads: if one transaction
+    reads an absent or tombstoned key and another transaction inserts that key
+    after `read_ts`, the first transaction aborts on commit.
 25. MVCC tombstone parser tests cover valid `[KvKind::Tombstone]`, invalid
     tombstone payloads, and `[KvKind::Inline]` empty accepted only under
     pre-MVCC compatibility decoding.
+26. `scan` records yielded LSM snapshot keys in the `PointKeySerializable`
+    `read_set`.
+27. Non-transactional `put`, `delete`, and `write_batch` operations conflict
+    with overlapping point-key serializable transactions.
+28. Transaction `commit` is single-use, and `put`/`delete` after commit are
+    rejected before any WAL or memtable mutation.
+29. Pre-MVCC migration maps raw keys to timestamp zero, rewrites kind-tagged
+    values, rejects mixed-format startup outside migration, and rolls back after
+    an interrupted migration.
+30. SST `max_ts` persists in format-versioned metadata and is recovered without
+    scanning keys during normal startup.
 
 Recommended commands:
 
@@ -831,9 +896,9 @@ not know the exact commit timestamp. Bloom filters must hash user keys only.
 ### 10.4 Serializable Granularity
 
 Point-key set tracking is lightweight but not full predicate serializability.
-The first implementation records point keys only and documents that range
-predicates are not serializable. Preventing range phantoms requires a later
-predicate/range validation phase.
+The first implementation records point keys and yielded scan keys only, and
+documents that range predicates are not serializable. Preventing range phantoms
+requires a later predicate/range validation phase.
 
 ### 10.5 vLog Key Validation
 
@@ -845,12 +910,9 @@ internal keys avoids this ambiguity.
 
 ## 11. Open Questions
 
-1. Should `serializable` mode conservatively reject range-write phantoms, or
-   document point-key serializability for the first phase?
-2. Should pre-MVCC data directories be rejected, migrated to timestamp zero, or
-   treated as unsupported?
-3. Should `max_ts` be stored in the SST file footer for fast recovery, or
-   derived by opening table metadata?
+1. Should a future `IsolationLevel::Serializable` add predicate/range
+   validation for full serializability, and what range-lock representation
+   should it use?
 
 ---
 
@@ -861,7 +923,7 @@ The MVCC implementation is complete when:
 1. `TS_ENABLED` is true and production paths use timestamped keys.
 2. `KvEngine::get` and `scan` are snapshot-consistent.
 3. `Transaction` supports repeatable reads and atomic commits.
-4. Serializable mode detects point-key read/write conflicts.
+4. `PointKeySerializable` detects point-key read/write conflicts.
 5. WAL recovery preserves versions and resumes timestamp allocation safely.
 6. Compaction reclaims obsolete versions without breaking active snapshots or
    resurrecting older data.

--- a/rfcs/005-mvcc.md
+++ b/rfcs/005-mvcc.md
@@ -879,9 +879,9 @@ Required tests:
 24. Point-key serializable OCC records negative point reads: if one transaction
     reads an absent or tombstoned key and another transaction inserts that key
     after `read_ts`, the first transaction aborts on commit.
-25. MVCC tombstone parser tests cover valid `[KvKind::Tombstone]`, invalid
-    tombstone payloads, and `[KvKind::Inline]` empty accepted only under
-    pre-MVCC compatibility decoding.
+25. MVCC tombstone parser tests cover valid `[KvKind::Tombstone]` (single byte,
+    no payload), invalid tombstone payloads, and `[KvKind::Inline]` with empty
+    payload as a valid empty value under MVCC decoding.
 26. `scan` records yielded LSM snapshot keys in the `PointKeySerializable`
     `read_set`.
 27. Non-transactional `put`, `delete`, and `write_batch` operations conflict

--- a/rfcs/005-mvcc.md
+++ b/rfcs/005-mvcc.md
@@ -39,7 +39,7 @@ The current engine is effectively single-version:
 This is enough for basic LSM behavior, but it creates correctness and API
 limitations:
 
-1. A long range scan can observe a mix of old and new writes.
+1. A long-range scan can observe a mix of old and new writes.
 2. Transaction APIs cannot provide repeatable reads.
 3. Point-key serializable transactions need a read/write conflict model.
 4. Compaction cannot safely drop overwritten versions without knowing active
@@ -415,6 +415,8 @@ pub struct Transaction {
     read_guard: ReadGuard,
     inner: Arc<LsmStorageInner>,
     /// Raw user-key ordered local writes, not encoded internal keys.
+    /// Wrapped in `Arc` so `TxnIterator` can hold an independent reference
+    /// for merging local writes with the LSM snapshot during `scan`.
     local_storage: Arc<SkipMap<Bytes, WriteOp>>,
     committed: Arc<AtomicBool>,
     key_sets: Option<Mutex<(HashSet<Bytes>, HashSet<Bytes>)>>,
@@ -471,10 +473,17 @@ pub enum IsolationLevel {
 repeatable snapshot reads, and write-write conflicts are resolved by version
 order: a later commit creates a newer version. This is intentionally
 last-writer-wins rather than full snapshot isolation, which would reject
-concurrent write-write conflicts.
+concurrent write-write conflicts. Last-writer-wins is chosen deliberately: it
+avoids write-write conflict aborts for the common case of independent key
+updates, at the cost of allowing lost updates when two transactions write the
+same key concurrently. Callers who need stronger guarantees should use
+`PointKeySerializable`.
 
 `ReadCommitted` is reserved for non-transactional API behavior that should read
-the latest published timestamp per operation. `PointKeySerializable` adds
+the latest published timestamp per operation. Each non-transactional `get` or
+`scan` registers a short-lived `ReadGuard` (pin latest, read, unpin) so the
+watermark is temporarily raised for the duration of the operation, but does not
+hold a long-lived snapshot across multiple calls. `PointKeySerializable` adds
 point-key optimistic concurrency control. `Transaction` tracks:
 
 1. `read_set`: raw user keys read from the LSM snapshot.

--- a/rfcs/005-mvcc.md
+++ b/rfcs/005-mvcc.md
@@ -622,7 +622,12 @@ therefore requires adding per-table `max_ts` metadata.
 1. `first_key`: first internal key in the SST.
 2. `last_key`: last internal key in the SST.
 3. `max_ts`: highest commit timestamp in the SST.
-4. Bloom filter entries: user-key hashes, not full internal-key hashes.
+4. `min_ts`: lowest commit timestamp in the SST.
+5. Bloom filter entries: user-key hashes, not full internal-key hashes.
+
+Persisting `min_ts` allows older snapshot readers (`read_ts < sst.min_ts`) to
+skip the entire SST during point lookups and scans, avoiding unnecessary I/O
+for historical snapshots.
 
 Range overlap must compare user-key portions of bounds. Point-get bloom checks
 must also use decoded user-key hashes. Memtable incremental bloom filters must
@@ -689,6 +694,15 @@ internal key. The primary strategy is to rewrite value pointers while building
 compaction output, replacing the value for the exact internal key that survives
 version GC. This keeps pointer movement coordinated with SST version selection
 and avoids inventing a new latest version just to move an old value.
+
+**Tradeoff:** Rewriting value pointers during compaction reintroduces value
+write amplification — the core cost that WiscKey-style key/value separation was
+designed to avoid. This is acceptable when only live versions are rewritten (dead
+versions are dropped, not copied), and when large values dominate the vLog. If
+write amplification becomes a bottleneck, the independent background vLog GC
+(next paragraph) should be prioritized so that compaction only rewrites pointers
+for versions it is already touching, while background GC handles cold vLog files
+separately.
 
 An independent background vLog GC may be added later, but it must use an
 internal-version CAS API keyed by encoded internal key and expected

--- a/rfcs/005-mvcc.md
+++ b/rfcs/005-mvcc.md
@@ -94,7 +94,7 @@ Compaction can drop ts=097 once it is below the MVCC watermark and shadowed.
 
 The core change is replacing raw user keys in memtables, WALs, SST blocks, and
 iterators with byte-order-preserving internal keys. Bloom filters remain
-user-key based so snapshot point lookups do not need to know an exact commit
+user-key-based so snapshot point lookups do not need to know an exact commit
 timestamp:
 
 ```text
@@ -504,14 +504,25 @@ Non-transactional `put`, `delete`, and `write_batch` operations must record
 their canonicalized write sets in `committed_txns` when
 `PointKeySerializable` is enabled. Otherwise, a point-key serializable
 transaction that read key `k` before a normal `put(k)` could commit without
-seeing the conflict.
+seeing the conflict. These non-transactional write paths should also prune
+`committed_txns` entries older than `mvcc.watermark()` under `commit_lock` to
+prevent unbounded memory growth in workloads dominated by non-transactional
+writes with infrequent transaction commits.
 
 Transactions have an atomic completion flag. `put`, `delete`, and `commit`
 first check that the transaction is still open. `commit` changes the flag from
 open to committed before acquiring `commit_lock`; a second `commit` or any later
 mutation returns an error and cannot append WAL records or memtable entries.
+Because `Transaction` is shared through `Arc` and local writes go into a
+concurrent `SkipMap`, the close-and-drain step in `commit` must be atomic with
+respect to `put`/`delete` — e.g., via a transaction-state mutex or `RwLock` that
+makes the check-open-and-insert indivisible with commit's close-and-drain.
 `abort`/`Drop` releases the read guard for transactions that did not commit, and
 successful commit releases the read guard after the commit path finishes.
+
+Read-only transactions (empty `write_set`) bypass the write-related commit steps:
+they release their `ReadGuard` and return success immediately without acquiring
+`commit_lock`, allocating a `commit_ts`, or appending to the WAL.
 
 On commit:
 
@@ -577,8 +588,7 @@ decoder for WAL recovery, SST reads, memtable values, and vLog pointer values.
 
 MVCC tombstones are encoded as exactly one byte: `[KvKind::Tombstone]`.
 Tombstone payload bytes are invalid. `[KvKind::Inline]` with an empty payload is
-accepted only by pre-MVCC compatibility decoding and must not be emitted by MVCC
-writers.
+a valid empty value in MVCC; only `[KvKind::Tombstone]` marks a delete.
 
 #### 6.9.1 Migration Strategy
 
@@ -715,8 +725,8 @@ impl KvEngine {
 impl Transaction {
     pub fn get(&self, key: &[u8]) -> Result<Option<Bytes>>;
     pub fn scan(self: &Arc<Self>, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> Result<TxnIterator>;
-    pub fn put(&self, key: &[u8], value: &[u8]);
-    pub fn delete(&self, key: &[u8]);
+    pub fn put(&self, key: &[u8], value: &[u8]) -> Result<()>;
+    pub fn delete(&self, key: &[u8]) -> Result<()>;
     pub fn commit(&self) -> Result<()>;
 }
 ```
@@ -914,6 +924,23 @@ requires a later predicate/range validation phase.
 If vLog entries continue validating only user keys, stale pointers from older
 versions can appear valid for newer versions of the same key. Using full
 internal keys avoids this ambiguity.
+
+### 10.6 Watermark Lag from Long-Running Transactions
+
+A long-running read transaction (e.g., a large scan or a backup) pins the MVCC
+watermark to its `read_ts`. This prevents compaction from garbage collecting old
+versions newer than the pinned watermark and prevents pruning of `committed_txns`
+newer than the pinned watermark. The result is disk space amplification (obsolete
+versions accumulate) and memory growth (unpruned `committed_txns` metadata).
+
+Mitigations to consider during implementation:
+
+1. **Transaction timeouts** — abort or warn if a transaction holds a `ReadGuard`
+   beyond a configurable duration.
+2. **Maximum watermark age** — periodically check whether the oldest `ReadGuard`
+   exceeds a threshold and log or alert.
+3. **Background GC advisory** — let compaction report the gap between the
+   watermark and `latest_commit_ts` so operators can detect lag.
 
 ---
 

--- a/rfcs/005-mvcc.md
+++ b/rfcs/005-mvcc.md
@@ -1,0 +1,869 @@
+# RFC 005: Multi-Version Concurrency Control
+
+**Status:** Proposed  
+**Date:** 2026-06-06  
+**Author:** kv-engine Contributors  
+**Tracking Issue:** N/A (design RFC)
+
+---
+
+## 1. Summary
+
+This RFC proposes adding multi-version concurrency control (MVCC) to kv-engine.
+MVCC stores multiple committed versions of the same user key, each tagged with a
+monotonic commit timestamp. Readers choose a stable read timestamp and only see
+versions committed at or before that timestamp, while writers create newer
+versions without overwriting older ones immediately.
+
+The design provides:
+
+1. Snapshot reads for `get` and `scan`.
+2. Atomic write batches with one commit timestamp per batch.
+3. Optional point-key serializable optimistic transactions.
+4. Safe garbage collection of old versions using an active-reader watermark.
+5. Compatibility with WAL, compaction, block cache, and value-log separation.
+
+---
+
+## 2. Motivation
+
+The current engine is effectively single-version:
+
+1. `MemTable` maps `user_key -> value`.
+2. SSTs contain one visible value per key after iterator merge.
+3. Deletes are represented as empty values.
+4. `KvEngine::new_txn()` and the `mvcc` module are mostly placeholders.
+5. `key.rs` has compatibility helpers marked for removal once MVCC is enabled.
+
+This is enough for basic LSM behavior, but it creates correctness and API
+limitations:
+
+1. A long range scan can observe a mix of old and new writes.
+2. Transaction APIs cannot provide repeatable reads.
+3. Serializable writes need a read/write conflict model.
+4. Compaction cannot safely drop overwritten versions without knowing active
+   reader timestamps.
+5. vLog GC can race with historical readers unless version liveness is tied to
+   the MVCC watermark.
+
+MVCC addresses these by making version visibility explicit and by giving
+compaction a precise lower bound for reclaiming obsolete versions.
+
+---
+
+## 3. Goals
+
+1. Preserve the existing non-transactional API shape where possible.
+2. Make every user write visible at exactly one commit timestamp.
+3. Provide snapshot isolation for reads and scans.
+4. Provide optional point-key serializable optimistic transactions when
+   `LsmStorageOptions::serializable` is enabled.
+5. Keep foreground reads lock-free apart from short timestamp bookkeeping.
+6. Let compaction reclaim obsolete versions once watermark, tombstone, and
+   overlap rules prove they are no longer needed.
+7. Keep WAL recovery deterministic by preserving versioned keys on disk.
+
+## 4. Non-Goals
+
+1. Distributed transactions.
+2. External timestamp assignment by callers.
+3. Cross-database atomicity.
+4. Predicate-lock based serializability for arbitrary range predicates in the
+   first implementation.
+5. Retaining unlimited historical versions after they fall below the MVCC
+   watermark.
+
+---
+
+## 5. Design Overview
+
+```text
+User key:  "user:42"
+
+Internal versions, sorted by user key ascending and timestamp descending:
+
+  user:42 @ ts=105  -> "newest"
+  user:42 @ ts=101  -> "older"
+  user:42 @ ts=097  -> tombstone
+
+Snapshot read at read_ts=102 sees ts=101.
+Snapshot read at read_ts=110 sees ts=105.
+Compaction can drop ts=097 once it is below the MVCC watermark and shadowed.
+```
+
+The core change is replacing raw user keys in memtables, WALs, SST blocks, bloom
+filters, and iterators with byte-order-preserving internal keys:
+
+```text
+internal_key = escaped_user_key || terminator || inverted_ts
+inverted_ts = u64::MAX - commit_ts, encoded big-endian
+```
+
+The timestamp suffix alone does **not** preserve raw byte ordering for prefix
+keys such as `a` and `aa`. To keep the existing byte-ordered memtable, block,
+and SST search machinery correct, the internal-key encoding must preserve this
+logical order under ordinary byte comparison:
+
+1. User keys sort ascending.
+2. For the same user key, newer timestamps sort before older timestamps.
+
+Reads seek to `encode_internal_key(user_key, read_ts)` and choose the first
+version with the same decoded user key whose commit timestamp is less than or
+equal to `read_ts`.
+Scans merge all LSM sources using raw byte order over encoded internal keys,
+collapse duplicate decoded user keys, and expose only the first visible version
+per user key.
+
+---
+
+## 6. Detailed Design
+
+### 6.1 Internal Key Format
+
+Enable timestamped keys by replacing the current `TS_ENABLED: false` placeholder
+with a real key layout.
+
+```rust
+pub const TS_ENABLED: bool = true;
+
+pub struct Key<T: AsRef<[u8]>>(T);
+```
+
+The byte layout is:
+
+```text
+[escaped_user_key][0x00 0x00 terminator][inverted_ts: u64 big-endian]
+```
+
+Escaping rules:
+
+1. A non-zero user-key byte `b` is encoded as `b`.
+2. A zero byte `0x00` in the user key is encoded as `0x00 0xff`.
+3. The end of the user key is encoded as `0x00 0x00`.
+4. The timestamp suffix follows the terminator.
+
+This preserves raw user-key lexicographic order under ordinary byte comparison:
+the terminator sorts before an escaped embedded zero, and both sort before any
+non-zero byte after a shared prefix. For equal user keys, `inverted_ts` makes
+newer versions sort first. The implementation can therefore keep
+`SkipMap<Bytes, _>` and existing block/SST binary search data structures, but
+all user-key extraction, bound construction, bloom hashing, and deduplication
+must decode the escaped user-key portion.
+
+Required helpers:
+
+```rust
+impl<T: AsRef<[u8]>> Key<T> {
+    pub fn decode_user_key(&self) -> Cow<'_, [u8]>;
+    pub fn decode_user_key_into(&self, scratch: &mut Vec<u8>);
+    pub fn encoded_user_key(&self) -> &[u8];
+    pub fn ts(&self) -> u64;
+    pub fn raw_ref(&self) -> &[u8];
+}
+
+impl Key<Vec<u8>> {
+    pub fn from_user_key_ts(user_key: &[u8], ts: u64) -> Self;
+    pub fn set_from_user_key_ts(&mut self, user_key: &[u8], ts: u64);
+}
+
+impl<'a> Key<&'a [u8]> {
+    pub fn from_slice_with_ts(user_key: &'a [u8], ts: u64) -> KeyVec;
+}
+```
+
+The current `for_testing_*_no_ts` helpers should stay during migration, but
+production code should stop using no-timestamp constructors once MVCC is
+enabled.
+
+All physical seek and range paths must operate on encoded internal keys:
+
+1. Physical `MemTable` storage may continue to use `SkipMap<Bytes, _>` because
+   the encoding is byte-order preserving.
+2. `BlockIterator` binary search, `SsTable::find_block_idx`, `point_get`,
+   concat iterator table selection, and SST `range_overlap` must compare
+   encoded internal keys or decoded user-key bounds consistently.
+3. Any remaining comparison of raw unescaped user keys against encoded internal
+   keys is a correctness bug and should be covered by prefix-key tests.
+
+Public APIs accept raw user keys. Physical memtable/SST/block APIs accept
+encoded internal keys. The implementation should make this boundary explicit
+with distinct wrappers such as `UserKeySlice` and `InternalKeySlice`, or with
+helper names that include `user_key` vs `internal_key`. Reusing
+`KeySlice::from_slice` for both roles is no longer acceptable because it can
+silently pass raw user bounds into encoded-key structures.
+
+The logical user key is not always borrowable from an escaped internal key:
+embedded `0x00` bytes must be decoded from `0x00 0xff`. Helpers should either
+return `Cow<[u8]>`, decode into caller-provided scratch, or operate on the
+encoded user-key prefix when only ordering/equality is needed.
+
+Encoded internal key length must be validated before writing to any format that
+stores key lengths as `u16` or otherwise has fixed-width lengths. The effective
+limit is on encoded internal key bytes, not raw user-key bytes. If MVCC needs
+larger keys, the format-versioned WAL/SST/vLog/vLog-index records must widen
+their length fields first.
+
+Important current limits and validation points:
+
+| Format area | Current constraint | MVCC requirement |
+| --- | --- | --- |
+| WAL records | key/value lengths are stored as `u16` | Validate encoded key and tagged value length before WAL append, or widen in the MVCC WAL format. |
+| Block entries | key length, prefix-overlap, suffix length, value length, and entry offsets use `u16` | Validate each encoded key/value and block offset before adding to `BlockBuilder`. |
+| Block metadata | per-block metadata offsets, first/last key lengths, block offsets, and metadata offset-vector entries use fixed-width fields or direct casts | Validate every encoded first/last key length, block offset, metadata-entry offset, and metadata offset-vector entry before persisting, or widen them in the MVCC SST format. |
+| SST footer/offsets | metadata and bloom offsets are fixed-width fields | Validate metadata and bloom offsets before writing the footer, or widen them in the MVCC SST format. |
+| vLog entries | key lengths are fixed-width in the current entry format | Store and validate full encoded internal keys, or widen key lengths. |
+| vLog index | key/index entry lengths inherit current fixed-width assumptions | Validate encoded internal key length before index insert and persistence. |
+
+### 6.2 Timestamp Allocation
+
+`LsmMvccInner` owns the global timestamp state:
+
+```rust
+pub(crate) struct LsmMvccInner {
+    pub(crate) write_lock: Mutex<()>,
+    pub(crate) commit_lock: Mutex<()>,
+    pub(crate) ts: Arc<Mutex<(u64, Watermark)>>,
+    pub(crate) committed_txns: Arc<Mutex<BTreeMap<u64, CommittedTxnData>>>,
+}
+```
+
+Rules:
+
+1. `latest_commit_ts()` returns the highest published commit timestamp only.
+   Reserved or merely WAL-durable timestamps are not visible to foreground
+   readers.
+2. A read transaction gets its timestamp through `ReadGuard::new_latest`, which
+   reads `latest_commit_ts()` and registers that timestamp atomically.
+3. A write commit increments the global timestamp under `commit_lock`.
+4. All records in one `write_batch` share the same `commit_ts`.
+5. On recovery, the engine initializes the timestamp counter to the highest
+   commit timestamp found in WALs and SSTs.
+
+Before timestamp assignment, each write batch must be canonicalized by raw user
+key. If the same user key appears multiple times in one batch or transaction
+commit, the last operation wins and only one internal key is written for that
+user key at the batch `commit_ts`. Rejecting duplicate user keys is also safe,
+but silently writing multiple records with the same `(user_key, commit_ts)` is
+not allowed.
+
+Commit timestamp assignment has two states:
+
+1. **Reserved:** a writer has allocated `commit_ts`, but readers must not use it
+   yet.
+2. **Published:** all WAL records are durable, all memtable entries for the
+   batch are visible, and `latest_commit_ts` has advanced.
+
+The required commit order is:
+
+1. Acquire `commit_lock`.
+2. Reserve `commit_ts = latest_commit_ts + 1` without publishing it.
+3. Append and sync one atomic WAL batch record when WAL is enabled.
+4. Insert all versioned records into the active memtable while the memtable
+   cannot be frozen.
+5. Publish `latest_commit_ts = commit_ts`.
+6. Release `commit_lock`.
+
+This prevents a reader from choosing a timestamp whose batch is only partially
+installed.
+
+The `write_lock` is used only for APIs that need single-writer semantics during
+the first implementation. The long-term target is to keep independent writes
+concurrent and serialize only commit timestamp assignment plus memtable append.
+
+### 6.3 Watermark
+
+`Watermark` tracks active read timestamps:
+
+```rust
+pub struct Watermark {
+    readers: BTreeMap<u64, usize>,
+}
+```
+
+Semantics:
+
+1. `add_reader(ts)` increments the active reader count for `ts`.
+2. `remove_reader(ts)` decrements the count and removes the entry at zero.
+3. `watermark()` returns the smallest active read timestamp.
+4. If there are no active readers, `watermark()` returns `None`.
+5. `LsmMvccInner::watermark()` returns the smallest active timestamp, or the
+   latest commit timestamp when no readers are active.
+
+Versions with `commit_ts < watermark` are candidates for reclamation, not
+automatically invisible garbage. For each user key, compaction must keep the
+newest version below the watermark when that version could be the state observed
+by the oldest active reader, and must also preserve tombstones or older versions
+when overlap rules require them.
+
+All snapshot readers need a guard, not only explicit transactions:
+
+```rust
+pub(crate) struct ReadGuard {
+    read_ts: u64,
+    mvcc: Arc<LsmMvccInner>,
+}
+```
+
+`LsmStorageInner` should store `mvcc: Option<Arc<LsmMvccInner>>` so guards and
+iterators can own the MVCC handle independently of borrowed storage state.
+`ReadGuard::new_latest` must acquire the MVCC timestamp mutex, read the
+published latest timestamp, register that timestamp in the watermark, and only
+then release the mutex. Splitting timestamp acquisition and registration would
+allow compaction to observe a watermark that excludes the new reader. `Drop`
+unregisters the timestamp. `Transaction` stores one guard for the transaction
+lifetime. `scan` stores one guard inside the returned iterator wrapper. Point
+`get` may use a short-lived guard around lookup and value resolution.
+
+### 6.4 Non-Transactional Reads
+
+`KvEngine::get(key)` should become a snapshot read at the latest committed
+timestamp:
+
+```text
+guard = ReadGuard::new_latest(mvcc)
+lookup(key, guard.read_ts())
+```
+
+The lookup path changes from exact raw-key lookup to version lookup:
+
+1. Build seek key `encode_internal_key(user_key, read_ts)`.
+2. Check active memtable, immutable memtables, L0 SSTs, and lower levels.
+3. For each source, return the first entry with matching `user_key`.
+4. Merge candidates by internal key order; the first visible candidate is the
+   latest version at or below `read_ts`.
+5. A tombstone returns `None`.
+
+Because internal keys include timestamps, bloom filters should hash only
+`user_key` for point lookups. This avoids false negatives when looking up
+`user_key` at a read timestamp that does not exactly match a committed version.
+
+### 6.5 Snapshot Scans
+
+`scan(lower, upper)` uses one `ReadGuard` and one `read_ts` for the whole
+iterator lifetime. It must not observe writes committed after iterator creation.
+
+The scan flow is:
+
+1. Seek broadly using internal-key bounds, then apply user-key bound filtering
+   in the MVCC iterator.
+2. Merge memtable, immutable memtables, L0, and lower-level SST iterators.
+3. Skip entries with `commit_ts > read_ts`.
+4. Collapse duplicate user keys by yielding only the newest visible version.
+5. Suppress tombstones.
+
+Bounds are interpreted on user keys, not internal keys:
+
+1. `Included(lower)`: start at the first internal key whose user key is
+   `>= lower`.
+2. `Excluded(lower)`: start at the first internal key whose user key is
+   `> lower`.
+3. `Included(upper)`: stop after yielding versions whose user key is `<= upper`.
+4. `Excluded(upper)`: stop before yielding any version whose user key is
+   `>= upper`.
+5. `Unbounded`: no user-key-side restriction.
+
+The implementation can use approximate internal seeks for efficiency, but the
+iterator must enforce these user-key predicates after decoding each internal
+key. This avoids accidentally including historical versions of an excluded
+bound key.
+
+`FusedIterator<LsmIterator>` can remain the public iterator wrapper, but
+`LsmIterator` must become MVCC-aware: comparisons for deduplication use
+`user_key`, while source ordering still uses full internal keys.
+
+### 6.6 Writes and Tombstones
+
+All writes are stored as internal keys with a commit timestamp:
+
+```text
+put("k", "v")    -> ("k" @ commit_ts) = "v"
+delete("k")      -> ("k" @ commit_ts) = tombstone
+write_batch(...) -> every record uses the same commit_ts
+```
+
+MVCC should add an explicit tombstone representation instead of relying on empty
+values:
+
+```rust
+pub enum WriteOp {
+    Put(Bytes),
+    Delete,
+}
+
+pub enum KvKind {
+    Inline = 0,
+    ValuePointer = 1,
+    Tombstone = 2,
+}
+```
+
+The current empty-value tombstone encoding is ambiguous because `put(k, b"")`
+and `delete(k)` encode identically, especially in vLog mode where
+`[KvKind::Inline]` with no payload is already treated as a delete. Transaction
+local storage should store `WriteOp`, and persisted values should use
+`KvKind::Tombstone` once MVCC is enabled.
+
+### 6.7 Transactions
+
+`KvEngine::new_txn()` should return `Result<Arc<Transaction>>` instead of
+`Result<()>`.
+Each transaction has:
+
+```rust
+pub struct Transaction {
+    read_ts: u64,
+    read_guard: ReadGuard,
+    inner: Arc<LsmStorageInner>,
+    /// Raw user-key ordered local writes, not encoded internal keys.
+    local_storage: Arc<SkipMap<Bytes, WriteOp>>,
+    committed: Arc<AtomicBool>,
+    key_sets: Option<Mutex<(HashSet<Bytes>, HashSet<Bytes>)>>,
+}
+```
+
+Transaction behavior:
+
+1. `get` checks `local_storage` first, then reads the LSM at `read_ts`.
+2. `put` and `delete` write uncommitted raw user-key entries into
+   `local_storage`. Multiple writes to the same local key collapse with
+   last-op-wins semantics before commit.
+3. `scan` merges `local_storage` with the stable LSM snapshot at `read_ts`.
+   The transaction-local merge layer emits decoded user keys plus explicit
+   `WriteOp`/value-kind information; it must not rely on
+   `StorageIterator::value() -> &[u8]` to represent tombstones.
+4. `commit` uses the Section 6.2 commit protocol: reserve `commit_ts`, rewrite
+   local entries as internal keys, encode `WriteOp::Delete` as
+   `KvKind::Tombstone`, append/sync the WAL batch when enabled, insert all
+   entries while the active memtable cannot be frozen, and publish
+   `latest_commit_ts` only after the full batch is visible.
+5. `Drop` unregisters `read_ts` via `read_guard` if the transaction has not
+   already cleaned it up.
+
+`TxnLocalIterator` should not directly implement the existing byte-value
+`StorageIterator` contract for local deletes. Instead, introduce a transaction
+merge layer such as:
+
+```rust
+pub enum TxnEntry {
+    Put { key: Bytes, value: Bytes },
+    Delete { key: Bytes },
+}
+```
+
+`TxnIterator` then merges `TxnEntry` values with the MVCC LSM iterator by
+decoded user key and suppresses `Delete` entries in the public scan output.
+Alternatively, extend `StorageIterator` with an explicit value-kind/tombstone
+method before using it for transaction-local state.
+
+### 6.8 Serializable Mode
+
+When `serializable` is false, transactions provide repeatable snapshot reads.
+Write-write conflicts are resolved by version order: a later commit creates a
+newer version. This is intentionally last-writer-wins rather than full snapshot
+isolation, which would reject concurrent write-write conflicts.
+
+When `serializable` is true, the first implementation provides point-key
+serializable OCC. `Transaction` tracks:
+
+1. `read_set`: raw user keys read from the LSM snapshot.
+2. `write_set`: raw user keys written by the transaction.
+
+Every point key requested through `get` is added to `read_set` when the
+transaction consults the snapshot, including keys that return `None`, keys whose
+latest visible version is a tombstone, and keys later shadowed by local writes.
+This prevents a concurrent insert after `read_ts` from bypassing point-key
+conflict detection.
+
+On commit:
+
+1. Acquire `commit_lock`.
+2. Remove committed transaction records older than `mvcc.watermark()`.
+3. Check committed transactions with `commit_ts > read_ts`.
+4. Abort if any committed transaction's `write_set` intersects this
+   transaction's `read_set`.
+5. Reserve `commit_ts = latest_commit_ts + 1` without publishing it.
+6. Append and sync one atomic WAL batch record when WAL is enabled.
+7. Insert all versioned records while the memtable cannot be frozen.
+8. Record this transaction's write set in `committed_txns`.
+9. Publish `latest_commit_ts = commit_ts`.
+10. Release `commit_lock`.
+
+This is optimistic concurrency control. It prevents stale-read anomalies for
+point-key conflicts. It is not full predicate serializability: range reads can
+miss phantoms inserted after `read_ts` unless a later phase adds range predicate
+tracking or range validation. The public option can remain named
+`serializable` for compatibility, but documentation should describe the initial
+guarantee as point-key serializability.
+
+### 6.9 WAL and Recovery
+
+WAL records should store internal keys exactly as they appear in the memtable.
+This keeps recovery simple:
+
+1. Recover memtables from WAL into `SkipMap<encoded_internal_key, value>`.
+2. Recover SST metadata as today.
+3. Recover the maximum commit timestamp from complete WAL batches and either
+   persisted SST `max_ts` or a full SST key scan. SST metadata is sufficient
+   only if the MVCC SST format adds per-table or per-block `max_ts`.
+4. Initialize `LsmMvccInner::new(max_commit_ts)`.
+
+WAL writes must be batch-framed. A committed batch should be encoded as a single
+logical record containing `commit_ts`, entry count, entry lengths, payloads, and
+a checksum, or as data records followed by a checksum-protected commit marker.
+Recovery must replay either the whole batch or none of it. A truncated or
+checksum-invalid batch is ignored or causes recovery to truncate the WAL at the
+last valid batch boundary. Replaying a prefix of a batch with one commit
+timestamp is not allowed.
+
+Crash semantics must be explicit: if the engine syncs a complete WAL batch and
+then crashes before publishing `latest_commit_ts` to live readers, recovery may
+treat that complete batch as committed. This is the usual durable-before-ack
+window: the client may not have observed success, but the recovered database may
+include the write. If this behavior is not acceptable, the WAL format needs a
+separate durable publish marker and recovery must ignore synced-but-unpublished
+batches.
+
+The WAL already stores opaque key bytes, but mixed pre-MVCC and MVCC WALs are
+not distinguishable by the WAL record alone. MVCC therefore needs a manifest or
+directory format marker. Startup should reject mixed formats unless an explicit
+migration maps existing raw keys to timestamp zero.
+
+The persisted value format also needs this format marker. MVCC values should be
+kind-tagged in both vLog and non-vLog modes so `KvKind::Tombstone` is
+unambiguous. Migration rules must be storage-location aware: current non-vLog
+WAL/memtable values are raw bytes, while flushed SST values produced through
+`SsTableBuilder::add` may already be `KvKind::Inline`-prefixed, and vLog mode is
+kind-prefixed in more paths. The MVCC format marker must select the correct
+decoder for WAL recovery, SST reads, memtable values, and vLog pointer values.
+`KvKind::from_u8` and every parser must recognize `Tombstone = 2`.
+
+MVCC tombstones are encoded as exactly one byte: `[KvKind::Tombstone]`.
+Tombstone payload bytes are invalid. `[KvKind::Inline]` with an empty payload is
+accepted only by pre-MVCC compatibility decoding and must not be emitted by MVCC
+writers.
+
+SST recovery needs one of two approaches:
+
+1. Persist `max_ts` in a format-versioned SST footer and load it in
+   `SsTable::open`.
+2. Derive `max_ts` by scanning actual table keys on startup.
+
+Persisting `max_ts` is preferred because the current `SsTable::open` placeholder
+sets it to zero and cannot recover the global timestamp counter correctly.
+Current block metadata stores first and last keys only; because internal-key
+ordering is user-key-first, the maximum timestamp can appear in the middle of a
+block or table. Metadata-only recovery would require adding per-block or
+per-table `max_ts` metadata.
+
+### 6.10 SST Metadata and Bloom Filters
+
+`SsTable` already has a `max_ts` placeholder. MVCC should populate:
+
+1. `first_key`: first internal key in the SST.
+2. `last_key`: last internal key in the SST.
+3. `max_ts`: highest commit timestamp in the SST.
+4. Bloom filter entries: user-key hashes, not full internal-key hashes.
+
+Range overlap must compare user-key portions of bounds. Point-get bloom checks
+must also use decoded user-key hashes. Memtable incremental bloom filters must
+make the same change; hashing the full internal key would create false
+negatives for lookups at read timestamps that do not exactly match a committed
+version.
+
+### 6.11 Compaction and Version GC
+
+Compaction becomes responsible for dropping obsolete versions, but only when the
+compaction input proves that no older version outside the input can be
+resurrected. This is safe for bottommost/full-overlap compactions, or for tasks
+that explicitly expand overlaps to include every older version for the affected
+user-key range.
+
+For each user key in a safe compaction scope, while iterating versions from
+newest to oldest:
+
+1. Keep every version with `commit_ts > watermark`.
+2. Also keep the newest version with `commit_ts <= watermark`.
+3. Drop older versions below that retained boundary version.
+4. Preserve tombstones until they are below the watermark and no older version
+   needs to be hidden.
+
+Example with `watermark = 100`:
+
+```text
+k@120 -> keep, active readers may see it
+k@105 -> keep, active readers may see it
+k@090 -> keep, newest version <= watermark
+k@080 -> drop, hidden for all current and future readers
+```
+
+If the newest below-watermark version is a tombstone, the tombstone can be
+dropped only when the compaction scope proves that all older versions for the
+key are also being dropped or do not exist. This prevents deleted keys from
+reappearing from an older SST outside the compaction input.
+
+### 6.12 vLog Interaction
+
+MVCC and vLog can coexist because value pointers are stored as values under
+versioned internal keys.
+
+Required rules:
+
+1. vLog entry key validation must use the full internal key, not only the user
+   key, if different versions can point to different vLog entries.
+2. vLog reference tracking remains SST-based, but compaction version GC can
+   remove old pointer-bearing entries from new SSTs.
+3. vLog file reclamation remains safe only after SST references, memtable
+   references, active reader guards, and physical `Arc<SsTable>` snapshots that
+   may still contain the pointer are gone.
+4. A value pointer below the MVCC watermark may still be live if it is the
+   newest below-watermark version kept by compaction.
+
+The implementation can satisfy this by tying vLog file deletion to both MVCC
+watermark rules and a physical table-lifetime/epoch mechanism. Current manifest
+references alone are insufficient because old iterators can hold `Arc<SsTable>`
+after a compaction installs a newer state.
+
+vLog GC must be MVCC-version aware. Current-style key-current-state CAS is not
+sufficient because a historical value pointer belongs to one exact encoded
+internal key. GC may either:
+
+1. Rewrite value pointers while building compaction output, replacing the value
+   for the exact internal key that survives version GC.
+2. Use an internal-version CAS API keyed by encoded internal key and expected
+   `ValuePointer`, never by raw user key alone.
+
+GC must not create a new latest version just to move an old value, and it must
+not rewrite a pointer unless the exact internal-key version remains live.
+
+### 6.13 Cache Interaction
+
+Block cache keys remain `(sst_id, block_idx)`. MVCC does not require cache API
+changes.
+
+Backfill behavior remains valid:
+
+1. Flush backfills blocks containing versioned internal keys.
+2. Compaction backfills blocks after MVCC version GC.
+3. Old blocks are invalidated when their SSTs are removed.
+
+The value cache used by vLog must include enough identity to distinguish
+different versions. Caching by `ValuePointer` is sufficient because pointers are
+unique physical locations.
+
+---
+
+## 7. API Changes
+
+Proposed public API:
+
+```rust
+impl KvEngine {
+    pub fn new_txn(&self) -> Result<Arc<Transaction>>;
+}
+
+impl Transaction {
+    pub fn get(&self, key: &[u8]) -> Result<Option<Bytes>>;
+    pub fn scan(self: &Arc<Self>, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> Result<TxnIterator>;
+    pub fn put(&self, key: &[u8], value: &[u8]);
+    pub fn delete(&self, key: &[u8]);
+    pub fn commit(&self) -> Result<()>;
+}
+```
+
+`Result<Arc<Transaction>>` keeps the outer API compatible with fallible engine
+methods and lets the implementation return an error if MVCC is unavailable
+during migration.
+
+---
+
+## 8. Implementation Plan
+
+### Phase 1: Timestamped Keys
+
+1. Implement escaped internal key helpers in `key.rs`.
+2. Remove production use of no-timestamp constructors.
+3. Update memtable, block iterator, SST seek, range overlap, and test helpers
+   to use encoded internal keys and decoded user-key bounds correctly.
+4. Keep `TS_ENABLED` guarded tests to ease migration.
+
+### Phase 2: Format Hardening
+
+1. Add format markers for MVCC WAL, SST, value, vLog, and `.vidx` decoding.
+2. Replace unchecked fixed-width casts with checked conversions and error
+   propagation in block metadata, SST footer offsets, WAL records, vLog entries,
+   and `.vidx` persistence, or widen those fields in the MVCC format.
+3. Implement WAL batch framing, checksum validation, truncation behavior, and
+   max-timestamp extraction from complete batches only.
+
+### Phase 3: MVCC State and Watermark
+
+1. Implement `Watermark`.
+2. Initialize `mvcc: Some(Arc<LsmMvccInner>)` in `LsmStorageInner::open`.
+3. Recover max timestamp from complete WAL batches and persisted SST `max_ts` or
+   a full SST key scan.
+4. Add atomic `ReadGuard::new_latest` registration and cleanup.
+
+### Phase 4: Versioned Writes and Reads
+
+1. Add `KvKind::Tombstone` and update `KvKind::from_u8`, value parsers, SST
+   builder `add`/`add_raw` paths, compaction tombstone checks, vLog
+   reader/index logic, and compatibility handling.
+2. Canonicalize duplicate user keys in `put`, `delete`, transaction commits,
+   and `write_batch`.
+3. Assign commit timestamps and store internal keys in memtables and WALs.
+4. Implement version-aware `get`.
+5. Hash SST and memtable bloom entries by user key.
+
+### Phase 5: Snapshot Scans
+
+1. Make `LsmIterator` collapse duplicate user keys.
+2. Make memtable and SST range bounds timestamp-aware.
+3. Add scan tests for concurrent writes during iteration.
+
+### Phase 6: Transactions
+
+1. Implement `LsmMvccInner::new_txn`.
+2. Implement `Transaction::{get, scan, put, delete, commit}`.
+3. Implement the `TxnEntry`/transaction merge layer or extend
+   `StorageIterator` with explicit value-kind support.
+4. Add repeatable snapshot read tests.
+
+### Phase 7: Serializable OCC
+
+1. Replace the current `HashSet<u32>` sketches with read and write user-key
+   sets such as `HashSet<Bytes>`.
+2. Implement committed transaction pruning by watermark.
+3. Detect read/write conflicts at commit.
+4. Add conflict and no-conflict tests.
+
+### Phase 8: Compaction GC
+
+1. Populate SST `max_ts`.
+2. Add watermark-aware version dropping in compaction builders.
+3. Preserve tombstone semantics.
+4. Add tests for old-version reclamation.
+
+### Phase 9: vLog Integration
+
+1. Validate vLog entries against full internal keys.
+2. Make vLog GC rewrite exact live internal-key versions via compaction output
+   or internal-version CAS.
+3. Verify vLog GC with multiple versions of the same user key.
+4. Add tests covering pointer-bearing historical versions.
+
+---
+
+## 9. Testing Plan
+
+Required tests:
+
+1. Internal key ordering: same user key sorts newest timestamp first.
+2. `get` returns the newest version at or below the read timestamp.
+3. `delete` hides older versions for newer snapshots.
+4. `scan` yields one visible version per user key.
+5. Long-running scan does not observe concurrent writes.
+6. WAL recovery restores versioned keys and max timestamp.
+7. Snapshot transaction reads are repeatable.
+8. Transaction local writes shadow snapshot state.
+9. Serializable transaction aborts on read/write conflict.
+10. Serializable transaction commits when write sets do not conflict.
+11. Compaction keeps versions with `commit_ts > watermark`.
+12. Compaction keeps the newest version with `commit_ts <= watermark`.
+13. Compaction does not resurrect deleted keys.
+14. vLog values remain readable across multiple versions.
+15. vLog GC does not remove a pointer still visible to an old snapshot.
+16. Prefix user keys such as `a`, `a\x00`, and `aa` sort and seek correctly
+    across memtables, block binary search, SST point lookup, and range scans.
+17. WAL recovery ignores or truncates incomplete MVCC batch records and never
+    exposes a partial one-timestamp batch.
+18. WAL recovery follows the documented crash contract for a complete synced
+    batch that was not published before crash.
+19. Escaped user keys containing multiple `0x00` bytes decode back to the exact
+    original user key and deduplicate correctly during scans.
+20. Bloom filters hash decoded user keys consistently across memtable and SST
+    lookups.
+21. Keys whose encoded internal length exceeds the active format limit are
+    rejected before WAL, SST, vLog, or vLog-index writes.
+22. Duplicate user keys in one batch or transaction commit are canonicalized
+    with last-op-wins behavior, or rejected consistently.
+23. vLog index entries use full encoded internal keys and GC rewrites only exact
+    live internal-key versions, including embedded-zero keys and oversized-key
+    rejection.
+24. Serializable OCC records negative point reads: if one transaction reads an
+    absent or tombstoned key and another transaction inserts that key after
+    `read_ts`, the first transaction aborts on commit.
+25. MVCC tombstone parser tests cover valid `[KvKind::Tombstone]`, invalid
+    tombstone payloads, and `[KvKind::Inline]` empty accepted only under
+    pre-MVCC compatibility decoding.
+
+Recommended commands:
+
+```bash
+cargo nextest run --workspace --all-features --lib
+cargo nextest run --workspace --all-features --all-targets
+cargo make check
+```
+
+---
+
+## 10. Risks and Tradeoffs
+
+### 10.1 Key Size Overhead
+
+Every internal key gains at least 10 bytes: a 2-byte escaped-key terminator plus
+an 8-byte timestamp. Embedded `0x00` user-key bytes expand to `0x00 0xff`, so
+the overhead can be larger. Encoded-size validation must use the expanded
+internal key length. This increases memtable memory, SST block size, bloom input
+processing, and cache footprint. The tradeoff is necessary for versioned reads
+and simple compaction ordering.
+
+### 10.2 Iterator Complexity
+
+Scans must deduplicate by user key while ordering by internal key. This is the
+largest correctness risk. Tests should heavily cover boundary conditions,
+tombstones, and mixed memtable/SST versions.
+
+### 10.3 Bloom Filter Semantics
+
+Hashing full internal keys would make point lookups incorrect because callers do
+not know the exact commit timestamp. Bloom filters must hash user keys only.
+
+### 10.4 Serializable Granularity
+
+Point-key set tracking is lightweight but not full predicate serializability.
+The first implementation records point keys only and documents that range
+predicates are not serializable. Preventing range phantoms requires a later
+predicate/range validation phase.
+
+### 10.5 vLog Key Validation
+
+If vLog entries continue validating only user keys, stale pointers from older
+versions can appear valid for newer versions of the same key. Using full
+internal keys avoids this ambiguity.
+
+---
+
+## 11. Open Questions
+
+1. Should `serializable` mode conservatively reject range-write phantoms, or
+   document point-key serializability for the first phase?
+2. Should pre-MVCC data directories be rejected, migrated to timestamp zero, or
+   treated as unsupported?
+3. Should `max_ts` be stored in the SST file footer for fast recovery, or
+   derived by opening table metadata?
+
+---
+
+## 12. Success Criteria
+
+The MVCC implementation is complete when:
+
+1. `TS_ENABLED` is true and production paths use timestamped keys.
+2. `KvEngine::get` and `scan` are snapshot-consistent.
+3. `Transaction` supports repeatable reads and atomic commits.
+4. Serializable mode detects point-key read/write conflicts.
+5. WAL recovery preserves versions and resumes timestamp allocation safely.
+6. Compaction reclaims obsolete versions without breaking active snapshots or
+   resurrecting older data.
+7. vLog GC remains safe with historical versions.
+8. `cargo make check` passes.


### PR DESCRIPTION
## Summary

Enable Multi-Version Concurrency Control (MVCC) in the KV engine. Keys now carry timestamps for versioned reads/writes, snapshot scans, and automatic selection of the newest visible version across memtables, SSTs, and iterators. Includes an RFC document, Phase 1 implementation, and fixes from multiple rounds of code review.

## Changes

### MVCC Core (Phase 1)

- **Internal key encoding** (`key.rs`) — `TS_ENABLED = true`; escaped user key + `0x00 0x00` terminator + inverted `u64` timestamp (big-endian). Byte-order preserved: newer versions sort first.
- **Key API** — `Key<T>` gains `ts()`, `encoded_user_key()`, `decode_user_key()`, `decode_user_key_cow()`, `raw_ref()`. `KeyVec::from_user_key_ts()` encodes user key + timestamp. `for_testing_*` helpers updated.
- **MemTable** (`mem_table.rs`) — Bloom filter hashes decoded user keys. Added `get_versioned()` / `get_versioned_raw()` seeking from `encode(user_key, u64::MAX)` to find the newest matching entry. vLog deref decodes user key when `TS_ENABLED`.
- **SST point lookups** (`table.rs`) — `find_block_idx` uses encoded user-key ranges with earliest-match tracking for MVCC. `point_get_with_hash_and_key` returns both value and found key for cross-SST timestamp comparison. Bloom check unified using precomputed hash. `read_ts` filtering scans forward through versions, crossing block boundaries when needed.
- **SST builder** (`table/builder.rs`) — Stores encoded keys; max_ts tracked per SST.
- **Block iterator** (`block/iterator.rs`) — Binary search bounds adjusted for half-open insertion results.
- **SST iterator** (`table/iterator.rs`) — Advances across multiple blocks until positioned at/after target; vLog lookup key derived from decoded user key.
- **LsmIterator** (`lsm_iterator.rs`) — Caches both decoded `user_key` (for `key()` return and bound checks) and `encoded_user_key` (for version-skipping in `next()`). Skips all versions of tombstoned user keys.
- **Storage layer** (`lsm_storage.rs`) — `get()` / `get_with_kind()` encode lookup key with `u64::MAX`. MVCC memtable branch uses `get_versioned*`. `put()` routes through `mvcc.write()` which allocates commit ts. SST lookup scans all L0 and leveled SSTs to find newest version by timestamp. `scan()` encodes bounds and skips excluded-key versions. `mvcc_point_get_across_ssts` helper deduplicates L0/leveled lookup loops.
- **Compaction** (`compact.rs`) — Preserves tombstones when MVCC is enabled (runtime `self.mvcc.is_some()` check, not compile-time constant).
- **MVCC module** (`mvcc.rs`, `mvcc/watermark.rs`) — `LsmMvccInner::write()` allocates commit ts, encodes internal key, writes to memtable. `Watermark` tracks active readers; `watermark()` returns min active reader ts.
- **Tests** — Test harness and SST tests updated for timestamp-aware keys via `KeyVec::from_user_key_ts(..., 0)`.

### Review Fixes

- **Cross-block read_ts scanning** — When all versions in a block are newer than `read_ts`, continue to the next block instead of returning `None`.
- **Runtime MVCC gate** — Replace compile-time `key::TS_ENABLED` with runtime `self.mvcc.is_some()` in compaction tombstone preservation.
- **Escape-pair validation** — `decode_user_key_cow` now validates `0x00` bytes are followed by `0xff` for consistency with `find_terminator_offset`.
- **Deduplicated range_overlap** — Collapsed `Included`/`Excluded` match arms using guard patterns.
- **Descriptive .expect()** — Replaced bare `.unwrap()` on manifest access with `.expect("manifest initialized")`.
- **MVCC clock restart NOTE** — Documented that commit clock starts at 0 after restart; Phase 2 must recover max committed timestamp before enabling read_ts filtering.

## Verification

- 149/149 tests pass
- clippy clean, fmt clean
- All CI checks pass (codecov threshold and nightly benchmark timeout are pre-existing)
