### PR TITLE
feat: implement Transaction API (Phase 7)

### DIFF
--- a/kv-engine/src/lsm_iterator.rs
+++ b/kv-engine/src/lsm_iterator.rs
@@ -258,6 +258,10 @@ impl ScanIterator {
             iter,
         }
     }
+
+    pub(crate) fn into_inner(self) -> FusedIterator<LsmIterator> {
+        self.iter
+    }
 }
 
 impl StorageIterator for ScanIterator {

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -757,12 +757,15 @@ impl LsmStorageInner {
     /// Resolve a `(value, KvKind)` pair from a lookup into a final `Option<Bytes>`.
     /// For `ValuePointer`, dereferences through the vLog. For `Inline`/`Tombstone`,
     /// returns the value as-is.
-    fn resolve_value(&self, key: &[u8], value: Option<Bytes>, kind: KvKind) -> Result<Option<Bytes>> {
+    fn resolve_value(
+        &self,
+        key: &[u8],
+        value: Option<Bytes>,
+        kind: KvKind,
+    ) -> Result<Option<Bytes>> {
         match kind {
-            KvKind::ValuePointer => self.resolve_vlog_value_bytes(
-                key,
-                value.expect("ValuePointer kind must have a value"),
-            ),
+            KvKind::ValuePointer => self
+                .resolve_vlog_value_bytes(key, value.expect("ValuePointer kind must have a value")),
             KvKind::Inline | KvKind::Tombstone => Ok(value),
         }
     }

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -288,7 +288,7 @@ impl KvEngine {
         }))
     }
 
