### PR TITLE
feat: add prefix bloom filters for prefix_scan optimization

### DIFF
--- a/kv-engine/benches/vlog_benchmarks.rs
+++ b/kv-engine/benches/vlog_benchmarks.rs
@@ -12,7 +12,7 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use kv_engine::{
     compact::{CompactionOptions, LeveledCompactionOptions},
     iterators::StorageIterator,
-    lsm_storage::{KvEngine, LsmStorageOptions},
+    lsm_storage::{KvEngine, LsmStorageOptions, PrefixBloomOptions},
     vlog::ValueSeparationOptions,
 };
 
@@ -37,6 +37,7 @@ fn make_options(vlog_enabled: bool, min_value_size: usize) -> LsmStorageOptions 
         manifest_snapshot_threshold_bytes: 0,
         block_cache_capacity: 1792,
         enable_cache_backfill: true,
+        prefix_bloom: PrefixBloomOptions::default(),
     }
 }
 
@@ -67,6 +68,7 @@ fn make_options_with_compaction(vlog_enabled: bool, min_value_size: usize) -> Ls
         manifest_snapshot_threshold_bytes: 0,
         block_cache_capacity: 1792,
         enable_cache_backfill: true,
+        prefix_bloom: PrefixBloomOptions::default(),
     }
 }
 
@@ -122,6 +124,7 @@ fn make_options_with_cache(min_value_size: usize, cache_bytes: u64) -> LsmStorag
         manifest_snapshot_threshold_bytes: 0,
         block_cache_capacity: 1792,
         enable_cache_backfill: true,
+        prefix_bloom: PrefixBloomOptions::default(),
     }
 }
 
@@ -451,6 +454,7 @@ fn bench_cold_point_get(c: &mut Criterion) {
             manifest_snapshot_threshold_bytes: 0,
             block_cache_capacity: 4, // tiny — forces disk reads
             enable_cache_backfill: true,
+            prefix_bloom: PrefixBloomOptions::default(),
         }
     };
 
@@ -523,6 +527,7 @@ fn bench_flush_throughput(c: &mut Criterion) {
                         manifest_snapshot_threshold_bytes: 0,
                         block_cache_capacity: 1792,
                         enable_cache_backfill: true,
+                        prefix_bloom: PrefixBloomOptions::default(),
                     };
                     let lsm = KvEngine::open(dir.path(), options).unwrap();
                     (dir, lsm, 0usize)
@@ -588,6 +593,7 @@ fn bench_cold_scan(c: &mut Criterion) {
             manifest_snapshot_threshold_bytes: 0,
             block_cache_capacity: 4, // tiny — every block read hits disk
             enable_cache_backfill: true,
+            prefix_bloom: PrefixBloomOptions::default(),
         }
     };
 
@@ -670,6 +676,7 @@ fn bench_backfill_comparison(c: &mut Criterion) {
             manifest_snapshot_threshold_bytes: 0,
             block_cache_capacity,
             enable_cache_backfill: backfill,
+            prefix_bloom: PrefixBloomOptions::default(),
         }
     };
 
@@ -748,6 +755,7 @@ fn bench_compaction_backfill(c: &mut Criterion) {
             manifest_snapshot_threshold_bytes: 0,
             block_cache_capacity,
             enable_cache_backfill: backfill,
+            prefix_bloom: PrefixBloomOptions::default(),
         }
     };
 

--- a/kv-engine/src/bin/kv-engine-cli.rs
+++ b/kv-engine/src/bin/kv-engine-cli.rs
@@ -11,7 +11,7 @@ use kv_engine_wrapper::{
         TieredCompactionOptions,
     },
     iterators::StorageIterator,
-    lsm_storage::{KvEngine, LsmStorageOptions},
+    lsm_storage::{KvEngine, LsmStorageOptions, PrefixBloomOptions},
 };
 use rustyline::DefaultEditor;
 use wrapper::kv_engine_wrapper;
@@ -365,6 +365,7 @@ fn main() -> Result<()> {
             block_size: 4096,
             target_sst_size: 2 << 20, // 2MB
             num_memtable_limit: 3,
+            prefix_bloom: PrefixBloomOptions::default(),
             compaction_options: match args.compaction {
                 CompactionStrategy::None => CompactionOptions::NoCompaction,
                 CompactionStrategy::Simple => {

--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -12,7 +12,7 @@ use anyhow::Result;
 use kv_engine_wrapper::{
     compact::{CompactionOptions, LeveledCompactionOptions},
     iterators::StorageIterator,
-    lsm_storage::{KvEngine, LsmStorageOptions},
+    lsm_storage::{KvEngine, LsmStorageOptions, PrefixBloomOptions},
     vlog::ValueSeparationOptions,
 };
 use rand::prelude::*;
@@ -47,6 +47,7 @@ fn make_options(vlog: bool, wal: bool) -> LsmStorageOptions {
         manifest_snapshot_threshold_bytes: 4 << 20,
         block_cache_capacity: 8192,
         enable_cache_backfill: true,
+        prefix_bloom: PrefixBloomOptions::default(),
     }
 }
 

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -276,6 +276,7 @@ impl LsmStorageInner {
         let mut all_vlog_ids = vec![];
         let mut builder = SsTableBuilder::new(self.options.block_size);
         builder.set_collect_blocks(should_backfill);
+        builder.set_prefix_bloom_options(Some(self.options.prefix_bloom.clone()));
 
         // Snapshot the watermark once before the loop. When no active readers
         // exist, watermark() returns latest_commit_ts so everything below it
@@ -304,6 +305,7 @@ impl LsmStorageInner {
                 ret.push(Arc::new(sst));
                 builder = SsTableBuilder::new(self.options.block_size);
                 builder.set_collect_blocks(should_backfill);
+                builder.set_prefix_bloom_options(Some(self.options.prefix_bloom.clone()));
             }
 
             // Detect tombstones: single KvKind::Tombstone byte.

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -533,6 +533,7 @@ impl LsmStorageInner {
     /// Start the storage engine by either loading an existing directory or creating a new one if
     /// the directory does not exist.
     pub(crate) fn open(path: impl AsRef<Path>, options: LsmStorageOptions) -> Result<Self> {
+        options.prefix_bloom.validate()?;
         let vlog_enabled = options
             .value_separation
             .as_ref()

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -90,6 +90,72 @@ impl LsmStorageState {
     }
 }
 
+/// Options for SST-level prefix bloom filters.
+///
+/// When enabled, each SST may contain one or more prefix bloom filters
+/// (one per configured prefix length). These filters allow `prefix_scan`
+/// to skip SSTs that provably cannot contain matching prefixes before
+/// creating iterators.
+#[derive(Debug, Clone)]
+pub struct PrefixBloomOptions {
+    /// Enable SST prefix bloom filters. Defaults to `false`.
+    pub enabled: bool,
+    /// Prefix lengths, in bytes, to materialize per SST.
+    /// Must be non-empty when enabled, unique, sorted, all > 0, and all <= 64.
+    /// Defaults to `vec![8]`.
+    pub prefix_lengths: Vec<usize>,
+    /// Target false positive rate for each prefix filter.
+    /// Must be in `(0.0, 1.0)`. Defaults to `0.01`.
+    pub false_positive_rate: f64,
+}
+
+impl Default for PrefixBloomOptions {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            prefix_lengths: vec![8],
+            false_positive_rate: 0.01,
+        }
+    }
+}
+
+impl PrefixBloomOptions {
+    /// Validate prefix bloom options. Returns an error if the options are inconsistent.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if !self.enabled {
+            return Ok(());
+        }
+        anyhow::ensure!(
+            !self.prefix_lengths.is_empty(),
+            "prefix_bloom.prefix_lengths must be non-empty when enabled"
+        );
+        for (i, &len) in self.prefix_lengths.iter().enumerate() {
+            anyhow::ensure!(len > 0, "prefix_bloom.prefix_lengths[{}] must be > 0", i);
+            anyhow::ensure!(
+                len <= 64,
+                "prefix_bloom.prefix_lengths[{}] must be <= 64, got {}",
+                i,
+                len
+            );
+            if i > 0 {
+                anyhow::ensure!(
+                    len > self.prefix_lengths[i - 1],
+                    "prefix_bloom.prefix_lengths must be strictly increasing and unique, \
+                     but {} <= {}",
+                    len,
+                    self.prefix_lengths[i - 1]
+                );
+            }
+        }
+        anyhow::ensure!(
+            self.false_positive_rate > 0.0 && self.false_positive_rate < 1.0,
+            "prefix_bloom.false_positive_rate must be in (0.0, 1.0), got {}",
+            self.false_positive_rate
+        );
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct LsmStorageOptions {
     // Block size in bytes
@@ -115,6 +181,10 @@ pub struct LsmStorageOptions {
     /// flush and compaction. When enabled, recently flushed data stays warm in
     /// cache, eliminating the cache-miss cliff. Defaults to `true`.
     pub enable_cache_backfill: bool,
+    /// Options for SST-level prefix bloom filters. When enabled, `prefix_scan`
+    /// can skip SSTs that provably cannot contain matching prefixes.
+    /// Defaults to disabled.
+    pub prefix_bloom: PrefixBloomOptions,
 }
 
 impl LsmStorageOptions {
@@ -130,6 +200,7 @@ impl LsmStorageOptions {
             manifest_snapshot_threshold_bytes: 0, // disabled by default in tests
             block_cache_capacity: 1792,
             enable_cache_backfill: true,
+            prefix_bloom: PrefixBloomOptions::default(),
         }
     }
 
@@ -145,6 +216,7 @@ impl LsmStorageOptions {
             manifest_snapshot_threshold_bytes: 0,
             block_cache_capacity: 1792,
             enable_cache_backfill: true,
+            prefix_bloom: PrefixBloomOptions::default(),
         }
     }
 
@@ -160,6 +232,7 @@ impl LsmStorageOptions {
             manifest_snapshot_threshold_bytes: 0,
             block_cache_capacity: 1792,
             enable_cache_backfill: true,
+            prefix_bloom: PrefixBloomOptions::default(),
         }
     }
 }
