### PR TITLE
perf: eliminate unnecessary allocations on hot paths

### DIFF
--- a/kv-engine/src/key.rs
+++ b/kv-engine/src/key.rs
@@ -214,12 +214,15 @@ impl<T: AsRef<[u8]>> Key<T> {
     }
 
     /// Decode the user key into a caller-provided buffer.
+    /// On failure (non-encoded key), falls back to the raw key bytes.
     pub fn decode_user_key_into(&self, dst: &mut Vec<u8>) {
-        if let Some(prefix) = encoded_user_key_prefix(self.0.as_ref()) {
-            decode_user_key_into(prefix, dst);
-        } else {
-            dst.clear();
+        if let Some(prefix) = encoded_user_key_prefix(self.0.as_ref())
+            && decode_user_key_into(prefix, dst)
+        {
+            return;
         }
+        dst.clear();
+        dst.extend_from_slice(self.0.as_ref());
     }
 
     /// Return the raw encoded internal key bytes.

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1208,7 +1208,6 @@ impl LsmStorageInner {
     /// Returns `Ok(Some((value, kind, found_key)))` if found.
     /// `found_key` is the full encoded internal key of the matching entry,
     /// used for vLog key verification when the value is a ValuePointer.
-    #[allow(clippy::missing_const_for_thread_local)]
     fn lookup_memtable(
         &self,
         state: &LsmStorageState,
@@ -1221,19 +1220,13 @@ impl LsmStorageInner {
             // MVCC path: key is encode(user_key, u64::MAX), need versioned lookup
             thread_local! {
                 static USER_KEY_BUF: std::cell::RefCell<Vec<u8>> =
-                    std::cell::RefCell::new(Vec::new());
+                    const { std::cell::RefCell::new(Vec::new()) };
             }
             return USER_KEY_BUF.with(|buf| {
                 let mut user_key_buf = buf.borrow_mut();
                 user_key_buf.clear();
-                let user_key: &[u8] = if let Some(prefix) = crate::key::encoded_user_key_prefix(key)
-                    && crate::key::decode_user_key_into(prefix, &mut user_key_buf)
-                {
-                    &user_key_buf
-                } else {
-                    user_key_buf.clear();
-                    key
-                };
+                crate::key::KeySlice::from_slice(key).decode_user_key_into(&mut user_key_buf);
+                let user_key: &[u8] = &user_key_buf;
                 if vlog_enabled {
                     if let Some((raw, found_key)) =
                         state.memtable.get_versioned_raw_with_key(user_key, read_ts)

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1218,32 +1218,37 @@ impl LsmStorageInner {
         let vlog_enabled = self.vlog.is_some();
         if let Some(read_ts) = mvcc_read_ts {
             // MVCC path: key is encode(user_key, u64::MAX), need versioned lookup
-            let user_key =
-                crate::key::decode_user_key_cow(key).unwrap_or(std::borrow::Cow::Borrowed(key));
+            let mut user_key_buf = Vec::new();
+            let user_key: &[u8] = if let Some(prefix) = crate::key::encoded_user_key_prefix(key)
+                && crate::key::decode_user_key_into(prefix, &mut user_key_buf)
+            {
+                &user_key_buf
+            } else {
+                key
+            };
             if vlog_enabled {
-                if let Some((raw, found_key)) = state
-                    .memtable
-                    .get_versioned_raw_with_key(&user_key, read_ts)
+                if let Some((raw, found_key)) =
+                    state.memtable.get_versioned_raw_with_key(user_key, read_ts)
                 {
                     let (val, kind) = Self::parse_value_kind(raw);
                     return Ok(Some((val, kind, found_key)));
                 }
                 for m in state.imm_memtables.iter() {
-                    if let Some((raw, found_key)) = m.get_versioned_raw_with_key(&user_key, read_ts)
+                    if let Some((raw, found_key)) = m.get_versioned_raw_with_key(user_key, read_ts)
                     {
                         let (val, kind) = Self::parse_value_kind(raw);
                         return Ok(Some((val, kind, found_key)));
                     }
                 }
             } else {
-                if let Some(v) = state.memtable.get_versioned(&user_key, read_ts) {
+                if let Some(v) = state.memtable.get_versioned(user_key, read_ts) {
                     if Self::is_tombstone_value(&v) {
                         return Ok(Some((None, KvKind::Inline, Vec::new())));
                     }
                     return Ok(Some((Some(v), KvKind::Inline, Vec::new())));
                 }
                 for m in state.imm_memtables.iter() {
-                    if let Some(v) = m.get_versioned(&user_key, read_ts) {
+                    if let Some(v) = m.get_versioned(user_key, read_ts) {
                         if Self::is_tombstone_value(&v) {
                             return Ok(Some((None, KvKind::Inline, Vec::new())));
                         }

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1208,6 +1208,7 @@ impl LsmStorageInner {
     /// Returns `Ok(Some((value, kind, found_key)))` if found.
     /// `found_key` is the full encoded internal key of the matching entry,
     /// used for vLog key verification when the value is a ValuePointer.
+    #[allow(clippy::missing_const_for_thread_local)]
     fn lookup_memtable(
         &self,
         state: &LsmStorageState,
@@ -1218,44 +1219,54 @@ impl LsmStorageInner {
         let vlog_enabled = self.vlog.is_some();
         if let Some(read_ts) = mvcc_read_ts {
             // MVCC path: key is encode(user_key, u64::MAX), need versioned lookup
-            let mut user_key_buf = Vec::new();
-            let user_key: &[u8] = if let Some(prefix) = crate::key::encoded_user_key_prefix(key)
-                && crate::key::decode_user_key_into(prefix, &mut user_key_buf)
-            {
-                &user_key_buf
-            } else {
-                key
-            };
-            if vlog_enabled {
-                if let Some((raw, found_key)) =
-                    state.memtable.get_versioned_raw_with_key(user_key, read_ts)
+            thread_local! {
+                static USER_KEY_BUF: std::cell::RefCell<Vec<u8>> =
+                    std::cell::RefCell::new(Vec::new());
+            }
+            return USER_KEY_BUF.with(|buf| {
+                let mut user_key_buf = buf.borrow_mut();
+                user_key_buf.clear();
+                let user_key: &[u8] = if let Some(prefix) = crate::key::encoded_user_key_prefix(key)
+                    && crate::key::decode_user_key_into(prefix, &mut user_key_buf)
                 {
-                    let (val, kind) = Self::parse_value_kind(raw);
-                    return Ok(Some((val, kind, found_key)));
-                }
-                for m in state.imm_memtables.iter() {
-                    if let Some((raw, found_key)) = m.get_versioned_raw_with_key(user_key, read_ts)
+                    &user_key_buf
+                } else {
+                    user_key_buf.clear();
+                    key
+                };
+                if vlog_enabled {
+                    if let Some((raw, found_key)) =
+                        state.memtable.get_versioned_raw_with_key(user_key, read_ts)
                     {
                         let (val, kind) = Self::parse_value_kind(raw);
                         return Ok(Some((val, kind, found_key)));
                     }
-                }
-            } else {
-                if let Some(v) = state.memtable.get_versioned(user_key, read_ts) {
-                    if Self::is_tombstone_value(&v) {
-                        return Ok(Some((None, KvKind::Inline, Vec::new())));
+                    for m in state.imm_memtables.iter() {
+                        if let Some((raw, found_key)) =
+                            m.get_versioned_raw_with_key(user_key, read_ts)
+                        {
+                            let (val, kind) = Self::parse_value_kind(raw);
+                            return Ok(Some((val, kind, found_key)));
+                        }
                     }
-                    return Ok(Some((Some(v), KvKind::Inline, Vec::new())));
-                }
-                for m in state.imm_memtables.iter() {
-                    if let Some(v) = m.get_versioned(user_key, read_ts) {
+                } else {
+                    if let Some(v) = state.memtable.get_versioned(user_key, read_ts) {
                         if Self::is_tombstone_value(&v) {
                             return Ok(Some((None, KvKind::Inline, Vec::new())));
                         }
                         return Ok(Some((Some(v), KvKind::Inline, Vec::new())));
                     }
+                    for m in state.imm_memtables.iter() {
+                        if let Some(v) = m.get_versioned(user_key, read_ts) {
+                            if Self::is_tombstone_value(&v) {
+                                return Ok(Some((None, KvKind::Inline, Vec::new())));
+                            }
+                            return Ok(Some((Some(v), KvKind::Inline, Vec::new())));
+                        }
+                    }
                 }
-            }
+                Ok(None)
+            });
         } else {
             // Non-MVCC path: exact key lookup
             if vlog_enabled {

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -115,15 +115,25 @@ impl MemTable {
     /// Rebuild the bloom filter from existing skiplist entries.
     /// Used after WAL recovery where entries are inserted directly into the skiplist.
     fn rebuild_bloom(&self) {
+        let mut buf = Vec::new();
         for entry in self.map.iter() {
             let key = entry.key();
-            let hash_key = if crate::key::TS_ENABLED {
-                crate::key::decode_user_key(key).unwrap_or_else(|| key.to_vec())
+            let hash_src: &[u8] = if crate::key::TS_ENABLED {
+                if let Some(prefix) = crate::key::encoded_user_key_prefix(key) {
+                    buf.clear();
+                    if crate::key::decode_user_key_into(prefix, &mut buf) {
+                        &buf
+                    } else {
+                        key
+                    }
+                } else {
+                    key
+                }
             } else {
-                key.to_vec()
+                key
             };
             self.bloom
-                .push_hash(super::table::bloom::hash_key(&hash_key));
+                .push_hash(super::table::bloom::hash_key(hash_src));
         }
     }
 
@@ -198,10 +208,13 @@ impl MemTable {
         // Check bloom filter using the decoded user key. If the bloom says
         // "not contained" we can skip the skiplist lookup entirely.
         if crate::key::TS_ENABLED {
-            if let Some(user_key) = crate::key::decode_user_key(encoded_internal_key) {
-                let h = super::table::bloom::hash_key(&user_key);
-                if !self.bloom.may_contain_hash(h) {
-                    return None;
+            if let Some(prefix) = crate::key::encoded_user_key_prefix(encoded_internal_key) {
+                let mut buf = Vec::new();
+                if crate::key::decode_user_key_into(prefix, &mut buf) {
+                    let h = super::table::bloom::hash_key(&buf);
+                    if !self.bloom.may_contain_hash(h) {
+                        return None;
+                    }
                 }
             }
         } else {
@@ -231,14 +244,13 @@ impl MemTable {
         }
         let seek_key = Bytes::from(crate::key::encode_internal_key(user_key, u64::MAX));
         let seek_prefix = crate::key::encoded_user_key_prefix(&seek_key)
-            .expect("seek_key is newly encoded and guaranteed to be well-formed")
-            .to_vec();
-        let mut range = self.map.range::<Bytes, _>(seek_key..);
+            .expect("seek_key is newly encoded and guaranteed to be well-formed");
+        let mut range = self.map.range::<Bytes, _>(seek_key.clone()..);
         for entry in range.by_ref() {
             let found_key = entry.key();
             // Check if the decoded user key matches
             if let Some(found_user_key) = crate::key::encoded_user_key_prefix(found_key) {
-                if found_user_key != seek_prefix.as_slice() {
+                if found_user_key != seek_prefix {
                     // Different user key — no more versions to check.
                     break;
                 }
@@ -282,13 +294,12 @@ impl MemTable {
         }
         let seek_key = Bytes::from(crate::key::encode_internal_key(user_key, u64::MAX));
         let seek_prefix = crate::key::encoded_user_key_prefix(&seek_key)
-            .expect("seek_key is newly encoded and guaranteed to be well-formed")
-            .to_vec();
-        let mut range = self.map.range::<Bytes, _>(seek_key..);
+            .expect("seek_key is newly encoded and guaranteed to be well-formed");
+        let mut range = self.map.range::<Bytes, _>(seek_key.clone()..);
         for entry in range.by_ref() {
             let found_key = entry.key();
             if let Some(found_user_key) = crate::key::encoded_user_key_prefix(found_key) {
-                if found_user_key != seek_prefix.as_slice() {
+                if found_user_key != seek_prefix {
                     break;
                 }
             } else {
@@ -377,6 +388,7 @@ impl MemTable {
             wal.sync()?;
         }
 
+        let mut buf = Vec::new();
         for (key, value) in data {
             // Update bloom filter BEFORE skiplist insert. This ensures that a
             // concurrent reader never sees a false negative (bloom says "not
@@ -385,9 +397,18 @@ impl MemTable {
             // which just causes an unnecessary skiplist probe — harmless.
             // Hash the decoded user key (not the encoded internal key) so that
             // bloom filter lookups using raw user keys still match.
-            let user_key = key.decode_user_key_cow();
-            self.bloom
-                .push_hash(super::table::bloom::hash_key(&user_key));
+            if let Some(prefix) = crate::key::encoded_user_key_prefix(key.raw_ref()) {
+                buf.clear();
+                if crate::key::decode_user_key_into(prefix, &mut buf) {
+                    self.bloom.push_hash(super::table::bloom::hash_key(&buf));
+                } else {
+                    self.bloom
+                        .push_hash(super::table::bloom::hash_key(key.raw_ref()));
+                }
+            } else {
+                self.bloom
+                    .push_hash(super::table::bloom::hash_key(key.raw_ref()));
+            }
             self.map.insert(
                 shared_bytes_from_slice(key.raw_ref()),
                 shared_bytes_from_slice(value),

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -119,16 +119,9 @@ impl MemTable {
         for entry in self.map.iter() {
             let key = entry.key();
             let hash_src: &[u8] = if crate::key::TS_ENABLED {
-                if let Some(prefix) = crate::key::encoded_user_key_prefix(key) {
-                    buf.clear();
-                    if crate::key::decode_user_key_into(prefix, &mut buf) {
-                        &buf
-                    } else {
-                        key
-                    }
-                } else {
-                    key
-                }
+                buf.clear();
+                crate::key::KeySlice::from_slice(key).decode_user_key_into(&mut buf);
+                &buf
             } else {
                 key
             };
@@ -204,30 +197,23 @@ impl MemTable {
 
     /// Exact lookup by full encoded internal key (user key + timestamp).
     /// Used by GC to check if a specific version's pointer still matches.
-    #[allow(clippy::missing_const_for_thread_local)]
     pub fn get_raw_exact(&self, encoded_internal_key: &[u8]) -> Option<Bytes> {
         // Check bloom filter using the decoded user key. If the bloom says
         // "not contained" we can skip the skiplist lookup entirely.
         if crate::key::TS_ENABLED {
-            if let Some(prefix) = crate::key::encoded_user_key_prefix(encoded_internal_key) {
-                thread_local! {
-                    static BUF: std::cell::RefCell<Vec<u8>> =
-                        std::cell::RefCell::new(Vec::new());
-                }
-                let may_contain = BUF.with(|buf| {
-                    let mut b = buf.borrow_mut();
-                    b.clear();
-                    if crate::key::decode_user_key_into(prefix, &mut b) {
-                        let h = super::table::bloom::hash_key(&b);
-                        self.bloom.may_contain_hash(h)
-                    } else {
-                        b.clear();
-                        true
-                    }
-                });
-                if !may_contain {
-                    return None;
-                }
+            thread_local! {
+                static BUF: std::cell::RefCell<Vec<u8>> =
+                    const { std::cell::RefCell::new(Vec::new()) };
+            }
+            let may_contain = BUF.with(|buf| {
+                let mut b = buf.borrow_mut();
+                b.clear();
+                crate::key::KeySlice::from_slice(encoded_internal_key).decode_user_key_into(&mut b);
+                let h = super::table::bloom::hash_key(&b);
+                self.bloom.may_contain_hash(h)
+            });
+            if !may_contain {
+                return None;
             }
         } else {
             let h = super::table::bloom::hash_key(encoded_internal_key);
@@ -409,18 +395,9 @@ impl MemTable {
             // which just causes an unnecessary skiplist probe — harmless.
             // Hash the decoded user key (not the encoded internal key) so that
             // bloom filter lookups using raw user keys still match.
-            if let Some(prefix) = crate::key::encoded_user_key_prefix(key.raw_ref()) {
-                buf.clear();
-                if crate::key::decode_user_key_into(prefix, &mut buf) {
-                    self.bloom.push_hash(super::table::bloom::hash_key(&buf));
-                } else {
-                    self.bloom
-                        .push_hash(super::table::bloom::hash_key(key.raw_ref()));
-                }
-            } else {
-                self.bloom
-                    .push_hash(super::table::bloom::hash_key(key.raw_ref()));
-            }
+            buf.clear();
+            key.decode_user_key_into(&mut buf);
+            self.bloom.push_hash(super::table::bloom::hash_key(&buf));
             self.map.insert(
                 shared_bytes_from_slice(key.raw_ref()),
                 shared_bytes_from_slice(value),

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -204,17 +204,29 @@ impl MemTable {
 
     /// Exact lookup by full encoded internal key (user key + timestamp).
     /// Used by GC to check if a specific version's pointer still matches.
+    #[allow(clippy::missing_const_for_thread_local)]
     pub fn get_raw_exact(&self, encoded_internal_key: &[u8]) -> Option<Bytes> {
         // Check bloom filter using the decoded user key. If the bloom says
         // "not contained" we can skip the skiplist lookup entirely.
         if crate::key::TS_ENABLED {
             if let Some(prefix) = crate::key::encoded_user_key_prefix(encoded_internal_key) {
-                let mut buf = Vec::new();
-                if crate::key::decode_user_key_into(prefix, &mut buf) {
-                    let h = super::table::bloom::hash_key(&buf);
-                    if !self.bloom.may_contain_hash(h) {
-                        return None;
+                thread_local! {
+                    static BUF: std::cell::RefCell<Vec<u8>> =
+                        std::cell::RefCell::new(Vec::new());
+                }
+                let may_contain = BUF.with(|buf| {
+                    let mut b = buf.borrow_mut();
+                    b.clear();
+                    if crate::key::decode_user_key_into(prefix, &mut b) {
+                        let h = super::table::bloom::hash_key(&b);
+                        self.bloom.may_contain_hash(h)
+                    } else {
+                        b.clear();
+                        true
                     }
+                });
+                if !may_contain {
+                    return None;
                 }
             }
         } else {

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -34,6 +34,8 @@ pub struct SsTableBuilder {
     collect_blocks: bool,
     /// Maximum timestamp seen across all keys added to this SST.
     max_ts: u64,
+    /// Reusable buffer for decoding user keys (bloom hash computation).
+    user_key_buf: Vec<u8>,
 }
 
 impl SsTableBuilder {
@@ -52,6 +54,7 @@ impl SsTableBuilder {
             collected_blocks: Vec::new(),
             collect_blocks: false,
             max_ts: 0,
+            user_key_buf: Vec::new(),
         }
     }
 
@@ -75,6 +78,7 @@ impl SsTableBuilder {
             collected_blocks: Vec::new(),
             collect_blocks: false,
             max_ts: 0,
+            user_key_buf: Vec::new(),
         }
     }
 
@@ -195,24 +199,17 @@ impl SsTableBuilder {
         }
 
         if TS_ENABLED {
-            thread_local! {
-                static BUF: std::cell::RefCell<Vec<u8>> =
-                    std::cell::RefCell::new(Vec::new());
-            }
-            BUF.with(|buf| {
-                let mut b = buf.borrow_mut();
-                b.clear();
-                let hash_src: &[u8] = if let Some(prefix) =
-                    crate::key::encoded_user_key_prefix(key.raw_ref())
-                    && crate::key::decode_user_key_into(prefix, &mut b)
-                {
-                    &b
-                } else {
-                    b.clear();
-                    key.raw_ref()
-                };
-                self.key_hashes.push(super::bloom::hash_key(hash_src));
-            });
+            self.user_key_buf.clear();
+            let hash_src: &[u8] = if let Some(prefix) =
+                crate::key::encoded_user_key_prefix(key.raw_ref())
+                && crate::key::decode_user_key_into(prefix, &mut self.user_key_buf)
+            {
+                &self.user_key_buf
+            } else {
+                self.user_key_buf.clear();
+                key.raw_ref()
+            };
+            self.key_hashes.push(super::bloom::hash_key(hash_src));
         } else {
             self.key_hashes.push(super::bloom::hash_key(key.raw_ref()));
         }

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -199,16 +199,9 @@ impl SsTableBuilder {
 
         if TS_ENABLED {
             self.user_key_buf.clear();
-            let hash_src: &[u8] = if let Some(prefix) =
-                crate::key::encoded_user_key_prefix(key.raw_ref())
-                && crate::key::decode_user_key_into(prefix, &mut self.user_key_buf)
-            {
-                &self.user_key_buf
-            } else {
-                self.user_key_buf.clear();
-                key.raw_ref()
-            };
-            self.key_hashes.push(super::bloom::hash_key(hash_src));
+            key.decode_user_key_into(&mut self.user_key_buf);
+            self.key_hashes
+                .push(super::bloom::hash_key(&self.user_key_buf));
         } else {
             self.key_hashes.push(super::bloom::hash_key(key.raw_ref()));
         }

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -151,7 +151,6 @@ impl SsTableBuilder {
         self.add_inner(key, raw_value)
     }
 
-    #[allow(clippy::missing_const_for_thread_local)]
     fn add_inner(&mut self, key: KeySlice, value: &[u8]) -> Result<()> {
         // Track the maximum timestamp for SST metadata.
         if TS_ENABLED {

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -194,8 +194,16 @@ impl SsTableBuilder {
         }
 
         if TS_ENABLED {
-            let user_key = key.decode_user_key_cow();
-            self.key_hashes.push(super::bloom::hash_key(&user_key));
+            let mut buf = Vec::new();
+            let hash_src: &[u8] = if let Some(prefix) =
+                crate::key::encoded_user_key_prefix(key.raw_ref())
+                && crate::key::decode_user_key_into(prefix, &mut buf)
+            {
+                &buf
+            } else {
+                key.raw_ref()
+            };
+            self.key_hashes.push(super::bloom::hash_key(hash_src));
         } else {
             self.key_hashes.push(super::bloom::hash_key(key.raw_ref()));
         }

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -147,6 +147,7 @@ impl SsTableBuilder {
         self.add_inner(key, raw_value)
     }
 
+    #[allow(clippy::missing_const_for_thread_local)]
     fn add_inner(&mut self, key: KeySlice, value: &[u8]) -> Result<()> {
         // Track the maximum timestamp for SST metadata.
         if TS_ENABLED {
@@ -194,16 +195,24 @@ impl SsTableBuilder {
         }
 
         if TS_ENABLED {
-            let mut buf = Vec::new();
-            let hash_src: &[u8] = if let Some(prefix) =
-                crate::key::encoded_user_key_prefix(key.raw_ref())
-                && crate::key::decode_user_key_into(prefix, &mut buf)
-            {
-                &buf
-            } else {
-                key.raw_ref()
-            };
-            self.key_hashes.push(super::bloom::hash_key(hash_src));
+            thread_local! {
+                static BUF: std::cell::RefCell<Vec<u8>> =
+                    std::cell::RefCell::new(Vec::new());
+            }
+            BUF.with(|buf| {
+                let mut b = buf.borrow_mut();
+                b.clear();
+                let hash_src: &[u8] = if let Some(prefix) =
+                    crate::key::encoded_user_key_prefix(key.raw_ref())
+                    && crate::key::decode_user_key_into(prefix, &mut b)
+                {
+                    &b
+                } else {
+                    b.clear();
+                    key.raw_ref()
+                };
+                self.key_hashes.push(super::bloom::hash_key(hash_src));
+            });
         } else {
             self.key_hashes.push(super::bloom::hash_key(key.raw_ref()));
         }

--- a/todo.md
+++ b/todo.md
@@ -113,10 +113,10 @@ PR #85 (merged 2026-06-10). Version-aware GC with internal key storage in vLog.
 
 ## Performance Optimizations
 
-- [ ] `decode_user_key_cow` to avoid heap allocs in bloom hash, vLog deref
+- [x] `decode_user_key_cow` to avoid heap allocs in bloom hash, vLog deref (PR #87)
 - [x] Avoid cloning `encoded_user_key` in `lsm_iterator::next()` (PR #83: `decode_user_key_into` buffer reuse)
 - [x] Replace `is_some()` + `.unwrap()` with `if let Some(ref mvcc)` (PR #83)
-- [ ] Avoid `to_vec()` allocation in memtable seek prefix
+- [x] Avoid `to_vec()` allocation in memtable seek prefix (PR #87)
 - [x] Bloom filter in `get_raw_exact` to skip skiplist lookups (PR #85)
 - [x] Encoded prefix comparison in `lookup_by_user_key` to avoid heap allocs (PR #85)
 - [x] `partition_point` for leveled SST lookup in `get_with_kind_at_ts` (PR #85)

--- a/todo.md
+++ b/todo.md
@@ -123,7 +123,9 @@ PR #85 (merged 2026-06-10). Version-aware GC with internal key storage in vLog.
 
 ---
 
-## Testing Progress (30/30 from RFC §9)
+## Testing Progress (30/30 from RFC §9) ✅
+
+PR #86 (merged 2026-06-10). Final 4 tests (21, 22, 24, 25) + review fixes.
 
 - [x] 1. Internal key ordering: same user key sorts newest timestamp first
 - [x] 2. `get` returns newest version at or below read timestamp (read_ts wiring done; advanced filtering in Phase 5)


### PR DESCRIPTION
## Summary

Eliminate unnecessary heap allocations on hot read/write paths by switching from allocating decode functions to buffer-reusing `decode_user_key_into`, and by removing redundant `to_vec()` copies on seek prefixes.

## Changes

### Part 1: Remove `to_vec()` on seek prefix
- `mem_table.rs`: `get_versioned` and `get_versioned_raw_with_key` — drop `.to_vec()` on `encoded_user_key_prefix` result, keep `&[u8]` slice (source `seek_key` lives long enough). Use `seek_key.clone()` (cheap Bytes refcount bump) for the range bound.

### Part 2: `decode_user_key_into` buffer reuse
Replace `decode_user_key()` / `decode_user_key_cow()` with `decode_user_key_into()` at 5 hot call sites using a reusable `Vec<u8>` buffer:
- `rebuild_bloom` — loop over skiplist entries during WAL recovery
- `get_raw_exact` — GC liveness check per probe
- `put_batch` — loop over batch entries during insert
- SST builder `add` — per key during flush
- `lookup_memtable` — per point-get in MVCC mode

### Part 3: `KeyBytes::decode_user_key_into` fallback
Updated to fall back to raw key bytes on failure, matching `decode_user_key_cow` behavior.

## Verification
- [x] 353/353 tests pass
- [x] clippy clean
- [x] fmt clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Key decoding now preserves raw key bytes on decode failure so callers receive valid data instead of an empty buffer.

* **Performance**
  * Reduced allocations and improved efficiency for bloom-filter building, key-hash computation, memtable lookups, and table building by reusing buffers and decoding user keys into reusable scratch space.

* **Chores**
  * Documentation/testing notes updated to mark performance items and completed tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->