### PR TITLE
feat: implement ReadGuard for MVCC watermark registration

### DIFF
--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -301,9 +301,9 @@ impl LsmStorageInner {
             // With MVCC, preserve all versions (including tombstones) so older
             // timestamp reads can still see them. Only drop tombstones at the
             // bottom level in non-MVCC mode.
-            // TODO(Phase 9): Use watermark-aware version dropping — keep every
-            // version with commit_ts > watermark, plus the newest version with
-            // commit_ts <= watermark, and drop older versions.
+            // TODO(watermark-compaction): Use watermark-aware version dropping —
+            // keep every version with commit_ts > watermark, plus the newest
+            // version with commit_ts <= watermark, and drop older versions.
             if !is_tombstone || !compact_to_bottom_level || self.mvcc.is_some() {
                 builder.add_raw(iter.key(), iter.raw_value())?;
             }

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -301,6 +301,9 @@ impl LsmStorageInner {
             // With MVCC, preserve all versions (including tombstones) so older
             // timestamp reads can still see them. Only drop tombstones at the
             // bottom level in non-MVCC mode.
+            // TODO(Phase 9): Use watermark-aware version dropping — keep every
+            // version with commit_ts > watermark, plus the newest version with
+            // commit_ts <= watermark, and drop older versions.
             if !is_tombstone || !compact_to_bottom_level || self.mvcc.is_some() {
                 builder.add_raw(iter.key(), iter.raw_value())?;
             }

--- a/kv-engine/src/lsm_iterator.rs
+++ b/kv-engine/src/lsm_iterator.rs
@@ -27,13 +27,20 @@ pub struct LsmIterator {
     /// Encoded user-key prefix (MVCC only) — used to skip all versions of the
     /// current user key in `next()`.  Must stay in sync with `user_key`.
     encoded_user_key: Vec<u8>,
+    /// MVCC read timestamp — if set, versions with `ts > read_ts` are skipped
+    /// so the iterator only yields versions visible at this snapshot.
+    read_ts: Option<u64>,
 }
 
 impl LsmIterator {
-    pub(crate) fn new(iter: LsmIteratorInner, upper: Bound<Vec<u8>>) -> Result<Self> {
+    pub(crate) fn new(
+        iter: LsmIteratorInner,
+        upper: Bound<Vec<u8>>,
+        read_ts: Option<u64>,
+    ) -> Result<Self> {
         let mut iter = iter;
-        // Skip tombstones at the start
-        Self::skip_tombstones(&mut iter)?;
+        // Skip tombstones and versions beyond read_ts at the start
+        Self::skip_tombstones(&mut iter, read_ts)?;
 
         let (user_key, encoded_user_key) = if iter.is_valid() && TS_ENABLED {
             (
@@ -49,18 +56,35 @@ impl LsmIterator {
             upper,
             user_key,
             encoded_user_key,
+            read_ts,
         })
     }
 
-    /// Skip entries with empty values (tombstones). When MVCC is enabled,
-    /// skip all versions of a dead user key.
-    fn skip_tombstones(iter: &mut LsmIteratorInner) -> Result<()> {
+    /// Skip entries with empty values (tombstones) and versions beyond `read_ts`.
+    /// When MVCC is enabled, skip all versions of a dead user key, and for
+    /// each user key skip versions with `ts > read_ts` (invisible to this
+    /// snapshot) until we find one at or below `read_ts`.
+    fn skip_tombstones(iter: &mut LsmIteratorInner, read_ts: Option<u64>) -> Result<()> {
         while iter.is_valid() {
+            // Skip versions invisible to this snapshot
+            if TS_ENABLED && let Some(rts) = read_ts {
+                let user_key = iter.key().encoded_user_key().to_vec();
+                while iter.is_valid()
+                    && iter.key().encoded_user_key() == user_key.as_slice()
+                    && crate::key::extract_ts(iter.key().raw_ref()).is_some_and(|ts| ts > rts)
+                {
+                    iter.next()?;
+                }
+                // If we exhausted all versions of this user key, move on
+                if !iter.is_valid() || iter.key().encoded_user_key() != user_key.as_slice() {
+                    continue;
+                }
+            }
             if !iter.value().is_empty() {
                 return Ok(());
             }
+            // Tombstone — skip all versions of this dead user key
             if TS_ENABLED {
-                // Skip all versions of this dead user key
                 let dead_key = iter.key().encoded_user_key().to_vec();
                 while iter.is_valid() && iter.key().encoded_user_key() == dead_key.as_slice() {
                     iter.next()?;
@@ -112,8 +136,8 @@ impl StorageIterator for LsmIterator {
             {
                 self.inner.next()?;
             }
-            // Skip tombstones of the next user key(s)
-            Self::skip_tombstones(&mut self.inner)?;
+            // Skip tombstones and invisible versions of the next user key(s)
+            Self::skip_tombstones(&mut self.inner, self.read_ts)?;
             // Update cached user keys (decoded for key(), encoded for next())
             if self.inner.is_valid() {
                 self.user_key = self.inner.key().decode_user_key();

--- a/kv-engine/src/lsm_iterator.rs
+++ b/kv-engine/src/lsm_iterator.rs
@@ -9,6 +9,7 @@ use crate::{
     },
     key::TS_ENABLED,
     mem_table::MemTableIterator,
+    mvcc::ReadGuard,
     table::SsTableIterator,
 };
 
@@ -66,17 +67,28 @@ impl LsmIterator {
     /// snapshot) until we find one at or below `read_ts`.
     fn skip_tombstones(iter: &mut LsmIteratorInner, read_ts: Option<u64>) -> Result<()> {
         while iter.is_valid() {
+            // Extract the current encoded user key once per user-key group
+            // and reuse it in both the read_ts filtering and tombstone skip.
+            let encoded_user_key = if TS_ENABLED {
+                iter.key().encoded_user_key().to_vec()
+            } else {
+                Vec::new()
+            };
             // Skip versions invisible to this snapshot
             if TS_ENABLED && let Some(rts) = read_ts {
-                let user_key = iter.key().encoded_user_key().to_vec();
                 while iter.is_valid()
-                    && iter.key().encoded_user_key() == user_key.as_slice()
+                    && iter.key().encoded_user_key() == encoded_user_key.as_slice()
+                    // Note: `extract_ts` returning None (malformed key) falls
+                    // through here, treating the key as visible.  All keys
+                    // produced by this engine carry a valid timestamp suffix
+                    // when TS_ENABLED, so None indicates corrupt data.
                     && crate::key::extract_ts(iter.key().raw_ref()).is_some_and(|ts| ts > rts)
                 {
                     iter.next()?;
                 }
                 // If we exhausted all versions of this user key, move on
-                if !iter.is_valid() || iter.key().encoded_user_key() != user_key.as_slice() {
+                if !iter.is_valid() || iter.key().encoded_user_key() != encoded_user_key.as_slice()
+                {
                     continue;
                 }
             }
@@ -85,8 +97,9 @@ impl LsmIterator {
             }
             // Tombstone — skip all versions of this dead user key
             if TS_ENABLED {
-                let dead_key = iter.key().encoded_user_key().to_vec();
-                while iter.is_valid() && iter.key().encoded_user_key() == dead_key.as_slice() {
+                while iter.is_valid()
+                    && iter.key().encoded_user_key() == encoded_user_key.as_slice()
+                {
                     iter.next()?;
                 }
             } else {
@@ -214,6 +227,54 @@ impl<I: StorageIterator> StorageIterator for FusedIterator<I> {
         }
 
         Ok(())
+    }
+
+    fn num_active_iterators(&self) -> usize {
+        self.iter.num_active_iterators()
+    }
+}
+
+/// Iterator wrapper that holds a [`ReadGuard`] for the duration of a scan.
+/// This ensures the MVCC watermark reflects the active reader so compaction
+/// does not GC versions the iterator might still need.
+///
+/// Implements [`StorageIterator`] by delegating to the inner
+/// `FusedIterator<LsmIterator>`.  Cannot be constructed directly — obtained
+/// from [`crate::lsm_storage::KvEngine::scan`].
+pub struct ScanIterator {
+    _guard: Option<ReadGuard>,
+    iter: FusedIterator<LsmIterator>,
+}
+
+impl ScanIterator {
+    pub(crate) fn new(iter: FusedIterator<LsmIterator>, guard: Option<ReadGuard>) -> Self {
+        Self {
+            _guard: guard,
+            iter,
+        }
+    }
+}
+
+impl StorageIterator for ScanIterator {
+    type KeyType<'a>
+        = &'a [u8]
+    where
+        Self: 'a;
+
+    fn value(&self) -> &[u8] {
+        self.iter.value()
+    }
+
+    fn key(&self) -> Self::KeyType<'_> {
+        self.iter.key()
+    }
+
+    fn is_valid(&self) -> bool {
+        self.iter.is_valid()
+    }
+
+    fn next(&mut self) -> Result<()> {
+        self.iter.next()
     }
 
     fn num_active_iterators(&self) -> usize {

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -724,8 +724,8 @@ impl LsmStorageInner {
         // Pin read_ts once so memtable and SST lookups see the same snapshot.
         // The ReadGuard registers in the watermark so compaction won't GC
         // versions we might still read.
-        let _read_guard = self.mvcc.as_ref().map(|m| m.new_read_guard());
-        let mvcc_read_ts = _read_guard.as_ref().map(|g| g.read_ts());
+        let read_guard = self.mvcc.as_ref().map(|m| m.new_read_guard());
+        let mvcc_read_ts = read_guard.as_ref().map(|g| g.read_ts());
         // With MVCC, encode the user key with u64::MAX to seek to the newest version.
         let lookup_key;
         let encoded = if self.mvcc.is_some() {
@@ -830,8 +830,8 @@ impl LsmStorageInner {
         key: &[u8],
     ) -> Result<(Option<Bytes>, KvKind)> {
         let bloom_hash = crate::table::bloom::hash_key(key);
-        let _read_guard = self.mvcc.as_ref().map(|m| m.new_read_guard());
-        let mvcc_read_ts = _read_guard.as_ref().map(|g| g.read_ts());
+        let read_guard = self.mvcc.as_ref().map(|m| m.new_read_guard());
+        let mvcc_read_ts = read_guard.as_ref().map(|g| g.read_ts());
         let lookup_key;
         let encoded = if self.mvcc.is_some() {
             lookup_key = crate::key::encode_internal_key(key, u64::MAX);
@@ -1479,7 +1479,8 @@ impl LsmStorageInner {
     /// Create an iterator over a range of keys.
     pub fn scan(&self, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> Result<ScanIterator> {
         let state = self.state.load_full();
-        let _read_guard = self.mvcc.as_ref().map(|m| m.new_read_guard());
+        let read_guard = self.mvcc.as_ref().map(|m| m.new_read_guard());
+        let mvcc_read_ts = read_guard.as_ref().map(|g| g.read_ts());
         let mvcc_enabled = self.mvcc.is_some();
 
         // Encode bounds for MVCC using suffix-timestamp format.
@@ -1648,9 +1649,9 @@ impl LsmStorageInner {
         let m_iter = MergeIterator::create(concat_iters);
         let two_m = TwoMergeIterator::create(two_l0_iter, m_iter)?;
         // Upper bound for LsmIterator uses decoded user keys (not encoded)
-        let lit = LsmIterator::new(two_m, Self::into_vec(upper))?;
+        let lit = LsmIterator::new(two_m, Self::into_vec(upper), mvcc_read_ts)?;
 
-        Ok(ScanIterator::new(FusedIterator::new(lit), _read_guard))
+        Ok(ScanIterator::new(FusedIterator::new(lit), read_guard))
     }
 
     fn into_vec(b: Bound<&[u8]>) -> Bound<Vec<u8>> {

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -24,10 +24,10 @@ use crate::{
         two_merge_iterator::TwoMergeIterator,
     },
     key::KeySlice,
-    lsm_iterator::{FusedIterator, LsmIterator},
+    lsm_iterator::{FusedIterator, LsmIterator, ScanIterator},
     manifest::{Manifest, ManifestRecord},
     mem_table::{self, MemTable},
-    mvcc::{LsmMvccInner, ReadGuard},
+    mvcc::LsmMvccInner,
     table::{FileObject, SsTable, SsTableBuilder, SsTableIterator},
     vlog::{KvKind, ValueLog, ValuePointer, ValueSeparationOptions},
 };
@@ -1660,49 +1660,5 @@ impl LsmStorageInner {
             Bound::Excluded(k) => Bound::Excluded(k.to_vec()),
             Bound::Unbounded => Bound::Unbounded,
         }
-    }
-}
-
-/// Iterator wrapper that holds a `ReadGuard` for the duration of a scan.
-/// This ensures the MVCC watermark reflects the active reader so compaction
-/// does not GC versions the iterator might still need.
-pub struct ScanIterator {
-    _guard: Option<ReadGuard>,
-    iter: FusedIterator<LsmIterator>,
-}
-
-impl ScanIterator {
-    fn new(iter: FusedIterator<LsmIterator>, guard: Option<ReadGuard>) -> Self {
-        Self {
-            _guard: guard,
-            iter,
-        }
-    }
-}
-
-impl StorageIterator for ScanIterator {
-    type KeyType<'a>
-        = &'a [u8]
-    where
-        Self: 'a;
-
-    fn value(&self) -> &[u8] {
-        self.iter.value()
-    }
-
-    fn key(&self) -> Self::KeyType<'_> {
-        self.iter.key()
-    }
-
-    fn is_valid(&self) -> bool {
-        self.iter.is_valid()
-    }
-
-    fn next(&mut self) -> Result<()> {
-        self.iter.next()
-    }
-
-    fn num_active_iterators(&self) -> usize {
-        self.iter.num_active_iterators()
     }
 }

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -27,7 +27,7 @@ use crate::{
     lsm_iterator::{FusedIterator, LsmIterator},
     manifest::{Manifest, ManifestRecord},
     mem_table::{self, MemTable},
-    mvcc::LsmMvccInner,
+    mvcc::{LsmMvccInner, ReadGuard},
     table::{FileObject, SsTable, SsTableBuilder, SsTableIterator},
     vlog::{KvKind, ValueLog, ValuePointer, ValueSeparationOptions},
 };
@@ -198,7 +198,7 @@ pub(crate) struct LsmStorageInner {
     pub(crate) options: Arc<LsmStorageOptions>,
     pub(crate) compaction_controller: CompactionController,
     pub(crate) manifest: Option<Manifest>,
-    pub(crate) mvcc: Option<LsmMvccInner>,
+    pub(crate) mvcc: Option<Arc<LsmMvccInner>>,
     pub(crate) compaction_filters: Arc<Mutex<Vec<CompactionFilter>>>,
     /// Value Log manager for key-value separation. `None` if value separation is disabled.
     pub(crate) vlog: Option<Arc<ValueLog>>,
@@ -316,11 +316,7 @@ impl KvEngine {
         self.inner.sync()
     }
 
-    pub fn scan(
-        &self,
-        lower: Bound<&[u8]>,
-        upper: Bound<&[u8]>,
-    ) -> Result<FusedIterator<LsmIterator>> {
+    pub fn scan(&self, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> Result<ScanIterator> {
         self.inner.scan(lower, upper)
     }
 
@@ -701,7 +697,7 @@ impl LsmStorageInner {
             compaction_controller,
             manifest: Some(manifest),
             options: options.into(),
-            mvcc: Some(LsmMvccInner::new(max_commit_ts)),
+            mvcc: Some(Arc::new(LsmMvccInner::new(max_commit_ts))),
             compaction_filters: Arc::new(Mutex::new(Vec::new())),
             vlog,
             weak_self: std::sync::OnceLock::new(),
@@ -726,7 +722,10 @@ impl LsmStorageInner {
         let state = self.state.load();
         let bloom_hash = crate::table::bloom::hash_key(key);
         // Pin read_ts once so memtable and SST lookups see the same snapshot.
-        let mvcc_read_ts = self.mvcc.as_ref().map(|m| m.read_ts());
+        // The ReadGuard registers in the watermark so compaction won't GC
+        // versions we might still read.
+        let _read_guard = self.mvcc.as_ref().map(|m| m.new_read_guard());
+        let mvcc_read_ts = _read_guard.as_ref().map(|g| g.read_ts());
         // With MVCC, encode the user key with u64::MAX to seek to the newest version.
         let lookup_key;
         let encoded = if self.mvcc.is_some() {
@@ -831,7 +830,8 @@ impl LsmStorageInner {
         key: &[u8],
     ) -> Result<(Option<Bytes>, KvKind)> {
         let bloom_hash = crate::table::bloom::hash_key(key);
-        let mvcc_read_ts = self.mvcc.as_ref().map(|m| m.read_ts());
+        let _read_guard = self.mvcc.as_ref().map(|m| m.new_read_guard());
+        let mvcc_read_ts = _read_guard.as_ref().map(|g| g.read_ts());
         let lookup_key;
         let encoded = if self.mvcc.is_some() {
             lookup_key = crate::key::encode_internal_key(key, u64::MAX);
@@ -1477,12 +1477,9 @@ impl LsmStorageInner {
     }
 
     /// Create an iterator over a range of keys.
-    pub fn scan(
-        &self,
-        lower: Bound<&[u8]>,
-        upper: Bound<&[u8]>,
-    ) -> Result<FusedIterator<LsmIterator>> {
+    pub fn scan(&self, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> Result<ScanIterator> {
         let state = self.state.load_full();
+        let _read_guard = self.mvcc.as_ref().map(|m| m.new_read_guard());
         let mvcc_enabled = self.mvcc.is_some();
 
         // Encode bounds for MVCC using suffix-timestamp format.
@@ -1653,7 +1650,7 @@ impl LsmStorageInner {
         // Upper bound for LsmIterator uses decoded user keys (not encoded)
         let lit = LsmIterator::new(two_m, Self::into_vec(upper))?;
 
-        Ok(FusedIterator::new(lit))
+        Ok(ScanIterator::new(FusedIterator::new(lit), _read_guard))
     }
 
     fn into_vec(b: Bound<&[u8]>) -> Bound<Vec<u8>> {
@@ -1662,5 +1659,49 @@ impl LsmStorageInner {
             Bound::Excluded(k) => Bound::Excluded(k.to_vec()),
             Bound::Unbounded => Bound::Unbounded,
         }
+    }
+}
+
+/// Iterator wrapper that holds a `ReadGuard` for the duration of a scan.
+/// This ensures the MVCC watermark reflects the active reader so compaction
+/// does not GC versions the iterator might still need.
+pub struct ScanIterator {
+    _guard: Option<ReadGuard>,
+    iter: FusedIterator<LsmIterator>,
+}
+
+impl ScanIterator {
+    fn new(iter: FusedIterator<LsmIterator>, guard: Option<ReadGuard>) -> Self {
+        Self {
+            _guard: guard,
+            iter,
+        }
+    }
+}
+
+impl StorageIterator for ScanIterator {
+    type KeyType<'a>
+        = &'a [u8]
+    where
+        Self: 'a;
+
+    fn value(&self) -> &[u8] {
+        self.iter.value()
+    }
+
+    fn key(&self) -> Self::KeyType<'_> {
+        self.iter.key()
+    }
+
+    fn is_valid(&self) -> bool {
+        self.iter.is_valid()
+    }
+
+    fn next(&mut self) -> Result<()> {
+        self.iter.next()
+    }
+
+    fn num_active_iterators(&self) -> usize {
+        self.iter.num_active_iterators()
     }
 }

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -58,13 +58,13 @@ impl LsmMvccInner {
         memtable: &MemTable,
     ) -> Result<(), anyhow::Error> {
         let _write_guard = self.write_lock.lock();
-        let commit_ts = {
-            let mut ts = self.ts.lock();
-            ts.0 += 1;
-            ts.0
-        };
+        // Write to the memtable FIRST, then advance ts.0.  This ordering
+        // guarantees that a concurrent `new_read_guard()` never observes a
+        // read_ts whose version hasn't been written yet (no torn reads).
+        let commit_ts = self.ts.lock().0 + 1;
         let encoded_key = encode_internal_key(user_key, commit_ts);
         memtable.put(&encoded_key, value)?;
+        self.ts.lock().0 = commit_ts;
         Ok(())
     }
 

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -77,6 +77,48 @@ impl LsmMvccInner {
     pub fn new_txn(&self, inner: Arc<LsmStorageInner>, serializable: bool) -> Arc<Transaction> {
         unimplemented!()
     }
+
+    /// Create a `ReadGuard` that atomically reads the latest commit timestamp
+    /// and registers it in the watermark. The guard unregisters on drop.
+    pub fn new_read_guard(self: &Arc<Self>) -> ReadGuard {
+        ReadGuard::new_latest(Arc::clone(self))
+    }
+}
+
+/// RAII guard that registers a read timestamp in the MVCC watermark.
+///
+/// While the guard is alive, compaction will not GC versions at or above
+/// `read_ts`. On drop, the timestamp is unregistered and the watermark
+/// advances if this was the oldest reader.
+pub(crate) struct ReadGuard {
+    read_ts: u64,
+    mvcc: Arc<LsmMvccInner>,
+}
+
+impl ReadGuard {
+    /// Atomically read the latest commit timestamp and register it in the
+    /// watermark. The ts mutex is held for both operations so compaction
+    /// never sees a watermark that excludes this reader.
+    pub(crate) fn new_latest(mvcc: Arc<LsmMvccInner>) -> Self {
+        let read_ts = {
+            let mut ts = mvcc.ts.lock();
+            let latest = ts.0;
+            ts.1.add_reader(latest);
+            latest
+        };
+        Self { read_ts, mvcc }
+    }
+
+    pub fn read_ts(&self) -> u64 {
+        self.read_ts
+    }
+}
+
+impl Drop for ReadGuard {
+    fn drop(&mut self) {
+        let mut ts = self.mvcc.ts.lock();
+        ts.1.remove_reader(self.read_ts);
+    }
 }
 
 #[cfg(test)]
@@ -121,5 +163,89 @@ mod tests {
         mvcc.update_commit_ts(100);
         assert_eq!(mvcc.latest_commit_ts(), 100);
         assert_eq!(mvcc.read_ts(), 100);
+    }
+
+    // --- ReadGuard tests ---
+
+    #[test]
+    fn test_read_guard_registers_in_watermark() {
+        let mvcc = Arc::new(LsmMvccInner::new(50));
+        // No readers → watermark falls back to latest_commit_ts
+        assert_eq!(mvcc.watermark(), 50);
+
+        let guard = mvcc.new_read_guard();
+        assert_eq!(guard.read_ts(), 50);
+        // Watermark should now be the guard's read_ts (same as latest here)
+        assert_eq!(mvcc.watermark(), 50);
+    }
+
+    #[test]
+    fn test_read_guard_drop_unregisters() {
+        let mvcc = Arc::new(LsmMvccInner::new(50));
+        {
+            let _guard = mvcc.new_read_guard();
+            assert_eq!(mvcc.watermark(), 50);
+        }
+        // After guard is dropped, watermark falls back to latest_commit_ts
+        assert_eq!(mvcc.watermark(), 50);
+    }
+
+    #[test]
+    fn test_read_guard_multiple_readers() {
+        let mvcc = Arc::new(LsmMvccInner::new(50));
+        // Write to advance the timestamp
+        let memtable = crate::mem_table::MemTable::create(0);
+        mvcc.write(b"k", b"v1", &memtable).unwrap(); // ts=51
+        mvcc.write(b"k", b"v2", &memtable).unwrap(); // ts=52
+
+        let guard_old = ReadGuard::new_latest(Arc::clone(&mvcc)); // read_ts=52
+        mvcc.write(b"k", b"v3", &memtable).unwrap(); // ts=53
+        let guard_new = ReadGuard::new_latest(Arc::clone(&mvcc)); // read_ts=53
+
+        // Watermark should be the oldest reader (52)
+        assert_eq!(mvcc.watermark(), 52);
+
+        drop(guard_old);
+        // Now the only reader is at 53
+        assert_eq!(mvcc.watermark(), 53);
+
+        drop(guard_new);
+        // No readers → falls back to latest_commit_ts (53)
+        assert_eq!(mvcc.watermark(), 53);
+    }
+
+    #[test]
+    fn test_read_guard_duplicate_ts() {
+        let mvcc = Arc::new(LsmMvccInner::new(10));
+        let guard1 = ReadGuard::new_latest(Arc::clone(&mvcc));
+        let guard2 = ReadGuard::new_latest(Arc::clone(&mvcc));
+
+        // Both guards have the same read_ts=10, refcount=2
+        assert_eq!(guard1.read_ts(), 10);
+        assert_eq!(guard2.read_ts(), 10);
+        assert_eq!(mvcc.watermark(), 10);
+
+        drop(guard1);
+        // Still one reader at ts=10
+        assert_eq!(mvcc.watermark(), 10);
+
+        drop(guard2);
+        // No readers → falls back to latest_commit_ts
+        assert_eq!(mvcc.watermark(), 10);
+    }
+
+    #[test]
+    fn test_read_guard_atomic_acquisition() {
+        let mvcc = Arc::new(LsmMvccInner::new(100));
+        // The guard reads latest_commit_ts and registers in the watermark
+        // atomically under the same mutex lock. Verify that the watermark
+        // immediately reflects the reader (no window where compaction
+        // could see a stale watermark).
+        let guard = mvcc.new_read_guard();
+        assert_eq!(guard.read_ts(), 100);
+        // Watermark should be 100, not latest_commit_ts fallback
+        // (both happen to be 100 here, but the point is the reader is registered)
+        let ts = mvcc.ts.lock();
+        assert_eq!(ts.1.watermark(), Some(100));
     }
 }

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -69,8 +69,8 @@ impl LsmMvccInner {
     }
 
     /// Get a read timestamp (the latest committed ts).
-    /// This does NOT add a reader to the watermark — that's done via ReadGuard.
-    pub fn read_ts(&self) -> u64 {
+    /// This does NOT add a reader to the watermark — use `new_read_guard()` instead.
+    pub(crate) fn read_ts(&self) -> u64 {
         self.ts.lock().0
     }
 
@@ -109,7 +109,7 @@ impl ReadGuard {
         Self { read_ts, mvcc }
     }
 
-    pub fn read_ts(&self) -> u64 {
+    pub(crate) fn read_ts(&self) -> u64 {
         self.read_ts
     }
 }
@@ -170,24 +170,32 @@ mod tests {
     #[test]
     fn test_read_guard_registers_in_watermark() {
         let mvcc = Arc::new(LsmMvccInner::new(50));
-        // No readers → watermark falls back to latest_commit_ts
-        assert_eq!(mvcc.watermark(), 50);
+        let memtable = crate::mem_table::MemTable::create(0);
+        mvcc.write(b"k", b"v", &memtable).unwrap(); // ts=51
 
+        // Create guard at ts=51 while latest is still 51
         let guard = mvcc.new_read_guard();
-        assert_eq!(guard.read_ts(), 50);
-        // Watermark should now be the guard's read_ts (same as latest here)
-        assert_eq!(mvcc.watermark(), 50);
+        assert_eq!(guard.read_ts(), 51);
+        // Watermark should be 51 (registered reader), not 51 (latest fallback)
+        // Both happen to be 51 here, but the reader IS registered
+        let ts = mvcc.ts.lock();
+        assert_eq!(ts.1.watermark(), Some(51));
     }
 
     #[test]
     fn test_read_guard_drop_unregisters() {
         let mvcc = Arc::new(LsmMvccInner::new(50));
+        let memtable = crate::mem_table::MemTable::create(0);
+
         {
-            let _guard = mvcc.new_read_guard();
+            let _guard = mvcc.new_read_guard(); // read_ts=50
+            mvcc.write(b"k", b"v1", &memtable).unwrap(); // ts=51
+            mvcc.write(b"k", b"v2", &memtable).unwrap(); // ts=52
+            // Guard is still alive at ts=50, so watermark is 50
             assert_eq!(mvcc.watermark(), 50);
         }
-        // After guard is dropped, watermark falls back to latest_commit_ts
-        assert_eq!(mvcc.watermark(), 50);
+        // After guard drops, no readers → watermark falls back to latest (52)
+        assert_eq!(mvcc.watermark(), 52);
     }
 
     #[test]
@@ -235,7 +243,7 @@ mod tests {
     }
 
     #[test]
-    fn test_read_guard_atomic_acquisition() {
+    fn test_read_guard_registers_in_watermark_on_creation() {
         let mvcc = Arc::new(LsmMvccInner::new(100));
         // The guard reads latest_commit_ts and registers in the watermark
         // atomically under the same mutex lock. Verify that the watermark

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -80,7 +80,7 @@ impl LsmMvccInner {
 
     /// Create a `ReadGuard` that atomically reads the latest commit timestamp
     /// and registers it in the watermark. The guard unregisters on drop.
-    pub fn new_read_guard(self: &Arc<Self>) -> ReadGuard {
+    pub(crate) fn new_read_guard(self: &Arc<Self>) -> ReadGuard {
         ReadGuard::new_latest(Arc::clone(self))
     }
 }
@@ -97,8 +97,10 @@ pub(crate) struct ReadGuard {
 
 impl ReadGuard {
     /// Atomically read the latest commit timestamp and register it in the
-    /// watermark. The ts mutex is held for both operations so compaction
-    /// never sees a watermark that excludes this reader.
+    /// watermark. The ts mutex is held for both the read and the registration.
+    /// Because `write()` also holds this mutex when incrementing the counter,
+    /// a ReadGuard will always see a commit_ts that is either already committed
+    /// or not yet started — never a partially-applied write.
     pub(crate) fn new_latest(mvcc: Arc<LsmMvccInner>) -> Self {
         let read_ts = {
             let mut ts = mvcc.ts.lock();
@@ -243,17 +245,19 @@ mod tests {
     }
 
     #[test]
-    fn test_read_guard_registers_in_watermark_on_creation() {
+    fn test_read_guard_watermark_pins_after_write() {
         let mvcc = Arc::new(LsmMvccInner::new(100));
-        // The guard reads latest_commit_ts and registers in the watermark
-        // atomically under the same mutex lock. Verify that the watermark
-        // immediately reflects the reader (no window where compaction
-        // could see a stale watermark).
-        let guard = mvcc.new_read_guard();
+        let guard = mvcc.new_read_guard(); // read_ts=100
         assert_eq!(guard.read_ts(), 100);
-        // Watermark should be 100, not latest_commit_ts fallback
-        // (both happen to be 100 here, but the point is the reader is registered)
-        let ts = mvcc.ts.lock();
-        assert_eq!(ts.1.watermark(), Some(100));
+
+        // Advance the timestamp — watermark should stay pinned at 100
+        let memtable = crate::mem_table::MemTable::create(0);
+        mvcc.write(b"k", b"v1", &memtable).unwrap(); // ts=101
+        mvcc.write(b"k", b"v2", &memtable).unwrap(); // ts=102
+        assert_eq!(mvcc.watermark(), 100);
+
+        // After dropping the guard, watermark advances to latest
+        drop(guard);
+        assert_eq!(mvcc.watermark(), 102);
     }
 }

--- a/kv-engine/src/mvcc/txn.rs
+++ b/kv-engine/src/mvcc/txn.rs
@@ -14,10 +14,11 @@ use crate::{
     iterators::{StorageIterator, two_merge_iterator::TwoMergeIterator},
     lsm_iterator::{FusedIterator, LsmIterator},
     lsm_storage::LsmStorageInner,
+    mvcc::ReadGuard,
 };
 
 pub struct Transaction {
-    pub(crate) read_ts: u64,
+    pub(crate) read_guard: ReadGuard,
     pub(crate) inner: Arc<LsmStorageInner>,
     pub(crate) local_storage: Arc<SkipMap<Bytes, Bytes>>,
     pub(crate) committed: Arc<AtomicBool>,
@@ -48,7 +49,9 @@ impl Transaction {
 }
 
 impl Drop for Transaction {
-    fn drop(&mut self) {}
+    fn drop(&mut self) {
+        // ReadGuard::drop handles watermark cleanup automatically.
+    }
 }
 
 type SkipMapRangeIter<'a> =

--- a/kv-engine/src/mvcc/txn.rs
+++ b/kv-engine/src/mvcc/txn.rs
@@ -18,6 +18,8 @@ use crate::{
 };
 
 pub struct Transaction {
+    /// Holds the read timestamp and registers it in the MVCC watermark for
+    /// the transaction's lifetime, preventing GC of versions we might read.
     pub(crate) read_guard: ReadGuard,
     pub(crate) inner: Arc<LsmStorageInner>,
     pub(crate) local_storage: Arc<SkipMap<Bytes, Bytes>>,

--- a/kv-engine/src/mvcc/txn.rs
+++ b/kv-engine/src/mvcc/txn.rs
@@ -48,12 +48,6 @@ impl Transaction {
     }
 }
 
-impl Drop for Transaction {
-    fn drop(&mut self) {
-        // ReadGuard::drop handles watermark cleanup automatically.
-    }
-}
-
 type SkipMapRangeIter<'a> =
     crossbeam_skiplist::map::Range<'a, Bytes, (Bound<Bytes>, Bound<Bytes>), Bytes, Bytes>;
 

--- a/kv-engine/src/tests.rs
+++ b/kv-engine/src/tests.rs
@@ -10,6 +10,7 @@ mod leveled_compaction;
 mod manifest;
 mod memtable;
 mod merge_iterator;
+mod mvcc_scan;
 mod scan_flush;
 mod simple_leveled_compaction;
 mod sst;

--- a/kv-engine/src/tests/mvcc_scan.rs
+++ b/kv-engine/src/tests/mvcc_scan.rs
@@ -1,0 +1,163 @@
+use std::ops::Bound;
+
+use bytes::Bytes;
+use tempfile::tempdir;
+
+use super::harness::check_lsm_iter_result_by_key;
+use crate::{
+    iterators::StorageIterator,
+    lsm_storage::{KvEngine, LsmStorageOptions},
+};
+
+/// Scan sees only the latest version of each key (MVCC deduplication).
+#[test]
+fn test_scan_returns_latest_version() {
+    let dir = tempdir().unwrap();
+    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+
+    engine.put(b"k1", b"v1").unwrap();
+    engine.put(b"k2", b"v2").unwrap();
+    // Overwrite k1
+    engine.put(b"k1", b"v1_updated").unwrap();
+
+    let mut iter = engine.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    check_lsm_iter_result_by_key(
+        &mut iter,
+        vec![
+            (Bytes::from("k1"), Bytes::from("v1_updated")),
+            (Bytes::from("k2"), Bytes::from("v2")),
+        ],
+    );
+}
+
+/// Scan respects tombstones — deleted keys are not returned.
+#[test]
+fn test_scan_respects_tombstones() {
+    let dir = tempdir().unwrap();
+    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+
+    engine.put(b"a", b"va").unwrap();
+    engine.put(b"b", b"vb").unwrap();
+    engine.put(b"c", b"vc").unwrap();
+    engine.delete(b"b").unwrap();
+
+    let mut iter = engine.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    check_lsm_iter_result_by_key(
+        &mut iter,
+        vec![
+            (Bytes::from("a"), Bytes::from("va")),
+            (Bytes::from("c"), Bytes::from("vc")),
+        ],
+    );
+}
+
+/// Scan with bounds respects snapshot — later writes outside the scan's
+/// snapshot are invisible.
+#[test]
+fn test_scan_snapshot_isolation() {
+    let dir = tempdir().unwrap();
+    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+
+    engine.put(b"a", b"va").unwrap();
+    engine.put(b"b", b"vb").unwrap();
+
+    // First scan — sees a, b
+    let mut iter = engine.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    check_lsm_iter_result_by_key(
+        &mut iter,
+        vec![
+            (Bytes::from("a"), Bytes::from("va")),
+            (Bytes::from("b"), Bytes::from("vb")),
+        ],
+    );
+    drop(iter);
+
+    // Write more data
+    engine.put(b"a", b"va2").unwrap();
+    engine.put(b"c", b"vc").unwrap();
+
+    // Second scan — sees updated a and new c
+    let mut iter = engine.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    check_lsm_iter_result_by_key(
+        &mut iter,
+        vec![
+            (Bytes::from("a"), Bytes::from("va2")),
+            (Bytes::from("b"), Bytes::from("vb")),
+            (Bytes::from("c"), Bytes::from("vc")),
+        ],
+    );
+}
+
+/// Scan with lower and upper bounds.
+#[test]
+fn test_scan_bounded() {
+    let dir = tempdir().unwrap();
+    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+
+    engine.put(b"a", b"va").unwrap();
+    engine.put(b"b", b"vb").unwrap();
+    engine.put(b"c", b"vc").unwrap();
+    engine.put(b"d", b"vd").unwrap();
+
+    let mut iter = engine
+        .scan(Bound::Included(b"b"), Bound::Excluded(b"d"))
+        .unwrap();
+    check_lsm_iter_result_by_key(
+        &mut iter,
+        vec![
+            (Bytes::from("b"), Bytes::from("vb")),
+            (Bytes::from("c"), Bytes::from("vc")),
+        ],
+    );
+}
+
+/// Empty scan returns no results.
+#[test]
+fn test_scan_empty() {
+    let dir = tempdir().unwrap();
+    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+
+    let iter = engine.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    assert!(!iter.is_valid());
+}
+
+/// Scan deduplicates across many versions of the same key.
+#[test]
+fn test_scan_deduplicates_across_versions() {
+    let dir = tempdir().unwrap();
+    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+
+    for i in 0..10 {
+        engine.put(b"key", format!("v{i}").as_bytes()).unwrap();
+    }
+
+    let mut iter = engine.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    check_lsm_iter_result_by_key(&mut iter, vec![(Bytes::from("key"), Bytes::from("v9"))]);
+}
+
+/// ReadGuard pins the watermark — versions at or above the guard's read_ts
+/// are protected from GC while the guard is alive.
+#[test]
+fn test_read_guard_pins_watermark() {
+    let dir = tempdir().unwrap();
+    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+
+    engine.put(b"k", b"v1").unwrap();
+    engine.put(b"k", b"v2").unwrap();
+
+    // Pin snapshot at ts=2
+    let mvcc = engine.inner.mvcc.as_ref().unwrap();
+    let guard = mvcc.new_read_guard();
+    let pinned_ts = guard.read_ts();
+
+    // Advance the timestamp
+    engine.put(b"k", b"v3").unwrap();
+    engine.put(b"k", b"v4").unwrap();
+
+    // Watermark should still be at or below pinned_ts
+    assert!(mvcc.watermark() <= pinned_ts);
+
+    // After dropping the guard, watermark can advance
+    drop(guard);
+    assert!(mvcc.watermark() > pinned_ts);
+}

--- a/todo.md
+++ b/todo.md
@@ -38,7 +38,7 @@ PR #70 (merged 2026-06-07). Internal key encoding, MVCC-aware reads/scans/compac
 - [x] Watermark
 - [x] `LsmMvccInner` initialization
 - [x] Recover max timestamp from WAL/SST
-- [ ] `ReadGuard` registration and cleanup
+- [x] `ReadGuard` registration and cleanup
 
 ---
 


### PR DESCRIPTION
## Summary

Add RAII ReadGuard that atomically reads the latest commit timestamp and registers it in the MVCC watermark on construction, and unregisters on drop. This ensures compaction can see active readers and won't GC versions they might still need.

## Changes

- Add ReadGuard struct with new_latest(), read_ts(), Drop
- Add LsmMvccInner::new_read_guard() factory method
- Update get()/get_with_kind_inner() to use short-lived ReadGuard
- Create ScanIterator wrapper that holds ReadGuard for scan lifetime
- Update Transaction to store ReadGuard instead of bare read_ts
- Change mvcc field to Arc<LsmMvccInner> for shared ownership
- Add 5 tests for ReadGuard lifecycle and watermark integration

## Verification

- [x] 256 tests pass
- [x] clippy clean
- [x] fmt clean

Closes Phase 4 of MVCC TODO (ReadGuard registration and cleanup).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reads and scans now pin their snapshot timestamp for their full lifetime, preventing visible versions from being removed during long-running reads.

* **API Changes**
  * Scan API now returns an iterator that preserves read-side lifetime semantics so snapshots remain stable while iterating.

* **Tests**
  * Added tests covering read-pinning registration, cleanup, watermark behavior, and snapshot-aware scanning.

* **Docs**
  * Updated progress notes to reflect read-pinning implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->