### PR TITLE
feat: TiKV memcomparable key encoding + cross-level MVCC lookup fix

### DIFF
--- a/kv-engine/src/key.rs
+++ b/kv-engine/src/key.rs
@@ -519,6 +519,16 @@ mod tests {
         assert!(k_a.as_key_slice() < k_b.as_key_slice());
     }
 
+    #[test]
+    fn test_key_ordering_full_group_prefix() {
+        // Keys whose length is an exact multiple of 8 must sort BEFORE longer
+        // keys with the same prefix. The terminator group ensures this.
+        let k8 = KeyVec::from_user_key_ts(b"abcdefgh", 1);  // 8 bytes
+        let k9 = KeyVec::from_user_key_ts(b"abcdefghi", 1); // 9 bytes (same prefix)
+        assert!(k8.as_key_slice() < k9.as_key_slice(),
+            "8-byte key must sort before 9-byte key with same prefix");
+    }
+
     // --- encode_internal_key_to_buf ---
 
     #[test]

--- a/kv-engine/src/key.rs
+++ b/kv-engine/src/key.rs
@@ -128,7 +128,10 @@ pub fn decode_user_key_into(encoded_prefix: &[u8], dst: &mut Vec<u8>) -> bool {
                 return false;
             }
             // Padding bytes must be 0x00 to preserve sort order
-            if !group[ENC_GROUP_SIZE - pad_count..].iter().all(|&b| b == ENC_PAD) {
+            if !group[ENC_GROUP_SIZE - pad_count..]
+                .iter()
+                .all(|&b| b == ENC_PAD)
+            {
                 return false;
             }
             dst.extend_from_slice(&group[..ENC_GROUP_SIZE - pad_count]);

--- a/kv-engine/src/key.rs
+++ b/kv-engine/src/key.rs
@@ -122,12 +122,22 @@ pub fn decode_user_key_into(encoded_prefix: &[u8], dst: &mut Vec<u8>) -> bool {
         if pad_count > ENC_GROUP_SIZE {
             return false;
         }
-        dst.extend_from_slice(&group[..ENC_GROUP_SIZE - pad_count]);
-        i += ENC_GROUP_SIZE + 1;
         if pad_count > 0 {
-            // Last group: must be at the end
+            // Empty group (pad_count == 8) only valid for empty key at position 0
+            if pad_count == ENC_GROUP_SIZE && i > 0 {
+                return false;
+            }
+            // Padding bytes must be 0x00 to preserve sort order
+            if !group[ENC_GROUP_SIZE - pad_count..].iter().all(|&b| b == ENC_PAD) {
+                return false;
+            }
+            dst.extend_from_slice(&group[..ENC_GROUP_SIZE - pad_count]);
+            i += ENC_GROUP_SIZE + 1;
+            // Padded group must be the last group
             return i == encoded_prefix.len();
         }
+        dst.extend_from_slice(group);
+        i += ENC_GROUP_SIZE + 1;
     }
     i == encoded_prefix.len()
 }
@@ -578,6 +588,31 @@ mod tests {
         // Marker 0x00 would imply pad_count = 0xFF - 0x00 = 255 > 8 → invalid
         let mut data = vec![0u8; 8];
         data.push(0x00); // bad marker
+        let mut dst = Vec::new();
+        assert!(!decode_user_key_into(&data, &mut dst));
+    }
+
+    #[test]
+    fn test_decode_user_key_into_non_zero_padding() {
+        // pad_count=5, but padding bytes are 0x01 instead of 0x00 → invalid
+        let mut data = vec![0x41; 8]; // group: "AAAAAAAA"
+        data.push(0xFC); // marker = 0xFF - 3 → pad_count=3
+        // Append a second group with non-zero padding
+        let mut group2 = vec![0x42, 0x42, 0x42, 0x42, 0x42, 0x01, 0x01, 0x01]; // bad padding
+        group2.push(0xFC); // marker = 0xFF - 3 → pad_count=3
+        data.extend_from_slice(&group2);
+        let mut dst = Vec::new();
+        assert!(!decode_user_key_into(&data, &mut dst));
+    }
+
+    #[test]
+    fn test_decode_user_key_into_empty_group_at_nonzero_pos() {
+        // pad_count=8 (empty group) at position > 0 → invalid
+        let mut data = vec![0x41; 8]; // first group: valid full group
+        data.push(0xFF); // marker = 0xFF - 0 → pad_count=0, full group
+        // Second group: empty (pad_count=8) — invalid at position > 0
+        data.extend_from_slice(&[0x00; 8]);
+        data.push(0xF7); // marker = 0xFF - 8 → pad_count=8
         let mut dst = Vec::new();
         assert!(!decode_user_key_into(&data, &mut dst));
     }

