### PR TITLE
fix: guard leveled compaction ratio check against zero last-level size

### DIFF
--- a/kv-engine/src/tests/harness.rs
+++ b/kv-engine/src/tests/harness.rs
@@ -374,20 +374,22 @@ pub fn check_compaction_ratio(storage: Arc<KvEngine>) {
             assert!(l0_sst_num < level0_file_num_compaction_trigger);
             assert!(level_size.len() <= max_levels);
             let last_level_size = *level_size.last().unwrap();
-            let mut multiplier = 1.0;
-            for idx in (1..level_size.len()).rev() {
-                multiplier *= level_size_multiplier as f64;
-                let this_size = level_size[idx - 1];
-                assert!(
-                    // do not add hard requirement on level size multiplier considering bloom
-                    // filters...
-                    this_size as f64 / last_level_size as f64 <= 1.0 / multiplier + 0.5,
-                    "L{}/L_max, {}/{}>>1.0/{}",
-                    state.levels[idx - 1].0,
-                    this_size,
-                    last_level_size,
-                    multiplier
-                );
+            if last_level_size > 0 {
+                let mut multiplier = 1.0;
+                for idx in (1..level_size.len()).rev() {
+                    multiplier *= level_size_multiplier as f64;
+                    let this_size = level_size[idx - 1];
+                    assert!(
+                        // do not add hard requirement on level size multiplier considering bloom
+                        // filters...
+                        this_size as f64 / last_level_size as f64 <= 1.0 / multiplier + 0.5,
+                        "L{}/L_max, {}/{}>>1.0/{}",
+                        state.levels[idx - 1].0,
+                        this_size,
+                        last_level_size,
+                        multiplier
+                    );
+                }
             }
             assert!(
                 num_iters <= l0_sst_num + num_memtables + max_levels + extra_iterators,


### PR DESCRIPTION
## Summary

When the last level has zero SSTs (intermediate compaction state), the ratio check divides by zero producing NaN, which always fails the <= assertion. Skip the check when `last_level_size == 0`, matching the existing guard in `simple_leveled_compaction`.

## Problem

The assertion `this_size as f64 / last_level_size as f64 <= 1.0 / multiplier + 0.5` panics when `last_level_size` is 0 because `0.0 / 0.0 = NaN` and `NaN <= anything` is false.

Error in CI: `L3/L_max, 0/0>>1.0/2`

## Fix

Wrap the ratio check loop in `if last_level_size > 0 { ... }`, consistent with the existing guard in the `SimpleLeveled` branch (line 350: `if prev_size == 0 || this_size == 0 { continue; }`).

## Verification
- [x] 5/5 runs pass locally
- [x] Fixes flaky `leveled_compaction::test_integration` under ASan (352/353 passed in CI)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined compaction ratio assertions to conditionally validate multiplier relationships based on level size state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->