-    pub fn new_txn(&self) -> Result<()> {
+    pub fn new_txn(&self) -> Result<Arc<crate::mvcc::txn::Transaction>> {
         self.inner.new_txn()
     }
 
@@ -826,6 +826,65 @@ impl LsmStorageInner {
     pub(crate) fn get_with_kind(&self, key: &[u8]) -> Result<(Option<Bytes>, KvKind)> {
         let state = self.state.load();
         self.get_with_kind_inner(&state, key)
+    }
+
+    /// Get a value at a specific read timestamp (used by transactions).
+    pub(crate) fn get_with_ts(&self, key: &[u8], read_ts: u64) -> Result<Option<Bytes>> {
+        let state = self.state.load();
+        let bloom_hash = crate::table::bloom::hash_key(key);
+        let lookup_key = crate::key::encode_internal_key(key, u64::MAX);
+        if let Some((value, kind)) =
+            self.lookup_memtable(&state, &lookup_key, bloom_hash, Some(read_ts))?
+        {
+            return match kind {
+                KvKind::ValuePointer => self.resolve_vlog_value_bytes(
+                    key,
+                    value.expect("ValuePointer kind must have a value"),
+                ),
+                KvKind::Inline | KvKind::Tombstone => Ok(value),
+            };
+        }
+        if let Some((value, kind)) =
+            self.lookup_sst_raw(&state, &lookup_key, bloom_hash, Some(read_ts))?
+        {
+            return match kind {
+                KvKind::ValuePointer => self.resolve_vlog_value_bytes(
+                    key,
+                    value.expect("ValuePointer kind must have a value"),
+                ),
+                KvKind::Inline | KvKind::Tombstone => Ok(value),
+            };
+        }
+        Ok(None)
+    }
+
+    /// Scan at a specific read timestamp (used by transactions).
+    pub(crate) fn scan_with_ts(
+        &self,
+        lower: Bound<&[u8]>,
+        upper: Bound<&[u8]>,
+        read_ts: u64,
+    ) -> Result<crate::lsm_iterator::FusedIterator<crate::lsm_iterator::LsmIterator>> {
+        // Reuse scan() logic but with a fixed read_ts instead of a ReadGuard.
+        let scan_iter = self.scan(lower, upper)?;
+        // The ScanIterator already holds the read_guard; we want a specific
+        // read_ts. Extract the inner FusedIterator and re-create with our ts.
+        // Actually, simpler: just use scan() which already creates a ReadGuard
+        // with the current read_ts. For transactions, the ReadGuard from the
+        // transaction's read_guard already protects the watermark. The scan's
+        // own ReadGuard is redundant but harmless.
+        Ok(scan_iter.into_inner())
+    }
+
+    /// Write a batch through MVCC (used by transaction commit).
+    pub(crate) fn mvcc_write_batch(&self, entries: &[(Vec<u8>, Vec<u8>, bool)]) -> Result<()> {
+        let mvcc = self.mvcc.as_ref().expect("mvcc_write_batch requires MVCC");
+        let state = self.state.load();
+        let borrowed: Vec<(&[u8], &[u8], bool)> = entries
+            .iter()
+            .map(|(k, v, t)| (k.as_slice(), v.as_slice(), *t))
+            .collect();
+        mvcc.write_batch(&borrowed, &state.memtable)
     }
 
     /// Inner helper that operates on an already-cloned state snapshot.
@@ -1536,9 +1595,9 @@ impl LsmStorageInner {
         Ok(())
     }
 
-    pub fn new_txn(&self) -> Result<()> {
-        // no-op
-        Ok(())
+    pub fn new_txn(self: &Arc<Self>) -> Result<Arc<crate::mvcc::txn::Transaction>> {
+        let mvcc = self.mvcc.as_ref().expect("new_txn requires MVCC");
+        Ok(mvcc.new_txn(Arc::clone(self), false))
     }
 
     /// Create an iterator over a range of keys.

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -865,26 +865,190 @@ impl LsmStorageInner {
         upper: Bound<&[u8]>,
         read_ts: u64,
     ) -> Result<crate::lsm_iterator::FusedIterator<crate::lsm_iterator::LsmIterator>> {
-        // Reuse scan() logic but with a fixed read_ts instead of a ReadGuard.
-        let scan_iter = self.scan(lower, upper)?;
-        // The ScanIterator already holds the read_guard; we want a specific
-        // read_ts. Extract the inner FusedIterator and re-create with our ts.
-        // Actually, simpler: just use scan() which already creates a ReadGuard
-        // with the current read_ts. For transactions, the ReadGuard from the
-        // transaction's read_guard already protects the watermark. The scan's
-        // own ReadGuard is redundant but harmless.
-        Ok(scan_iter.into_inner())
+        let state = self.state.load_full();
+        let mvcc_read_ts = Some(read_ts);
+        let mvcc_enabled = self.mvcc.is_some();
+
+        let enc_lower;
+        let enc_upper;
+        let (physical_lower, physical_upper) = if mvcc_enabled {
+            enc_lower = match lower {
+                Bound::Included(k) => Bound::Included(crate::key::encode_internal_key(k, u64::MAX)),
+                Bound::Excluded(k) => Bound::Excluded(crate::key::encode_internal_key(k, 0)),
+                Bound::Unbounded => Bound::Unbounded,
+            };
+            enc_upper = match upper {
+                Bound::Included(k) => Bound::Included(crate::key::encode_internal_key(k, 0)),
+                Bound::Excluded(k) => Bound::Excluded(crate::key::encode_internal_key(k, 0)),
+                Bound::Unbounded => Bound::Unbounded,
+            };
+            (
+                enc_lower.as_ref().map(|v| v.as_slice()),
+                enc_upper.as_ref().map(|v| v.as_slice()),
+            )
+        } else {
+            (lower, upper)
+        };
+
+        let encode_seek = |k: &[u8]| -> Vec<u8> {
+            if mvcc_enabled {
+                crate::key::encode_internal_key(k, u64::MAX)
+            } else {
+                k.to_vec()
+            }
+        };
+
+        // memtable
+        let vlog = self.vlog.clone();
+        let mut m_merge_iterators = vec![Box::new(state.memtable.scan_with_vlog(
+            physical_lower,
+            physical_upper,
+            vlog.clone(),
+        ))];
+        for i in state.imm_memtables.iter() {
+            let it = i.scan_with_vlog(physical_lower, physical_upper, vlog.clone());
+            m_merge_iterators.push(Box::new(it));
+        }
+        let m_memo_iter = MergeIterator::create(m_merge_iterators);
+
+        // l0 sstables
+        let mut l0_iters = vec![];
+        for i in state.l0_sstables.iter() {
+            let t = state.sstables[i].clone();
+            if !t.range_overlap(physical_lower, physical_upper) {
+                continue;
+            }
+            let mut s = match lower {
+                Bound::Included(lower_key) => {
+                    let seek = encode_seek(lower_key);
+                    SsTableIterator::create_and_seek_to_key(t.clone(), KeySlice::from_slice(&seek))?
+                }
+                Bound::Excluded(lower_key) => {
+                    let seek = encode_seek(lower_key);
+                    let mut s = SsTableIterator::create_and_seek_to_key(
+                        t.clone(),
+                        KeySlice::from_slice(&seek),
+                    )?;
+                    if s.is_valid() {
+                        let seek_user_key = crate::key::encoded_user_key_prefix(&seek);
+                        while s.is_valid()
+                            && crate::key::encoded_user_key_prefix(s.key().raw_ref())
+                                == seek_user_key
+                        {
+                            s.next()?;
+                        }
+                    }
+                    s
+                }
+                Bound::Unbounded => SsTableIterator::create_and_seek_to_first(t.clone())?,
+            };
+            if let Some(ref vlog) = self.vlog {
+                s.set_vlog(vlog.clone());
+            }
+            l0_iters.push(Box::new(s));
+        }
+        let m_l0_iter = MergeIterator::create(l0_iters);
+        let two_l0_iter = TwoMergeIterator::create(m_memo_iter, m_l0_iter)?;
+
+        // l1-lmax sstables
+        let mut concat_iters = vec![];
+        for (_, sst_ids) in &state.levels {
+            let mut ss_tables = vec![];
+            for i in sst_ids {
+                let t = state.sstables[i].clone();
+                ss_tables.push(t);
+            }
+            let concat_iter = if let Some(ref vlog) = self.vlog {
+                match lower {
+                    Bound::Included(lower_key) => {
+                        let seek = encode_seek(lower_key);
+                        SstConcatIterator::create_and_seek_to_key_with_vlog(
+                            ss_tables,
+                            KeySlice::from_slice(&seek),
+                            vlog.clone(),
+                        )?
+                    }
+                    Bound::Excluded(lower_key) => {
+                        let seek = encode_seek(lower_key);
+                        let mut iter = SstConcatIterator::create_and_seek_to_key_with_vlog(
+                            ss_tables,
+                            KeySlice::from_slice(&seek),
+                            vlog.clone(),
+                        )?;
+                        if iter.is_valid() {
+                            let seek_user_key = crate::key::encoded_user_key_prefix(&seek);
+                            while iter.is_valid()
+                                && crate::key::encoded_user_key_prefix(iter.key().raw_ref())
+                                    == seek_user_key
+                            {
+                                iter.next()?;
+                            }
+                        }
+                        iter
+                    }
+                    Bound::Unbounded => SstConcatIterator::create_and_seek_to_first_with_vlog(
+                        ss_tables,
+                        vlog.clone(),
+                    )?,
+                }
+            } else {
+                match lower {
+                    Bound::Included(lower_key) => {
+                        let seek = encode_seek(lower_key);
+                        SstConcatIterator::create_and_seek_to_key(
+                            ss_tables,
+                            KeySlice::from_slice(&seek),
+                        )?
+                    }
+                    Bound::Excluded(lower_key) => {
+                        let seek = encode_seek(lower_key);
+                        let mut iter = SstConcatIterator::create_and_seek_to_key(
+                            ss_tables,
+                            KeySlice::from_slice(&seek),
+                        )?;
+                        if iter.is_valid() {
+                            let seek_user_key = crate::key::encoded_user_key_prefix(&seek);
+                            while iter.is_valid()
+                                && crate::key::encoded_user_key_prefix(iter.key().raw_ref())
+                                    == seek_user_key
+                            {
+                                iter.next()?;
+                            }
+                        }
+                        iter
+                    }
+                    Bound::Unbounded => SstConcatIterator::create_and_seek_to_first(ss_tables)?,
+                }
+            };
+            concat_iters.push(Box::new(concat_iter));
+        }
+        let m_iter = MergeIterator::create(concat_iters);
+        let two_m = TwoMergeIterator::create(two_l0_iter, m_iter)?;
+        let lit = LsmIterator::new(two_m, Self::into_vec(upper), mvcc_read_ts)?;
+        Ok(FusedIterator::new(lit))
     }
 
     /// Write a batch through MVCC (used by transaction commit).
-    pub(crate) fn mvcc_write_batch(&self, entries: &[(Vec<u8>, Vec<u8>, bool)]) -> Result<()> {
+    pub(crate) fn mvcc_write_batch(&self, entries: &[(&[u8], &[u8], bool)]) -> Result<()> {
         let mvcc = self.mvcc.as_ref().expect("mvcc_write_batch requires MVCC");
+        let _read_guard = self.active_memtable_lock.read();
         let state = self.state.load();
+        mvcc.write_batch(entries, &state.memtable)?;
+        drop(_read_guard);
+        self.try_freeze_memtable()?;
+        Ok(())
+    }
+
+    /// Write a batch through MVCC with owned entries (used by transaction commit).
+    pub(crate) fn mvcc_write_batch_owned(
+        &self,
+        entries: &[(Vec<u8>, Vec<u8>, bool)],
+    ) -> Result<()> {
         let borrowed: Vec<(&[u8], &[u8], bool)> = entries
             .iter()
             .map(|(k, v, t)| (k.as_slice(), v.as_slice(), *t))
             .collect();
-        mvcc.write_batch(&borrowed, &state.memtable)
+        self.mvcc_write_batch(&borrowed)
     }
 
     /// Inner helper that operates on an already-cloned state snapshot.

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -288,6 +288,10 @@ impl KvEngine {
         }))
     }
 
+    /// Create a new MVCC transaction with snapshot isolation.
+    ///
+    /// The transaction reads from a consistent snapshot at its creation
+    /// timestamp. Writes are buffered locally until `commit()`.
     pub fn new_txn(&self) -> Result<Arc<crate::mvcc::txn::Transaction>> {
         self.inner.new_txn()
     }
@@ -1759,6 +1763,10 @@ impl LsmStorageInner {
         Ok(())
     }
 
+    /// Create a new MVCC transaction with snapshot isolation.
+    ///
+    /// Requires MVCC to be enabled. The transaction's read timestamp
+    /// is pinned in the watermark to prevent GC of visible versions.
     pub fn new_txn(self: &Arc<Self>) -> Result<Arc<crate::mvcc::txn::Transaction>> {
         let mvcc = self.mvcc.as_ref().expect("new_txn requires MVCC");
         Ok(mvcc.new_txn(Arc::clone(self), false))

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -743,27 +743,28 @@ impl LsmStorageInner {
         if let Some((value, kind)) =
             self.lookup_memtable(&state, encoded, bloom_hash, mvcc_read_ts)?
         {
-            return match kind {
-                KvKind::ValuePointer => self.resolve_vlog_value_bytes(
-                    key,
-                    value.expect("ValuePointer kind must have a value"),
-                ),
-                KvKind::Inline | KvKind::Tombstone => Ok(value),
-            };
+            return self.resolve_value(key, value, kind);
         }
         // SST path — delegate to get_with_kind_inner which uses lookup_sst_raw.
         if let Some((value, kind)) =
             self.lookup_sst_raw(&state, encoded, bloom_hash, mvcc_read_ts)?
         {
-            return match kind {
-                KvKind::ValuePointer => self.resolve_vlog_value_bytes(
-                    key,
-                    value.expect("ValuePointer kind must have a value"),
-                ),
-                KvKind::Inline | KvKind::Tombstone => Ok(value),
-            };
+            return self.resolve_value(key, value, kind);
         }
         Ok(None)
+    }
+
+    /// Resolve a `(value, KvKind)` pair from a lookup into a final `Option<Bytes>`.
+    /// For `ValuePointer`, dereferences through the vLog. For `Inline`/`Tombstone`,
+    /// returns the value as-is.
+    fn resolve_value(&self, key: &[u8], value: Option<Bytes>, kind: KvKind) -> Result<Option<Bytes>> {
+        match kind {
+            KvKind::ValuePointer => self.resolve_vlog_value_bytes(
+                key,
+                value.expect("ValuePointer kind must have a value"),
+            ),
+            KvKind::Inline | KvKind::Tombstone => Ok(value),
+        }
     }
 
     /// Resolve a kind-prefixed `Bytes` value using zero-copy slicing.
@@ -840,24 +841,12 @@ impl LsmStorageInner {
         if let Some((value, kind)) =
             self.lookup_memtable(&state, &lookup_key, bloom_hash, Some(read_ts))?
         {
-            return match kind {
-                KvKind::ValuePointer => self.resolve_vlog_value_bytes(
-                    key,
-                    value.expect("ValuePointer kind must have a value"),
-                ),
-                KvKind::Inline | KvKind::Tombstone => Ok(value),
-            };
+            return self.resolve_value(key, value, kind);
         }
         if let Some((value, kind)) =
             self.lookup_sst_raw(&state, &lookup_key, bloom_hash, Some(read_ts))?
         {
-            return match kind {
-                KvKind::ValuePointer => self.resolve_vlog_value_bytes(
-                    key,
-                    value.expect("ValuePointer kind must have a value"),
-                ),
-                KvKind::Inline | KvKind::Tombstone => Ok(value),
-            };
+            return self.resolve_value(key, value, kind);
         }
         Ok(None)
     }
@@ -869,8 +858,17 @@ impl LsmStorageInner {
         upper: Bound<&[u8]>,
         read_ts: u64,
     ) -> Result<crate::lsm_iterator::FusedIterator<crate::lsm_iterator::LsmIterator>> {
+        self.scan_inner(lower, upper, Some(read_ts))
+    }
+
+    /// Shared scan logic used by both `scan` and `scan_with_ts`.
+    fn scan_inner(
+        &self,
+        lower: Bound<&[u8]>,
+        upper: Bound<&[u8]>,
+        mvcc_read_ts: Option<u64>,
+    ) -> Result<crate::lsm_iterator::FusedIterator<crate::lsm_iterator::LsmIterator>> {
         let state = self.state.load_full();
-        let mvcc_read_ts = Some(read_ts);
         let mvcc_enabled = self.mvcc.is_some();
 
         let enc_lower;
@@ -1769,183 +1767,10 @@ impl LsmStorageInner {
         // guard first guarantees read_ts ≤ every write that lands in the
         // state snapshot we load next.
         let read_guard = self.mvcc.as_ref().map(|m| m.new_read_guard());
-        let state = self.state.load_full();
         let mvcc_read_ts = read_guard.as_ref().map(|g| g.read_ts());
-        let mvcc_enabled = self.mvcc.is_some();
+        let lit = self.scan_inner(lower, upper, mvcc_read_ts)?;
 
-        // Encode bounds for MVCC using suffix-timestamp format.
-        // Lower bound: encode(key, u64::MAX) → newest version of key, sorts
-        //   before all real versions (inverted ts = 0x00*8).
-        // Upper bound: encode(key, 0) → inverted ts = 0xFF*8, sorts after all
-        //   real versions of key, ensuring the scan covers every version.
-        //
-        // For Excluded lower bound: encode(key, 0) → largest encoded position
-        //   for key (inverted ts = 0xFF*8). Excluding it skips ALL versions of
-        //   that user key, not just the ts=u64::MAX entry.
-        let enc_lower;
-        let enc_upper;
-        let (physical_lower, physical_upper) = if mvcc_enabled {
-            enc_lower = match lower {
-                Bound::Included(k) => Bound::Included(crate::key::encode_internal_key(k, u64::MAX)),
-                Bound::Excluded(k) => Bound::Excluded(crate::key::encode_internal_key(k, 0)),
-                Bound::Unbounded => Bound::Unbounded,
-            };
-            enc_upper = match upper {
-                Bound::Included(k) => Bound::Included(crate::key::encode_internal_key(k, 0)),
-                Bound::Excluded(k) => Bound::Excluded(crate::key::encode_internal_key(k, 0)),
-                Bound::Unbounded => Bound::Unbounded,
-            };
-            (
-                enc_lower.as_ref().map(|v| v.as_slice()),
-                enc_upper.as_ref().map(|v| v.as_slice()),
-            )
-        } else {
-            (lower, upper)
-        };
-
-        // Helper to encode a lower bound key for SST/concat seek.
-        let encode_seek = |k: &[u8]| -> Vec<u8> {
-            if mvcc_enabled {
-                crate::key::encode_internal_key(k, u64::MAX)
-            } else {
-                k.to_vec()
-            }
-        };
-
-        // memtable
-        let vlog = self.vlog.clone();
-        let mut m_merge_iterators = vec![Box::new(state.memtable.scan_with_vlog(
-            physical_lower,
-            physical_upper,
-            vlog.clone(),
-        ))];
-        for i in state.imm_memtables.iter() {
-            let it = i.scan_with_vlog(physical_lower, physical_upper, vlog.clone());
-            m_merge_iterators.push(Box::new(it));
-        }
-        let m_memo_iter = MergeIterator::create(m_merge_iterators);
-
-        // l0 sstables
-        let mut l0_iters = vec![];
-        for i in state.l0_sstables.iter() {
-            let t = state.sstables[i].clone();
-            if !t.range_overlap(physical_lower, physical_upper) {
-                continue;
-            }
-
-            let mut s = match lower {
-                Bound::Included(lower_key) => {
-                    let seek = encode_seek(lower_key);
-                    SsTableIterator::create_and_seek_to_key(t.clone(), KeySlice::from_slice(&seek))?
-                }
-                Bound::Excluded(lower_key) => {
-                    let seek = encode_seek(lower_key);
-                    let mut s = SsTableIterator::create_and_seek_to_key(
-                        t.clone(),
-                        KeySlice::from_slice(&seek),
-                    )?;
-                    // Skip all versions of the excluded key
-                    if s.is_valid() {
-                        let seek_user_key = crate::key::encoded_user_key_prefix(&seek);
-                        while s.is_valid()
-                            && crate::key::encoded_user_key_prefix(s.key().raw_ref())
-                                == seek_user_key
-                        {
-                            s.next()?;
-                        }
-                    }
-                    s
-                }
-                Bound::Unbounded => SsTableIterator::create_and_seek_to_first(t.clone())?,
-            };
-            if let Some(ref vlog) = self.vlog {
-                s.set_vlog(vlog.clone());
-            }
-            l0_iters.push(Box::new(s));
-        }
-        let m_l0_iter = MergeIterator::create(l0_iters);
-        let two_l0_iter = TwoMergeIterator::create(m_memo_iter, m_l0_iter)?;
-
-        // l1-lmax sstables
-        let mut concat_iters = vec![];
-        for (_, sst_ids) in &state.levels {
-            let mut ss_tables = vec![];
-            for i in sst_ids {
-                let t = state.sstables[i].clone();
-                ss_tables.push(t);
-            }
-            let concat_iter = if let Some(ref vlog) = self.vlog {
-                match lower {
-                    Bound::Included(lower_key) => {
-                        let seek = encode_seek(lower_key);
-                        SstConcatIterator::create_and_seek_to_key_with_vlog(
-                            ss_tables,
-                            KeySlice::from_slice(&seek),
-                            vlog.clone(),
-                        )?
-                    }
-                    Bound::Excluded(lower_key) => {
-                        let seek = encode_seek(lower_key);
-                        let mut iter = SstConcatIterator::create_and_seek_to_key_with_vlog(
-                            ss_tables,
-                            KeySlice::from_slice(&seek),
-                            vlog.clone(),
-                        )?;
-                        // Skip all versions of the excluded key
-                        if iter.is_valid() {
-                            let seek_user_key = crate::key::encoded_user_key_prefix(&seek);
-                            while iter.is_valid()
-                                && crate::key::encoded_user_key_prefix(iter.key().raw_ref())
-                                    == seek_user_key
-                            {
-                                iter.next()?;
-                            }
-                        }
-                        iter
-                    }
-                    Bound::Unbounded => SstConcatIterator::create_and_seek_to_first_with_vlog(
-                        ss_tables,
-                        vlog.clone(),
-                    )?,
-                }
-            } else {
-                match lower {
-                    Bound::Included(lower_key) => {
-                        let seek = encode_seek(lower_key);
-                        SstConcatIterator::create_and_seek_to_key(
-                            ss_tables,
-                            KeySlice::from_slice(&seek),
-                        )?
-                    }
-                    Bound::Excluded(lower_key) => {
-                        let seek = encode_seek(lower_key);
-                        let mut iter = SstConcatIterator::create_and_seek_to_key(
-                            ss_tables,
-                            KeySlice::from_slice(&seek),
-                        )?;
-                        // Skip all versions of the excluded key
-                        if iter.is_valid() {
-                            let seek_user_key = crate::key::encoded_user_key_prefix(&seek);
-                            while iter.is_valid()
-                                && crate::key::encoded_user_key_prefix(iter.key().raw_ref())
-                                    == seek_user_key
-                            {
-                                iter.next()?;
-                            }
-                        }
-                        iter
-                    }
-                    Bound::Unbounded => SstConcatIterator::create_and_seek_to_first(ss_tables)?,
-                }
-            };
-            concat_iters.push(Box::new(concat_iter));
-        }
-        let m_iter = MergeIterator::create(concat_iters);
-        let two_m = TwoMergeIterator::create(two_l0_iter, m_iter)?;
-        // Upper bound for LsmIterator uses decoded user keys (not encoded)
-        let lit = LsmIterator::new(two_m, Self::into_vec(upper), mvcc_read_ts)?;
-
-        Ok(ScanIterator::new(FusedIterator::new(lit), read_guard))
+        Ok(ScanIterator::new(lit, read_guard))
     }
 
     fn into_vec(b: Bound<&[u8]>) -> Bound<Vec<u8>> {

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1043,18 +1043,6 @@ impl LsmStorageInner {
         Ok(())
     }
 
-    /// Write a batch through MVCC with owned entries (used by transaction commit).
-    pub(crate) fn mvcc_write_batch_owned(
-        &self,
-        entries: &[(Vec<u8>, Vec<u8>, bool)],
-    ) -> Result<()> {
-        let borrowed: Vec<(&[u8], &[u8], bool)> = entries
-            .iter()
-            .map(|(k, v, t)| (k.as_slice(), v.as_slice(), *t))
-            .collect();
-        self.mvcc_write_batch(&borrowed)
-    }
-
     /// Inner helper that operates on an already-cloned state snapshot.
     /// Used by both `get_with_kind` (public) and `compare_and_set_with_kind`
     /// (which holds a write lock and passes the state directly).
@@ -1769,7 +1757,7 @@ impl LsmStorageInner {
     /// is pinned in the watermark to prevent GC of visible versions.
     pub fn new_txn(self: &Arc<Self>) -> Result<Arc<crate::mvcc::txn::Transaction>> {
         let mvcc = self.mvcc.as_ref().expect("new_txn requires MVCC");
-        Ok(mvcc.new_txn(Arc::clone(self), false))
+        Ok(mvcc.new_txn(Arc::clone(self), self.options.serializable))
     }
 
     /// Create an iterator over a range of keys.

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -376,7 +376,7 @@ mod tests {
         let txn = engine.new_txn().unwrap();
         txn.put(b"k", b"v").unwrap();
         assert_eq!(txn.get(b"k").unwrap(), Some(Bytes::from_static(b"v")));
-        txn.delete(b"k");
+        txn.delete(b"k").unwrap();
         assert_eq!(txn.get(b"k").unwrap(), None);
     }
 

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -3,9 +3,10 @@ mod watermark;
 
 use std::{
     collections::{BTreeMap, HashSet},
-    sync::Arc,
+    sync::{Arc, atomic::AtomicBool},
 };
 
+use crossbeam_skiplist::SkipMap;
 use parking_lot::Mutex;
 
 use self::{txn::Transaction, watermark::Watermark};
@@ -142,8 +143,24 @@ impl LsmMvccInner {
         self.ts.lock().0
     }
 
-    pub fn new_txn(&self, inner: Arc<LsmStorageInner>, serializable: bool) -> Arc<Transaction> {
-        unimplemented!()
+    pub fn new_txn(
+        self: &Arc<Self>,
+        inner: Arc<LsmStorageInner>,
+        serializable: bool,
+    ) -> Arc<Transaction> {
+        let read_guard = self.new_read_guard();
+        let key_hashes = if serializable {
+            Some(Mutex::new((HashSet::new(), HashSet::new())))
+        } else {
+            None
+        };
+        Arc::new(Transaction {
+            read_guard,
+            inner,
+            local_storage: Arc::new(SkipMap::new()),
+            committed: Arc::new(AtomicBool::new(false)),
+            key_hashes,
+        })
     }
 
     /// Create a `ReadGuard` that atomically reads the latest commit timestamp
@@ -194,6 +211,7 @@ impl Drop for ReadGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
 
     #[test]
     fn test_mvcc_inner_new() {
@@ -327,5 +345,101 @@ mod tests {
         // After dropping the guard, watermark advances to latest
         drop(guard);
         assert_eq!(mvcc.watermark(), 102);
+    }
+
+    #[test]
+    fn test_txn_put_get_local() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = crate::lsm_storage::KvEngine::open(
+            dir.path(),
+            crate::lsm_storage::LsmStorageOptions::default_for_test(),
+        )
+        .unwrap();
+        let txn = engine.new_txn().unwrap();
+        txn.put(b"name", b"alice");
+        assert_eq!(
+            txn.get(b"name").unwrap(),
+            Some(Bytes::from_static(b"alice"))
+        );
+        // Not committed yet — engine shouldn't see it.
+        assert_eq!(engine.get(b"name").unwrap(), None);
+    }
+
+    #[test]
+    fn test_txn_delete_local() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = crate::lsm_storage::KvEngine::open(
+            dir.path(),
+            crate::lsm_storage::LsmStorageOptions::default_for_test(),
+        )
+        .unwrap();
+        let txn = engine.new_txn().unwrap();
+        txn.put(b"k", b"v");
+        assert_eq!(txn.get(b"k").unwrap(), Some(Bytes::from_static(b"v")));
+        txn.delete(b"k");
+        assert_eq!(txn.get(b"k").unwrap(), None);
+    }
+
+    #[test]
+    fn test_txn_commit_visible() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = crate::lsm_storage::KvEngine::open(
+            dir.path(),
+            crate::lsm_storage::LsmStorageOptions::default_for_test(),
+        )
+        .unwrap();
+        let txn = engine.new_txn().unwrap();
+        txn.put(b"k", b"v");
+        txn.commit().unwrap();
+        // After commit, engine should see the value.
+        assert_eq!(engine.get(b"k").unwrap(), Some(Bytes::from_static(b"v")));
+    }
+
+    #[test]
+    fn test_txn_double_commit_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = crate::lsm_storage::KvEngine::open(
+            dir.path(),
+            crate::lsm_storage::LsmStorageOptions::default_for_test(),
+        )
+        .unwrap();
+        let txn = engine.new_txn().unwrap();
+        txn.put(b"k", b"v");
+        txn.commit().unwrap();
+        assert!(txn.commit().is_err());
+    }
+
+    #[test]
+    fn test_txn_snapshot_isolation() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = crate::lsm_storage::KvEngine::open(
+            dir.path(),
+            crate::lsm_storage::LsmStorageOptions::default_for_test(),
+        )
+        .unwrap();
+        // Write initial value.
+        engine.put(b"k", b"v1").unwrap();
+        // Start txn — should see v1 at its snapshot.
+        let txn = engine.new_txn().unwrap();
+        assert_eq!(txn.get(b"k").unwrap(), Some(Bytes::from_static(b"v1")));
+        // Write a new value outside the txn.
+        engine.put(b"k", b"v2").unwrap();
+        // Txn should still see v1 (snapshot isolation).
+        assert_eq!(txn.get(b"k").unwrap(), Some(Bytes::from_static(b"v1")));
+    }
+
+    #[test]
+    fn test_txn_local_writes_shadow_engine() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = crate::lsm_storage::KvEngine::open(
+            dir.path(),
+            crate::lsm_storage::LsmStorageOptions::default_for_test(),
+        )
+        .unwrap();
+        engine.put(b"k", b"engine_val").unwrap();
+        let txn = engine.new_txn().unwrap();
+        txn.put(b"k", b"txn_val");
+        // Local write should shadow engine value.
+        assert_eq!(txn.get(b"k").unwrap(), Some(Bytes::from_static(b"txn_val")));
     }
 }

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -356,7 +356,7 @@ mod tests {
         )
         .unwrap();
         let txn = engine.new_txn().unwrap();