@@ -350,14 +423,11 @@ impl KvEngine {
 
     /// Return all visible keys whose user key starts with `prefix`, in sorted
     /// key order. An empty prefix is equivalent to a full scan.
+    ///
+    /// When prefix bloom filters are enabled, irrelevant SSTs are skipped
+    /// before creating iterators.
     pub fn prefix_scan(&self, prefix: &[u8]) -> Result<ScanIterator> {
-        if prefix.is_empty() {
-            return self.scan(Bound::Unbounded, Bound::Unbounded);
-        }
-        match prefix_upper_bound(prefix) {
-            Some(upper) => self.scan(Bound::Included(prefix), Bound::Excluded(&upper)),
-            None => self.scan(Bound::Included(prefix), Bound::Unbounded),
-        }
+        self.inner.prefix_scan(prefix)
     }
 
     /// Only call this in test cases due to race conditions
@@ -995,7 +1065,18 @@ impl LsmStorageInner {
         upper: Bound<&[u8]>,
         read_ts: u64,
     ) -> Result<crate::lsm_iterator::FusedIterator<crate::lsm_iterator::LsmIterator>> {
-        self.scan_inner(lower, upper, Some(read_ts))
+        self.scan_inner(lower, upper, Some(read_ts), None)
+    }
+
+    /// Scan with a prefix hint for prefix bloom filter pruning.
+    pub(crate) fn scan_with_prefix_hint(
+        &self,
+        lower: Bound<&[u8]>,
+        upper: Bound<&[u8]>,
+        read_ts: u64,
+        prefix_hint: &[u8],
+    ) -> Result<crate::lsm_iterator::FusedIterator<crate::lsm_iterator::LsmIterator>> {
+        self.scan_inner(lower, upper, Some(read_ts), Some(prefix_hint))
     }
 
     /// Shared scan logic used by both `scan` and `scan_with_ts`.
@@ -1004,6 +1085,7 @@ impl LsmStorageInner {
         lower: Bound<&[u8]>,
         upper: Bound<&[u8]>,
         mvcc_read_ts: Option<u64>,
+        prefix_hint: Option<&[u8]>,
     ) -> Result<crate::lsm_iterator::FusedIterator<crate::lsm_iterator::LsmIterator>> {
         let state = self.state.load_full();
         let mvcc_enabled = self.mvcc.is_some();
@@ -1057,6 +1139,14 @@ impl LsmStorageInner {
             if !t.range_overlap(physical_lower, physical_upper) {
                 continue;
             }
+            // Prefix bloom pruning: skip SSTs that provably cannot contain
+            // keys matching the prefix hint.
+            if self.options.prefix_bloom.enabled
+                && let Some(prefix) = prefix_hint
+                && !t.may_contain_prefix(prefix)
+            {
+                continue;
+            }
             let mut s = match lower {
                 Bound::Included(lower_key) => {
                     let seek = encode_seek(lower_key);
@@ -1095,7 +1185,17 @@ impl LsmStorageInner {
             let mut ss_tables = vec![];
             for i in sst_ids {
                 let t = state.sstables[i].clone();
+                // Prefix bloom pruning for L1+ SSTs.
+                if self.options.prefix_bloom.enabled
+                    && let Some(prefix) = prefix_hint
+                    && !t.may_contain_prefix(prefix)
+                {
+                    continue;
+                }
                 ss_tables.push(t);
+            }
+            if ss_tables.is_empty() {
+                continue;
             }
             let concat_iter = if let Some(ref vlog) = self.vlog {
                 match lower {
@@ -1973,6 +2073,7 @@ impl LsmStorageInner {
             let mut builder =
                 SsTableBuilder::new_with_vlog(self.options.block_size, vlog_builder, vs_opts);
             builder.set_collect_blocks(self.options.enable_cache_backfill);
+            builder.set_prefix_bloom_options(Some(self.options.prefix_bloom.clone()));
             memtable_to_flush.flush(&mut builder)?;
             let vlog_ids = builder.vlog_file_ids().to_vec();
             // Extract vLog index entries before build_with_backfill() consumes the builder
@@ -2006,6 +2107,7 @@ impl LsmStorageInner {
         } else {
             let mut builder = SsTableBuilder::new(self.options.block_size);
             builder.set_collect_blocks(self.options.enable_cache_backfill);
+            builder.set_prefix_bloom_options(Some(self.options.prefix_bloom.clone()));
             memtable_to_flush.flush(&mut builder)?;
             let (sst, blocks) = builder.build_with_backfill(
                 sst_id,
@@ -2093,8 +2195,25 @@ impl LsmStorageInner {
         // state snapshot we load next.
         let read_guard = self.mvcc.as_ref().map(|m| m.new_read_guard());
         let mvcc_read_ts = read_guard.as_ref().map(|g| g.read_ts());
-        let lit = self.scan_inner(lower, upper, mvcc_read_ts)?;
+        let lit = self.scan_inner(lower, upper, mvcc_read_ts, None)?;
 
+        Ok(ScanIterator::new(lit, read_guard))
+    }
+
+    /// Create an iterator for a prefix scan with prefix bloom filter pruning.
+    pub fn prefix_scan(&self, prefix: &[u8]) -> Result<ScanIterator> {
+        if prefix.is_empty() {
+            return self.scan(Bound::Unbounded, Bound::Unbounded);
+        }
+        let read_guard = self.mvcc.as_ref().map(|m| m.new_read_guard());
+        let mvcc_read_ts = read_guard.as_ref().map(|g| g.read_ts());
+        let upper_bound = prefix_upper_bound(prefix);
+        let lower = Bound::Included(prefix);
+        let upper = match &upper_bound {
+            Some(upper) => Bound::Excluded(upper.as_slice()),
+            None => Bound::Unbounded,
+        };
+        let lit = self.scan_inner(lower, upper, mvcc_read_ts, Some(prefix))?;
         Ok(ScanIterator::new(lit, read_guard))
     }
 

--- a/kv-engine/src/mvcc/txn.rs
+++ b/kv-engine/src/mvcc/txn.rs
@@ -107,14 +107,35 @@ impl Transaction {
 
     /// Return all visible keys whose user key starts with `prefix`, in sorted
     /// key order. An empty prefix is equivalent to a full scan.
+    ///
+    /// When prefix bloom filters are enabled, irrelevant SSTs are skipped
+    /// before creating iterators.
     pub fn prefix_scan(self: &Arc<Self>, prefix: &[u8]) -> Result<TxnIterator> {
         if prefix.is_empty() {
             return self.scan(Bound::Unbounded, Bound::Unbounded);
         }
-        match prefix_upper_bound(prefix) {
-            Some(upper) => self.scan(Bound::Included(prefix), Bound::Excluded(&upper)),
-            None => self.scan(Bound::Included(prefix), Bound::Unbounded),
-        }
+        self.ensure_not_committed()?;
+        anyhow::ensure!(
+            self.read_set.is_none(),
+            "prefix_scan() is not supported for serializable transactions until phantom/range tracking is implemented"
+        );
+        let upper_bound = prefix_upper_bound(prefix);
+        let lower = Bound::Included(prefix);
+        let upper = match &upper_bound {
+            Some(upper) => Bound::Excluded(upper.as_slice()),
+            None => Bound::Unbounded,
+        };
+        let lsm_iter = self
+            .inner
+            .scan_with_prefix_hint(lower, upper, self.read_ts, prefix)?;
+        let mut local_iter = TxnLocalIterator::new(
+            self.local_storage.clone(),
+            |map| map.range::<Bytes, _>((map_bound(lower), map_bound(upper))),
+            (Bytes::new(), Bytes::new()),
+        );
+        local_iter.next()?;
+        let merged = TwoMergeIterator::create(local_iter, lsm_iter)?;
+        TxnIterator::create(Arc::clone(self), merged)
     }
 
     /// Buffer a write locally.

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -262,13 +262,17 @@ impl SsTable {
                 "SST prefix_bloom_offset out of bounds: {}",
                 prefix_bloom_off
             );
+            let section_end = footer_start - SIZE_OF_U32 as u64;
+            anyhow::ensure!(
+                prefix_bloom_off < section_end,
+                "SST prefix_bloom_offset ({}) >= section_end ({})",
+                prefix_bloom_off,
+                section_end
+            );
             let bloom_off = file
                 .read(prefix_bloom_off - SIZE_OF_U32 as u64, SIZE_OF_U32 as u64)?
                 .as_slice()
                 .get_u32() as u64;
-            // The prefix bloom section ends where the prefix_bloom_offset
-            // field is written (footer_start - 4).
-            let section_end = footer_start - SIZE_OF_U32 as u64;
 
             // Decode prefix bloom section.
             let prefix_blooms = Self::decode_prefix_blooms(&file, prefix_bloom_off, section_end)?;
@@ -394,6 +398,12 @@ impl SsTable {
             "SST prefix bloom section too small: {} bytes",
             section_size
         );
+        let section_size_usize = usize::try_from(section_size).map_err(|_| {
+            anyhow::anyhow!(
+                "SST prefix bloom section too large for platform: {} bytes",
+                section_size
+            )
+        })?;
         let section = file.read(prefix_bloom_offset, section_size)?;
         let filter_count = (&section[0..2]).get_u16() as usize;
         anyhow::ensure!(
@@ -402,14 +412,14 @@ impl SsTable {
         );
         let table_len = 2 + filter_count * (2 + 4 + 4); // u16 + u32 + u32 per entry
         anyhow::ensure!(
-            section_size as usize >= table_len,
+            section_size_usize >= table_len,
             "SST prefix bloom section too small for {} filters: need {} bytes, have {}",
             filter_count,
             table_len,
             section_size
         );
         let filter_bytes_start = table_len;
-        let filter_bytes_len = section_size as usize - filter_bytes_start;
+        let filter_bytes_len = section_size_usize - filter_bytes_start;
         let mut filters = Vec::with_capacity(filter_count);
         let mut prev_prefix_len = 0usize;
         let mut prev_end = 0usize;

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -21,10 +21,35 @@ const SIZE_OF_U64: usize = mem::size_of::<u64>();
 
 /// Magic number for MVCC-format SSTs: "MVCC" in ASCII.
 const SST_MVCC_MAGIC: u32 = 0x4D56_4343;
-/// Footer version for MVCC-format SSTs.
+/// Footer version for MVCC-format SSTs (no prefix bloom).
 const SST_FOOTER_VERSION_V2: u8 = 2;
+/// Footer version for SSTs with prefix bloom filters.
+const SST_FOOTER_VERSION_V3: u8 = 3;
 /// Size of the MVCC footer extension: max_ts (8) + magic (4) + version (1) = 13 bytes.
 const MVCC_FOOTER_EXTRA: u64 = (SIZE_OF_U64 + SIZE_OF_U32 + 1) as u64;
+
+/// A single prefix bloom filter for a specific prefix length.
+#[derive(Debug)]
+pub(crate) struct PrefixBloom {
+    pub(crate) prefix_len: usize,
+    pub(crate) bloom: Bloom,
+}
+
+/// Collection of prefix bloom filters for an SST, sorted by prefix_len ascending.
+#[derive(Debug)]
+pub(crate) struct PrefixBloomSet {
+    filters: Vec<PrefixBloom>,
+}
+
+impl PrefixBloomSet {
+    /// Find the best (longest) filter whose `prefix_len <= query_len`.
+    pub(crate) fn best_filter_for(&self, query_len: usize) -> Option<&PrefixBloom> {
+        self.filters
+            .iter()
+            .rev()
+            .find(|f| f.prefix_len <= query_len)
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BlockMeta {
@@ -167,6 +192,8 @@ pub struct SsTable {
     pub(crate) bloom: Option<Bloom>,
     /// The maximum timestamp stored in this SST, implemented in MVCC.
     max_ts: u64,
+    /// Prefix bloom filters for prefix scan pruning. Present only in v3 SSTs.
+    pub(crate) prefix_blooms: Option<PrefixBloomSet>,
 }
 
 impl SsTable {
@@ -183,34 +210,86 @@ impl SsTable {
             "SST file too small: {} bytes",
             file.size()
         );
-        // Read the tail region in a single I/O call.  MVCC footer is 13 bytes
-        // plus the preceding 4-byte bloom_offset = 17 bytes from the end.
-        // For legacy SSTs we only need the last 4 bytes, but reading 17 is
-        // harmless and avoids a second read for the common MVCC case.
-        let tail_size = MVCC_FOOTER_EXTRA as usize + SIZE_OF_U32;
-        let tail_start = file.size().saturating_sub(tail_size as u64);
+        // Read the tail region in a single I/O call.  v3 footer needs 21 bytes
+        // (bloom_offset:4 + prefix_bloom_offset:4 + max_ts:8 + magic:4 + version:1),
+        // v2 needs 17 bytes (bloom_offset:4 + max_ts:8 + magic:4 + version:1).
+        // Read 21 to cover both cases.
+        let v3_tail_size = MVCC_FOOTER_EXTRA as usize + SIZE_OF_U32 + SIZE_OF_U32;
+        let tail_start = file.size().saturating_sub(v3_tail_size as u64);
         let tail = file.read(tail_start, file.size() - tail_start)?;
-        // `tail` contains the last min(file_size, 17) bytes.
-        // Detect MVCC footer by checking BOTH magic AND version at their
-        // expected positions — a legacy SST whose 4-byte bloom_offset happens
-        // to end in 0x02 must NOT be mistaken for MVCC.
-        let is_mvcc = tail.len() >= tail_size
-            && tail[tail.len() - 1] == SST_FOOTER_VERSION_V2
+
+        // Detect MVCC footer by checking magic AND version at their expected
+        // positions. Version can be 2 (no prefix bloom) or 3 (with prefix bloom).
+        let version = tail[tail.len() - 1];
+        let has_mvcc_magic = tail.len() >= (MVCC_FOOTER_EXTRA as usize + SIZE_OF_U32)
             && (&tail[tail.len() - 5..tail.len() - 1]).get_u32() == SST_MVCC_MAGIC;
-        let (bloom_offset_base, max_ts, bloom_offset) = if is_mvcc {
-            // MVCC tail layout: [bloom_offset: u32][max_ts: u64][magic: u32][version: u8]
-            //                   bytes 0..4    bytes 4..12   bytes 12..16  byte 16
+        if has_mvcc_magic && version != SST_FOOTER_VERSION_V2 && version != SST_FOOTER_VERSION_V3 {
+            anyhow::bail!(
+                "unsupported MVCC footer version: {} (expected {} or {})",
+                version,
+                SST_FOOTER_VERSION_V2,
+                SST_FOOTER_VERSION_V3
+            );
+        }
+        let is_mvcc = has_mvcc_magic
+            && (version == SST_FOOTER_VERSION_V2 || version == SST_FOOTER_VERSION_V3);
+
+        let (bloom_offset_base, max_ts, bloom_offset, prefix_bloom_set) = if is_mvcc
+            && version == SST_FOOTER_VERSION_V3
+        {
+            // v3 file layout (from end of file):
+            //   [version:1][magic:4][max_ts:8][prefix_bloom_offset:4]
+            //   [prefix_bloom_section (variable size)]
+            //   [bloom_offset:4]
+            //
+            // The 21-byte tail read captures the fixed 17-byte footer
+            // extension plus 4 bytes of the preceding data. The
+            // prefix_bloom_offset is at a fixed position within the tail.
+            let footer_start = file.size() - MVCC_FOOTER_EXTRA;
+            let footer = &tail[tail.len() - MVCC_FOOTER_EXTRA as usize..];
+            let max_ts = (&footer[0..8]).get_u64();
+            // prefix_bloom_offset is at file position (footer_start - 4),
+            // which is tail[4..8] in the 21-byte read.
+            let prefix_bloom_off = (&tail[tail.len() - MVCC_FOOTER_EXTRA as usize - SIZE_OF_U32
+                ..tail.len() - MVCC_FOOTER_EXTRA as usize])
+                .get_u32() as u64;
+            // bloom_offset is at the 4 bytes immediately before the prefix
+            // bloom section. Read it from the file using prefix_bloom_off
+            // as an anchor (the 21-byte tail does NOT capture bloom_offset
+            // when the prefix bloom section is non-empty).
+            anyhow::ensure!(
+                prefix_bloom_off >= SIZE_OF_U32 as u64,
+                "SST prefix_bloom_offset out of bounds: {}",
+                prefix_bloom_off
+            );
+            let bloom_off = file
+                .read(prefix_bloom_off - SIZE_OF_U32 as u64, SIZE_OF_U32 as u64)?
+                .as_slice()
+                .get_u32() as u64;
+            // The prefix bloom section ends where the prefix_bloom_offset
+            // field is written (footer_start - 4).
+            let section_end = footer_start - SIZE_OF_U32 as u64;
+
+            // Decode prefix bloom section.
+            let prefix_blooms = Self::decode_prefix_blooms(&file, prefix_bloom_off, section_end)?;
+
+            // bloom_offset_base = start of prefix bloom section (bloom data
+            // ends right before it).
+            (prefix_bloom_off, max_ts, bloom_off, prefix_blooms)
+        } else if is_mvcc {
+            // v2 tail layout: [bloom_offset: u32][max_ts: u64][magic: u32][version: u8]
+            //                 bytes 0..4    bytes 4..12   bytes 12..16  byte 16
             let footer = &tail[tail.len() - MVCC_FOOTER_EXTRA as usize..];
             let max_ts = (&footer[0..8]).get_u64();
             let footer_start = file.size() - MVCC_FOOTER_EXTRA;
             let bloom_off = (&tail[tail.len() - MVCC_FOOTER_EXTRA as usize - SIZE_OF_U32
                 ..tail.len() - MVCC_FOOTER_EXTRA as usize])
                 .get_u32() as u64;
-            (footer_start, max_ts, bloom_off)
+            (footer_start, max_ts, bloom_off, None)
         } else {
             // Legacy footer: last 4 bytes are bloom_offset.
             let bloom_off = (&tail[tail.len() - SIZE_OF_U32..]).get_u32() as u64;
-            (file.size(), 0, bloom_off)
+            (file.size(), 0, bloom_off, None)
         };
         anyhow::ensure!(
             bloom_offset >= SIZE_OF_U32 as u64
@@ -281,7 +360,134 @@ impl SsTable {
             last_key,
             bloom: Some(bloom),
             max_ts,
+            prefix_blooms: prefix_bloom_set,
         })
+    }
+
+    /// Decode the prefix bloom section from a v3 SST.
+    ///
+    /// The section is at `[prefix_bloom_offset, prefix_bloom_offset_field)`.
+    ///
+    /// Format:
+    /// ```text
+    /// u16 filter_count
+    /// repeated filter_count times:
+    ///     u16 prefix_len
+    ///     u32 filter_offset
+    ///     u32 filter_len
+    /// filter bytes...
+    /// ```
+    fn decode_prefix_blooms(
+        file: &FileObject,
+        prefix_bloom_offset: u64,
+        prefix_bloom_offset_field: u64,
+    ) -> Result<Option<PrefixBloomSet>> {
+        anyhow::ensure!(
+            prefix_bloom_offset < prefix_bloom_offset_field,
+            "SST prefix bloom section has invalid bounds: offset={}, field={}",
+            prefix_bloom_offset,
+            prefix_bloom_offset_field
+        );
+        let section_size = prefix_bloom_offset_field - prefix_bloom_offset;
+        anyhow::ensure!(
+            section_size >= 2,
+            "SST prefix bloom section too small: {} bytes",
+            section_size
+        );
+        let section = file.read(prefix_bloom_offset, section_size)?;
+        let filter_count = (&section[0..2]).get_u16() as usize;
+        anyhow::ensure!(
+            filter_count > 0,
+            "SST v3 prefix bloom section has filter_count=0"
+        );
+        let table_len = 2 + filter_count * (2 + 4 + 4); // u16 + u32 + u32 per entry
+        anyhow::ensure!(
+            section_size as usize >= table_len,
+            "SST prefix bloom section too small for {} filters: need {} bytes, have {}",
+            filter_count,
+            table_len,
+            section_size
+        );
+        let filter_bytes_start = table_len;
+        let filter_bytes_len = section_size as usize - filter_bytes_start;
+        let mut filters = Vec::with_capacity(filter_count);
+        let mut prev_prefix_len = 0usize;
+        let mut prev_end = 0u32;
+        for i in 0..filter_count {
+            let entry_start = 2 + i * 10;
+            let prefix_len = (&section[entry_start..entry_start + 2]).get_u16() as usize;
+            let filter_offset = (&section[entry_start + 2..entry_start + 6]).get_u32() as usize;
+            let filter_len = (&section[entry_start + 6..entry_start + 10]).get_u32() as usize;
+
+            // Validate: prefix_len strictly increasing, within cap.
+            anyhow::ensure!(
+                prefix_len > 0 && prefix_len <= 64,
+                "SST prefix bloom filter[{}]: invalid prefix_len={}",
+                i,
+                prefix_len
+            );
+            if i > 0 {
+                anyhow::ensure!(
+                    prefix_len > prev_prefix_len,
+                    "SST prefix bloom filter[{}]: prefix_len={} not strictly increasing after {}",
+                    i,
+                    prefix_len,
+                    prev_prefix_len
+                );
+            }
+            // Validate: filter_offset + filter_len within filter_bytes area.
+            let filter_end = filter_offset.checked_add(filter_len).ok_or_else(|| {
+                anyhow::anyhow!("SST prefix bloom filter[{}]: offset overflow", i)
+            })?;
+            anyhow::ensure!(
+                filter_end <= filter_bytes_len,
+                "SST prefix bloom filter[{}]: extends beyond section ({} + {} > {})",
+                i,
+                filter_offset,
+                filter_len,
+                filter_bytes_len
+            );
+            // Validate: filter_len >= 2 (at least one filter byte + k byte).
+            anyhow::ensure!(
+                filter_len >= 2,
+                "SST prefix bloom filter[{}]: filter_len={} too small",
+                i,
+                filter_len
+            );
+            // Validate: non-overlapping, sorted by offset.
+            if i > 0 {
+                anyhow::ensure!(
+                    filter_offset as u32 >= prev_end,
+                    "SST prefix bloom filter[{}]: overlaps with previous filter",
+                    i
+                );
+            }
+            // Validate: first filter starts at 0, last filter ends at filter_bytes_len.
+            if i == 0 {
+                anyhow::ensure!(
+                    filter_offset == 0,
+                    "SST prefix bloom filter[0]: offset must be 0, got {}",
+                    filter_offset
+                );
+            }
+            if i == filter_count - 1 {
+                anyhow::ensure!(
+                    filter_end == filter_bytes_len,
+                    "SST prefix bloom filter[{}]: must end at section end ({} != {})",
+                    i,
+                    filter_end,
+                    filter_bytes_len
+                );
+            }
+
+            let filter_data = &section[filter_bytes_start + filter_offset
+                ..filter_bytes_start + filter_offset + filter_len];
+            let bloom = bloom::Bloom::decode(filter_data)?;
+            filters.push(PrefixBloom { prefix_len, bloom });
+            prev_prefix_len = prefix_len;
+            prev_end = filter_end as u32;
+        }
+        Ok(Some(PrefixBloomSet { filters }))
     }
 
     /// Create a mock SST with only first key + last key metadata
@@ -301,6 +507,7 @@ impl SsTable {
             last_key,
             bloom: None,
             max_ts: 0,
+            prefix_blooms: None,
         }
     }
 
@@ -575,5 +782,23 @@ impl SsTable {
         };
 
         true
+    }
+
+    /// Check if this SST may contain keys with the given prefix.
+    ///
+    /// Returns `true` when no prefix bloom metadata is available (old SST or
+    /// prefix bloom disabled). Returns `false` only when the prefix bloom
+    /// filter proves the SST cannot contain matching keys.
+    pub(crate) fn may_contain_prefix(&self, prefix: &[u8]) -> bool {
+        let Some(ref prefix_blooms) = self.prefix_blooms else {
+            return true;
+        };
+        let Some(filter) = prefix_blooms.best_filter_for(prefix.len()) else {
+            return true;
+        };
+        debug_assert!(prefix.len() >= filter.prefix_len);
+        filter
+            .bloom
+            .may_contain(bloom::hash_key(&prefix[..filter.prefix_len]))
     }
 }

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -412,7 +412,7 @@ impl SsTable {
         let filter_bytes_len = section_size as usize - filter_bytes_start;
         let mut filters = Vec::with_capacity(filter_count);
         let mut prev_prefix_len = 0usize;
-        let mut prev_end = 0u32;
+        let mut prev_end = 0usize;
         for i in 0..filter_count {
             let entry_start = 2 + i * 10;
             let prefix_len = (&section[entry_start..entry_start + 2]).get_u16() as usize;
@@ -457,7 +457,7 @@ impl SsTable {
             // Validate: non-overlapping, sorted by offset.
             if i > 0 {
                 anyhow::ensure!(
-                    filter_offset as u32 >= prev_end,
+                    filter_offset >= prev_end,
                     "SST prefix bloom filter[{}]: overlaps with previous filter",
                     i
                 );
@@ -485,7 +485,7 @@ impl SsTable {
             let bloom = bloom::Bloom::decode(filter_data)?;
             filters.push(PrefixBloom { prefix_len, bloom });
             prev_prefix_len = prefix_len;
-            prev_end = filter_end as u32;
+            prev_end = filter_end;
         }
         Ok(Some(PrefixBloomSet { filters }))
     }

--- a/kv-engine/src/table/bloom.rs
+++ b/kv-engine/src/table/bloom.rs
@@ -75,8 +75,12 @@ impl Bloom {
         buf.put_u8(self.k);
     }
 
-    /// Get bloom filter bits per key from entries count and FPR
+    /// Get bloom filter bits per key from entries count and FPR.
+    /// Returns 0 when `entries == 0` (callers must guard against empty filters).
     pub fn bloom_bits_per_key(entries: usize, false_positive_rate: f64) -> usize {
+        if entries == 0 {
+            return 0;
+        }
         let size = -(entries as f64) * false_positive_rate.ln() / std::f64::consts::LN_2.powi(2);
         let locs = (size / (entries as f64)).ceil();
         locs as usize

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -319,26 +319,27 @@ impl SsTableBuilder {
         let section_start = buf.len();
         // Placeholder for filter_count — filled in below.
         buf.put_u16(0);
-        let filter_count = prefix_set.filters.len();
+        let filter_count =
+            u16::try_from(prefix_set.filters.len()).expect("too many prefix bloom filters");
         let table_entry_size = 2 + 4 + 4; // u16 + u32 + u32
-        let filter_bytes_start = section_start + 2 + filter_count * table_entry_size;
-        let mut current_offset = 0usize;
+        let filter_bytes_start = section_start + 2 + filter_count as usize * table_entry_size;
+        let mut current_offset = 0u32;
         // Write filter table entries and collect encoded filter bytes.
         let mut filter_bytes = Vec::new();
         for filter in &prefix_set.filters {
             let mut encoded = Vec::new();
             filter.bloom.encode(&mut encoded);
             let filter_offset = current_offset;
-            let filter_len = encoded.len();
-            debug_assert!(filter.prefix_len <= u16::MAX as usize);
-            buf.put_u16(filter.prefix_len as u16);
-            buf.put_u32(filter_offset as u32);
-            buf.put_u32(filter_len as u32);
+            let filter_len =
+                u32::try_from(encoded.len()).expect("prefix bloom filter exceeds 4 GiB");
+            buf.put_u16(u16::try_from(filter.prefix_len).expect("prefix_len exceeds u16"));
+            buf.put_u32(filter_offset);
+            buf.put_u32(filter_len);
             filter_bytes.extend_from_slice(&encoded);
             current_offset += filter_len;
         }
         // Patch filter_count.
-        (&mut buf[section_start..section_start + 2]).put_u16(filter_count as u16);
+        (&mut buf[section_start..section_start + 2]).put_u16(filter_count);
         // Append filter bytes.
         buf.extend_from_slice(&filter_bytes);
     }

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -104,6 +104,13 @@ impl SsTableBuilder {
     /// Set prefix bloom filter options. When enabled, prefix hashes are
     /// collected during key insertion for building prefix bloom filters.
     pub fn set_prefix_bloom_options(&mut self, options: Option<PrefixBloomOptions>) {
+        if let Some(ref opts) = options {
+            if opts.enabled {
+                for &len in &opts.prefix_lengths {
+                    self.prefix_hash_sets.entry(len).or_default();
+                }
+            }
+        }
         self.prefix_bloom_options = options;
     }
 
@@ -228,7 +235,7 @@ impl SsTableBuilder {
                 for &len in &opts.prefix_lengths {
                     if self.user_key_buf.len() >= len {
                         let h = super::bloom::hash_key(&self.user_key_buf[..len]);
-                        self.prefix_hash_sets.entry(len).or_default().push(h);
+                        self.prefix_hash_sets.get_mut(&len).unwrap().push(h);
                     }
                 }
             }
@@ -242,7 +249,7 @@ impl SsTableBuilder {
                 for &len in &opts.prefix_lengths {
                     if raw.len() >= len {
                         let h = super::bloom::hash_key(&raw[..len]);
-                        self.prefix_hash_sets.entry(len).or_default().push(h);
+                        self.prefix_hash_sets.get_mut(&len).unwrap().push(h);
                     }
                 }
             }

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -323,8 +323,6 @@ impl SsTableBuilder {
         buf.put_u16(0);
         let filter_count =
             u16::try_from(prefix_set.filters.len()).context("too many prefix bloom filters")?;
-        let table_entry_size = 2 + 4 + 4; // u16 + u32 + u32
-        let filter_bytes_start = section_start + 2 + filter_count as usize * table_entry_size;
         let mut current_offset = 0u32;
         // Write filter table entries and collect encoded filter bytes.
         let mut filter_bytes = Vec::new();

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -104,11 +104,11 @@ impl SsTableBuilder {
     /// Set prefix bloom filter options. When enabled, prefix hashes are
     /// collected during key insertion for building prefix bloom filters.
     pub fn set_prefix_bloom_options(&mut self, options: Option<PrefixBloomOptions>) {
-        if let Some(ref opts) = options {
-            if opts.enabled {
-                for &len in &opts.prefix_lengths {
-                    self.prefix_hash_sets.entry(len).or_default();
-                }
+        if let Some(ref opts) = options
+            && opts.enabled
+        {
+            for &len in &opts.prefix_lengths {
+                self.prefix_hash_sets.entry(len).or_default();
             }
         }
         self.prefix_bloom_options = options;

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -315,12 +315,15 @@ impl SsTableBuilder {
     ///     u32 filter_len
     /// filter bytes...
     /// ```
-    fn encode_prefix_bloom_section(prefix_set: &super::PrefixBloomSet, buf: &mut Vec<u8>) {
+    fn encode_prefix_bloom_section(
+        prefix_set: &super::PrefixBloomSet,
+        buf: &mut Vec<u8>,
+    ) -> Result<()> {
         let section_start = buf.len();
         // Placeholder for filter_count — filled in below.
         buf.put_u16(0);
         let filter_count =
-            u16::try_from(prefix_set.filters.len()).expect("too many prefix bloom filters");
+            u16::try_from(prefix_set.filters.len()).context("too many prefix bloom filters")?;
         let table_entry_size = 2 + 4 + 4; // u16 + u32 + u32
         let filter_bytes_start = section_start + 2 + filter_count as usize * table_entry_size;
         let mut current_offset = 0u32;
@@ -331,8 +334,8 @@ impl SsTableBuilder {
             filter.bloom.encode(&mut encoded);
             let filter_offset = current_offset;
             let filter_len =
-                u32::try_from(encoded.len()).expect("prefix bloom filter exceeds 4 GiB");
-            buf.put_u16(u16::try_from(filter.prefix_len).expect("prefix_len exceeds u16"));
+                u32::try_from(encoded.len()).context("prefix bloom filter exceeds 4 GiB")?;
+            buf.put_u16(u16::try_from(filter.prefix_len).context("prefix_len exceeds u16::MAX")?);
             buf.put_u32(filter_offset);
             buf.put_u32(filter_len);
             filter_bytes.extend_from_slice(&encoded);
@@ -342,6 +345,7 @@ impl SsTableBuilder {
         (&mut buf[section_start..section_start + 2]).put_u16(filter_count);
         // Append filter bytes.
         buf.extend_from_slice(&filter_bytes);
+        Ok(())
     }
 
     /// Builds the SSTable and writes it to the given path. Use the `FileObject` structure to
@@ -420,7 +424,7 @@ impl SsTableBuilder {
         if let Some(ref prefix_set) = prefix_bloom_set {
             // Write v3 footer with prefix bloom section.
             let prefix_bloom_offset = buf.len();
-            Self::encode_prefix_bloom_section(prefix_set, &mut buf);
+            Self::encode_prefix_bloom_section(prefix_set, &mut buf)?;
             buf.put_u32(
                 u32::try_from(prefix_bloom_offset)
                     .context("prefix bloom offset exceeds u32::MAX")?,

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -326,8 +326,9 @@ impl SsTableBuilder {
         let mut current_offset = 0u32;
         // Write filter table entries and collect encoded filter bytes.
         let mut filter_bytes = Vec::new();
+        let mut encoded = Vec::new();
         for filter in &prefix_set.filters {
-            let mut encoded = Vec::new();
+            encoded.clear();
             filter.bloom.encode(&mut encoded);
             let filter_offset = current_offset;
             let filter_len =

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -235,7 +235,10 @@ impl SsTableBuilder {
                 for &len in &opts.prefix_lengths {
                     if self.user_key_buf.len() >= len {
                         let h = super::bloom::hash_key(&self.user_key_buf[..len]);
-                        self.prefix_hash_sets.get_mut(&len).unwrap().push(h);
+                        self.prefix_hash_sets
+                            .get_mut(&len)
+                            .expect("prefix_hash_sets pre-populated in set_prefix_bloom_options")
+                            .push(h);
                     }
                 }
             }
@@ -249,7 +252,10 @@ impl SsTableBuilder {
                 for &len in &opts.prefix_lengths {
                     if raw.len() >= len {
                         let h = super::bloom::hash_key(&raw[..len]);
-                        self.prefix_hash_sets.get_mut(&len).unwrap().push(h);
+                        self.prefix_hash_sets
+                            .get_mut(&len)
+                            .expect("prefix_hash_sets pre-populated in set_prefix_bloom_options")
+                            .push(h);
                     }
                 }
             }

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -1,4 +1,4 @@
-use std::{mem, path::Path, sync::Arc};
+use std::{collections::HashMap, mem, path::Path, sync::Arc};
 
 use anyhow::{Context, Result, bail};
 use bytes::{BufMut, Bytes};
@@ -10,7 +10,7 @@ use super::{
 use crate::{
     block::{Block, BlockBuilder},
     key::{KeyBytes, KeySlice, TS_ENABLED},
-    lsm_storage::BlockCache,
+    lsm_storage::{BlockCache, PrefixBloomOptions},
     vlog::{KvKind, ValueLogBuilder, ValuePointer, ValueSeparationOptions, index::VlogIndexEntry},
 };
 
@@ -36,6 +36,15 @@ pub struct SsTableBuilder {
     max_ts: u64,
     /// Reusable buffer for decoding user keys (bloom hash computation).
     user_key_buf: Vec<u8>,
+    /// Prefix bloom filter options. When `Some` and enabled, prefix hashes
+    /// are collected during key insertion for building prefix bloom filters.
+    prefix_bloom_options: Option<PrefixBloomOptions>,
+    /// Per-prefix-length hash collections for prefix bloom filters.
+    /// Key is the prefix length, value is the collected prefix hashes.
+    /// Duplicates are tolerated and deduped at build time (same approach
+    /// as the full-key bloom filter) to avoid false negatives from
+    /// hash collisions in a HashSet.
+    prefix_hash_sets: HashMap<usize, Vec<u32>>,
 }
 
 impl SsTableBuilder {
@@ -55,6 +64,8 @@ impl SsTableBuilder {
             collect_blocks: false,
             max_ts: 0,
             user_key_buf: Vec::new(),
+            prefix_bloom_options: None,
+            prefix_hash_sets: HashMap::new(),
         }
     }
 
@@ -79,6 +90,8 @@ impl SsTableBuilder {
             collect_blocks: false,
             max_ts: 0,
             user_key_buf: Vec::new(),
+            prefix_bloom_options: None,
+            prefix_hash_sets: HashMap::new(),
         }
     }
 
@@ -86,6 +99,12 @@ impl SsTableBuilder {
     /// When enabled, `build_with_backfill()` will return the collected blocks.
     pub fn set_collect_blocks(&mut self, collect: bool) {
         self.collect_blocks = collect;
+    }
+
+    /// Set prefix bloom filter options. When enabled, prefix hashes are
+    /// collected during key insertion for building prefix bloom filters.
+    pub fn set_prefix_bloom_options(&mut self, options: Option<PrefixBloomOptions>) {
+        self.prefix_bloom_options = options;
     }
 
     pub fn is_empty(&self) -> bool {
@@ -202,8 +221,31 @@ impl SsTableBuilder {
             key.decode_user_key_into(&mut self.user_key_buf);
             self.key_hashes
                 .push(super::bloom::hash_key(&self.user_key_buf));
+            // Collect prefix bloom hashes from decoded user key.
+            if let Some(ref opts) = self.prefix_bloom_options
+                && opts.enabled
+            {
+                for &len in &opts.prefix_lengths {
+                    if self.user_key_buf.len() >= len {
+                        let h = super::bloom::hash_key(&self.user_key_buf[..len]);
+                        self.prefix_hash_sets.entry(len).or_default().push(h);
+                    }
+                }
+            }
         } else {
             self.key_hashes.push(super::bloom::hash_key(key.raw_ref()));
+            // Collect prefix bloom hashes from raw key (non-MVCC).
+            if let Some(ref opts) = self.prefix_bloom_options
+                && opts.enabled
+            {
+                let raw = key.raw_ref();
+                for &len in &opts.prefix_lengths {
+                    if raw.len() >= len {
+                        let h = super::bloom::hash_key(&raw[..len]);
+                        self.prefix_hash_sets.entry(len).or_default().push(h);
+                    }
+                }
+            }
         }
         Ok(())
     }
@@ -228,6 +270,77 @@ impl SsTableBuilder {
             .as_mut()
             .map(|b| b.take_entries())
             .unwrap_or_default()
+    }
+
+    /// Build prefix bloom filters from collected prefix hashes.
+    ///
+    /// Returns `Some(PrefixBloomSet)` if prefix bloom is enabled and at least
+    /// one prefix length has non-empty hash set. Returns `None` otherwise.
+    fn build_prefix_blooms(&self) -> Option<super::PrefixBloomSet> {
+        let opts = self.prefix_bloom_options.as_ref()?;
+        if !opts.enabled {
+            return None;
+        }
+        let mut filters = Vec::new();
+        for &len in &opts.prefix_lengths {
+            if let Some(hashes) = self.prefix_hash_sets.get(&len)
+                && !hashes.is_empty()
+            {
+                let mut hashes = hashes.clone();
+                hashes.sort_unstable();
+                hashes.dedup();
+                let bpk = Bloom::bloom_bits_per_key(hashes.len(), opts.false_positive_rate);
+                let bloom = Bloom::build_from_key_hashes(&hashes, bpk);
+                filters.push(super::PrefixBloom {
+                    prefix_len: len,
+                    bloom,
+                });
+            }
+        }
+        if filters.is_empty() {
+            None
+        } else {
+            Some(super::PrefixBloomSet { filters })
+        }
+    }
+
+    /// Encode the prefix bloom section into the buffer.
+    ///
+    /// Format:
+    /// ```text
+    /// u16 filter_count
+    /// repeated filter_count times:
+    ///     u16 prefix_len
+    ///     u32 filter_offset
+    ///     u32 filter_len
+    /// filter bytes...
+    /// ```
+    fn encode_prefix_bloom_section(prefix_set: &super::PrefixBloomSet, buf: &mut Vec<u8>) {
+        let section_start = buf.len();
+        // Placeholder for filter_count — filled in below.
+        buf.put_u16(0);
+        let filter_count = prefix_set.filters.len();
+        let table_entry_size = 2 + 4 + 4; // u16 + u32 + u32
+        let filter_bytes_start = section_start + 2 + filter_count * table_entry_size;
+        let mut current_offset = 0usize;
+        // Write filter table entries and collect encoded filter bytes.
+        let mut filter_bytes = Vec::new();
+        for filter in &prefix_set.filters {
+            let mut encoded = Vec::new();
+            filter.bloom.encode(&mut encoded);
+            let filter_offset = current_offset;
+            let filter_len = encoded.len();
+            debug_assert!(filter.prefix_len <= u16::MAX as usize);
+            buf.put_u16(filter.prefix_len as u16);
+            buf.put_u32(filter_offset as u32);
+            buf.put_u32(filter_len as u32);
+            filter_bytes.extend_from_slice(&encoded);
+            current_offset += filter_len;
+        }
+        // Patch filter_count.
+        (&mut buf[section_start..section_start + 2]).put_u16(filter_count as u16);
+        // Append filter bytes.
+        buf.extend_from_slice(&filter_bytes);
     }
 
     /// Builds the SSTable and writes it to the given path. Use the `FileObject` structure to
@@ -279,6 +392,9 @@ impl SsTableBuilder {
         };
         self.meta.push(meta);
 
+        // Build prefix bloom filters before consuming self.builder.
+        let prefix_bloom_set = self.build_prefix_blooms();
+
         let final_block = self.builder.build();
         let data = if self.collect_blocks && self.has_data {
             let data = final_block.encode_ref()?;
@@ -300,10 +416,23 @@ impl SsTableBuilder {
         bloom.encode(&mut buf);
         buf.put_u32(u32::try_from(bloom_offset).context("bloom offset exceeds u32::MAX")?);
 
-        // MVCC footer extension: max_ts + magic + version byte.
-        buf.put_u64(self.max_ts);
-        buf.put_u32(super::SST_MVCC_MAGIC);
-        buf.put_u8(super::SST_FOOTER_VERSION_V2);
+        if let Some(ref prefix_set) = prefix_bloom_set {
+            // Write v3 footer with prefix bloom section.
+            let prefix_bloom_offset = buf.len();
+            Self::encode_prefix_bloom_section(prefix_set, &mut buf);
+            buf.put_u32(
+                u32::try_from(prefix_bloom_offset)
+                    .context("prefix bloom offset exceeds u32::MAX")?,
+            );
+            buf.put_u64(self.max_ts);
+            buf.put_u32(super::SST_MVCC_MAGIC);
+            buf.put_u8(super::SST_FOOTER_VERSION_V3);
+        } else {
+            // Write v2 footer (no prefix bloom metadata).
+            buf.put_u64(self.max_ts);
+            buf.put_u32(super::SST_MVCC_MAGIC);
+            buf.put_u8(super::SST_FOOTER_VERSION_V2);
+        }
 
         let file = FileObject::create(path.as_ref(), buf)?;
 
@@ -331,6 +460,7 @@ impl SsTableBuilder {
             last_key,
             bloom: Some(bloom),
             max_ts: self.max_ts,
+            prefix_blooms: prefix_bloom_set,
         };
         Ok((sst, self.collected_blocks))
     }

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -276,17 +276,16 @@ impl SsTableBuilder {
     ///
     /// Returns `Some(PrefixBloomSet)` if prefix bloom is enabled and at least
     /// one prefix length has non-empty hash set. Returns `None` otherwise.
-    fn build_prefix_blooms(&self) -> Option<super::PrefixBloomSet> {
+    fn build_prefix_blooms(&mut self) -> Option<super::PrefixBloomSet> {
         let opts = self.prefix_bloom_options.as_ref()?;
         if !opts.enabled {
             return None;
         }
         let mut filters = Vec::new();
         for &len in &opts.prefix_lengths {
-            if let Some(hashes) = self.prefix_hash_sets.get(&len)
+            if let Some(hashes) = self.prefix_hash_sets.get_mut(&len)
                 && !hashes.is_empty()
             {
-                let mut hashes = hashes.clone();
                 hashes.sort_unstable();
                 hashes.dedup();
                 let bpk = Bloom::bloom_bits_per_key(hashes.len(), opts.false_positive_rate);

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -289,7 +289,7 @@ impl SsTableBuilder {
                 hashes.sort_unstable();
                 hashes.dedup();
                 let bpk = Bloom::bloom_bits_per_key(hashes.len(), opts.false_positive_rate);
-                let bloom = Bloom::build_from_key_hashes(&hashes, bpk);
+                let bloom = Bloom::build_from_key_hashes(hashes, bpk);
                 filters.push(super::PrefixBloom {
                     prefix_len: len,
                     bloom,

--- a/kv-engine/src/tests/cache_backfill.rs
+++ b/kv-engine/src/tests/cache_backfill.rs
@@ -3,7 +3,7 @@
 use tempfile::tempdir;
 
 use crate::{
-    lsm_storage::{KvEngine, LsmStorageOptions},
+    lsm_storage::{KvEngine, LsmStorageOptions, PrefixBloomOptions},
     tests::harness::sync,
 };
 
@@ -160,6 +160,7 @@ fn test_compaction_backfill_perf_comparison() {
             manifest_snapshot_threshold_bytes: 0,
             block_cache_capacity,
             enable_cache_backfill: backfill,
+            prefix_bloom: PrefixBloomOptions::default(),
         }
     };
 

--- a/kv-engine/src/tests/lsm_storage_extra.rs
+++ b/kv-engine/src/tests/lsm_storage_extra.rs
@@ -4,7 +4,7 @@ use tempfile::tempdir;
 use crate::{
     compact::CompactionOptions,
     iterators::StorageIterator,
-    lsm_storage::{KvEngine, LsmStorageOptions, WriteBatchRecord},
+    lsm_storage::{KvEngine, LsmStorageOptions, PrefixBloomOptions, WriteBatchRecord},
     vlog::ValueSeparationOptions,
 };
 
@@ -37,6 +37,7 @@ fn test_cache_stats_with_vlog() {
         manifest_snapshot_threshold_bytes: 0,
         block_cache_capacity: 1024,
         enable_cache_backfill: true,
+        prefix_bloom: PrefixBloomOptions::default(),
     };
     let engine = KvEngine::open(&dir, options).unwrap();
 
@@ -77,6 +78,7 @@ fn test_vlog_stats_with_vlog() {
         manifest_snapshot_threshold_bytes: 0,
         block_cache_capacity: 1024,
         enable_cache_backfill: true,
+        prefix_bloom: PrefixBloomOptions::default(),
     };
     let engine = KvEngine::open(&dir, options).unwrap();
 

--- a/kv-engine/src/tests/prefix_scan.rs
+++ b/kv-engine/src/tests/prefix_scan.rs
@@ -7,7 +7,7 @@ use super::harness::{check_lsm_iter_result_by_key, sync};
 use crate::{
     compact::CompactionOptions,
     iterators::StorageIterator,
-    lsm_storage::{KvEngine, LsmStorageOptions, prefix_upper_bound},
+    lsm_storage::{KvEngine, LsmStorageOptions, PrefixBloomOptions, prefix_upper_bound},
 };
 
 // ── Unit tests for prefix_upper_bound ──────────────────────────────────────
@@ -274,6 +274,7 @@ fn serializable_options() -> LsmStorageOptions {
         manifest_snapshot_threshold_bytes: 0,
         block_cache_capacity: 1024,
         enable_cache_backfill: true,
+        prefix_bloom: PrefixBloomOptions::default(),
     }
 }
 
@@ -550,4 +551,251 @@ fn test_prefix_scan_compaction_with_delete_gc() {
 
     let mut iter = engine.prefix_scan(b"user:").unwrap();
     check_lsm_iter_result_by_key(&mut iter, vec![(Bytes::from("user:1"), Bytes::from("v1"))]);
+}
+
+// ── Prefix bloom filter tests ────────────────────────────────────────────
+
+fn prefix_bloom_options(prefix_lengths: Vec<usize>) -> LsmStorageOptions {
+    LsmStorageOptions {
+        block_size: 4096,
+        target_sst_size: 2 << 20,
+        compaction_options: CompactionOptions::NoCompaction,
+        enable_wal: false,
+        num_memtable_limit: 50,
+        serializable: false,
+        value_separation: None,
+        manifest_snapshot_threshold_bytes: 0,
+        block_cache_capacity: 1792,
+        enable_cache_backfill: true,
+        prefix_bloom: PrefixBloomOptions {
+            enabled: true,
+            prefix_lengths,
+            false_positive_rate: 0.01,
+        },
+    }
+}
+
+#[test]
+fn test_prefix_bloom_basic_flushed_ssts() {
+    let dir = tempdir().unwrap();
+    let engine = KvEngine::open(&dir, prefix_bloom_options(vec![6])).unwrap();
+
+    // Write keys with different prefixes and flush to SSTs.
+    engine.put(b"tenant:1:user:1", b"v1").unwrap();
+    engine.put(b"tenant:1:user:2", b"v2").unwrap();
+    engine.put(b"tenant:2:user:1", b"v3").unwrap();
+    engine.put(b"other:data", b"v4").unwrap();
+    sync(&engine.inner);
+
+    // Prefix scan for "tenant:1:" should return only tenant:1 keys.
+    let mut iter = engine.prefix_scan(b"tenant:1:").unwrap();
+    check_lsm_iter_result_by_key(
+        &mut iter,
+        vec![
+            (Bytes::from("tenant:1:user:1"), Bytes::from("v1")),
+            (Bytes::from("tenant:1:user:2"), Bytes::from("v2")),
+        ],
+    );
+
+    // Prefix scan for "tenant:2:" should return only tenant:2 keys.
+    let mut iter = engine.prefix_scan(b"tenant:2:").unwrap();
+    check_lsm_iter_result_by_key(
+        &mut iter,
+        vec![(Bytes::from("tenant:2:user:1"), Bytes::from("v3"))],
+    );
+
+    // Missing prefix should return empty.
+    let iter = engine.prefix_scan(b"tenant:3:").unwrap();
+    assert!(!iter.is_valid());
+}
+
+#[test]
+fn test_prefix_bloom_with_multiple_ssts() {
+    let dir = tempdir().unwrap();
+    let engine = KvEngine::open(&dir, prefix_bloom_options(vec![8])).unwrap();
+
+    // Write and flush multiple SSTs with different tenant prefixes.
+    engine.put(b"user:001:data", b"a").unwrap();
+    sync(&engine.inner);
+    engine.put(b"user:002:data", b"b").unwrap();
+    sync(&engine.inner);
+    engine.put(b"user:003:data", b"c").unwrap();
+    sync(&engine.inner);
+
+    // Each prefix scan should find only the matching key.
+    let mut iter = engine.prefix_scan(b"user:001:").unwrap();
+    check_lsm_iter_result_by_key(
+        &mut iter,
+        vec![(Bytes::from("user:001:data"), Bytes::from("a"))],
+    );
+
+    let mut iter = engine.prefix_scan(b"user:002:").unwrap();
+    check_lsm_iter_result_by_key(
+        &mut iter,
+        vec![(Bytes::from("user:002:data"), Bytes::from("b"))],
+    );
+}
+
+#[test]
+fn test_prefix_bloom_preserves_correctness_after_compaction() {
+    let dir = tempdir().unwrap();
+    let mut opts = prefix_bloom_options(vec![6]);
+    opts.compaction_options =
+        CompactionOptions::Simple(crate::compact::SimpleLeveledCompactionOptions {
+            size_ratio_percent: 200,
+            level0_file_num_compaction_trigger: 2,
+            max_levels: 3,
+        });
+    opts.num_memtable_limit = 2;
+    let engine = KvEngine::open(&dir, opts).unwrap();
+
+    // Write data and trigger compaction.
+    engine.put(b"tenant:1:key1", b"v1").unwrap();
+    engine.put(b"tenant:2:key1", b"v2").unwrap();
+    sync(&engine.inner);
+    engine.put(b"tenant:1:key2", b"v3").unwrap();
+    engine.put(b"tenant:3:key1", b"v4").unwrap();
+    sync(&engine.inner);
+
+    // Results should be correct after compaction.
+    let mut iter = engine.prefix_scan(b"tenant:1:").unwrap();
+    check_lsm_iter_result_by_key(
+        &mut iter,
+        vec![
+            (Bytes::from("tenant:1:key1"), Bytes::from("v1")),
+            (Bytes::from("tenant:1:key2"), Bytes::from("v3")),
+        ],
+    );
+}
+
+#[test]
+fn test_prefix_bloom_short_prefix_fallback() {
+    let dir = tempdir().unwrap();
+    // Configure prefix length 8, but query with prefix shorter than 8 bytes.
+    // The bloom filter should not reject any SST (fallback to range scan).
+    let engine = KvEngine::open(&dir, prefix_bloom_options(vec![8])).unwrap();
+
+    engine.put(b"ab:data", b"v1").unwrap();
+    engine.put(b"ac:data", b"v2").unwrap();
+    engine.put(b"bb:data", b"v3").unwrap();
+    sync(&engine.inner);
+
+    // Query with 2-byte prefix (shorter than configured length 8).
+    let mut iter = engine.prefix_scan(b"ab").unwrap();
+    check_lsm_iter_result_by_key(&mut iter, vec![(Bytes::from("ab:data"), Bytes::from("v1"))]);
+}
+
+#[test]
+fn test_prefix_bloom_disabled_same_results() {
+    // Verify that prefix_scan with prefix bloom enabled returns the same
+    // results as with it disabled.
+    let dir_disabled = tempdir().unwrap();
+    let dir_enabled = tempdir().unwrap();
+
+    let engine_disabled =
+        KvEngine::open(&dir_disabled, LsmStorageOptions::default_for_test()).unwrap();
+    let engine_enabled = KvEngine::open(&dir_enabled, prefix_bloom_options(vec![6])).unwrap();
+
+    let keys: Vec<Vec<u8>> = (0..50)
+        .map(|i| format!("user:{:03}:data", i).into_bytes())
+        .collect();
+    for key in &keys {
+        engine_disabled.put(key, b"val").unwrap();
+        engine_enabled.put(key, b"val").unwrap();
+    }
+    sync(&engine_disabled.inner);
+    sync(&engine_enabled.inner);
+
+    // Both should return the same results for "user:01:" prefix.
+    let mut iter_disabled = engine_disabled.prefix_scan(b"user:01:").unwrap();
+    let mut iter_enabled = engine_enabled.prefix_scan(b"user:01:").unwrap();
+
+    let mut results_disabled = vec![];
+    while iter_disabled.is_valid() {
+        results_disabled.push((
+            Bytes::copy_from_slice(iter_disabled.key()),
+            Bytes::copy_from_slice(iter_disabled.value()),
+        ));
+        iter_disabled.next().unwrap();
+    }
+    let mut results_enabled = vec![];
+    while iter_enabled.is_valid() {
+        results_enabled.push((
+            Bytes::copy_from_slice(iter_enabled.key()),
+            Bytes::copy_from_slice(iter_enabled.value()),
+        ));
+        iter_enabled.next().unwrap();
+    }
+    assert_eq!(results_disabled, results_enabled);
+}
+
+#[test]
+fn test_prefix_bloom_with_mvcc_versions() {
+    let dir = tempdir().unwrap();
+    let engine = KvEngine::open(&dir, prefix_bloom_options(vec![6])).unwrap();
+
+    // Write multiple versions of the same key.
+    engine.put(b"user:1:data", b"v1").unwrap();
+    engine.put(b"user:1:data", b"v2").unwrap();
+    engine.put(b"user:2:data", b"v3").unwrap();
+    sync(&engine.inner);
+
+    // Should see only the latest version.
+    let mut iter = engine.prefix_scan(b"user:1").unwrap();
+    check_lsm_iter_result_by_key(
+        &mut iter,
+        vec![(Bytes::from("user:1:data"), Bytes::from("v2"))],
+    );
+}
+
+#[test]
+fn test_prefix_bloom_v3_reopen_from_disk() {
+    let dir = tempdir().unwrap();
+    let opts = prefix_bloom_options(vec![6]);
+
+    // Phase 1: write data and flush to v3 SSTs, then drop engine.
+    {
+        let engine = KvEngine::open(&dir, opts.clone()).unwrap();
+        engine.put(b"user:1:data", b"v1").unwrap();
+        engine.put(b"user:2:data", b"v2").unwrap();
+        engine.put(b"other:data", b"v3").unwrap();
+        sync(&engine.inner);
+        // engine dropped here — SSTs written to disk with v3 footer
+    }
+
+    // Phase 2: reopen — exercises SsTable::open() v3 decode path.
+    {
+        let engine = KvEngine::open(&dir, opts).unwrap();
+
+        // Prefix scan exercises prefix bloom decode.
+        let mut iter = engine.prefix_scan(b"user:1").unwrap();
+        check_lsm_iter_result_by_key(
+            &mut iter,
+            vec![(Bytes::from("user:1:data"), Bytes::from("v1"))],
+        );
+
+        // Point get exercises whole-key bloom decode on v3 SST.
+        assert_eq!(engine.get(b"user:2:data").unwrap(), Some(Bytes::from("v2")));
+
+        // Missing prefix should return empty.
+        let iter = engine.prefix_scan(b"tenant:").unwrap();
+        assert!(!iter.is_valid());
+    }
+}
+
+#[test]
+fn test_prefix_bloom_short_keys_emit_v2() {
+    let dir = tempdir().unwrap();
+    // Configure prefix length 16, but all keys are shorter than 16 bytes.
+    // The builder should emit a v2 SST (no prefix bloom metadata).
+    let opts = prefix_bloom_options(vec![16]);
+    let engine = KvEngine::open(&dir, opts).unwrap();
+
+    engine.put(b"ab", b"v1").unwrap();
+    engine.put(b"cd", b"v2").unwrap();
+    sync(&engine.inner);
+
+    // Results should still be correct — prefix bloom simply doesn't apply.
+    let mut iter = engine.prefix_scan(b"ab").unwrap();
+    check_lsm_iter_result_by_key(&mut iter, vec![(Bytes::from("ab"), Bytes::from("v1"))]);
 }

--- a/kv-engine/src/tests/txn_serializable.rs
+++ b/kv-engine/src/tests/txn_serializable.rs
@@ -5,7 +5,7 @@ use tempfile::tempdir;
 
 use crate::{
     compact::CompactionOptions,
-    lsm_storage::{KvEngine, LsmStorageOptions},
+    lsm_storage::{KvEngine, LsmStorageOptions, PrefixBloomOptions},
 };
 
 fn serializable_options() -> LsmStorageOptions {
@@ -20,6 +20,7 @@ fn serializable_options() -> LsmStorageOptions {
         manifest_snapshot_threshold_bytes: 0,
         block_cache_capacity: 1024,
         enable_cache_backfill: true,
+        prefix_bloom: PrefixBloomOptions::default(),
     }
 }
 

--- a/kv-engine/src/tests/vlog_integration_tests/cache.rs
+++ b/kv-engine/src/tests/vlog_integration_tests/cache.rs
@@ -4,7 +4,6 @@ use super::*;
 fn test_value_cache_hit_miss() {
     let dir = tempfile::tempdir().unwrap();
     let options = LsmStorageOptions {
-        prefix_bloom: PrefixBloomOptions::default(),
         block_size: 256,
         target_sst_size: 1 << 20,
         num_memtable_limit: 2,
@@ -20,6 +19,7 @@ fn test_value_cache_hit_miss() {
         manifest_snapshot_threshold_bytes: 0,
         block_cache_capacity: 1024,
         enable_cache_backfill: true,
+        prefix_bloom: PrefixBloomOptions::default(),
     };
     let storage = KvEngine::open(dir.path(), options).unwrap();
 

--- a/kv-engine/src/tests/vlog_integration_tests/cache.rs
+++ b/kv-engine/src/tests/vlog_integration_tests/cache.rs
@@ -4,6 +4,7 @@ use super::*;
 fn test_value_cache_hit_miss() {
     let dir = tempfile::tempdir().unwrap();
     let options = LsmStorageOptions {
+        prefix_bloom: PrefixBloomOptions::default(),
         block_size: 256,
         target_sst_size: 1 << 20,
         num_memtable_limit: 2,
@@ -83,6 +84,7 @@ fn test_value_cache_disabled_by_default() {
         manifest_snapshot_threshold_bytes: 0,
         block_cache_capacity: 1024,
         enable_cache_backfill: true,
+        prefix_bloom: PrefixBloomOptions::default(),
     };
     let storage = KvEngine::open(dir.path(), options).unwrap();
 
@@ -122,6 +124,7 @@ fn test_value_cache_enabled_by_default() {
         manifest_snapshot_threshold_bytes: 0,
         block_cache_capacity: 1024,
         enable_cache_backfill: true,
+        prefix_bloom: PrefixBloomOptions::default(),
     };
     let storage = KvEngine::open(dir.path(), options).unwrap();
 

--- a/kv-engine/src/tests/vlog_integration_tests/mod.rs
+++ b/kv-engine/src/tests/vlog_integration_tests/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     compact::CompactionOptions,
     iterators::StorageIterator,
     key::KeySlice,
-    lsm_storage::{KvEngine, LsmStorageInner, LsmStorageOptions},
+    lsm_storage::{KvEngine, LsmStorageInner, LsmStorageOptions, PrefixBloomOptions},
     table::SsTableBuilder,
     vlog::ValueSeparationOptions,
 };
@@ -34,6 +34,7 @@ fn options_with_vlog_enabled(block_size: usize, target_sst_size: usize) -> LsmSt
         manifest_snapshot_threshold_bytes: 0,
         block_cache_capacity: 1024,
         enable_cache_backfill: true,
+        prefix_bloom: PrefixBloomOptions::default(),
     }
 }
 
@@ -64,6 +65,7 @@ fn options_with_vlog_and_compaction(
         manifest_snapshot_threshold_bytes: 0,
         block_cache_capacity: 1024,
         enable_cache_backfill: true,
+        prefix_bloom: PrefixBloomOptions::default(),
     }
 }
 


### PR DESCRIPTION
## Summary

Implements RFC 007: SST-level prefix bloom filters that allow `prefix_scan` to skip SSTs that provably cannot contain matching prefixes before creating iterators.

## Changes

- Add `PrefixBloomOptions` to `LsmStorageOptions` (disabled by default)
- Add `PrefixBloom`/`PrefixBloomSet` data structures to `SsTable`
- Extend `SsTableBuilder` to collect prefix hashes per configured length during key insertion
- Add v3 SST footer format with prefix bloom section (backward compatible with v2)
- Add v3 footer decode with full canonical encoding validation (7 rules from RFC §6.5.2)
- Add `may_contain_prefix()` for probabilistic prefix rejection
- Wire `scan_inner` with `prefix_hint` for L0 and L1+ prefix bloom pruning
- Wire `KvEngine::prefix_scan` and `Transaction::prefix_scan` to pass prefix hint

## SST Format (v3)



v2 SSTs remain fully backward compatible. v3 is only written when prefix bloom is enabled and at least one prefix length has non-empty hash set.

## Design Decisions

- **Fixed prefix lengths** (e.g. `[4, 8]`) — pragmatic, bounded metadata, supports common schemas
- **Vec<u32> with sort+dedup** (not HashSet) for prefix hashes — avoids false negatives from hash collisions
- **Disabled by default** — changes SST metadata size, should be benchmarked per workload
- **User-key hashing only** — MVCC timestamps never part of prefix bloom hash
- **SST-level filters** (not per-block) — simpler first step, prunes whole files

## Verification

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` passes
- [x] `cargo test` — 389 tests pass (381 existing + 8 new prefix bloom tests)
- [x] v3 SST reopen-from-disk test exercises the decode path
- [x] 3-round adversarial review completed, all critical/major findings fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable prefix bloom filters persisted in a new table format to speed up prefix scans.

* **Improvements**
  * Prefix-scan paths now use bloom-guided pruning to skip irrelevant tables, improving read/scan performance and compaction behavior.
  * CLI and benchmarks default to enabling prefix bloom options for realistic testing.

* **Tests**
  * Expanded tests covering prefix-bloom behavior, compaction, and reopen scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->