--- a/kv-engine/src/key.rs
+++ b/kv-engine/src/key.rs
@@ -200,6 +200,8 @@ impl<T: AsRef<[u8]>> Key<T> {
     pub fn decode_user_key_into(&self, dst: &mut Vec<u8>) {
         if let Some(prefix) = encoded_user_key_prefix(self.0.as_ref()) {
             decode_user_key_into(prefix, dst);
+        } else {
+            dst.clear();
         }
     }
 

--- a/kv-engine/src/key.rs
+++ b/kv-engine/src/key.rs
@@ -175,7 +175,7 @@ impl<T: AsRef<[u8]>> Key<T> {
         extract_ts(self.0.as_ref()).unwrap_or(0)
     }
 
-    /// Return the encoded user-key prefix (with escaping, without terminator).
+    /// Return the encoded user-key prefix (memcomparable form, without timestamp suffix).
     pub fn encoded_user_key(&self) -> &[u8] {
         encoded_user_key_prefix(self.0.as_ref()).unwrap_or_else(|| self.0.as_ref())
     }
@@ -203,9 +203,8 @@ impl<T: AsRef<[u8]>> Key<T> {
     }
 
     /// For testing: return the comparable key bytes.
-    /// When TS_ENABLED, returns the encoded user-key prefix (escaped form,
-    /// without terminator or timestamp). For keys without embedded zero bytes
-    /// this equals the raw user key.
+    /// When TS_ENABLED, returns the encoded user-key prefix (memcomparable form,
+    /// without timestamp suffix).
     pub fn for_testing_key_ref(&self) -> &[u8] {
         if TS_ENABLED {
             self.encoded_user_key()
@@ -593,11 +592,8 @@ mod tests {
 
     #[test]
     fn test_extract_ts_exactly_minimum() {
-        // 17 bytes: 9 bytes encoded key + 8 bytes ts
-        let mut enc = vec![0u8; 9]; // empty key (8 zeros + marker 0xF8)
-        enc[8] = 0xF8;
-        enc.extend_from_slice(&42u64.to_be_bytes()); // ts=42 → inv_ts
-        // Wait, we need inv_ts = u64::MAX - 42
+        // 17 bytes: 9 bytes encoded user key + 8 bytes ts
+        // Marker 0xF8 = 0xFF - 7 → 1 user data byte + 7 padding
         let inv_ts = u64::MAX - 42;
         let mut enc = vec![0u8; 9];
         enc[8] = 0xF8;

--- a/kv-engine/src/key.rs
+++ b/kv-engine/src/key.rs
@@ -52,24 +52,21 @@ fn encode_memcomparable_user_key_to(buf: &mut Vec<u8>, user_key: &[u8]) {
         buf.push(ENC_MARKER);
     }
     let remainder = chunks.remainder();
-    // Emit a remainder group if there's leftover data OR if the key is empty
-    // (empty key still needs one group of 8 zero bytes).
-    if !remainder.is_empty() || user_key.is_empty() {
-        let pad_count = ENC_GROUP_SIZE - remainder.len();
-        buf.extend_from_slice(remainder);
-        buf.resize(buf.len() + pad_count, ENC_PAD);
-        buf.push(ENC_MARKER.wrapping_sub(pad_count as u8));
-    }
+    // Always emit a final padded group (terminator). This ensures every encoded
+    // key ends with a marker < 0xFF, which is required for correct lexicographic
+    // sort order — without it, a key whose length is an exact multiple of 8
+    // would end with marker 0xFF and sort incorrectly after longer keys with
+    // the same prefix.
+    let pad_count = ENC_GROUP_SIZE - remainder.len();
+    buf.extend_from_slice(remainder);
+    buf.resize(buf.len() + pad_count, ENC_PAD);
+    buf.push(ENC_MARKER.wrapping_sub(pad_count as u8));
 }
 
 /// Encode a user key + timestamp into an internal key byte vector.
 pub fn encode_internal_key(user_key: &[u8], ts: u64) -> Vec<u8> {
-    // Number of groups: empty key = 1, exact multiple = len/8, else ceil(len/8)
-    let groups = if user_key.is_empty() {
-        1
-    } else {
-        user_key.len().div_ceil(ENC_GROUP_SIZE)
-    };
+    // Always one extra group for the terminator (even for empty key).
+    let groups = user_key.len() / ENC_GROUP_SIZE + 1;
     let encoded_len = groups * (ENC_GROUP_SIZE + 1) + 8;
     let mut buf = Vec::with_capacity(encoded_len);
     encode_memcomparable_user_key_to(&mut buf, user_key);
@@ -123,10 +120,6 @@ pub fn decode_user_key_into(encoded_prefix: &[u8], dst: &mut Vec<u8>) -> bool {
             return false;
         }
         if pad_count > 0 {
-            // Empty group (pad_count == 8) only valid for empty key at position 0
-            if pad_count == ENC_GROUP_SIZE && i > 0 {
-                return false;
-            }
             // Padding bytes must be 0x00 to preserve sort order
             if !group[ENC_GROUP_SIZE - pad_count..]
                 .iter()
@@ -250,11 +243,7 @@ impl Key<Vec<u8>> {
     /// Set from a user key + timestamp, reusing buffer capacity.
     pub fn set_from_user_key_ts(&mut self, user_key: &[u8], ts: u64) {
         self.0.clear();
-        let groups = if user_key.is_empty() {
-            1
-        } else {
-            user_key.len().div_ceil(ENC_GROUP_SIZE)
-        };
+        let groups = user_key.len() / ENC_GROUP_SIZE + 1;
         self.0.reserve(groups * (ENC_GROUP_SIZE + 1) + 8);
         encode_internal_key_to_buf(&mut self.0, user_key, ts);
     }
@@ -422,16 +411,19 @@ mod tests {
 
     #[test]
     fn test_encode_full_group_key() {
-        // "abcdefgh" = 8 bytes → no pad → marker = 0xFF
+        // "abcdefgh" = 8 bytes → group1 (8 bytes + 0xFF) + terminator (8 zeros + 0xF7)
         let enc = encode_internal_key(b"abcdefgh", 1);
-        assert_eq!(enc.len(), 17); // 9 (encoded key) + 8 (ts)
+        assert_eq!(enc.len(), 26); // 18 (encoded key) + 8 (ts)
         assert_eq!(&enc[0..8], b"abcdefgh");
-        assert_eq!(enc[8], 0xFF); // marker (no padding)
+        assert_eq!(enc[8], 0xFF); // group1 marker (no padding)
+        assert_eq!(&enc[9..17], &[0, 0, 0, 0, 0, 0, 0, 0]); // terminator padding
+        assert_eq!(enc[17], 0xF7); // terminator marker = 0xFF - 8
     }
 
     #[test]
     fn test_encode_two_group_key() {
-        // "abcdefghi" = 9 bytes → group1 (8 bytes + 0xFF) + group2 (1 byte + pad 7 + 0xF8)
+        // "abcdefghi" = 9 bytes → group1 (8+0xFF) + group2 (1+pad7+0xF8)
+        // The group2 with pad_count=7 IS the terminator (marker < 0xFF)
         let enc = encode_internal_key(b"abcdefghi", 0);
         assert_eq!(enc.len(), 26); // 18 (encoded key) + 8 (ts)
         assert_eq!(&enc[0..8], b"abcdefgh");
@@ -609,15 +601,17 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_user_key_into_empty_group_at_nonzero_pos() {
-        // pad_count=8 (empty group) at position > 0 → invalid
-        let mut data = vec![0x41; 8]; // first group: valid full group
+    fn test_decode_user_key_into_empty_terminator_group() {
+        // pad_count=8 (empty terminator group) at position > 0 is valid —
+        // this is the terminator for keys whose length is an exact multiple of 8.
+        let mut data = vec![0x41; 8]; // first group: "AAAAAAAA"
         data.push(0xFF); // marker = 0xFF - 0 → pad_count=0, full group
-        // Second group: empty (pad_count=8) — invalid at position > 0
+        // Second group: empty terminator (pad_count=8)
         data.extend_from_slice(&[0x00; 8]);
         data.push(0xF7); // marker = 0xFF - 8 → pad_count=8
         let mut dst = Vec::new();
-        assert!(!decode_user_key_into(&data, &mut dst));
+        assert!(decode_user_key_into(&data, &mut dst));
+        assert_eq!(dst, b"AAAAAAAA");
     }
 
     // --- extract_ts edge cases ---

--- a/kv-engine/src/key.rs
+++ b/kv-engine/src/key.rs
@@ -525,10 +525,12 @@ mod tests {
     fn test_key_ordering_full_group_prefix() {
         // Keys whose length is an exact multiple of 8 must sort BEFORE longer
         // keys with the same prefix. The terminator group ensures this.
-        let k8 = KeyVec::from_user_key_ts(b"abcdefgh", 1);  // 8 bytes
+        let k8 = KeyVec::from_user_key_ts(b"abcdefgh", 1); // 8 bytes
         let k9 = KeyVec::from_user_key_ts(b"abcdefghi", 1); // 9 bytes (same prefix)
-        assert!(k8.as_key_slice() < k9.as_key_slice(),
-            "8-byte key must sort before 9-byte key with same prefix");
+        assert!(
+            k8.as_key_slice() < k9.as_key_slice(),
+            "8-byte key must sort before 9-byte key with same prefix"
+        );
     }
 
     // --- encode_internal_key_to_buf ---

--- a/kv-engine/src/key.rs
+++ b/kv-engine/src/key.rs
@@ -22,36 +22,57 @@ pub(crate) fn shared_bytes_from_slice(src: &[u8]) -> Bytes {
 }
 
 // ---------------------------------------------------------------------------
-// Internal key encoding helpers (RFC Section 6.1)
+// Internal key encoding helpers
 //
-// Format: [escaped_user_key][0x00 0x00 terminator][inverted_ts: u64 BE]
+// Format: [memcomparable_user_key][!ts: u64 BE]
 //
-// Escaping rules:
-//   - Non-zero byte `b`      → `b`
-//   - Zero byte `0x00`       → `0x00 0xff`
-//   - End of user key        → `0x00 0x00`
-//   - Inverted timestamp     → `u64::MAX - ts`, big-endian
+// TiKV-style memcomparable encoding for user keys:
+//   - Bytes are split into 8-byte groups
+//   - Each group is followed by a marker byte
+//   - Last group: padded with 0x00, marker = 0xFF - pad_count
+//   - Marker 0xFF means no padding (full 8-byte group)
 //
-// This preserves byte-order: user keys sort ascending, and for the same user
-// key newer timestamps (higher ts → lower inverted_ts) sort first.
+// Timestamp suffix:
+//   - `!ts` (bitwise NOT) stored as big-endian u64
+//   - Higher ts → lower !ts → sorts first within a user key
+//
+// This preserves byte-order for memcmp: user keys sort lexicographically,
+// and for the same user key newer timestamps sort first.
 // ---------------------------------------------------------------------------
+
+const ENC_GROUP_SIZE: usize = 8;
+const ENC_MARKER: u8 = 0xFF;
+const ENC_PAD: u8 = 0x00;
+
+/// Encode the user key portion using TiKV memcomparable encoding.
+fn encode_memcomparable_user_key_to(buf: &mut Vec<u8>, user_key: &[u8]) {
+    let mut chunks = user_key.chunks_exact(ENC_GROUP_SIZE);
+    for chunk in &mut chunks {
+        buf.extend_from_slice(chunk);
+        buf.push(ENC_MARKER);
+    }
+    let remainder = chunks.remainder();
+    // Emit a remainder group if there's leftover data OR if the key is empty
+    // (empty key still needs one group of 8 zero bytes).
+    if !remainder.is_empty() || user_key.is_empty() {
+        let pad_count = ENC_GROUP_SIZE - remainder.len();
+        buf.extend_from_slice(remainder);
+        buf.resize(buf.len() + pad_count, ENC_PAD);
+        buf.push(ENC_MARKER.wrapping_sub(pad_count as u8));
+    }
+}
 
 /// Encode a user key + timestamp into an internal key byte vector.
 pub fn encode_internal_key(user_key: &[u8], ts: u64) -> Vec<u8> {
-    // Worst case: every byte is 0x00 (doubled) + 2-byte terminator + 8-byte ts
-    let mut buf = Vec::with_capacity(user_key.len() * 2 + 2 + 8);
-    for &b in user_key {
-        if b == 0 {
-            buf.push(0x00);
-            buf.push(0xff);
-        } else {
-            buf.push(b);
-        }
-    }
-    // Terminator: 0x00 0x00
-    buf.push(0x00);
-    buf.push(0x00);
-    // Inverted timestamp, big-endian
+    // Number of groups: empty key = 1, exact multiple = len/8, else ceil(len/8)
+    let groups = if user_key.is_empty() {
+        1
+    } else {
+        user_key.len().div_ceil(ENC_GROUP_SIZE)
+    };
+    let encoded_len = groups * (ENC_GROUP_SIZE + 1) + 8;
+    let mut buf = Vec::with_capacity(encoded_len);
+    encode_memcomparable_user_key_to(&mut buf, user_key);
     let inv_ts = u64::MAX - ts;
     buf.extend_from_slice(&inv_ts.to_be_bytes());
     buf
@@ -59,119 +80,75 @@ pub fn encode_internal_key(user_key: &[u8], ts: u64) -> Vec<u8> {
 
 /// Append an encoded internal key to an existing buffer.
 pub fn encode_internal_key_to_buf(buf: &mut Vec<u8>, user_key: &[u8], ts: u64) {
-    for &b in user_key {
-        if b == 0 {
-            buf.push(0x00);
-            buf.push(0xff);
-        } else {
-            buf.push(b);
-        }
-    }
-    buf.push(0x00);
-    buf.push(0x00);
+    encode_memcomparable_user_key_to(buf, user_key);
     let inv_ts = u64::MAX - ts;
     buf.extend_from_slice(&inv_ts.to_be_bytes());
 }
 
-/// Find the offset of the `0x00 0x00` terminator in an encoded internal key.
-/// Returns `None` if the terminator is not found (malformed key).
-fn find_terminator_offset(encoded: &[u8]) -> Option<usize> {
-    let mut i = 0;
-    while i < encoded.len() {
-        if encoded[i] == 0x00 {
-            if i + 1 >= encoded.len() {
-                return None;
-            }
-            match encoded[i + 1] {
-                0x00 => return Some(i), // terminator
-                0xff => i += 2,         // escaped zero, skip both
-                _ => return None,       // malformed
-            }
-        } else {
-            i += 1;
-        }
+/// Extract the encoded user-key prefix (memcomparable form, without timestamp).
+/// Returns the bytes before the 8-byte suffix timestamp.
+pub fn encoded_user_key_prefix(encoded: &[u8]) -> Option<&[u8]> {
+    // Minimum: 1 group (9 bytes) + 8-byte ts = 17 bytes
+    if encoded.len() < 17 {
+        return None;
     }
-    None
+    Some(&encoded[..encoded.len() - 8])
 }
 
-/// Decode the user key from an encoded internal key into a destination buffer.
-/// Returns `false` if the encoded key is malformed.
-pub fn decode_user_key_into(encoded: &[u8], dst: &mut Vec<u8>) -> bool {
+/// Extract the timestamp from an encoded internal key.
+/// Returns `None` if the key is too short or malformed.
+pub fn extract_ts(encoded: &[u8]) -> Option<u64> {
+    if encoded.len() < 17 {
+        return None;
+    }
+    let ts_start = encoded.len() - 8;
+    let inv_ts = u64::from_be_bytes(encoded[ts_start..].try_into().ok()?);
+    Some(u64::MAX - inv_ts)
+}
+
+/// Decode the memcomparable-encoded user key prefix into a destination buffer.
+/// Returns `false` if the encoded prefix is malformed.
+pub fn decode_user_key_into(encoded_prefix: &[u8], dst: &mut Vec<u8>) -> bool {
     dst.clear();
+    // The encoded prefix must be a multiple of (ENC_GROUP_SIZE + 1) bytes
+    if encoded_prefix.is_empty() || !encoded_prefix.len().is_multiple_of(ENC_GROUP_SIZE + 1) {
+        return false;
+    }
     let mut i = 0;
-    while i < encoded.len() {
-        if encoded[i] == 0x00 {
-            if i + 1 >= encoded.len() {
-                return false;
-            }
-            match encoded[i + 1] {
-                0x00 => return true, // terminator
-                0xff => dst.push(0), // escaped zero
-                _ => return false,   // malformed
-            }
-            i += 2;
-        } else {
-            dst.push(encoded[i]);
-            i += 1;
+    while i + ENC_GROUP_SIZE <= encoded_prefix.len() {
+        let group = &encoded_prefix[i..i + ENC_GROUP_SIZE];
+        let marker = encoded_prefix[i + ENC_GROUP_SIZE];
+        let pad_count = ENC_MARKER.wrapping_sub(marker) as usize;
+        if pad_count > ENC_GROUP_SIZE {
+            return false;
+        }
+        dst.extend_from_slice(&group[..ENC_GROUP_SIZE - pad_count]);
+        i += ENC_GROUP_SIZE + 1;
+        if pad_count > 0 {
+            // Last group: must be at the end
+            return i == encoded_prefix.len();
         }
     }
-    false // no terminator found
+    i == encoded_prefix.len()
 }
 
 /// Decode the user key from an encoded internal key.
 /// Returns `None` if the key is malformed.
 pub fn decode_user_key(encoded: &[u8]) -> Option<Vec<u8>> {
+    let prefix = encoded_user_key_prefix(encoded)?;
     let mut buf = Vec::new();
-    if decode_user_key_into(encoded, &mut buf) {
+    if decode_user_key_into(prefix, &mut buf) {
         Some(buf)
     } else {
         None
     }
 }
 
-/// Extract the encoded user-key prefix (including escaping, excluding terminator).
-/// This is useful for comparisons that don't need the decoded key.
-pub fn encoded_user_key_prefix(encoded: &[u8]) -> Option<&[u8]> {
-    find_terminator_offset(encoded).map(|off| &encoded[..off])
-}
-
-/// Extract the timestamp from an encoded internal key.
-/// Returns `None` if the key is too short or malformed.
-pub fn extract_ts(encoded: &[u8]) -> Option<u64> {
-    let term_off = find_terminator_offset(encoded)?;
-    let ts_start = term_off + 2; // skip 0x00 0x00
-    if ts_start + 8 > encoded.len() {
-        return None;
-    }
-    let inv_ts = u64::from_be_bytes(encoded[ts_start..ts_start + 8].try_into().ok()?);
-    Some(u64::MAX - inv_ts)
-}
-
-/// Decode the user key into a `Cow`. If the key contains no escaped zeros,
-/// the borrowed variant avoids allocation.
+/// Decode the user key into a `Cow`.
+/// With memcomparable encoding, decoding always requires processing markers,
+/// so this always returns `Cow::Owned`.
 pub fn decode_user_key_cow(encoded: &[u8]) -> Option<Cow<'_, [u8]>> {
-    let term_off = find_terminator_offset(encoded)?;
-    let escaped = &encoded[..term_off];
-    // Check if escaping is needed
-    if !escaped.contains(&0x00) {
-        return Some(Cow::Borrowed(escaped));
-    }
-    let mut buf = Vec::with_capacity(term_off);
-    let mut i = 0;
-    while i < term_off {
-        if escaped[i] == 0x00 {
-            // Must be 0x00 0xff (escaped zero)
-            if i + 1 >= term_off || escaped[i + 1] != 0xff {
-                return None; // malformed
-            }
-            buf.push(0);
-            i += 2;
-        } else {
-            buf.push(escaped[i]);
-            i += 1;
-        }
-    }
-    Some(Cow::Owned(buf))
+    decode_user_key(encoded).map(Cow::Owned)
 }
 
 pub struct Key<T: AsRef<[u8]>>(T);
@@ -215,7 +192,9 @@ impl<T: AsRef<[u8]>> Key<T> {
 
     /// Decode the user key into a caller-provided buffer.
     pub fn decode_user_key_into(&self, dst: &mut Vec<u8>) {
-        decode_user_key_into(self.0.as_ref(), dst);
+        if let Some(prefix) = encoded_user_key_prefix(self.0.as_ref()) {
+            decode_user_key_into(prefix, dst);
+        }
     }
 
     /// Return the raw encoded internal key bytes.
@@ -259,8 +238,12 @@ impl Key<Vec<u8>> {
     /// Set from a user key + timestamp, reusing buffer capacity.
     pub fn set_from_user_key_ts(&mut self, user_key: &[u8], ts: u64) {
         self.0.clear();
-        // Reserve enough for worst-case encoding
-        self.0.reserve(user_key.len() * 2 + 10);
+        let groups = if user_key.is_empty() {
+            1
+        } else {
+            user_key.len().div_ceil(ENC_GROUP_SIZE)
+        };
+        self.0.reserve(groups * (ENC_GROUP_SIZE + 1) + 8);
         encode_internal_key_to_buf(&mut self.0, user_key, ts);
     }
 
@@ -390,6 +373,11 @@ mod tests {
             (b"hello", u64::MAX),
             (b"", 100),
             (&[0x00, 0x01, 0x00, 0xff], 999),
+            (b"a", 1),                // exactly 1 group
+            (b"abcdefgh", 7),         // exactly 1 full group
+            (b"abcdefghi", 8),        // 2 groups (1 full + 1 partial)
+            (b"abcdefghijklmnop", 9), // exactly 2 full groups
+            (&[0x00; 16], 42),        // all zeros, 2 groups
         ];
         for (uk, ts) in cases {
             let enc = encode_internal_key(uk, ts);
@@ -398,49 +386,88 @@ mod tests {
         }
     }
 
-    // --- decode_user_key_cow ---
+    // --- memcomparable encoding structure ---
 
     #[test]
-    fn test_decode_user_key_cow_no_zeros_borrowed() {
-        // No 0x00 bytes → Cow::Borrowed (zero-copy)
+    fn test_encode_empty_key() {
+        let enc = encode_internal_key(b"", 0);
+        // Empty key: 1 group of 8 zero bytes + marker 0xF8 + 8-byte ts = 17 bytes
+        assert_eq!(enc.len(), 17);
+        assert_eq!(enc[8], 247); // marker = 0xFF - 8 = 247
+        // Timestamp for ts=0: !0 = u64::MAX
+        assert_eq!(&enc[9..17], &u64::MAX.to_be_bytes());
+    }
+
+    #[test]
+    fn test_encode_short_key() {
+        // "key" = 3 bytes → pad 5 → marker = 0xFF - 5 = 0xFA
+        let enc = encode_internal_key(b"key", 100);
+        assert_eq!(enc.len(), 17); // 9 (encoded key) + 8 (ts)
+        assert_eq!(&enc[0..3], b"key");
+        assert_eq!(&enc[3..8], &[0, 0, 0, 0, 0]); // padding
+        assert_eq!(enc[8], 0xFA); // marker
+    }
+
+    #[test]
+    fn test_encode_full_group_key() {
+        // "abcdefgh" = 8 bytes → no pad → marker = 0xFF
+        let enc = encode_internal_key(b"abcdefgh", 1);
+        assert_eq!(enc.len(), 17); // 9 (encoded key) + 8 (ts)
+        assert_eq!(&enc[0..8], b"abcdefgh");
+        assert_eq!(enc[8], 0xFF); // marker (no padding)
+    }
+
+    #[test]
+    fn test_encode_two_group_key() {
+        // "abcdefghi" = 9 bytes → group1 (8 bytes + 0xFF) + group2 (1 byte + pad 7 + 0xF8)
+        let enc = encode_internal_key(b"abcdefghi", 0);
+        assert_eq!(enc.len(), 26); // 18 (encoded key) + 8 (ts)
+        assert_eq!(&enc[0..8], b"abcdefgh");
+        assert_eq!(enc[8], 0xFF); // group1 marker
+        assert_eq!(enc[9], b'i');
+        assert_eq!(&enc[10..17], &[0, 0, 0, 0, 0, 0, 0]); // padding
+        assert_eq!(enc[17], 0xF8); // group2 marker = 0xFF - 7
+    }
+
+    #[test]
+    fn test_encode_all_zeros_key() {
+        let key = [0x00u8; 5];
+        let enc = encode_internal_key(&key, 42);
+        assert_eq!(enc.len(), 17); // 9 + 8
+        assert_eq!(&enc[0..5], &[0, 0, 0, 0, 0]);
+        assert_eq!(&enc[5..8], &[0, 0, 0]); // pad
+        assert_eq!(enc[8], 0xFC); // marker = 0xFF - 3
+        assert_eq!(decode_user_key(&enc).unwrap(), key);
+    }
+
+    // --- decode_user_key_cow (always Owned with memcomparable) ---
+
+    #[test]
+    fn test_decode_user_key_cow_always_owned() {
+        // Memcomparable encoding always requires decoding (markers differ from data)
         let enc = encode_internal_key(b"abc", 10);
         let cow = decode_user_key_cow(&enc).unwrap();
         assert_eq!(&*cow, b"abc");
-        // Should be borrowed, not owned
+        // Always Owned — memcomparable always needs decode
         match cow {
-            std::borrow::Cow::Borrowed(_) => {}
-            _ => panic!("expected Borrowed variant for key without zeros"),
+            std::borrow::Cow::Owned(_) => {}
+            _ => panic!("expected Owned variant with memcomparable encoding"),
         }
     }
 
     #[test]
-    fn test_decode_user_key_cow_with_zeros_owned() {
-        // Contains 0x00 bytes → Cow::Owned
+    fn test_decode_user_key_cow_with_zeros() {
         let enc = encode_internal_key(&[0x00, 0x42, 0x00], 5);
         let cow = decode_user_key_cow(&enc).unwrap();
         assert_eq!(&*cow, &[0x00, 0x42, 0x00]);
     }
 
-    #[test]
-    fn test_decode_user_key_cow_malformed_escape_returns_none() {
-        // 0x00 followed by 0x01 (not 0x00 or 0xff) → malformed
-        let malformed = [0x41, 0x00, 0x01, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0];
-        assert!(decode_user_key_cow(&malformed).is_none());
-    }
-
-    #[test]
-    fn test_decode_user_key_cow_trailing_zero_returns_none() {
-        // Ends with bare 0x00 (no second byte) → malformed
-        let malformed = [0x41, 0x00];
-        assert!(decode_user_key_cow(&malformed).is_none());
-    }
-
     // --- decode_user_key ---
 
     #[test]
-    fn test_decode_user_key_malformed_returns_none() {
-        let malformed = [0x41, 0x00, 0x02, 0x00, 0x00, 0, 0, 0, 0, 0, 0, 0, 0];
-        assert!(decode_user_key(&malformed).is_none());
+    fn test_decode_user_key_too_short() {
+        // Less than 17 bytes → None
+        assert!(decode_user_key(&[0u8; 16]).is_none());
     }
 
     // --- encoded_user_key_prefix ---
@@ -449,8 +476,17 @@ mod tests {
     fn test_encoded_user_key_prefix() {
         let enc = encode_internal_key(b"key", 100);
         let prefix = encoded_user_key_prefix(&enc).unwrap();
-        // Prefix is the escaped form (no 0x00 bytes in "key")
-        assert_eq!(prefix, b"key");
+        // Prefix is the memcomparable-encoded user key (without 8-byte ts suffix)
+        assert_eq!(prefix.len(), 9); // 1 group of 8 + marker
+        assert_eq!(&prefix[0..3], b"key");
+        assert_eq!(prefix[8], 0xFA); // marker = 0xFF - 5
+    }
+
+    #[test]
+    fn test_encoded_user_key_prefix_multi_group() {
+        let enc = encode_internal_key(b"abcdefghi", 1);
+        let prefix = encoded_user_key_prefix(&enc).unwrap();
+        assert_eq!(prefix.len(), 18); // 2 groups * 9
     }
 
     // --- Key accessors ---
@@ -460,7 +496,8 @@ mod tests {
         let k = KeyVec::from_user_key_ts(b"mykey", 42);
         assert_eq!(k.ts(), 42);
         assert_eq!(k.decode_user_key(), b"mykey");
-        assert_eq!(k.encoded_user_key(), b"mykey");
+        // encoded_user_key returns the memcomparable prefix
+        assert_eq!(k.encoded_user_key().len(), 9); // 1 group + marker
     }
 
     #[test]
@@ -469,6 +506,13 @@ mod tests {
         let k_new = KeyVec::from_user_key_ts(b"same", 100);
         let k_old = KeyVec::from_user_key_ts(b"same", 1);
         assert!(k_new.as_key_slice() < k_old.as_key_slice());
+    }
+
+    #[test]
+    fn test_key_ordering_different_user_keys() {
+        let k_a = KeyVec::from_user_key_ts(b"aaa", 10);
+        let k_b = KeyVec::from_user_key_ts(b"bbb", 10);
+        assert!(k_a.as_key_slice() < k_b.as_key_slice());
     }
 
     // --- encode_internal_key_to_buf ---
@@ -491,7 +535,6 @@ mod tests {
 
     #[test]
     fn test_encode_internal_key_to_buf_append() {
-        // Verify it appends to existing buffer content
         let mut buf = b"prefix".to_vec();
         encode_internal_key_to_buf(&mut buf, b"k", 1);
         assert!(buf.starts_with(b"prefix"));
@@ -519,43 +562,47 @@ mod tests {
     // --- decode_user_key_into edge cases ---
 
     #[test]
-    fn test_decode_user_key_into_trailing_zero() {
-        // Bare 0x00 at end (no second byte) → false
-        let mut dst = Vec::new();
-        assert!(!decode_user_key_into(&[0x41, 0x00], &mut dst));
-    }
-
-    #[test]
-    fn test_decode_user_key_into_no_terminator() {
-        // No 0x00 at all → false (no terminator found)
-        let mut dst = Vec::new();
-        assert!(!decode_user_key_into(&[0x41, 0x42, 0x43], &mut dst));
-    }
-
-    #[test]
     fn test_decode_user_key_into_empty() {
         let mut dst = Vec::new();
-        // Empty input → false (no terminator)
         assert!(!decode_user_key_into(&[], &mut dst));
+    }
+
+    #[test]
+    fn test_decode_user_key_into_not_multiple_of_group() {
+        // 5 bytes is not a multiple of 9 (ENC_GROUP_SIZE + 1)
+        let mut dst = Vec::new();
+        assert!(!decode_user_key_into(&[0u8; 5], &mut dst));
+    }
+
+    #[test]
+    fn test_decode_user_key_into_bad_marker() {
+        // Marker 0x00 would imply pad_count = 0xFF - 0x00 = 255 > 8 → invalid
+        let mut data = vec![0u8; 8];
+        data.push(0x00); // bad marker
+        let mut dst = Vec::new();
+        assert!(!decode_user_key_into(&data, &mut dst));
     }
 
     // --- extract_ts edge cases ---
 
     #[test]
     fn test_extract_ts_too_short() {
-        // Terminator found but not enough bytes for timestamp
-        let enc = [0x41, 0x00, 0x00]; // terminator at offset 1, need 8 more bytes
-        assert!(extract_ts(&enc).is_none());
+        // Less than 17 bytes → None
+        assert!(extract_ts(&[0u8; 16]).is_none());
     }
 
-    // --- encoded_user_key_prefix with zeros ---
-
     #[test]
-    fn test_encoded_user_key_prefix_with_zeros() {
-        let enc = encode_internal_key(&[0x00, 0x42, 0x00], 50);
-        let prefix = encoded_user_key_prefix(&enc).unwrap();
-        // Escaped form: 0x00→0x00 0xff, 0x42→0x42, 0x00→0x00 0xff
-        assert_eq!(prefix, &[0x00, 0xff, 0x42, 0x00, 0xff]);
+    fn test_extract_ts_exactly_minimum() {
+        // 17 bytes: 9 bytes encoded key + 8 bytes ts
+        let mut enc = vec![0u8; 9]; // empty key (8 zeros + marker 0xF8)
+        enc[8] = 0xF8;
+        enc.extend_from_slice(&42u64.to_be_bytes()); // ts=42 → inv_ts
+        // Wait, we need inv_ts = u64::MAX - 42
+        let inv_ts = u64::MAX - 42;
+        let mut enc = vec![0u8; 9];
+        enc[8] = 0xF8;
+        enc.extend_from_slice(&inv_ts.to_be_bytes());
+        assert_eq!(extract_ts(&enc).unwrap(), 42);
     }
 
     // --- Key trait methods ---
@@ -686,11 +733,11 @@ mod tests {
 
     #[test]
     fn test_key_encoded_user_key_fallback() {
-        // When encoded_user_key_prefix returns None (malformed key),
+        // When encoded_user_key_prefix returns None (key too short),
         // falls back to raw_ref
-        let k = KeySlice::from_slice(b"no_terminator");
+        let k = KeySlice::from_slice(b"short"); // 5 bytes < 17
         let uk = k.encoded_user_key();
-        assert_eq!(uk, b"no_terminator");
+        assert_eq!(uk, b"short");
     }
 
     #[test]
@@ -704,60 +751,29 @@ mod tests {
     fn test_key_vec_for_testing_key_ref() {
         let k = KeyVec::from_user_key_ts(b"key", 1);
         // for_testing_key_ref returns encoded_user_key when TS_ENABLED
+        // Memcomparable prefix for "key" = [k, e, y, 0, 0, 0, 0, 0, 0xFA]
         let r = k.for_testing_key_ref();
-        assert_eq!(r, b"key");
+        assert_eq!(r, &[b'k', b'e', b'y', 0, 0, 0, 0, 0, 0xFA]);
     }
 
     #[test]
-    fn test_decode_user_key_cow_malformed_escape_in_escaped_region() {
-        // Construct a key where the escaped region (before terminator)
-        // contains 0x00 not followed by 0xff
-        // Build: user_key="A" (0x41), then 0x00 0x01 (malformed escape), then terminator
-        let mut enc = vec![0x41, 0x00, 0x01]; // malformed: 0x00 followed by 0x01
-        enc.extend_from_slice(&[0x00, 0x00]); // terminator
-        enc.extend_from_slice(&[0, 0, 0, 0, 0, 0, 0, 1]); // ts=1 (inverted: MAX-1)
-        assert!(decode_user_key_cow(&enc).is_none());
+    fn test_decode_user_key_cow_malformed_short() {
+        // Too short for any valid encoded key
+        assert!(decode_user_key_cow(&[0x41, 0x00]).is_none());
     }
 
     #[test]
-    fn test_decode_user_key_cow_trailing_zero_in_escaped_region() {
-        // 0x00 at the end of escaped region (no second byte before terminator)
-        let enc = vec![0x41, 0x00]; // trailing 0x00 with no following byte
-        // No terminator → find_terminator_offset returns None → decode_user_key_cow returns None
-        assert!(decode_user_key_cow(&enc).is_none());
+    fn test_extract_ts_malformed_short() {
+        assert!(extract_ts(&[0x41, 0x42, 0x43]).is_none());
     }
 
     #[test]
-    fn test_extract_ts_malformed_no_terminator() {
-        // No terminator at all
-        let enc = [0x41, 0x42, 0x43];
-        assert!(extract_ts(&enc).is_none());
-    }
-
-    #[test]
-    fn test_extract_ts_short_after_terminator() {
-        // Terminator found but only 4 bytes after (need 8)
-        let enc = [0x41, 0x00, 0x00, 0, 0, 0, 0];
-        assert!(extract_ts(&enc).is_none());
-    }
-
-    #[test]
-    fn test_encoded_user_key_prefix_no_terminator() {
+    fn test_encoded_user_key_prefix_short() {
         assert!(encoded_user_key_prefix(b"no_term").is_none());
     }
 
     #[test]
-    fn test_decode_user_key_no_terminator() {
+    fn test_decode_user_key_short() {
         assert!(decode_user_key(b"no_term").is_none());
-    }
-
-    #[test]
-    fn test_decode_user_key_into_malformed() {
-        let mut dst = Vec::new();
-        // 0x00 followed by 0x02 (not 0x00 or 0xff) → malformed
-        assert!(!decode_user_key_into(
-            &[0x41, 0x00, 0x02, 0x00, 0x00],
-            &mut dst
-        ));
     }
 }

--- a/kv-engine/src/lsm_iterator.rs
+++ b/kv-engine/src/lsm_iterator.rs
@@ -105,7 +105,7 @@ impl StorageIterator for LsmIterator {
         if TS_ENABLED {
             // Skip all remaining versions of the current user key.
             // Compare encoded prefixes (not decoded) so keys with 0x00 bytes
-            // match correctly through the escaping layer.
+            // match correctly through the memcomparable encoding layer.
             let current_encoded = self.encoded_user_key.clone();
             while self.inner.is_valid()
                 && self.inner.key().encoded_user_key() == current_encoded.as_slice()

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -924,28 +924,6 @@ impl LsmStorageInner {
     /// Returns `Ok(Some((value, kind)))` with the parsed value and kind.
     /// MVCC helper: scan a set of SSTs and return the newest version of `key`
     /// visible at `read_ts`. Used by both L0 and leveled lookup paths.
-    fn mvcc_point_get_across_ssts(
-        sstables: &std::collections::HashMap<usize, Arc<SsTable>>,
-        sst_ids: &[usize],
-        key: &[u8],
-        bloom_hash: u32,
-        read_ts: u64,
-    ) -> Result<Option<Bytes>> {
-        let mut best: Option<(Bytes, u64)> = None;
-        for id in sst_ids {
-            if let Some(s) = sstables.get(id)
-                && let Some((raw, found_key)) =
-                    s.point_get_with_hash_and_key(key, bloom_hash, Some(read_ts))?
-            {
-                let ts = crate::key::extract_ts(&found_key).unwrap_or(0);
-                if best.as_ref().is_none_or(|(_, best_ts)| ts > *best_ts) {
-                    best = Some((raw, ts));
-                }
-            }
-        }
-        Ok(best.map(|(raw, _ts)| raw))
-    }
-
     fn lookup_sst_raw(
         &self,
         state: &LsmStorageState,
@@ -953,18 +931,23 @@ impl LsmStorageInner {
         bloom_hash: u32,
         mvcc_read_ts: Option<u64>,
     ) -> Result<Option<(Option<Bytes>, KvKind)>> {
+        // For MVCC: accumulate the newest visible version across ALL levels
+        // (L0 + L1+) before returning. A key's versions may be split across
+        // levels after compaction, so we must check every level.
+        let mut best: Option<(Bytes, u64)> = None;
+
         // L0 SSTs — may overlap, check each one
         if let Some(read_ts) = mvcc_read_ts {
-            // MVCC: L0 SSTs may contain different versions of the same key.
-            // Check all and return the newest visible at read_ts.
-            if let Some(raw) = Self::mvcc_point_get_across_ssts(
-                &state.sstables,
-                &state.l0_sstables,
-                key,
-                bloom_hash,
-                read_ts,
-            )? {
-                return Ok(Some(Self::parse_value_kind(raw)));
+            for id in state.l0_sstables.iter() {
+                if let Some(s) = state.sstables.get(id)
+                    && let Some((raw, found_key)) =
+                        s.point_get_with_hash_and_key(key, bloom_hash, Some(read_ts))?
+                {
+                    let ts = crate::key::extract_ts(&found_key).unwrap_or(0);
+                    if best.as_ref().is_none_or(|(_, best_ts)| ts > *best_ts) {
+                        best = Some((raw, ts));
+                    }
+                }
             }
         } else {
             for id in state.l0_sstables.iter() {
@@ -975,14 +958,8 @@ impl LsmStorageInner {
                 }
             }
         }
-        // Leveled SSTs — with MVCC, the encoded key at u64::MAX sorts before the
-        // SST's first_key (at ts=0), so binary search on encoded keys doesn't work
-        // directly. Instead, check each SST; the bloom filter provides fast
-        // rejection (O(1) per SST, typically <1% false positive rate).
-        // Pre-compute the escaped search prefix once per key — the escaping
-        // scheme (0x00 → 0x00 0xff) preserves lexicographical order, so no
-        // decoding is needed for range comparisons.  Only compute when MVCC
-        // is active to avoid an unnecessary scan on the non-MVCC path.
+        // Leveled SSTs — with MVCC, accumulate the newest version across
+        // all levels without returning early.
         let search_prefix =
             mvcc_read_ts.map(|_| crate::key::encoded_user_key_prefix(key).unwrap_or(key));
         for (_, sst_ids) in state.levels.iter() {
@@ -1003,16 +980,11 @@ impl LsmStorageInner {
                         .encoded_user_key()
                         <= search_prefix
                 });
-                let mut level_best: Option<(Bytes, u64)> = None;
-                // Scan left from idx-1 while the SST's last_key still
-                // matches the search user key.
                 for i in (0..idx).rev() {
                     let sst = state
                         .sstables
                         .get(&sst_ids[i])
                         .expect("SST must exist in sstables map");
-                    // Stop scanning left once the SST's range ends before
-                    // our search user key.
                     if sst.last_key().encoded_user_key() < search_prefix {
                         break;
                     }
@@ -1020,13 +992,10 @@ impl LsmStorageInner {
                         sst.point_get_with_hash_and_key(key, bloom_hash, Some(read_ts))?
                     {
                         let ts = crate::key::extract_ts(&found_key).unwrap_or(0);
-                        if level_best.as_ref().is_none_or(|(_, best_ts)| ts > *best_ts) {
-                            level_best = Some((raw, ts));
+                        if best.as_ref().is_none_or(|(_, best_ts)| ts > *best_ts) {
+                            best = Some((raw, ts));
                         }
                     }
-                }
-                if let Some((raw, _)) = level_best {
-                    return Ok(Some(Self::parse_value_kind(raw)));
                 }
             } else {
                 let idx =
@@ -1041,6 +1010,9 @@ impl LsmStorageInner {
                     return Ok(Some(Self::parse_value_kind(raw)));
                 }
             }
+        }
+        if let Some((raw, _)) = best {
+            return Ok(Some(Self::parse_value_kind(raw)));
         }
         Ok(None)
     }
@@ -1493,8 +1465,11 @@ impl LsmStorageInner {
         let state = self.state.load_full();
         let mvcc_enabled = self.mvcc.is_some();
 
-        // Encode bounds for MVCC: lower with u64::MAX (first version of key),
-        // upper with 0 (last version of key, largest byte value).
+        // Encode bounds for MVCC using suffix-timestamp format.
+        // Lower bound: encode(key, u64::MAX) → newest version of key, sorts
+        //   before all real versions (inverted ts = 0x00*8).
+        // Upper bound: encode(key, 0) → inverted ts = 0xFF*8, sorts after all
+        //   real versions of key, ensuring the scan covers every version.
         let enc_lower;
         let enc_upper;
         let (physical_lower, physical_upper) = if mvcc_enabled {

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -999,11 +999,14 @@ impl LsmStorageInner {
                         break;
                     }
                     // Remaining SSTs are sorted descending by key prefix;
-                    // once max_ts can't beat the best, no later SST can either.
+                    // Skip SSTs that cannot contain a newer version.
+                    // max_ts is NOT monotonically ordered across leveled SSTs
+                    // (different SSTs cover different key ranges), so we must
+                    // continue scanning rather than breaking.
                     if let Some((_, best_ts)) = best
                         && sst.max_ts() <= best_ts
                     {
-                        break;
+                        continue;
                     }
                     if let Some((raw, found_key)) =
                         sst.point_get_with_hash_and_key(key, bloom_hash, Some(read_ts))?

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -922,8 +922,6 @@ impl LsmStorageInner {
     /// Shared SST lookup for `get()` and `get_with_kind_inner()`.
     /// Searches L0 + leveled SSTs. Returns `Ok(None)` if not found.
     /// Returns `Ok(Some((value, kind)))` with the parsed value and kind.
-    /// MVCC helper: scan a set of SSTs and return the newest version of `key`
-    /// visible at `read_ts`. Used by both L0 and leveled lookup paths.
     fn lookup_sst_raw(
         &self,
         state: &LsmStorageState,
@@ -970,8 +968,10 @@ impl LsmStorageInner {
         }
         // Leveled SSTs — with MVCC, accumulate the newest version across
         // all levels without returning early.
-        let search_prefix =
-            mvcc_read_ts.map(|_| crate::key::encoded_user_key_prefix(key).unwrap_or(key));
+        let search_prefix = mvcc_read_ts.map(|_| {
+            crate::key::encoded_user_key_prefix(key)
+                .expect("key must be a valid encoded internal key when mvcc_read_ts is set")
+        });
         for (_, sst_ids) in state.levels.iter() {
             if let Some(read_ts) = mvcc_read_ts {
                 // Leveled SSTs (L1+) have non-overlapping user key ranges.
@@ -998,11 +998,12 @@ impl LsmStorageInner {
                     if sst.last_key().encoded_user_key() < search_prefix {
                         break;
                     }
-                    // Skip SSTs that cannot contain a newer version.
+                    // Remaining SSTs are sorted descending by key prefix;
+                    // once max_ts can't beat the best, no later SST can either.
                     if let Some((_, best_ts)) = best
                         && sst.max_ts() <= best_ts
                     {
-                        continue;
+                        break;
                     }
                     if let Some((raw, found_key)) =
                         sst.point_get_with_hash_and_key(key, bloom_hash, Some(read_ts))?

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -939,9 +939,19 @@ impl LsmStorageInner {
         // L0 SSTs — may overlap, check each one
         if let Some(read_ts) = mvcc_read_ts {
             for id in state.l0_sstables.iter() {
-                if let Some(s) = state.sstables.get(id)
-                    && let Some((raw, found_key)) =
-                        s.point_get_with_hash_and_key(key, bloom_hash, Some(read_ts))?
+                let s = match state.sstables.get(id) {
+                    Some(s) => s,
+                    None => continue,
+                };
+                // Skip SSTs that cannot contain a newer version than what
+                // we already found (max_ts is the highest ts in this SST).
+                if let Some((_, best_ts)) = best
+                    && s.max_ts() <= best_ts
+                {
+                    continue;
+                }
+                if let Some((raw, found_key)) =
+                    s.point_get_with_hash_and_key(key, bloom_hash, Some(read_ts))?
                 {
                     let ts = crate::key::extract_ts(&found_key).unwrap_or(0);
                     if best.as_ref().is_none_or(|(_, best_ts)| ts > *best_ts) {
@@ -987,6 +997,12 @@ impl LsmStorageInner {
                         .expect("SST must exist in sstables map");
                     if sst.last_key().encoded_user_key() < search_prefix {
                         break;
+                    }
+                    // Skip SSTs that cannot contain a newer version.
+                    if let Some((_, best_ts)) = best
+                        && sst.max_ts() <= best_ts
+                    {
+                        continue;
                     }
                     if let Some((raw, found_key)) =
                         sst.point_get_with_hash_and_key(key, bloom_hash, Some(read_ts))?

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -454,9 +454,11 @@ impl SsTable {
             return Ok(None);
         }
         // Find candidate block via metadata binary search.
+        // With suffix-timestamp format, `find_block_idx` already searches for
+        // the earliest matching block via `earliest_match`. No extra backward
+        // search is needed here.
         let mut blk_idx = self.find_block_idx(KeySlice::from_slice(key));
         let mut block = self.read_block_cached(blk_idx)?;
-        // Seek within the block
         let mut blk_iter =
             crate::block::BlockIterator::create_and_seek_to_key(block, KeySlice::from_slice(key));
         // If the block iterator is positioned before the target key (can happen

--- a/kv-engine/src/tests/sst.rs
+++ b/kv-engine/src/tests/sst.rs
@@ -324,6 +324,72 @@ fn test_sst_multi_version_key_ordering() {
     assert!(k_mid.as_key_slice() < k_old.as_key_slice());
 }
 
+/// Verify that MVCC point lookup finds a version in a leftward SST even when
+/// a rightward SST has a higher max_ts but does not contain the target key.
+///
+/// This exercises the leveled SST scan loop where we iterate from right to
+/// left. Using `break` (instead of `continue`) when `max_ts <= best_ts`
+/// could prematurely skip SSTs that contain the version we're looking for
+/// when `max_ts` is not monotonically ordered across the scan direction.
+#[test]
+fn test_sst_leveled_scan_finds_key_across_different_max_ts() {
+    let dir = tempdir().unwrap();
+
+    // SST-right: contains key "X" at ts=200 → max_ts=200
+    // Does NOT contain key "Z".
+    let mut builder_right = SsTableBuilder::new(128);
+    builder_right
+        .add_raw(KeyVec::from_user_key_ts(b"X", 200).as_key_slice(), b"v200")
+        .unwrap();
+    let sst_right = builder_right
+        .build_for_test(dir.path().join("right.sst"))
+        .unwrap();
+    assert_eq!(sst_right.max_ts(), 200);
+
+    // SST-left: contains key "Z" at ts=80 → max_ts=80
+    // Lower max_ts than SST-right, but has the key we want.
+    let mut builder_left = SsTableBuilder::new(128);
+    builder_left
+        .add_raw(KeyVec::from_user_key_ts(b"Z", 80).as_key_slice(), b"v80")
+        .unwrap();
+    let sst_left = builder_left
+        .build_for_test(dir.path().join("left.sst"))
+        .unwrap();
+    assert_eq!(sst_left.max_ts(), 80);
+
+    // Simulate the leveled scan: right-to-left (right first, then left).
+    // SSTs are sorted by key range; "Z" > "X", so SST-left is to the right
+    // of SST-right in key-order. But for the scan we process SST-right first.
+    let ssts = [&sst_right, &sst_left];
+    let seek = crate::key::encode_internal_key(b"Z", u64::MAX);
+    let bh = crate::table::bloom::hash_key(b"Z");
+    let read_ts: u64 = 200;
+
+    let mut best: Option<(Bytes, u64)> = None;
+    for sst in &ssts {
+        // max_ts skip: skip if this SST can't beat the current best.
+        if let Some((_, best_ts)) = best {
+            if sst.max_ts() <= best_ts {
+                // With `continue`: skip this SST, keep scanning.
+                // With `break`: stop entirely — would miss SST-left's version.
+                continue;
+            }
+        }
+        if let Some((raw, found_key)) =
+            sst.point_get_with_hash_and_key(&seek, bh, Some(read_ts)).unwrap()
+        {
+            let ts = crate::key::extract_ts(&found_key).unwrap_or(0);
+            if best.as_ref().is_none_or(|(_, best_ts)| ts > *best_ts) {
+                best = Some((raw, ts));
+            }
+        }
+    }
+
+    let (val, ts) = best.expect("should find key Z at ts=80");
+    assert_eq!(ts, 80);
+    assert_eq!(val.as_ref(), b"v80");
+}
+
 #[test]
 fn test_sst_max_ts_round_trip() {
     let dir = tempdir().unwrap();

--- a/kv-engine/src/tests/sst.rs
+++ b/kv-engine/src/tests/sst.rs
@@ -375,8 +375,9 @@ fn test_sst_leveled_scan_finds_key_across_different_max_ts() {
                 continue;
             }
         }
-        if let Some((raw, found_key)) =
-            sst.point_get_with_hash_and_key(&seek, bh, Some(read_ts)).unwrap()
+        if let Some((raw, found_key)) = sst
+            .point_get_with_hash_and_key(&seek, bh, Some(read_ts))
+            .unwrap()
         {
             let ts = crate::key::extract_ts(&found_key).unwrap_or(0);
             if best.as_ref().is_none_or(|(_, best_ts)| ts > *best_ts) {

--- a/kv-engine/src/tests/sst.rs
+++ b/kv-engine/src/tests/sst.rs
@@ -246,9 +246,11 @@ fn generate_multi_version_sst(dir: &tempfile::TempDir, block_size: usize) -> SsT
 fn test_sst_multi_version_point_get_newest() {
     let dir = tempdir().unwrap();
     let sst = generate_multi_version_sst(&dir, 128);
-    // Without read_ts (None) → returns newest version (ts=10)
+    // Seek key must be an encoded internal key (not raw user key).
+    // Use ts=u64::MAX to seek to the newest version of "A".
+    let seek = crate::key::encode_internal_key(b"A", u64::MAX);
     let (val, found_key) = sst
-        .point_get_with_hash_and_key(b"A", crate::table::bloom::hash_key(b"A"), None)
+        .point_get_with_hash_and_key(&seek, crate::table::bloom::hash_key(b"A"), None)
         .unwrap()
         .unwrap();
     assert_eq!(&*val, b"A_v10");
@@ -260,10 +262,12 @@ fn test_sst_multi_version_point_get_with_read_ts() {
     let dir = tempdir().unwrap();
     let sst = generate_multi_version_sst(&dir, 128);
     let bh = crate::table::bloom::hash_key(b"A");
+    // Seek key uses read_ts so the binary search lands at the right version.
+    let seek = |ts: u64| crate::key::encode_internal_key(b"A", ts);
 
     // read_ts=7 → should return ts=5 version (newest <= 7)
     let (val, found_key) = sst
-        .point_get_with_hash_and_key(b"A", bh, Some(7))
+        .point_get_with_hash_and_key(&seek(7), bh, Some(7))
         .unwrap()
         .unwrap();
     assert_eq!(&*val, b"A_v5");
@@ -271,7 +275,7 @@ fn test_sst_multi_version_point_get_with_read_ts() {
 
     // read_ts=10 → should return ts=10 version
     let (val, found_key) = sst
-        .point_get_with_hash_and_key(b"A", bh, Some(10))
+        .point_get_with_hash_and_key(&seek(10), bh, Some(10))
         .unwrap()
         .unwrap();
     assert_eq!(&*val, b"A_v10");
@@ -279,7 +283,7 @@ fn test_sst_multi_version_point_get_with_read_ts() {
 
     // read_ts=2 → should return ts=1 version
     let (val, found_key) = sst
-        .point_get_with_hash_and_key(b"A", bh, Some(2))
+        .point_get_with_hash_and_key(&seek(2), bh, Some(2))
         .unwrap()
         .unwrap();
     assert_eq!(&*val, b"A_v1");
@@ -287,7 +291,7 @@ fn test_sst_multi_version_point_get_with_read_ts() {
 
     // read_ts=0 → below all versions, returns None
     assert!(
-        sst.point_get_with_hash_and_key(b"A", bh, Some(0))
+        sst.point_get_with_hash_and_key(&seek(0), bh, Some(0))
             .unwrap()
             .is_none()
     );
@@ -299,10 +303,11 @@ fn test_sst_multi_version_cross_block_read_ts() {
     let dir = tempdir().unwrap();
     let sst = generate_multi_version_sst(&dir, 16);
     let bh = crate::table::bloom::hash_key(b"A");
+    let seek = crate::key::encode_internal_key(b"A", 7);
 
     // read_ts=7 → should still find ts=5 even if it's in a later block
     let (val, found_key) = sst
-        .point_get_with_hash_and_key(b"A", bh, Some(7))
+        .point_get_with_hash_and_key(&seek, bh, Some(7))
         .unwrap()
         .unwrap();
     assert_eq!(&*val, b"A_v5");

--- a/kv-engine/src/tests/sst.rs
+++ b/kv-engine/src/tests/sst.rs
@@ -368,12 +368,12 @@ fn test_sst_leveled_scan_finds_key_across_different_max_ts() {
     let mut best: Option<(Bytes, u64)> = None;
     for sst in &ssts {
         // max_ts skip: skip if this SST can't beat the current best.
-        if let Some((_, best_ts)) = best {
-            if sst.max_ts() <= best_ts {
-                // With `continue`: skip this SST, keep scanning.
-                // With `break`: stop entirely — would miss SST-left's version.
-                continue;
-            }
+        // With `continue`: skip this SST, keep scanning.
+        // With `break`: stop entirely — would miss SST-left's version.
+        if let Some((_, best_ts)) = best
+            && sst.max_ts() <= best_ts
+        {
+            continue;
         }
         if let Some((raw, found_key)) = sst
             .point_get_with_hash_and_key(&seek, bh, Some(read_ts))


### PR DESCRIPTION
## Summary

Switch key encoding from 0x00-escaping to TiKV memcomparable group-of-8+marker format, and fix MVCC point-lookup to accumulate the newest visible version across all LSM levels.

## Changes

### TiKV memcomparable key encoding ()
- Replace 0x00-escaping with TiKV memcomparable encoding: bytes split into 8-byte groups, each followed by a marker byte (0xFF - pad_count)
- New format: `[memcomparable_user_key][!ts: u64 BE]`
- Sort order preserved: memcomparable maintains lexicographic order, inverted timestamp keeps newer versions sorting first
- All callers unchanged — key.rs API maintains same semantics

### Cross-level version accumulation ()
- Inline `mvcc_point_get_across_ssts` into `lookup_sst_raw` and accumulate `best` across L0 + all leveled tiers
- Add `max_ts` early-skip optimization: skip SSTs whose max_ts cannot beat current best
- Fix compaction ratio check to skip when either level is empty

### SST seek key correctness ()
- Fix multi-version SST tests to pass encoded internal keys to `point_get_with_hash_and_key`

### Manifest format detection
- Add manifest format version detection for MVCC vs legacy directories

## Verification
- [x] 247 tests pass
- [x] cargo fmt clean
- [x] cargo clippy clean (-D warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Multi-version lookups now scan across storage levels and reliably return the newest visible version.

* **New Features**
  * Internal key encoding switched to a memcomparable format with an inverted timestamp suffix for consistent ordering.

* **Tests**
  * MVCC point-get tests updated to use encoded seek keys to validate version resolution.

* **Documentation**
  * Clarified scan bound and timestamp-encoding ordering semantics and block-selection comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->