### PR TITLE
feat: watermark-aware version dropping in compaction (Phase 9)

### DIFF
--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -664,7 +664,7 @@ impl LsmStorageInner {
         }
     }
 
-    fn trigger_compaction(&self) -> Result<()> {
+    pub(crate) fn trigger_compaction(&self) -> Result<()> {
         let task = self
             .compaction_controller
             .generate_compaction_task(self.state.load_full().as_ref());

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -277,6 +277,18 @@ impl LsmStorageInner {
         let mut builder = SsTableBuilder::new(self.options.block_size);
         builder.set_collect_blocks(should_backfill);
 
+        // Snapshot the watermark once before the loop. When no active readers
+        // exist, watermark() returns latest_commit_ts so everything below it
+        // is eligible for GC.
+        let watermark = self.mvcc.as_ref().map(|m| m.watermark());
+
+        // Track state for watermark-aware version dropping. Keys iterate
+        // newest-first within each user key (inverted ts encoding), so we
+        // keep all versions above the watermark and only the newest version
+        // at or below the watermark per user key.
+        let mut prev_user_key: Vec<u8> = Vec::new();
+        let mut seen_below_watermark = false;
+
         while iter.is_valid() {
             if builder.estimated_size() >= self.options.target_sst_size {
                 all_vlog_ids.extend_from_slice(builder.vlog_file_ids());
@@ -297,13 +309,38 @@ impl LsmStorageInner {
             // Detect tombstones: single KvKind::Tombstone byte.
             let raw = iter.raw_value();
             let is_tombstone = raw.len() == 1 && raw[0] == crate::vlog::KvKind::Tombstone as u8;
-            // With MVCC, preserve all versions (including tombstones) so older
-            // timestamp reads can still see them. Only drop tombstones at the
-            // bottom level in non-MVCC mode.
-            // TODO(watermark-compaction): Use watermark-aware version dropping —
-            // keep every version with commit_ts > watermark, plus the newest
-            // version with commit_ts <= watermark, and drop older versions.
-            if !is_tombstone || !compact_to_bottom_level || self.mvcc.is_some() {
+
+            let should_keep = if let Some(wm) = watermark {
+                let key = iter.key();
+                let ts = key.ts();
+                let user_key = key.encoded_user_key();
+
+                // New user key group — reset tracking state
+                if user_key != prev_user_key {
+                    prev_user_key.clear();
+                    prev_user_key.extend_from_slice(user_key);
+                    seen_below_watermark = false;
+                }
+
+                if ts > wm {
+                    // Active readers might need this version — always keep
+                    true
+                } else if !seen_below_watermark {
+                    // First version at or below the watermark for this user
+                    // key — keep as the newest visible version. Drop tombstones
+                    // at the bottom level since no reader can see them.
+                    seen_below_watermark = true;
+                    !(is_tombstone && compact_to_bottom_level)
+                } else {
+                    // Older version at or below the watermark — drop
+                    false
+                }
+            } else {
+                // No MVCC — drop tombstones at the bottom level only
+                !is_tombstone || !compact_to_bottom_level
+            };
+
+            if should_keep {
                 builder.add_raw(iter.key(), iter.raw_value())?;
             }
             iter.next()?;

--- a/kv-engine/src/tests/compaction.rs
+++ b/kv-engine/src/tests/compaction.rs
@@ -320,7 +320,6 @@ fn test_watermark_gc_preserves_versions_for_active_reader() {
     let dir = tempdir().unwrap();
     let storage =
         Arc::new(LsmStorageInner::open(&dir, LsmStorageOptions::default_for_test()).unwrap());
-    let _txn = storage.new_txn().unwrap();
 
     storage.put(b"a", b"v1").unwrap();
     sync(&storage);
@@ -366,7 +365,7 @@ fn test_watermark_gc_drops_tombstone_at_bottom() {
     storage.force_full_compaction().unwrap();
 
     // Both the put and the tombstone are at/below watermark — both dropped.
-    let mut iter = construct_merge_iterator_over_storage(&storage.state.load());
+    let iter = construct_merge_iterator_over_storage(&storage.state.load());
     assert!(!iter.is_valid());
 }
 

--- a/kv-engine/src/tests/compaction.rs
+++ b/kv-engine/src/tests/compaction.rs
@@ -336,7 +336,8 @@ fn test_watermark_gc_preserves_versions_for_active_reader() {
 
     storage.force_full_compaction().unwrap();
 
-    // All versions visible to the reader (ts=1..=4) are preserved.
+    // Versions ts=2..=4 are above the watermark (always kept).
+    // Version ts=1 is the newest at/below the watermark (kept as visible snapshot).
     let mut iter = construct_merge_iterator_over_storage(&storage.state.load());
     check_iter_result_by_key(
         &mut iter,
@@ -393,4 +394,38 @@ fn test_watermark_gc_multiple_keys() {
             (Bytes::from_static(b"b"), Bytes::from_static(b"b1")),
         ],
     );
+}
+
+#[test]
+fn test_watermark_gc_preserves_tombstone_at_non_bottom_level() {
+    // Tombstone at a non-bottom level is preserved even below the watermark,
+    // because deeper levels may still have older versions.
+    use crate::compact::{CompactionOptions, LeveledCompactionOptions};
+
+    let dir = tempdir().unwrap();
+    let options = LsmStorageOptions::default_for_compaction_test(CompactionOptions::Leveled(
+        LeveledCompactionOptions {
+            level_size_multiplier: 2,
+            level0_file_num_compaction_trigger: 1,
+            max_levels: 3,
+            base_level_size_mb: 128,
+        },
+    ));
+    let storage = Arc::new(LsmStorageInner::open(&dir, options).unwrap());
+
+    // Write "a" = "v1" and flush to L0, then compact to L1.
+    storage.put(b"a", b"v1").unwrap();
+    sync(&storage);
+    storage.trigger_compaction().unwrap();
+
+    // Delete "a" (tombstone) and flush to L0.
+    storage.delete(b"a").unwrap();
+    sync(&storage);
+
+    // Compact L0→L1. L1 is not the bottom level (L2 exists),
+    // so the tombstone must be preserved to hide the older "a"=v1 in L1.
+    storage.trigger_compaction().unwrap();
+
+    // Tombstone masks the older version — key is deleted.
+    assert_eq!(storage.get(b"a").unwrap(), None);
 }

--- a/kv-engine/src/tests/compaction.rs
+++ b/kv-engine/src/tests/compaction.rs
@@ -287,3 +287,111 @@ fn test_task3_integration() {
     assert_eq!(storage.get(b"--").unwrap(), None);
     assert_eq!(storage.get(b"555").unwrap(), None);
 }
+
+#[test]
+fn test_watermark_gc_drops_old_versions() {
+    // No active readers → watermark = latest_commit_ts.
+    // After compaction, only the newest version of each key survives.
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(&dir, LsmStorageOptions::default_for_test()).unwrap());
+
+    storage.put(b"a", b"v1").unwrap();
+    sync(&storage);
+    storage.put(b"a", b"v2").unwrap();
+    sync(&storage);
+    storage.put(b"a", b"v3").unwrap();
+    sync(&storage);
+
+    storage.force_full_compaction().unwrap();
+
+    let mut iter = construct_merge_iterator_over_storage(&storage.state.load());
+    check_iter_result_by_key(
+        &mut iter,
+        vec![(Bytes::from_static(b"a"), Bytes::from_static(b"v3"))],
+    );
+}
+
+#[test]
+fn test_watermark_gc_preserves_versions_for_active_reader() {
+    // Active reader at ts=1 pins the watermark at 1.
+    // Versions with ts > watermark (ts=2, ts=3, ts=4) are all kept.
+    // The newest version at ts <= watermark (ts=1) is also kept.
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(&dir, LsmStorageOptions::default_for_test()).unwrap());
+    let _txn = storage.new_txn().unwrap();
+
+    storage.put(b"a", b"v1").unwrap();
+    sync(&storage);
+
+    // Pin a reader at the current latest_commit_ts (ts=1).
+    let _reader = storage.new_txn().unwrap();
+
+    storage.put(b"a", b"v2").unwrap();
+    sync(&storage);
+    storage.put(b"a", b"v3").unwrap();
+    sync(&storage);
+    storage.put(b"a", b"v4").unwrap();
+    sync(&storage);
+
+    storage.force_full_compaction().unwrap();
+
+    // All versions visible to the reader (ts=1..=4) are preserved.
+    let mut iter = construct_merge_iterator_over_storage(&storage.state.load());
+    check_iter_result_by_key(
+        &mut iter,
+        vec![
+            (Bytes::from_static(b"a"), Bytes::from_static(b"v4")),
+            (Bytes::from_static(b"a"), Bytes::from_static(b"v3")),
+            (Bytes::from_static(b"a"), Bytes::from_static(b"v2")),
+            (Bytes::from_static(b"a"), Bytes::from_static(b"v1")),
+        ],
+    );
+}
+
+#[test]
+fn test_watermark_gc_drops_tombstone_at_bottom() {
+    // Tombstone at the bottom level with ts <= watermark is dropped
+    // (no reader can see it, no lower level has older versions).
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(&dir, LsmStorageOptions::default_for_test()).unwrap());
+
+    storage.put(b"a", b"v1").unwrap();
+    sync(&storage);
+    storage.delete(b"a").unwrap();
+    sync(&storage);
+
+    storage.force_full_compaction().unwrap();
+
+    // Both the put and the tombstone are at/below watermark — both dropped.
+    let mut iter = construct_merge_iterator_over_storage(&storage.state.load());
+    assert!(!iter.is_valid());
+}
+
+#[test]
+fn test_watermark_gc_multiple_keys() {
+    // Interleaved versions of different keys are handled independently.
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(&dir, LsmStorageOptions::default_for_test()).unwrap());
+
+    storage.put(b"a", b"a1").unwrap();
+    sync(&storage);
+    storage.put(b"b", b"b1").unwrap();
+    storage.put(b"a", b"a2").unwrap();
+    sync(&storage);
+
+    storage.force_full_compaction().unwrap();
+
+    // Only the newest version of each key survives.
+    let mut iter = construct_merge_iterator_over_storage(&storage.state.load());
+    check_iter_result_by_key(
+        &mut iter,
+        vec![
+            (Bytes::from_static(b"a"), Bytes::from_static(b"a2")),
+            (Bytes::from_static(b"b"), Bytes::from_static(b"b1")),
+        ],
+    );
+}

--- a/todo.md
+++ b/todo.md
@@ -90,8 +90,8 @@ PR #82 (merged 2026-06-10). Optimistic concurrency control for serializable isol
 
 - [x] Preserve tombstones during compaction when MVCC enabled
 - [x] Populate SST `max_ts` (persisted in v2 footer, recovered on open)
-- [ ] Watermark-aware version dropping in compaction
-- [ ] Tests for old-version reclamation
+- [x] Watermark-aware version dropping in compaction
+- [x] Tests for old-version reclamation
 
 ---
 
@@ -126,9 +126,9 @@ PR #82 (merged 2026-06-10). Optimistic concurrency control for serializable isol
 - [x] 8. Transaction local writes shadow snapshot state (test_txn_local_writes_shadow_engine in mvcc.rs)
 - [x] 9. Point-key serializable transaction aborts on read/write conflict
 - [x] 10. Point-key serializable transaction commits when write sets do not conflict
-- [ ] 11. Compaction keeps versions with `commit_ts > watermark`
-- [ ] 12. Compaction keeps newest version with `commit_ts <= watermark`
-- [ ] 13. Compaction does not resurrect deleted keys
+- [x] 11. Compaction keeps versions with `commit_ts > watermark`
+- [x] 12. Compaction keeps newest version with `commit_ts <= watermark`
+- [x] 13. Compaction does not resurrect deleted keys
 - [ ] 14. vLog values remain readable across multiple versions
 - [ ] 15. vLog GC does not remove pointer still visible to old snapshot
 - [x] 16. Prefix user keys sort and seek correctly


### PR DESCRIPTION
## Summary

Implements watermark-aware version dropping during compaction — the core mechanism for MVCC garbage collection. Old versions no longer visible to any active reader are dropped during compaction, reclaiming disk space.

## Changes

**`kv-engine/src/compact.rs`** — Modified `compact_from_iter()`:
- Snapshot the watermark once before the compaction loop
- Track current user key and whether a version at/below the watermark has been kept
- For each key (sorted newest-first within user key groups):
  - `ts > watermark` → always keep (active readers may need it)
  - First version with `ts <= watermark` → keep as newest visible version
  - Older versions with `ts <= watermark` → drop
  - Tombstones at bottom level with `ts <= watermark` → drop

**`kv-engine/src/tests/compaction.rs`** — 4 new tests:
- `test_watermark_gc_drops_old_versions` — no active readers, only newest version survives
- `test_watermark_gc_preserves_versions_for_active_reader` — pinned reader preserves all versions above watermark
- `test_watermark_gc_drops_tombstone_at_bottom` — tombstone dropped when no reader can see it
- `test_watermark_gc_multiple_keys` — interleaved keys handled independently

**`todo.md`** — Phase 9 items marked complete, tests 11-13 checked off

## Review Fixes

| Finding | Source | Fix |
|---------|--------|-----|
| `_txn` pins watermark at 0, bypassing `ts <= wm` path | Gemini | Removed `_txn`; `_reader` (after first write) pins watermark at 1 |
| `unused-mut` on iterator in tombstone test | Clippy | Removed `mut` |

## Test Results

343 tests pass, 0 failures. Clippy clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compaction is now watermark-aware: preserves versions required by active readers while removing obsolete versions and cleaning up bottom-level tombstones for improved storage efficiency.

* **Tests**
  * Added integration tests validating garbage collection during full compaction, including pinned-reader scenarios, multi-key histories, iterator behavior, and tombstone handling.

* **Documentation**
  * Updated roadmap/todo to mark MVCC compaction GC and related tests as completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->