### PR TITLE
fix: write_batch MVCC timestamps and unified tombstone representation

### DIFF
--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -294,13 +294,9 @@ impl LsmStorageInner {
                 builder.set_collect_blocks(should_backfill);
             }
 
-            // Detect tombstones: single KvKind::Tombstone byte, or legacy
-            // single KvKind::Inline byte (vlog mode only).
+            // Detect tombstones: single KvKind::Tombstone byte.
             let raw = iter.raw_value();
-            let is_tombstone = (raw.len() == 1 && raw[0] == crate::vlog::KvKind::Tombstone as u8)
-                || (self.vlog.is_some()
-                    && raw.len() == 1
-                    && raw[0] == crate::vlog::KvKind::Inline as u8);
+            let is_tombstone = raw.len() == 1 && raw[0] == crate::vlog::KvKind::Tombstone as u8;
             // With MVCC, preserve all versions (including tombstones) so older
             // timestamp reads can still see them. Only drop tombstones at the
             // bottom level in non-MVCC mode.

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -294,14 +294,13 @@ impl LsmStorageInner {
                 builder.set_collect_blocks(should_backfill);
             }
 
-            // Detect tombstones: non-vlog mode uses empty values, vlog mode
-            // uses [KvKind::Tombstone] or legacy [KvKind::Inline] (single byte).
+            // Detect tombstones: single KvKind::Tombstone byte, or legacy
+            // single KvKind::Inline byte (vlog mode only).
             let raw = iter.raw_value();
-            let is_tombstone = raw.is_empty()
+            let is_tombstone = (raw.len() == 1 && raw[0] == crate::vlog::KvKind::Tombstone as u8)
                 || (self.vlog.is_some()
                     && raw.len() == 1
-                    && (raw[0] == crate::vlog::KvKind::Tombstone as u8
-                        || raw[0] == crate::vlog::KvKind::Inline as u8));
+                    && raw[0] == crate::vlog::KvKind::Inline as u8);
             // With MVCC, preserve all versions (including tombstones) so older
             // timestamp reads can still see them. Only drop tombstones at the
             // bottom level in non-MVCC mode.

--- a/kv-engine/src/lsm_iterator.rs
+++ b/kv-engine/src/lsm_iterator.rs
@@ -61,6 +61,11 @@ impl LsmIterator {
         })
     }
 
+    /// Check if a value represents a tombstone (single KvKind::Tombstone byte).
+    fn is_tombstone_value(v: &[u8]) -> bool {
+        v.len() == 1 && v[0] == crate::vlog::KvKind::Tombstone as u8
+    }
+
     /// Skip entries with empty values (tombstones) and versions beyond `read_ts`.
     /// When MVCC is enabled, skip all versions of a dead user key, and for
     /// each user key skip versions with `ts > read_ts` (invisible to this
@@ -92,7 +97,7 @@ impl LsmIterator {
                     continue;
                 }
             }