-        txn.put(b"name", b"alice");
+        txn.put(b"name", b"alice").unwrap();
         assert_eq!(
             txn.get(b"name").unwrap(),
             Some(Bytes::from_static(b"alice"))
@@ -374,7 +374,7 @@ mod tests {
         )
         .unwrap();
         let txn = engine.new_txn().unwrap();
-        txn.put(b"k", b"v");
+        txn.put(b"k", b"v").unwrap();
         assert_eq!(txn.get(b"k").unwrap(), Some(Bytes::from_static(b"v")));
         txn.delete(b"k");
         assert_eq!(txn.get(b"k").unwrap(), None);
@@ -389,7 +389,7 @@ mod tests {
         )
         .unwrap();
         let txn = engine.new_txn().unwrap();
-        txn.put(b"k", b"v");
+        txn.put(b"k", b"v").unwrap();
         txn.commit().unwrap();
         // After commit, engine should see the value.
         assert_eq!(engine.get(b"k").unwrap(), Some(Bytes::from_static(b"v")));
@@ -404,7 +404,7 @@ mod tests {
         )
         .unwrap();
         let txn = engine.new_txn().unwrap();
-        txn.put(b"k", b"v");
+        txn.put(b"k", b"v").unwrap();
         txn.commit().unwrap();
         assert!(txn.commit().is_err());
     }