-            if !iter.value().is_empty() {
+            if !Self::is_tombstone_value(iter.value()) {
                 return Ok(());
             }
             // Tombstone — skip all versions of this dead user key
@@ -158,8 +163,8 @@ impl StorageIterator for LsmIterator {
             }
         } else {
             self.inner.next()?;
-            // Legacy: skip empty values
-            while self.inner.is_valid() && self.inner.value().is_empty() {
+            // Legacy: skip tombstone values
+            while self.inner.is_valid() && Self::is_tombstone_value(self.inner.value()) {
                 self.inner.next()?;
             }
         }

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1205,19 +1205,18 @@ impl LsmStorageInner {
             let state = self.state.load_full();
             if let Some(ref mvcc) = self.mvcc {
                 // MVCC path: allocate a single commit_ts for the entire batch.
-                let entries: Vec<(Vec<u8>, Vec<u8>, bool)> = indices
+                let entries: Vec<(&[u8], &[u8], bool)> = indices
                     .iter()
                     .map(|&idx| match &batch[idx] {
                         WriteBatchRecord::Put(key, value) => {
-                            (key.as_ref().to_vec(), value.as_ref().to_vec(), false)
+                            (key.as_ref(), value.as_ref(), false)
                         }
-                        WriteBatchRecord::Del(key) => (key.as_ref().to_vec(), Vec::new(), true),
+                        WriteBatchRecord::Del(key) => (key.as_ref(), &[] as &[u8], true),
                     })
                     .collect();
                 mvcc.write_batch(&entries, &state.memtable)?;
             } else {
                 // Non-MVCC path: write raw user keys directly.
-                let vlog_enabled = state.memtable.vlog_enabled();
                 let mut raw_data = vec![];
                 for idx in indices {
                     match &batch[idx] {
@@ -1228,15 +1227,10 @@ impl LsmStorageInner {
                             ));
                         }
                         WriteBatchRecord::Put(key, value) => {
-                            let val = if vlog_enabled {
-                                let mut p = Vec::with_capacity(1 + value.as_ref().len());
-                                p.push(crate::vlog::KvKind::Inline as u8);
-                                p.extend_from_slice(value.as_ref());
-                                p
-                            } else {
-                                value.as_ref().to_vec()
-                            };
-                            raw_data.push((KeySlice::from_slice(key.as_ref()), val));
+                            let mut p = Vec::with_capacity(1 + value.as_ref().len());
+                            p.push(crate::vlog::KvKind::Inline as u8);
+                            p.extend_from_slice(value.as_ref());
+                            raw_data.push((KeySlice::from_slice(key.as_ref()), p));
                         }
                     }
                 }

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1208,9 +1208,7 @@ impl LsmStorageInner {
                 let entries: Vec<(&[u8], &[u8], bool)> = indices
                     .iter()
                     .map(|&idx| match &batch[idx] {
-                        WriteBatchRecord::Put(key, value) => {
-                            (key.as_ref(), value.as_ref(), false)
-                        }
+                        WriteBatchRecord::Put(key, value) => (key.as_ref(), value.as_ref(), false),
                         WriteBatchRecord::Del(key) => (key.as_ref(), &[] as &[u8], true),
                     })
                     .collect();

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -797,9 +797,14 @@ impl LsmStorageInner {
 
     /// Parse a kind-prefixed raw value into (value, kind).
     /// Takes owned `Bytes` to enable zero-copy slicing for inline values.
+    /// Check if a raw value represents a tombstone (single KvKind::Tombstone byte).
+    fn is_tombstone_value(v: &Bytes) -> bool {
+        v.len() == 1 && v[0] == crate::vlog::KvKind::Tombstone as u8
+    }
+
     fn parse_value_kind(raw: Bytes) -> (Option<Bytes>, KvKind) {
         if raw.is_empty() {
-            return (None, KvKind::Inline);
+            return (Some(raw), KvKind::Inline);
         }
         match KvKind::from_u8(raw[0]) {
             Some(KvKind::ValuePointer) => (Some(raw), KvKind::ValuePointer),
@@ -876,14 +881,14 @@ impl LsmStorageInner {
                 }
             } else {
                 if let Some(v) = state.memtable.get_versioned(&user_key, read_ts) {
-                    if v.is_empty() {
+                    if Self::is_tombstone_value(&v) {
                         return Ok(Some((None, KvKind::Inline)));
                     }
                     return Ok(Some((Some(v), KvKind::Inline)));
                 }
                 for m in state.imm_memtables.iter() {
                     if let Some(v) = m.get_versioned(&user_key, read_ts) {
-                        if v.is_empty() {
+                        if Self::is_tombstone_value(&v) {
                             return Ok(Some((None, KvKind::Inline)));
                         }
                         return Ok(Some((Some(v), KvKind::Inline)));
@@ -903,14 +908,14 @@ impl LsmStorageInner {
                 }
             } else {
                 if let Some(v) = state.memtable.get_with_hash(key, bloom_hash) {
-                    if v.is_empty() {
+                    if Self::is_tombstone_value(&v) {
                         return Ok(Some((None, KvKind::Inline)));
                     }
                     return Ok(Some((Some(v), KvKind::Inline)));
                 }
                 for m in state.imm_memtables.iter() {
                     if let Some(v) = m.get_with_hash(key, bloom_hash) {
-                        if v.is_empty() {
+                        if Self::is_tombstone_value(&v) {
                             return Ok(Some((None, KvKind::Inline)));
                         }
                         return Ok(Some((Some(v), KvKind::Inline)));
@@ -1150,7 +1155,11 @@ impl LsmStorageInner {
                     still_matches = Self::values_match(&current_val, current_kind, old, *old_kind);
                 }
             } else if let Some(v) = state.memtable.get(key) {
-                let current_val = if v.is_empty() { None } else { Some(v) };
+                let current_val = if Self::is_tombstone_value(&v) {
+                    None
+                } else {
+                    Some(v)
+                };
                 still_matches = Self::values_match(&current_val, KvKind::Inline, old, *old_kind);
             }
 
@@ -1172,9 +1181,10 @@ impl LsmStorageInner {
         Ok(results)
     }
 
-    /// Write a batch of data into the storage. Implement in compaction.
+    /// Write a batch of data into the storage.
     /// Canonicalizes duplicate user keys: only the last operation per key in
-    /// the batch is written.
+    /// the batch is written. When MVCC is enabled, all entries share a single
+    /// commit timestamp.
     pub fn write_batch<T: AsRef<[u8]>>(&self, batch: &[WriteBatchRecord<T>]) -> Result<()> {
         // Deduplicate: keep only the last operation per user key.
         let mut last_op = std::collections::HashMap::new();
@@ -1193,34 +1203,47 @@ impl LsmStorageInner {
         {
             let _guard = self.active_memtable_lock.read();
             let state = self.state.load_full();
-            let vlog_enabled = state.memtable.vlog_enabled();
-            let mut raw_data = vec![];
-            for idx in indices {
-                match &batch[idx] {
-                    WriteBatchRecord::Del(key) => {
-                        let val = if vlog_enabled {
-                            vec![crate::vlog::KvKind::Tombstone as u8]
-                        } else {
-                            vec![]
-                        };
-                        raw_data.push((KeySlice::from_slice(key.as_ref()), val));
-                    }
-                    WriteBatchRecord::Put(key, value) => {
-                        let val = if vlog_enabled {
-                            let mut p = Vec::with_capacity(1 + value.as_ref().len());
-                            p.push(crate::vlog::KvKind::Inline as u8);
-                            p.extend_from_slice(value.as_ref());
-                            p
-                        } else {
-                            value.as_ref().to_vec()
-                        };
-                        raw_data.push((KeySlice::from_slice(key.as_ref()), val));
+            if let Some(ref mvcc) = self.mvcc {
+                // MVCC path: allocate a single commit_ts for the entire batch.
+                let entries: Vec<(Vec<u8>, Vec<u8>, bool)> = indices
+                    .iter()
+                    .map(|&idx| match &batch[idx] {
+                        WriteBatchRecord::Put(key, value) => {
+                            (key.as_ref().to_vec(), value.as_ref().to_vec(), false)
+                        }
+                        WriteBatchRecord::Del(key) => (key.as_ref().to_vec(), Vec::new(), true),
+                    })
+                    .collect();
+                mvcc.write_batch(&entries, &state.memtable)?;
+            } else {
+                // Non-MVCC path: write raw user keys directly.
+                let vlog_enabled = state.memtable.vlog_enabled();
+                let mut raw_data = vec![];
+                for idx in indices {
+                    match &batch[idx] {
+                        WriteBatchRecord::Del(key) => {
+                            raw_data.push((
+                                KeySlice::from_slice(key.as_ref()),
+                                vec![crate::vlog::KvKind::Tombstone as u8],
+                            ));
+                        }
+                        WriteBatchRecord::Put(key, value) => {
+                            let val = if vlog_enabled {
+                                let mut p = Vec::with_capacity(1 + value.as_ref().len());
+                                p.push(crate::vlog::KvKind::Inline as u8);
+                                p.extend_from_slice(value.as_ref());
+                                p
+                            } else {
+                                value.as_ref().to_vec()
+                            };
+                            raw_data.push((KeySlice::from_slice(key.as_ref()), val));
+                        }
                     }
                 }
+                let refs: Vec<(KeySlice, &[u8])> =
+                    raw_data.iter().map(|(k, v)| (*k, v.as_slice())).collect();
+                state.memtable.put_raw_batch(&refs)?;
             }
-            let refs: Vec<(KeySlice, &[u8])> =
-                raw_data.iter().map(|(k, v)| (*k, v.as_slice())).collect();
-            state.memtable.put_raw_batch(&refs)?;
         }
 
         self.try_freeze_memtable()

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1268,7 +1268,15 @@ impl LsmStorageInner {
 
     /// Put a key-value pair into the storage by writing into the current memtable.
     /// When MVCC is enabled, encodes the key with an allocated commit timestamp.
+    ///
+    /// # Panics / Errors
+    /// Rejects values that are exactly the tombstone marker byte (`[0x02]`),
+    /// since those would be indistinguishable from a deletion marker.
     pub fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
+        anyhow::ensure!(
+            !(value.len() == 1 && value[0] == crate::vlog::KvKind::Tombstone as u8),
+            "value must not be the tombstone marker byte (0x02)"
+        );
         {
             let _guard = self.active_memtable_lock.read();
             let state = self.state.load_full();

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -303,11 +303,7 @@ impl MemTable {
     /// When vlog_enabled, stores `[KvKind::Tombstone]` as a single-byte value.
     /// When vlog disabled, stores an empty value (legacy behavior).
     pub fn put_tombstone(&self, key: &[u8]) -> Result<()> {
-        if self.vlog_enabled {
-            self.put_raw(key, &[crate::vlog::KvKind::Tombstone as u8])
-        } else {
-            self.put_raw(key, &[])
-        }
+        self.put_raw(key, &[crate::vlog::KvKind::Tombstone as u8])
     }
 
     /// Put a raw key-value pair into the mem-table without kind prefixing.
@@ -440,7 +436,13 @@ impl MemTable {
                     builder.add(key, raw)?;
                 }
             } else {
-                builder.add(key, e.value())?;
+                let val = e.value();
+                if val.len() == 1 && val[0] == crate::vlog::KvKind::Tombstone as u8 {
+                    // Tombstone — pass through as-is (no KvKind::Inline prefix)
+                    builder.add_raw(key, val)?;
+                } else {
+                    builder.add(key, val)?;
+                }
             }
         }
 

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -418,7 +418,11 @@ impl MemTable {
                 builder.add_raw(key, val)?;
             } else {
                 // Inline entry — strip KvKind prefix, let add() handle value separation
-                let raw = if !val.is_empty() { &val[1..] } else { val.as_ref() };
+                let raw = if !val.is_empty() {
+                    &val[1..]
+                } else {
+                    val.as_ref()
+                };
                 builder.add(key, raw)?;
             }
         }

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -553,6 +553,10 @@ impl MemTableIterator {
             return val.clone();
         }
 
+        // Tombstone — return as-is so callers can detect via is_tombstone_value
+        if val[0] == KvKind::Tombstone as u8 {
+            return val.clone();
+        }
         // Not a ValuePointer — strip kind prefix (Inline or unknown)
         if val[0] != KvKind::ValuePointer as u8 {
             return val.slice(1..);

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -162,7 +162,7 @@ impl MemTable {
         }
         self.map.get(key).map(|x| {
             let val = x.value();
-            if self.vlog_enabled && !val.is_empty() {
+            if !val.is_empty() && val[0] != crate::vlog::KvKind::Tombstone as u8 {
                 val.slice(1..)
             } else {
                 val.clone()
@@ -222,7 +222,7 @@ impl MemTable {
                 continue;
             }
             let val = entry.value();
-            if self.vlog_enabled && !val.is_empty() {
+            if !val.is_empty() && val[0] != crate::vlog::KvKind::Tombstone as u8 {
                 return Some(val.slice(1..));
             } else {
                 return Some(val.clone());
@@ -285,17 +285,13 @@ impl MemTable {
 
     /// Put a key-value pair into the mem-table.
     ///
-    /// When vlog_enabled, wraps the value with a KvKind::Inline prefix.
+    /// Always prepends `KvKind::Inline` so values are self-describing
+    /// regardless of vlog mode.
     pub fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
-        if self.vlog_enabled {
-            // Prepend KvKind::Inline prefix
-            let mut prefixed = Vec::with_capacity(1 + value.len());
-            prefixed.push(crate::vlog::KvKind::Inline as u8);
-            prefixed.extend_from_slice(value);
-            self.put_raw(key, &prefixed)
-        } else {
-            self.put_raw(key, value)
-        }
+        let mut prefixed = Vec::with_capacity(1 + value.len());
+        prefixed.push(crate::vlog::KvKind::Inline as u8);
+        prefixed.extend_from_slice(value);
+        self.put_raw(key, &prefixed)
     }
 
     /// Write a tombstone (deletion marker) for the given key.
@@ -357,23 +353,18 @@ impl MemTable {
 
     /// Implement this in MVCC.
     pub fn put_batch(&self, data: &[(KeySlice, &[u8])]) -> Result<()> {
-        if self.vlog_enabled {
-            // Prefix each value with KvKind::Inline
-            let prefixed: Vec<(KeySlice, Vec<u8>)> = data
-                .iter()
-                .map(|(k, v)| {
-                    let mut p = Vec::with_capacity(1 + v.len());
-                    p.push(crate::vlog::KvKind::Inline as u8);
-                    p.extend_from_slice(v);
-                    (*k, p)
-                })
-                .collect();
-            let refs: Vec<(KeySlice, &[u8])> =
-                prefixed.iter().map(|(k, v)| (*k, v.as_slice())).collect();
-            self.put_raw_batch(&refs)
-        } else {
-            self.put_raw_batch(data)
-        }
+        let prefixed: Vec<(KeySlice, Vec<u8>)> = data
+            .iter()
+            .map(|(k, v)| {
+                let mut p = Vec::with_capacity(1 + v.len());
+                p.push(crate::vlog::KvKind::Inline as u8);
+                p.extend_from_slice(v);
+                (*k, p)
+            })
+            .collect();
+        let refs: Vec<(KeySlice, &[u8])> =
+            prefixed.iter().map(|(k, v)| (*k, v.as_slice())).collect();
+        self.put_raw_batch(&refs)
     }
 
     pub fn sync_wal(&self) -> Result<()> {
@@ -418,31 +409,17 @@ impl MemTable {
         for e in self.map.iter() {
             let key_bytes = Key::from_bytes(e.key().clone());
             let key = key_bytes.as_key_slice();
-            if self.vlog_enabled {
-                let val = e.value();
-                if !val.is_empty()
-                    && (val[0] == crate::vlog::KvKind::ValuePointer as u8
-                        || val[0] == crate::vlog::KvKind::Tombstone as u8)
-                {
-                    // ValuePointer or Tombstone — pass through as-is
-                    builder.add_raw(key, val)?;
-                } else {
-                    // Inline entry — strip prefix, let add() handle value separation
-                    let raw = if !val.is_empty() {
-                        &val[1..]
-                    } else {
-                        val.as_ref()
-                    };
-                    builder.add(key, raw)?;
-                }
+            let val = e.value();
+            if !val.is_empty()
+                && (val[0] == crate::vlog::KvKind::ValuePointer as u8
+                    || val[0] == crate::vlog::KvKind::Tombstone as u8)
+            {
+                // ValuePointer or Tombstone — pass through as-is
+                builder.add_raw(key, val)?;
             } else {
-                let val = e.value();
-                if val.len() == 1 && val[0] == crate::vlog::KvKind::Tombstone as u8 {
-                    // Tombstone — pass through as-is (no KvKind::Inline prefix)
-                    builder.add_raw(key, val)?;
-                } else {
-                    builder.add(key, val)?;
-                }
+                // Inline entry — strip KvKind prefix, let add() handle value separation
+                let raw = if !val.is_empty() { &val[1..] } else { val.as_ref() };
+                builder.add(key, raw)?;
             }
         }
 
@@ -509,11 +486,7 @@ impl StorageIterator for MemTableIterator {
     type KeyType<'a> = KeySlice<'a>;
 
     fn value(&self) -> &[u8] {
-        if *self.borrow_vlog_enabled() {
-            self.borrow_resolved().as_ref()
-        } else {
-            self.borrow_item().1.as_ref()
-        }
+        self.borrow_resolved().as_ref()
     }
 
     fn key(&self) -> KeySlice<'_> {
@@ -549,7 +522,7 @@ impl MemTableIterator {
         item: &(Bytes, Bytes),
     ) -> Bytes {
         let val = &item.1;
-        if !*vlog_enabled || val.is_empty() {
+        if val.is_empty() {
             return val.clone();
         }
 

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -9,7 +9,11 @@ use std::{
 use parking_lot::Mutex;
 
 use self::{txn::Transaction, watermark::Watermark};
-use crate::{key::encode_internal_key, lsm_storage::LsmStorageInner, mem_table::MemTable};
+use crate::{
+    key::{KeySlice, encode_internal_key},
+    lsm_storage::LsmStorageInner,
+    mem_table::MemTable,
+};
 
 pub(crate) struct CommittedTxnData {
     pub(crate) key_hashes: HashSet<u32>,
@@ -78,6 +82,45 @@ impl LsmMvccInner {
         let commit_ts = self.ts.lock().0 + 1;
         let encoded_key = encode_internal_key(user_key, commit_ts);
         memtable.put_tombstone(&encoded_key)?;
+        self.ts.lock().0 = commit_ts;
+        Ok(())
+    }
+
+    /// Write a batch of operations atomically under a single commit timestamp.
+    /// Each entry is `(user_key, value, is_tombstone)`.
+    pub fn write_batch(
+        &self,
+        entries: &[(Vec<u8>, Vec<u8>, bool)],
+        memtable: &MemTable,
+    ) -> Result<(), anyhow::Error> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+        let _write_guard = self.write_lock.lock();
+        let commit_ts = self.ts.lock().0 + 1;
+        let encoded: Vec<(Vec<u8>, &[u8], bool)> = entries
+            .iter()
+            .map(|(key, value, is_tombstone)| {
+                (
+                    encode_internal_key(key, commit_ts),
+                    value.as_slice(),
+                    *is_tombstone,
+                )
+            })
+            .collect();
+        let tombstone_val: [u8; 1] = [crate::vlog::KvKind::Tombstone as u8];
+        let raw: Vec<(KeySlice, &[u8])> = encoded
+            .iter()
+            .map(|(key, value, is_tombstone)| {
+                let k = KeySlice::from_slice(key);
+                if *is_tombstone {
+                    (k, &tombstone_val as &[u8])
+                } else {
+                    (k, *value)
+                }
+            })
+            .collect();
+        memtable.put_raw_batch(&raw)?;
         self.ts.lock().0 = commit_ts;
         Ok(())
     }

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -61,6 +61,10 @@ impl LsmMvccInner {
         value: &[u8],
         memtable: &MemTable,
     ) -> Result<(), anyhow::Error> {
+        anyhow::ensure!(
+            !(value.len() == 1 && value[0] == crate::vlog::KvKind::Tombstone as u8),
+            "value must not be the tombstone marker byte (0x02)"
+        );
         let _write_guard = self.write_lock.lock();
         // Write to the memtable FIRST, then advance ts.0.  This ordering
         // guarantees that a concurrent `new_read_guard()` never observes a
@@ -109,11 +113,35 @@ impl LsmMvccInner {
             })
             .collect();
         let tombstone_val: [u8; 1] = [crate::vlog::KvKind::Tombstone as u8];
+        let vlog_enabled = memtable.vlog_enabled();
+        // When vlog is enabled, non-tombstone entries need a KvKind::Inline
+        // prefix so the flush path can distinguish them from ValuePointers.
+        // Pre-build the prefixed values so references stay valid.
+        let prefixed: Vec<Vec<u8>> = if vlog_enabled {
+            encoded
+                .iter()
+                .map(|(_, value, is_tombstone)| {
+                    if *is_tombstone {
+                        vec![crate::vlog::KvKind::Tombstone as u8]
+                    } else {
+                        let mut p = Vec::with_capacity(1 + value.len());
+                        p.push(crate::vlog::KvKind::Inline as u8);
+                        p.extend_from_slice(value);
+                        p
+                    }
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
         let raw: Vec<(KeySlice, &[u8])> = encoded
             .iter()
-            .map(|(key, value, is_tombstone)| {
+            .enumerate()
+            .map(|(i, (key, value, is_tombstone))| {
                 let k = KeySlice::from_slice(key);
-                if *is_tombstone {
+                if vlog_enabled {
+                    (k, prefixed[i].as_slice())
+                } else if *is_tombstone {
                     (k, &tombstone_val as &[u8])
                 } else {
                     (k, *value)

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -105,11 +105,7 @@ impl LsmMvccInner {
         let encoded: Vec<(Vec<u8>, &[u8], bool)> = entries
             .iter()
             .map(|(key, value, is_tombstone)| {
-                (
-                    encode_internal_key(key, commit_ts),
-                    *value,
-                    *is_tombstone,
-                )
+                (encode_internal_key(key, commit_ts), *value, *is_tombstone)
             })
             .collect();
         // Always prefix non-tombstone values with KvKind::Inline so values

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -94,7 +94,7 @@ impl LsmMvccInner {
     /// Each entry is `(user_key, value, is_tombstone)`.
     pub fn write_batch(
         &self,
-        entries: &[(Vec<u8>, Vec<u8>, bool)],
+        entries: &[(&[u8], &[u8], bool)],
         memtable: &MemTable,
     ) -> Result<(), anyhow::Error> {
         if entries.is_empty() {
@@ -107,45 +107,32 @@ impl LsmMvccInner {
             .map(|(key, value, is_tombstone)| {
                 (
                     encode_internal_key(key, commit_ts),
-                    value.as_slice(),
+                    *value,
                     *is_tombstone,
                 )
             })
             .collect();
-        let tombstone_val: [u8; 1] = [crate::vlog::KvKind::Tombstone as u8];
-        let vlog_enabled = memtable.vlog_enabled();
-        // When vlog is enabled, non-tombstone entries need a KvKind::Inline
-        // prefix so the flush path can distinguish them from ValuePointers.
-        // Pre-build the prefixed values so references stay valid.
-        let prefixed: Vec<Vec<u8>> = if vlog_enabled {
-            encoded
-                .iter()
-                .map(|(_, value, is_tombstone)| {
-                    if *is_tombstone {
-                        vec![crate::vlog::KvKind::Tombstone as u8]
-                    } else {
-                        let mut p = Vec::with_capacity(1 + value.len());
-                        p.push(crate::vlog::KvKind::Inline as u8);
-                        p.extend_from_slice(value);
-                        p
-                    }
-                })
-                .collect()
-        } else {
-            Vec::new()
-        };
+        // Always prefix non-tombstone values with KvKind::Inline so values
+        // are self-describing regardless of vlog mode.
+        let prefixed: Vec<Vec<u8>> = encoded
+            .iter()
+            .map(|(_, value, is_tombstone)| {
+                if *is_tombstone {
+                    vec![crate::vlog::KvKind::Tombstone as u8]
+                } else {
+                    let mut p = Vec::with_capacity(1 + value.len());
+                    p.push(crate::vlog::KvKind::Inline as u8);
+                    p.extend_from_slice(value);
+                    p
+                }
+            })
+            .collect();
         let raw: Vec<(KeySlice, &[u8])> = encoded
             .iter()
             .enumerate()
-            .map(|(i, (key, value, is_tombstone))| {
+            .map(|(i, (key, _, _))| {
                 let k = KeySlice::from_slice(key);
-                if vlog_enabled {
-                    (k, prefixed[i].as_slice())
-                } else if *is_tombstone {
-                    (k, &tombstone_val as &[u8])
-                } else {
-                    (k, *value)
-                }
+                (k, prefixed[i].as_slice())
             })
             .collect();
         memtable.put_raw_batch(&raw)?;

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -97,6 +97,10 @@ impl SsTableBuilder {
     /// Note: You should split a new block when the current block is full.(`std::mem::replace` may
     /// be helpful here)
     pub fn add(&mut self, key: KeySlice, value: &[u8]) -> Result<()> {
+        // Tombstone marker — pass through as-is (no KvKind::Inline prefix)
+        if value.len() == 1 && value[0] == KvKind::Tombstone as u8 {
+            return self.add_inner(key, value);
+        }
         if self.vlog_options.enabled
             && value.len() >= self.vlog_options.min_value_size
             && !value.is_empty()

--- a/kv-engine/src/table/iterator.rs
+++ b/kv-engine/src/table/iterator.rs
@@ -139,8 +139,9 @@ impl StorageIterator for SsTableIterator {
                 payload
             }
             Some(KvKind::Tombstone) => {
-                // Tombstone marker — no value
-                &[]
+                // Tombstone marker — return the raw kind byte so callers can
+                // detect it via `is_tombstone_value`.
+                &raw[..1]
             }
             Some(KvKind::ValuePointer) => {
                 // Check cache first (safe: only accessed from this iterator)

--- a/kv-engine/src/tests/compaction.rs
+++ b/kv-engine/src/tests/compaction.rs
@@ -1,7 +1,7 @@
 use std::{ops::Bound, path::Path, sync::Arc};
 
 use bytes::Bytes;
-use harness::construct_merge_iterator_over_storage;
+use harness::{TOMBSTONE_VALUE, construct_merge_iterator_over_storage};
 use tempfile::tempdir;
 
 use self::harness::{check_iter_result_by_key, check_lsm_iter_result_by_key, sync};
@@ -36,11 +36,17 @@ fn test_task1_full_compaction() {
         check_iter_result_by_key(
             &mut iter,
             vec![
-                (Bytes::from_static(b"0"), Bytes::from_static(b"")),
+                (
+                    Bytes::from_static(b"0"),
+                    Bytes::from_static(TOMBSTONE_VALUE),
+                ),
                 (Bytes::from_static(b"0"), Bytes::from_static(b"v2")),
                 (Bytes::from_static(b"0"), Bytes::from_static(b"v1")),
                 (Bytes::from_static(b"1"), Bytes::from_static(b"v2")),
-                (Bytes::from_static(b"2"), Bytes::from_static(b"")),
+                (
+                    Bytes::from_static(b"2"),
+                    Bytes::from_static(TOMBSTONE_VALUE),
+                ),
                 (Bytes::from_static(b"2"), Bytes::from_static(b"v2")),
             ],
         );
@@ -48,9 +54,15 @@ fn test_task1_full_compaction() {
         check_iter_result_by_key(
             &mut iter,
             vec![
-                (Bytes::from_static(b"0"), Bytes::from_static(b"")),
+                (
+                    Bytes::from_static(b"0"),
+                    Bytes::from_static(TOMBSTONE_VALUE),
+                ),
                 (Bytes::from_static(b"1"), Bytes::from_static(b"v2")),
-                (Bytes::from_static(b"2"), Bytes::from_static(b"")),
+                (
+                    Bytes::from_static(b"2"),
+                    Bytes::from_static(TOMBSTONE_VALUE),
+                ),
             ],
         );
     }
@@ -61,11 +73,17 @@ fn test_task1_full_compaction() {
         check_iter_result_by_key(
             &mut iter,
             vec![
-                (Bytes::from_static(b"0"), Bytes::from_static(b"")),
+                (
+                    Bytes::from_static(b"0"),
+                    Bytes::from_static(TOMBSTONE_VALUE),
+                ),
                 (Bytes::from_static(b"0"), Bytes::from_static(b"v2")),
                 (Bytes::from_static(b"0"), Bytes::from_static(b"v1")),
                 (Bytes::from_static(b"1"), Bytes::from_static(b"v2")),
-                (Bytes::from_static(b"2"), Bytes::from_static(b"")),
+                (
+                    Bytes::from_static(b"2"),
+                    Bytes::from_static(TOMBSTONE_VALUE),
+                ),
                 (Bytes::from_static(b"2"), Bytes::from_static(b"v2")),
             ],
         );
@@ -86,13 +104,22 @@ fn test_task1_full_compaction() {
             &mut iter,
             vec![
                 (Bytes::from_static(b"0"), Bytes::from_static(b"v3")),
-                (Bytes::from_static(b"0"), Bytes::from_static(b"")),
+                (
+                    Bytes::from_static(b"0"),
+                    Bytes::from_static(TOMBSTONE_VALUE),
+                ),
                 (Bytes::from_static(b"0"), Bytes::from_static(b"v2")),
                 (Bytes::from_static(b"0"), Bytes::from_static(b"v1")),
-                (Bytes::from_static(b"1"), Bytes::from_static(b"")),
+                (
+                    Bytes::from_static(b"1"),
+                    Bytes::from_static(TOMBSTONE_VALUE),
+                ),
                 (Bytes::from_static(b"1"), Bytes::from_static(b"v2")),
                 (Bytes::from_static(b"2"), Bytes::from_static(b"v3")),
-                (Bytes::from_static(b"2"), Bytes::from_static(b"")),
+                (
+                    Bytes::from_static(b"2"),
+                    Bytes::from_static(TOMBSTONE_VALUE),
+                ),
                 (Bytes::from_static(b"2"), Bytes::from_static(b"v2")),
             ],
         );
@@ -101,7 +128,10 @@ fn test_task1_full_compaction() {
             &mut iter,
             vec![
                 (Bytes::from_static(b"0"), Bytes::from_static(b"v3")),
-                (Bytes::from_static(b"1"), Bytes::from_static(b"")),
+                (
+                    Bytes::from_static(b"1"),
+                    Bytes::from_static(TOMBSTONE_VALUE),
+                ),
                 (Bytes::from_static(b"2"), Bytes::from_static(b"v3")),
             ],
         );
@@ -114,13 +144,22 @@ fn test_task1_full_compaction() {
             &mut iter,
             vec![
                 (Bytes::from_static(b"0"), Bytes::from_static(b"v3")),
-                (Bytes::from_static(b"0"), Bytes::from_static(b"")),
+                (
+                    Bytes::from_static(b"0"),
+                    Bytes::from_static(TOMBSTONE_VALUE),
+                ),
                 (Bytes::from_static(b"0"), Bytes::from_static(b"v2")),
                 (Bytes::from_static(b"0"), Bytes::from_static(b"v1")),
-                (Bytes::from_static(b"1"), Bytes::from_static(b"")),
+                (
+                    Bytes::from_static(b"1"),
+                    Bytes::from_static(TOMBSTONE_VALUE),
+                ),
                 (Bytes::from_static(b"1"), Bytes::from_static(b"v2")),
                 (Bytes::from_static(b"2"), Bytes::from_static(b"v3")),
-                (Bytes::from_static(b"2"), Bytes::from_static(b"")),
+                (
+                    Bytes::from_static(b"2"),
+                    Bytes::from_static(TOMBSTONE_VALUE),
+                ),
                 (Bytes::from_static(b"2"), Bytes::from_static(b"v2")),
             ],
         );

--- a/kv-engine/src/tests/harness.rs
+++ b/kv-engine/src/tests/harness.rs
@@ -15,7 +15,11 @@ use crate::{
     key::{KeySlice, KeyVec, TS_ENABLED},
     lsm_storage::{BlockCache, KvEngine, LsmStorageInner, LsmStorageState},
     table::{SsTable, SsTableBuilder, SsTableIterator},
+    vlog::KvKind,
 };
+
+/// Tombstone value used in tests — a single `KvKind::Tombstone` byte.
+pub const TOMBSTONE_VALUE: &[u8] = &[KvKind::Tombstone as u8];
 
 #[derive(Clone)]
 pub struct MockIterator {

--- a/kv-engine/src/tests/merge_iterator.rs
+++ b/kv-engine/src/tests/merge_iterator.rs
@@ -5,7 +5,7 @@ use tempfile::tempdir;
 
 use self::harness::{check_lsm_iter_result_by_key, generate_sst};
 use super::{
-    harness::{MockIterator, check_iter_result_by_key},
+    harness::{MockIterator, TOMBSTONE_VALUE, check_iter_result_by_key},
     *,
 };
 use crate::{
@@ -155,7 +155,10 @@ fn test_task2_storage_scan() {
     let sst2 = generate_sst(
         11,
         dir.path().join("11.sst"),
-        vec![(Bytes::from_static(b"4"), Bytes::from_static(b""))],
+        vec![(
+            Bytes::from_static(b"4"),
+            Bytes::from_static(TOMBSTONE_VALUE),
+        )],
         Some(storage.block_cache.clone()),
     );
     {
@@ -215,7 +218,10 @@ fn test_task3_storage_get() {
     let sst2 = generate_sst(
         11,
         dir.path().join("11.sst"),
-        vec![(Bytes::from_static(b"4"), Bytes::from_static(b""))],
+        vec![(
+            Bytes::from_static(b"4"),
+            Bytes::from_static(TOMBSTONE_VALUE),
+        )],
         Some(storage.block_cache.clone()),
     );
     {


### PR DESCRIPTION
## Summary

- `write_batch` now allocates a single commit timestamp through MVCC when enabled, satisfying RFC §5 requirement that all records in one batch share the same `commit_ts`
- Tombstone representation unified: all tombstones use a single `KvKind::Tombstone` byte (0x02) instead of empty values, eliminating ambiguity with legitimate empty puts

## Changes

**MVCC write_batch:**
- Added `LsmMvccInner::write_batch()` — acquires write lock, allocates one commit_ts, encodes all keys atomically
- `LsmStorageInner::write_batch()` routes through MVCC path when enabled, falls back to raw path otherwise

**Unified tombstone (0x02 byte):**
- `MemTable::put_tombstone()` always writes `[KvKind::Tombstone]` regardless of vlog mode
- `SsTableBuilder::add()` detects tombstones and passes through without `KvKind::Inline` prefix
- `SsTableIterator::value()` returns tombstone marker byte instead of empty slice
- `MemTable::flush()` detects tombstones in non-vlog mode, uses `add_raw`
- `LsmIterator::is_tombstone_value()` checks only for `KvKind::Tombstone` byte
- `LsmStorageInner::is_tombstone_value()` and `parse_value_kind()` updated consistently
- Compaction tombstone detection updated

## Verification

- [x] 274 tests pass
- [x] cargo fmt clean
- [x] cargo clippy clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added atomic batch write support for multi-key operations when MVCC is enabled

* **Refactor**
  * Standardized deletion marker handling across storage layers and iterators
  * Switched tombstone encoding/decoding to an explicit single-byte marker

* **Bug Fix**
  * Reject writing values that match the tombstone marker to avoid ambiguity

* **Tests**
  * Updated tests and fixtures to expect the new tombstone encoding
<!-- end of auto-generated comment: release notes by coderabbit.ai -->