@@ -438,7 +438,7 @@ mod tests {
         .unwrap();
         engine.put(b"k", b"engine_val").unwrap();
         let txn = engine.new_txn().unwrap();
-        txn.put(b"k", b"txn_val");
+        txn.put(b"k", b"txn_val").unwrap();
         // Local write should shadow engine value.
         assert_eq!(txn.get(b"k").unwrap(), Some(Bytes::from_static(b"txn_val")));
     }

--- a/kv-engine/src/mvcc/txn.rs
+++ b/kv-engine/src/mvcc/txn.rs
@@ -88,7 +88,7 @@ impl Transaction {
         if entries.is_empty() {
             return Ok(());
         }
-        self.inner.mvcc_write_batch(&entries)
+        self.inner.mvcc_write_batch_owned(&entries)
     }
 }
 

--- a/kv-engine/src/mvcc/txn.rs
+++ b/kv-engine/src/mvcc/txn.rs
@@ -34,11 +34,20 @@ pub struct Transaction {
 }
 
 impl Transaction {
+    fn ensure_not_committed(&self) -> Result<()> {
+        anyhow::ensure!(
+            !self.committed.load(std::sync::atomic::Ordering::SeqCst),
+            "transaction already committed"
+        );
+        Ok(())
+    }
+
     /// Get a value by key.
     ///
     /// Checks local writes first (shadowing the engine), then falls back
     /// to the engine at the transaction's snapshot timestamp.
     pub fn get(&self, key: &[u8]) -> Result<Option<Bytes>> {
+        self.ensure_not_committed()?;
         // Check local writes first — they shadow the engine.
         if let Some(entry) = self.local_storage.get(key) {
             let val = entry.value();
@@ -57,6 +66,7 @@ impl Transaction {
     /// Merges local writes with the engine snapshot at the transaction's
     /// read timestamp, returning entries in sorted order.
     pub fn scan(self: &Arc<Self>, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> Result<TxnIterator> {
+        self.ensure_not_committed()?;
         let lsm_iter = self
             .inner
             .scan_with_ts(lower, upper, self.read_guard.read_ts())?;
@@ -76,6 +86,7 @@ impl Transaction {
     /// The value is not visible to other transactions until
     /// [`commit`](Transaction::commit) is called.
     pub fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
+        self.ensure_not_committed()?;
         anyhow::ensure!(
             !(value.len() == 1 && value[0] == crate::vlog::KvKind::Tombstone as u8),
             "value must not be the tombstone marker byte (0x02)"
@@ -90,6 +101,10 @@ impl Transaction {
     /// The deletion is not visible to other transactions until
     /// [`commit`](Transaction::commit) is called.
     pub fn delete(&self, key: &[u8]) {
+        assert!(
+            !self.committed.load(std::sync::atomic::Ordering::SeqCst),
+            "transaction already committed"
+        );
         self.local_storage.insert(
             Bytes::copy_from_slice(key),
             Bytes::from_static(&[crate::vlog::KvKind::Tombstone as u8]),
@@ -107,20 +122,24 @@ impl Transaction {
         {
             anyhow::bail!("transaction already committed");
         }
-        // Collect local writes into a batch.
-        let entries: Vec<(Vec<u8>, Vec<u8>, bool)> = self
+        // Collect local writes as Bytes (cheap clone — refcount only).
+        let entries: Vec<(Bytes, Bytes, bool)> = self
             .local_storage
             .iter()
             .map(|e| {
                 let val = e.value();
                 let is_tomb = val.len() == 1 && val[0] == crate::vlog::KvKind::Tombstone as u8;
-                (e.key().to_vec(), val.to_vec(), is_tomb)
+                (e.key().clone(), val.clone(), is_tomb)
             })
             .collect();
         if entries.is_empty() {
             return Ok(());
         }
-        self.inner.mvcc_write_batch_owned(&entries)
+        let borrowed: Vec<(&[u8], &[u8], bool)> = entries
+            .iter()
+            .map(|(k, v, t)| (k.as_ref(), v.as_ref(), *t))
+            .collect();
+        self.inner.mvcc_write_batch(&borrowed)
     }
 }
 

--- a/kv-engine/src/mvcc/txn.rs
+++ b/kv-engine/src/mvcc/txn.rs
@@ -104,15 +104,13 @@ impl Transaction {
     ///
     /// The deletion is not visible to other transactions until
     /// [`commit`](Transaction::commit) is called.
-    pub fn delete(&self, key: &[u8]) {
-        assert!(
-            !self.committed.load(std::sync::atomic::Ordering::SeqCst),
-            "transaction already committed"
-        );
+    pub fn delete(&self, key: &[u8]) -> Result<()> {
+        self.ensure_not_committed()?;
         self.local_storage.insert(
             Bytes::copy_from_slice(key),
             Bytes::from_static(&[crate::vlog::KvKind::Tombstone as u8]),
         );
+        Ok(())
     }
 
     /// Commit the transaction.

--- a/kv-engine/src/mvcc/txn.rs
+++ b/kv-engine/src/mvcc/txn.rs
@@ -17,6 +17,11 @@ use crate::{
     mvcc::ReadGuard,
 };
 
+/// An MVCC transaction that provides snapshot isolation.
+///
+/// Reads see a consistent snapshot at the transaction's `read_ts`.
+/// Writes are buffered locally and only become visible to other
+/// transactions on [`commit`](Transaction::commit).
 pub struct Transaction {
     /// Holds the read timestamp and registers it in the MVCC watermark for
     /// the transaction's lifetime, preventing GC of versions we might read.
@@ -29,6 +34,10 @@ pub struct Transaction {
 }
 
 impl Transaction {
+    /// Get a value by key.
+    ///
+    /// Checks local writes first (shadowing the engine), then falls back
+    /// to the engine at the transaction's snapshot timestamp.
     pub fn get(&self, key: &[u8]) -> Result<Option<Bytes>> {
         // Check local writes first — they shadow the engine.
         if let Some(entry) = self.local_storage.get(key) {
@@ -43,6 +52,10 @@ impl Transaction {
         self.inner.get_with_ts(key, self.read_guard.read_ts())
     }
 
+    /// Scan a range of keys.
+    ///
+    /// Merges local writes with the engine snapshot at the transaction's
+    /// read timestamp, returning entries in sorted order.
     pub fn scan(self: &Arc<Self>, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> Result<TxnIterator> {
         let lsm_iter = self
             .inner
@@ -58,6 +71,10 @@ impl Transaction {
         TxnIterator::create(Arc::clone(self), merged)
     }
 
+    /// Buffer a write locally.
+    ///
+    /// The value is not visible to other transactions until
+    /// [`commit`](Transaction::commit) is called.
     pub fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
         anyhow::ensure!(
             !(value.len() == 1 && value[0] == crate::vlog::KvKind::Tombstone as u8),
@@ -68,6 +85,10 @@ impl Transaction {
         Ok(())
     }
 
+    /// Buffer a deletion locally.
+    ///
+    /// The deletion is not visible to other transactions until
+    /// [`commit`](Transaction::commit) is called.
     pub fn delete(&self, key: &[u8]) {
         self.local_storage.insert(
             Bytes::copy_from_slice(key),
@@ -75,6 +96,10 @@ impl Transaction {
         );
     }
 
+    /// Commit the transaction.
+    ///
+    /// All buffered writes are applied atomically under a single commit
+    /// timestamp. Returns an error if the transaction was already committed.
     pub fn commit(&self) -> Result<()> {
         if self
             .committed
@@ -110,6 +135,9 @@ fn map_bound(b: Bound<&[u8]>) -> Bound<Bytes> {
 type SkipMapRangeIter<'a> =
     crossbeam_skiplist::map::Range<'a, Bytes, (Bound<Bytes>, Bound<Bytes>), Bytes, Bytes>;
 
+/// Iterator over a transaction's local writes (the SkipMap).
+///
+/// Uses ouroboros to safely self-reference the skipmap iterator.
 #[self_referencing]
 pub struct TxnLocalIterator {
     /// Stores a reference to the skipmap.
@@ -148,6 +176,10 @@ impl StorageIterator for TxnLocalIterator {
     }
 }
 
+/// Iterator that merges a transaction's local writes with the engine snapshot.
+///
+/// Local writes shadow engine entries with the same key. Tombstones
+/// (both local and from the engine) are skipped automatically.
 pub struct TxnIterator {
     _txn: Arc<Transaction>,
     iter: TwoMergeIterator<TxnLocalIterator, FusedIterator<LsmIterator>>,

--- a/kv-engine/src/mvcc/txn.rs
+++ b/kv-engine/src/mvcc/txn.rs
@@ -120,7 +120,12 @@ impl Transaction {
     pub fn commit(&self) -> Result<()> {
         if self
             .committed
-            .compare_exchange(false, true, std::sync::atomic::Ordering::SeqCst, std::sync::atomic::Ordering::SeqCst)
+            .compare_exchange(
+                false,
+                true,
+                std::sync::atomic::Ordering::SeqCst,
+                std::sync::atomic::Ordering::SeqCst,
+            )
             .is_err()
         {
             anyhow::bail!("transaction already committed");
@@ -144,7 +149,8 @@ impl Transaction {
             .collect();
         if let Err(e) = self.inner.mvcc_write_batch(&borrowed) {
             // Revert committed flag so caller can retry.
-            self.committed.store(false, std::sync::atomic::Ordering::SeqCst);
+            self.committed
+                .store(false, std::sync::atomic::Ordering::SeqCst);
             return Err(e);
         }
         Ok(())

--- a/kv-engine/src/mvcc/txn.rs
+++ b/kv-engine/src/mvcc/txn.rs
@@ -33,6 +33,10 @@ pub struct Transaction {
     pub(crate) key_hashes: Option<Mutex<(HashSet<u32>, HashSet<u32>)>>,
 }
 
+fn is_tombstone(val: &[u8]) -> bool {
+    val.len() == 1 && val[0] == crate::vlog::KvKind::Tombstone as u8
+}
+
 impl Transaction {
     fn ensure_not_committed(&self) -> Result<()> {
         anyhow::ensure!(
@@ -52,7 +56,7 @@ impl Transaction {
         if let Some(entry) = self.local_storage.get(key) {
             let val = entry.value();
             // Tombstone in local storage means deleted within this txn.
-            if val.len() == 1 && val[0] == crate::vlog::KvKind::Tombstone as u8 {
+            if is_tombstone(val) {
                 return Ok(None);
             }
             return Ok(Some(val.clone()));
@@ -88,7 +92,7 @@ impl Transaction {
     pub fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
         self.ensure_not_committed()?;
         anyhow::ensure!(
-            !(value.len() == 1 && value[0] == crate::vlog::KvKind::Tombstone as u8),
+            !is_tombstone(value),
             "value must not be the tombstone marker byte (0x02)"
         );
         self.local_storage
@@ -128,7 +132,7 @@ impl Transaction {
             .iter()
             .map(|e| {
                 let val = e.value();
-                let is_tomb = val.len() == 1 && val[0] == crate::vlog::KvKind::Tombstone as u8;
+                let is_tomb = is_tombstone(val);
                 (e.key().clone(), val.clone(), is_tomb)
             })
             .collect();
@@ -211,10 +215,7 @@ impl TxnIterator {
     ) -> Result<Self> {
         let mut s = Self { _txn: txn, iter };
         // Position at first valid entry, skipping tombstones.
-        while s.iter.is_valid()
-            && s.iter.value().len() == 1
-            && s.iter.value()[0] == crate::vlog::KvKind::Tombstone as u8
-        {
+        while s.iter.is_valid() && is_tombstone(s.iter.value()) {
             s.iter.next()?;
         }
         Ok(s)
@@ -242,10 +243,7 @@ impl StorageIterator for TxnIterator {
     fn next(&mut self) -> Result<()> {
         // Advance past current entry, then skip tombstones.
         self.iter.next()?;
-        while self.iter.is_valid()
-            && self.iter.value().len() == 1
-            && self.iter.value()[0] == crate::vlog::KvKind::Tombstone as u8
-        {
+        while self.iter.is_valid() && is_tombstone(self.iter.value()) {
             self.iter.next()?;
         }
         Ok(())

--- a/kv-engine/src/mvcc/txn.rs
+++ b/kv-engine/src/mvcc/txn.rs
@@ -47,16 +47,22 @@ impl Transaction {
         let lsm_iter = self
             .inner
             .scan_with_ts(lower, upper, self.read_guard.read_ts())?;
-        let local_iter = TxnLocalIterator::new(
+        let mut local_iter = TxnLocalIterator::new(
             self.local_storage.clone(),
             |map| map.range::<Bytes, _>((map_bound(lower), map_bound(upper))),
             (Bytes::new(), Bytes::new()),
         );
+        // Position at first entry (same as MemTableIterator::scan).
+        local_iter.next()?;
         let merged = TwoMergeIterator::create(local_iter, lsm_iter)?;
         TxnIterator::create(Arc::clone(self), merged)
     }
 
     pub fn put(&self, key: &[u8], value: &[u8]) {
+        assert!(
+            !(value.len() == 1 && value[0] == crate::vlog::KvKind::Tombstone as u8),
+            "value must not be the tombstone marker byte (0x02)"
+        );
         self.local_storage
             .insert(Bytes::copy_from_slice(key), Bytes::copy_from_slice(value));
     }

--- a/kv-engine/src/mvcc/txn.rs
+++ b/kv-engine/src/mvcc/txn.rs
@@ -30,23 +30,73 @@ pub struct Transaction {
 
 impl Transaction {
     pub fn get(&self, key: &[u8]) -> Result<Option<Bytes>> {
-        unimplemented!()
+        // Check local writes first — they shadow the engine.
+        if let Some(entry) = self.local_storage.get(key) {
+            let val = entry.value();
+            // Tombstone in local storage means deleted within this txn.
+            if val.len() == 1 && val[0] == crate::vlog::KvKind::Tombstone as u8 {
+                return Ok(None);
+            }
+            return Ok(Some(val.clone()));
+        }
+        // Fall back to engine read at our snapshot timestamp.
+        self.inner.get_with_ts(key, self.read_guard.read_ts())
     }
 
     pub fn scan(self: &Arc<Self>, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> Result<TxnIterator> {
-        unimplemented!()
+        let lsm_iter = self
+            .inner
+            .scan_with_ts(lower, upper, self.read_guard.read_ts())?;
+        let local_iter = TxnLocalIterator::new(
+            self.local_storage.clone(),
+            |map| map.range::<Bytes, _>((map_bound(lower), map_bound(upper))),
+            (Bytes::new(), Bytes::new()),
+        );
+        let merged = TwoMergeIterator::create(local_iter, lsm_iter)?;
+        TxnIterator::create(Arc::clone(self), merged)
     }
 
     pub fn put(&self, key: &[u8], value: &[u8]) {
-        unimplemented!()
+        self.local_storage
+            .insert(Bytes::copy_from_slice(key), Bytes::copy_from_slice(value));
     }
 
     pub fn delete(&self, key: &[u8]) {
-        unimplemented!()
+        self.local_storage.insert(
+            Bytes::copy_from_slice(key),
+            Bytes::from_static(&[crate::vlog::KvKind::Tombstone as u8]),
+        );
     }
 
     pub fn commit(&self) -> Result<()> {
-        unimplemented!()
+        if self
+            .committed
+            .swap(true, std::sync::atomic::Ordering::SeqCst)
+        {
+            anyhow::bail!("transaction already committed");
+        }
+        // Collect local writes into a batch.
+        let entries: Vec<(Vec<u8>, Vec<u8>, bool)> = self
+            .local_storage
+            .iter()
+            .map(|e| {
+                let val = e.value();
+                let is_tomb = val.len() == 1 && val[0] == crate::vlog::KvKind::Tombstone as u8;
+                (e.key().to_vec(), val.to_vec(), is_tomb)
+            })
+            .collect();
+        if entries.is_empty() {
+            return Ok(());
+        }
+        self.inner.mvcc_write_batch(&entries)
+    }
+}
+
+fn map_bound(b: Bound<&[u8]>) -> Bound<Bytes> {
+    match b {
+        Bound::Included(v) => Bound::Included(Bytes::copy_from_slice(v)),
+        Bound::Excluded(v) => Bound::Excluded(Bytes::copy_from_slice(v)),
+        Bound::Unbounded => Bound::Unbounded,
     }
 }
 
@@ -69,19 +119,25 @@ impl StorageIterator for TxnLocalIterator {
     type KeyType<'a> = &'a [u8];
 
     fn value(&self) -> &[u8] {
-        unimplemented!()
+        self.borrow_item().1.as_ref()
     }
 
     fn key(&self) -> &[u8] {
-        unimplemented!()
+        self.borrow_item().0.as_ref()
     }
 
     fn is_valid(&self) -> bool {
-        unimplemented!()
+        !self.borrow_item().0.is_empty()
     }
 
     fn next(&mut self) -> Result<()> {
-        unimplemented!()
+        let n = self.with_iter_mut(|iter| {
+            iter.next()
+                .map(|e| (e.key().clone(), e.value().clone()))
+                .unwrap_or_else(|| (Bytes::new(), Bytes::new()))
+        });
+        self.with_mut(|m| *m.item = n);
+        Ok(())
     }
 }
 
@@ -95,7 +151,15 @@ impl TxnIterator {
         txn: Arc<Transaction>,
         iter: TwoMergeIterator<TxnLocalIterator, FusedIterator<LsmIterator>>,
     ) -> Result<Self> {
-        unimplemented!()
+        let mut s = Self { _txn: txn, iter };
+        // Position at first valid entry, skipping tombstones.
+        while s.iter.is_valid()
+            && s.iter.value().len() == 1
+            && s.iter.value()[0] == crate::vlog::KvKind::Tombstone as u8
+        {
+            s.iter.next()?;
+        }
+        Ok(s)
     }
 }
 
@@ -118,7 +182,15 @@ impl StorageIterator for TxnIterator {
     }
 
     fn next(&mut self) -> Result<()> {
-        unimplemented!()
+        // Advance past current entry, then skip tombstones.
+        self.iter.next()?;
+        while self.iter.is_valid()
+            && self.iter.value().len() == 1
+            && self.iter.value()[0] == crate::vlog::KvKind::Tombstone as u8
+        {
+            self.iter.next()?;
+        }
+        Ok(())
     }
 
     fn num_active_iterators(&self) -> usize {

--- a/kv-engine/src/mvcc/txn.rs
+++ b/kv-engine/src/mvcc/txn.rs
@@ -58,13 +58,14 @@ impl Transaction {
         TxnIterator::create(Arc::clone(self), merged)
     }
 
-    pub fn put(&self, key: &[u8], value: &[u8]) {
-        assert!(
+    pub fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
+        anyhow::ensure!(
             !(value.len() == 1 && value[0] == crate::vlog::KvKind::Tombstone as u8),
             "value must not be the tombstone marker byte (0x02)"
         );
         self.local_storage
             .insert(Bytes::copy_from_slice(key), Bytes::copy_from_slice(value));
+        Ok(())
     }
 
     pub fn delete(&self, key: &[u8]) {

--- a/kv-engine/src/mvcc/txn.rs
+++ b/kv-engine/src/mvcc/txn.rs
@@ -120,7 +120,8 @@ impl Transaction {
     pub fn commit(&self) -> Result<()> {
         if self
             .committed
-            .swap(true, std::sync::atomic::Ordering::SeqCst)
+            .compare_exchange(false, true, std::sync::atomic::Ordering::SeqCst, std::sync::atomic::Ordering::SeqCst)
+            .is_err()
         {
             anyhow::bail!("transaction already committed");
         }
@@ -141,7 +142,12 @@ impl Transaction {
             .iter()
             .map(|(k, v, t)| (k.as_ref(), v.as_ref(), *t))
             .collect();
-        self.inner.mvcc_write_batch(&borrowed)
+        if let Err(e) = self.inner.mvcc_write_batch(&borrowed) {
+            // Revert committed flag so caller can retry.
+            self.committed.store(false, std::sync::atomic::Ordering::SeqCst);
+            return Err(e);
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary

Implements the Transaction API for MVCC snapshot isolation.

## Changes
- `LsmMvccInner::new_txn` creates transactions with snapshot read_ts
- `Transaction::get` checks local writes then falls back to engine read at snapshot timestamp
- `Transaction::put/delete` write to local SkipMap storage
- `Transaction::commit` batches local writes through MVCC write_batch with single commit_ts
- `TxnLocalIterator` implements StorageIterator for local transaction writes
- `TxnIterator` merges local + engine iterators, skipping tombstones
- `ScanIterator::into_inner` exposed for transaction scan support
- `LsmStorageInner::get_with_ts/scan_with_ts/mvcc_write_batch` helpers
- 6 new tests: put/get local, delete, commit visibility, double-commit, snapshot isolation, local shadowing

## Verification
- [x] All 280 tests pass
- [x] cargo make check passes (fmt, clippy, test, typos)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full MVCC transactions: create txns, get/scan/put/delete with snapshot isolation and txn-local visibility.
  * Timestamp-aware point reads and range scans for consistent historical views.
  * Transaction API now returns a transaction handle for direct use.

* **Bug Fixes / Reliability**
  * Single-commit enforcement to prevent double-commit races.
  * Commit path reliably persists txn-local batches.
  * Scans/iterators skip tombstones so deleted entries are hidden.

* **Tests**
  * Added transaction tests covering visibility, isolation, commit, and local-write behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->