### PR TITLE
feat: add persisted compaction filters

### DIFF
--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -547,6 +547,11 @@ impl LsmStorageInner {
                     .as_ref()
                     .is_some_and(|m| !m.can_publish_filter_deletion())
             {
+                // Clean up orphan SST files that were built but will not be
+                // published to the LSM state.
+                for sst in &new_ssts {
+                    let _ = std::fs::remove_file(self.path_of_sst(sst.sst_id()));
+                }
                 return Ok(());
             }
 
@@ -772,6 +777,11 @@ impl LsmStorageInner {
                     .as_ref()
                     .is_some_and(|m| !m.can_publish_filter_deletion())
             {
+                // Clean up orphan SST files that were built but will not be
+                // published to the LSM state.
+                for sst in &new_ssts {
+                    let _ = std::fs::remove_file(self.path_of_sst(sst.sst_id()));
+                }
                 return Ok(());
             }
 

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -266,7 +266,7 @@ impl LsmStorageInner {
         mut iter: impl for<'a> StorageIterator<KeyType<'a> = KeySlice<'a>> + 'static,
         compact_to_bottom_level: bool,
         is_upper_level_compaction: bool,
-    ) -> Result<(Vec<Arc<SsTable>>, Vec<u32>)> {
+    ) -> Result<(Vec<Arc<SsTable>>, Vec<u32>, bool)> {
         // Only backfill upper-level (L0/L1/L2) compactions. Data in these
         // levels is recently flushed or recently compacted — likely hot.
         // Deeper compactions operate on cold data — backfilling them would
@@ -283,14 +283,12 @@ impl LsmStorageInner {
         // is eligible for GC.
         let watermark = self.mvcc.as_ref().map(|m| m.watermark());
         let compaction_filters = self.snapshot_compaction_filters();
-        let max_filter_cutoff = compaction_filters.iter().map(|f| f.cutoff_ts).max();
         let can_publish_filter_deletion = compact_to_bottom_level
             && !compaction_filters.is_empty()
-            && max_filter_cutoff.is_some_and(|cutoff_ts| {
-                self.mvcc
-                    .as_ref()
-                    .is_some_and(|m| m.can_publish_filter_deletion(cutoff_ts))
-            });
+            && self
+                .mvcc
+                .as_ref()
+                .is_some_and(|m| m.can_publish_filter_deletion());
 
         // Track state for watermark-aware version dropping. Keys iterate
         // newest-first within each user key (inverted ts encoding), so we
@@ -387,7 +385,7 @@ impl LsmStorageInner {
 
         all_vlog_ids.sort_unstable();
         all_vlog_ids.dedup();
-        Ok((ret, all_vlog_ids))
+        Ok((ret, all_vlog_ids, can_publish_filter_deletion))
     }
 
     fn compact_from_iters(
@@ -396,7 +394,7 @@ impl LsmStorageInner {
         lower_level_iter: impl for<'a> StorageIterator<KeyType<'a> = KeySlice<'a>> + 'static,
         compact_to_bottom_level: bool,
         is_upper_level_compaction: bool,
-    ) -> Result<(Vec<Arc<SsTable>>, Vec<u32>)> {
+    ) -> Result<(Vec<Arc<SsTable>>, Vec<u32>, bool)> {
         let s_it = TwoMergeIterator::create(upper_level_iter, lower_level_iter)?;
 
         self.compact_from_iter(s_it, compact_to_bottom_level, is_upper_level_compaction)
@@ -408,7 +406,7 @@ impl LsmStorageInner {
         l1_sst_ids: &[usize],
         compact_to_bottom_level: bool,
         is_upper_level_compaction: bool,
-    ) -> Result<(Vec<Arc<SsTable>>, Vec<u32>)> {
+    ) -> Result<(Vec<Arc<SsTable>>, Vec<u32>, bool)> {
         let state = self.state.load_full();
         let mut m_it = vec![];
         for i in l0_sst_ids {
@@ -433,7 +431,7 @@ impl LsmStorageInner {
         )
     }
 
-    fn compact(&self, task: &CompactionTask) -> Result<(Vec<Arc<SsTable>>, Vec<u32>)> {
+    fn compact(&self, task: &CompactionTask) -> Result<(Vec<Arc<SsTable>>, Vec<u32>, bool)> {
         let state = self.state.load_full();
         match task {
             CompactionTask::Simple(SimpleLeveledCompactionTask {
@@ -519,7 +517,7 @@ impl LsmStorageInner {
             l1_sstables: ssts_to_compact.1.clone(),
         };
 
-        let (new_ssts, compact_vlog_ids) = self.compact(&task)?;
+        let (new_ssts, compact_vlog_ids, apply_filters) = self.compact(&task)?;
 
         // Collect vLog IDs from input SSTs before unregistering (for GC)
         let input_vlog_ids: Vec<u32> = if let Some(ref vlog) = self.vlog {
@@ -538,6 +536,20 @@ impl LsmStorageInner {
 
         {
             let _state_lock = self.state_lock.lock();
+
+            // Re-check filter safety under state_lock. Between the initial
+            // check in compact_from_iter and this publication point, a new
+            // ReadGuard may have been created. Filters are optional cleanup,
+            // so if new readers appeared, skip publishing the filtered result.
+            if apply_filters
+                && self
+                    .mvcc
+                    .as_ref()
+                    .is_some_and(|m| !m.can_publish_filter_deletion())
+            {
+                return Ok(());
+            }
+
             let mut snapshot = self.state.load().as_ref().clone();
 
             // Unregister vLog references for old SSTs
@@ -696,7 +708,7 @@ impl LsmStorageInner {
         let Some(t) = task.as_ref() else {
             return Ok(());
         };
-        let (new_ssts, compact_vlog_ids) = self.compact(t)?;
+        let (new_ssts, compact_vlog_ids, apply_filters) = self.compact(t)?;
         let new_sst_ids = new_ssts.iter().map(|x| x.sst_id()).collect::<Vec<_>>();
 
         // Collect input SST IDs for post-compaction GC
@@ -750,6 +762,19 @@ impl LsmStorageInner {
 
         let rm_sst_ids = {
             let _state_lock = self.state_lock.lock();
+
+            // Re-check filter safety under state_lock — same rationale as
+            // force_full_compaction. If new readers appeared since the initial
+            // check, skip publishing the filtered compaction result.
+            if apply_filters
+                && self
+                    .mvcc
+                    .as_ref()
+                    .is_some_and(|m| !m.can_publish_filter_deletion())
+            {
+                return Ok(());
+            }
+
             let mut snapshot = self.state.load().as_ref().clone();
             // specific for leveled compaction, need the sstables in the snapshot
             for s in &new_ssts {

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -282,6 +282,15 @@ impl LsmStorageInner {
         // exist, watermark() returns latest_commit_ts so everything below it
         // is eligible for GC.
         let watermark = self.mvcc.as_ref().map(|m| m.watermark());
+        let compaction_filters = self.snapshot_compaction_filters();
+        let max_filter_cutoff = compaction_filters.iter().map(|f| f.cutoff_ts).max();
+        let can_publish_filter_deletion = compact_to_bottom_level
+            && !compaction_filters.is_empty()
+            && max_filter_cutoff.is_some_and(|cutoff_ts| {
+                self.mvcc
+                    .as_ref()
+                    .is_some_and(|m| m.can_publish_filter_deletion(cutoff_ts))
+            });
 
         // Track state for watermark-aware version dropping. Keys iterate
         // newest-first within each user key (inverted ts encoding), so we
@@ -289,6 +298,7 @@ impl LsmStorageInner {
         // at or below the watermark per user key.
         let mut prev_user_key: Vec<u8> = Vec::new();
         let mut seen_below_watermark = false;
+        let mut decoded_user_key = Vec::new();
 
         while iter.is_valid() {
             if builder.estimated_size() >= self.options.target_sst_size {
@@ -342,8 +352,21 @@ impl LsmStorageInner {
                 !is_tombstone || !compact_to_bottom_level
             };
 
-            if should_keep {
+            let should_drop_for_filter =
+                should_keep && can_publish_filter_deletion && !is_tombstone && {
+                    let key = iter.key();
+                    key.decode_user_key_into(&mut decoded_user_key);
+                    self.record_compaction_filter_check();
+                    compaction_filters
+                        .iter()
+                        .any(|filter| filter.matches(&decoded_user_key, key.ts()))
+                };
+
+            if should_keep && !should_drop_for_filter {
                 builder.add_raw(iter.key(), iter.raw_value())?;
+            } else if should_drop_for_filter {
+                let dropped_bytes = (iter.key().raw_ref().len() + iter.raw_value().len()) as u64;
+                self.record_compaction_filter_drop(dropped_bytes);
             }
             iter.next()?;
         }

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     fs::{self, File},
     ops::Bound,
     path::{Path, PathBuf},
@@ -10,6 +10,7 @@ use anyhow::{Context, Ok, Result, anyhow};
 use arc_swap::ArcSwap;
 use bytes::Bytes;
 use parking_lot::{Mutex, MutexGuard, RwLock};
+use serde::{Deserialize, Serialize};
 
 use crate::{
     compact::{
@@ -249,8 +250,95 @@ pub struct CacheStats {
 }
 
 #[derive(Clone, Debug)]
-pub enum CompactionFilter {
+pub enum CompactionFilterRequest {
     Prefix(Bytes),
+}
+
+impl CompactionFilterRequest {
+    pub fn prefix(prefix: impl Into<Bytes>) -> Self {
+        Self::Prefix(prefix.into())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CompactionFilterKind {
+    Prefix(Vec<u8>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct InstalledCompactionFilter {
+    pub(crate) id: u64,
+    pub(crate) kind: CompactionFilterKind,
+    pub(crate) cutoff_ts: u64,
+}
+
+impl InstalledCompactionFilter {
+    fn info(&self) -> CompactionFilterInfo {
+        CompactionFilterInfo {
+            id: self.id,
+            kind: self.kind.clone(),
+            cutoff_ts: self.cutoff_ts,
+        }
+    }
+
+    pub(crate) fn matches(&self, user_key: &[u8], ts: u64) -> bool {
+        if ts > self.cutoff_ts {
+            return false;
+        }
+        match &self.kind {
+            CompactionFilterKind::Prefix(prefix) => user_key.starts_with(prefix),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CompactionFilterInfo {
+    pub id: u64,
+    pub kind: CompactionFilterKind,
+    pub cutoff_ts: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CompactionFilterStats {
+    pub entries_checked: u64,
+    pub entries_dropped: u64,
+    pub bytes_dropped: u64,
+    pub filters_active: usize,
+}
+
+#[derive(Default)]
+struct CompactionFilterRegistry {
+    active_filters: BTreeMap<u64, InstalledCompactionFilter>,
+    next_compaction_filter_id: u64,
+    stats: CompactionFilterStats,
+}
+
+impl CompactionFilterRegistry {
+    fn snapshot_filters(&self) -> Vec<InstalledCompactionFilter> {
+        self.active_filters.values().cloned().collect()
+    }
+
+    fn list(&self) -> Vec<CompactionFilterInfo> {
+        self.active_filters
+            .values()
+            .map(|filter| filter.info())
+            .collect()
+    }
+
+    fn stats(&self) -> CompactionFilterStats {
+        let mut stats = self.stats;
+        stats.filters_active = self.active_filters.len();
+        stats
+    }
+
+    fn note_check(&mut self) {
+        self.stats.entries_checked += 1;
+    }
+
+    fn note_drop(&mut self, bytes_dropped: u64) {
+        self.stats.entries_dropped += 1;
+        self.stats.bytes_dropped += bytes_dropped;
+    }
 }
 
 /// Compute the exclusive upper bound for a prefix scan.
@@ -295,7 +383,7 @@ pub(crate) struct LsmStorageInner {
     pub(crate) compaction_controller: CompactionController,
     pub(crate) manifest: Option<Manifest>,
     pub(crate) mvcc: Option<Arc<LsmMvccInner>>,
-    pub(crate) compaction_filters: Arc<Mutex<Vec<CompactionFilter>>>,
+    compaction_filters: Mutex<CompactionFilterRegistry>,
     /// Value Log manager for key-value separation. `None` if value separation is disabled.
     pub(crate) vlog: Option<Arc<ValueLog>>,
     /// Weak reference to the owning `Arc<LsmStorageInner>`, set after construction.
@@ -397,8 +485,29 @@ impl KvEngine {
         self.inner.write_batch(batch)
     }
 
-    pub fn add_compaction_filter(&self, compaction_filter: CompactionFilter) {
+    pub fn add_compaction_filter(&self, compaction_filter: CompactionFilterRequest) -> Result<u64> {
         self.inner.add_compaction_filter(compaction_filter)
+    }
+
+    pub fn add_compaction_filter_with_cutoff(
+        &self,
+        compaction_filter: CompactionFilterRequest,
+        cutoff_ts: u64,
+    ) -> Result<u64> {
+        self.inner
+            .add_compaction_filter_with_cutoff(compaction_filter, cutoff_ts)
+    }
+
+    pub fn remove_compaction_filter(&self, id: u64) -> Result<bool> {
+        self.inner.remove_compaction_filter(id)
+    }
+
+    pub fn list_compaction_filters(&self) -> Vec<CompactionFilterInfo> {
+        self.inner.list_compaction_filters()
+    }
+
+    pub fn compaction_filter_stats(&self) -> CompactionFilterStats {
+        self.inner.compaction_filter_stats()
     }
 
     pub fn get(&self, key: &[u8]) -> Result<Option<Bytes>> {
@@ -579,6 +688,9 @@ impl LsmStorageInner {
         let mut max_id = state.memtable.id();
         let manifest_path = path.join("MANIFEST");
         let mut recovered_vlog_refs: HashMap<usize, Vec<u32>> = HashMap::new();
+        let mut recovered_compaction_filters: BTreeMap<u64, InstalledCompactionFilter> =
+            BTreeMap::new();
+        let mut next_compaction_filter_id: u64 = 0;
         // Maximum commit timestamp recovered from WAL batches and SST metadata.
         let mut max_commit_ts: u64 = 0;
         let manifest = if !manifest_path.exists() {
@@ -688,6 +800,14 @@ impl LsmStorageInner {
                     ManifestRecord::GcCompaction(_old_id, _new_id, _count) => {
                         // GC compaction — references are updated via CAS + flush
                     }
+                    ManifestRecord::AddCompactionFilter(filter) => {
+                        next_compaction_filter_id =
+                            next_compaction_filter_id.max(filter.id.saturating_add(1));
+                        recovered_compaction_filters.insert(filter.id, filter);
+                    }
+                    ManifestRecord::RemoveCompactionFilter(id) => {
+                        recovered_compaction_filters.remove(&id);
+                    }
                     ManifestRecord::FormatVersion(_) => {
                         // Already validated above; nothing to replay.
                     }
@@ -697,6 +817,8 @@ impl LsmStorageInner {
                         next_sst_id,
                         vlog_references: snap_vlog_refs,
                         imm_memtable_ids: snap_imm_ids,
+                        active_compaction_filters,
+                        next_compaction_filter_id: snap_next_compaction_filter_id,
                         format_version: _,
                     } => {
                         // Snapshot supersedes all prior records — reconstruct state directly
@@ -719,8 +841,17 @@ impl LsmStorageInner {
                             im_memtables.insert(id);
                             max_id = max_id.max(id);
                         }
+                        recovered_compaction_filters = active_compaction_filters
+                            .into_iter()
+                            .map(|filter| (filter.id, filter))
+                            .collect();
+                        next_compaction_filter_id = snap_next_compaction_filter_id;
                     }
                 }
+            }
+            if let Some(max_filter_id) = recovered_compaction_filters.keys().next_back().copied() {
+                next_compaction_filter_id =
+                    next_compaction_filter_id.max(max_filter_id.saturating_add(1));
             }
             max_id += 1;
             // build imm_memtables and memtable
@@ -812,7 +943,11 @@ impl LsmStorageInner {
             manifest: Some(manifest),
             options: options.into(),
             mvcc: Some(Arc::new(LsmMvccInner::new(max_commit_ts))),
-            compaction_filters: Arc::new(Mutex::new(Vec::new())),
+            compaction_filters: Mutex::new(CompactionFilterRegistry {
+                active_filters: recovered_compaction_filters,
+                next_compaction_filter_id,
+                stats: CompactionFilterStats::default(),
+            }),
             vlog,
             weak_self: std::sync::OnceLock::new(),
             gc_handles: Mutex::new(Vec::new()),
@@ -826,9 +961,121 @@ impl LsmStorageInner {
         self.state.load().memtable.sync_wal()
     }
 
-    pub fn add_compaction_filter(&self, compaction_filter: CompactionFilter) {
-        let mut compaction_filters = self.compaction_filters.lock();
-        compaction_filters.push(compaction_filter);
+    pub fn add_compaction_filter(&self, compaction_filter: CompactionFilterRequest) -> Result<u64> {
+        let cutoff_ts = self.mvcc.as_ref().map_or(0, |mvcc| {
+            let _write_guard = mvcc.write_lock.lock();
+            mvcc.latest_commit_ts()
+        });
+        self.add_compaction_filter_with_cutoff(compaction_filter, cutoff_ts)
+    }
+
+    pub fn add_compaction_filter_with_cutoff(
+        &self,
+        compaction_filter: CompactionFilterRequest,
+        cutoff_ts: u64,
+    ) -> Result<u64> {
+        let _state_lock = self.state_lock.lock();
+        if let Some(mvcc) = self.mvcc.as_ref() {
+            let _write_guard = mvcc.write_lock.lock();
+            anyhow::ensure!(
+                cutoff_ts <= mvcc.latest_commit_ts(),
+                "compaction filter cutoff_ts {} exceeds latest commit ts {}",
+                cutoff_ts,
+                mvcc.latest_commit_ts()
+            );
+        }
+
+        let mut registry = self.compaction_filters.lock();
+        let kind = Self::validate_compaction_filter_request(compaction_filter)?;
+        anyhow::ensure!(
+            !registry
+                .active_filters
+                .values()
+                .any(|filter| filter.kind == kind && filter.cutoff_ts == cutoff_ts),
+            "duplicate active compaction filter"
+        );
+
+        let id = registry.next_compaction_filter_id;
+        let installed = InstalledCompactionFilter {
+            id,
+            kind,
+            cutoff_ts,
+        };
+        self.manifest
+            .as_ref()
+            .expect("manifest initialized")
+            .add_record(
+                &_state_lock,
+                ManifestRecord::AddCompactionFilter(installed.clone()),
+            )?;
+        registry.active_filters.insert(id, installed);
+        registry.next_compaction_filter_id = registry.next_compaction_filter_id.saturating_add(1);
+        drop(registry);
+        self.maybe_snapshot_manifest(&_state_lock)?;
+
+        Ok(id)
+    }
+
+    pub fn remove_compaction_filter(&self, id: u64) -> Result<bool> {
+        let _state_lock = self.state_lock.lock();
+        let mut registry = self.compaction_filters.lock();
+        let Some(filter) = registry.active_filters.remove(&id) else {
+            return Ok(false);
+        };
+
+        if let Err(err) = self
+            .manifest
+            .as_ref()
+            .expect("manifest initialized")
+            .add_record(&_state_lock, ManifestRecord::RemoveCompactionFilter(id))
+        {
+            registry.active_filters.insert(id, filter);
+            return Err(err);
+        }
+        drop(registry);
+        self.maybe_snapshot_manifest(&_state_lock)?;
+
+        Ok(true)
+    }
+
+    pub fn list_compaction_filters(&self) -> Vec<CompactionFilterInfo> {
+        self.compaction_filters.lock().list()
+    }
+
+    pub fn compaction_filter_stats(&self) -> CompactionFilterStats {
+        self.compaction_filters.lock().stats()
+    }
+
+    fn validate_compaction_filter_request(
+        compaction_filter: CompactionFilterRequest,
+    ) -> Result<CompactionFilterKind> {
+        match compaction_filter {
+            CompactionFilterRequest::Prefix(prefix) => {
+                anyhow::ensure!(
+                    !prefix.is_empty(),
+                    "compaction filter prefix must not be empty"
+                );
+                anyhow::ensure!(
+                    crate::key::encoded_internal_key_len(prefix.len())
+                        <= crate::key::MAX_ENCODED_KEY_LEN,
+                    "compaction filter prefix encoded key length exceeds maximum {}",
+                    crate::key::MAX_ENCODED_KEY_LEN
+                );
+                Ok(CompactionFilterKind::Prefix(prefix.to_vec()))
+            }
+        }
+    }
+
+    pub(crate) fn snapshot_compaction_filters(&self) -> Vec<InstalledCompactionFilter> {
+        self.compaction_filters.lock().snapshot_filters()
+    }
+
+    pub(crate) fn record_compaction_filter_check(&self) {
+        self.compaction_filters.lock().note_check();
+    }
+
+    pub(crate) fn record_compaction_filter_drop(&self, bytes_dropped: u64) {
+        self.compaction_filters.lock().note_drop(bytes_dropped);
     }
 
     /// Get a key from the storage.
@@ -1986,6 +2233,7 @@ impl LsmStorageInner {
                 }
             }
         }
+        let registry = self.compaction_filters.lock();
 
         let record = ManifestRecord::Snapshot {
             l0_sstables: state.l0_sstables.clone(),
@@ -1993,8 +2241,11 @@ impl LsmStorageInner {
             next_sst_id: self.next_sst_id.load(std::sync::atomic::Ordering::Acquire),
             vlog_references,
             imm_memtable_ids: state.imm_memtables.iter().map(|m| m.id()).collect(),
+            active_compaction_filters: registry.snapshot_filters(),
+            next_compaction_filter_id: registry.next_compaction_filter_id,
             format_version: crate::manifest::MANIFEST_FORMAT_VERSION,
         };
+        drop(registry);
         drop(guard);
 
         manifest.snapshot(record)

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -3,7 +3,10 @@ use std::{
     fs::{self, File},
     ops::Bound,
     path::{Path, PathBuf},
-    sync::{Arc, atomic::AtomicUsize},
+    sync::{
+        Arc,
+        atomic::{AtomicU64, AtomicUsize},
+    },
 };
 
 use anyhow::{Context, Ok, Result, anyhow};
@@ -300,17 +303,63 @@ pub struct CompactionFilterInfo {
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct CompactionFilterStats {
-    pub entries_checked: u64,
+    pub entries_eligible: u64,
     pub entries_dropped: u64,
     pub bytes_dropped: u64,
     pub filters_active: usize,
+}
+
+/// Lock-free atomic counters for compaction filter stats. These are updated
+/// from the compaction hot path without acquiring the registry mutex.
+pub(crate) struct CompactionFilterAtomicStats {
+    entries_eligible: AtomicU64,
+    entries_dropped: AtomicU64,
+    bytes_dropped: AtomicU64,
+}
+
+impl Default for CompactionFilterAtomicStats {
+    fn default() -> Self {
+        Self {
+            entries_eligible: AtomicU64::new(0),
+            entries_dropped: AtomicU64::new(0),
+            bytes_dropped: AtomicU64::new(0),
+        }
+    }
+}
+
+impl CompactionFilterAtomicStats {
+    fn note_check(&self) {
+        self.entries_eligible
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn note_drop(&self, bytes_dropped: u64) {
+        self.entries_dropped
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.bytes_dropped
+            .fetch_add(bytes_dropped, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn snapshot(&self, filters_active: usize) -> CompactionFilterStats {
+        CompactionFilterStats {
+            entries_eligible: self
+                .entries_eligible
+                .load(std::sync::atomic::Ordering::Relaxed),
+            entries_dropped: self
+                .entries_dropped
+                .load(std::sync::atomic::Ordering::Relaxed),
+            bytes_dropped: self
+                .bytes_dropped
+                .load(std::sync::atomic::Ordering::Relaxed),
+            filters_active,
+        }
+    }
 }
 
 #[derive(Default)]
 struct CompactionFilterRegistry {
     active_filters: BTreeMap<u64, InstalledCompactionFilter>,
     next_compaction_filter_id: u64,
-    stats: CompactionFilterStats,
 }
 
 impl CompactionFilterRegistry {
@@ -323,21 +372,6 @@ impl CompactionFilterRegistry {
             .values()
             .map(|filter| filter.info())
             .collect()
-    }
-
-    fn stats(&self) -> CompactionFilterStats {
-        let mut stats = self.stats;
-        stats.filters_active = self.active_filters.len();
-        stats
-    }
-
-    fn note_check(&mut self) {
-        self.stats.entries_checked += 1;
-    }
-
-    fn note_drop(&mut self, bytes_dropped: u64) {
-        self.stats.entries_dropped += 1;
-        self.stats.bytes_dropped += bytes_dropped;
     }
 }
 
@@ -384,6 +418,7 @@ pub(crate) struct LsmStorageInner {
     pub(crate) manifest: Option<Manifest>,
     pub(crate) mvcc: Option<Arc<LsmMvccInner>>,
     compaction_filters: Mutex<CompactionFilterRegistry>,
+    filter_stats: Arc<CompactionFilterAtomicStats>,
     /// Value Log manager for key-value separation. `None` if value separation is disabled.
     pub(crate) vlog: Option<Arc<ValueLog>>,
     /// Weak reference to the owning `Arc<LsmStorageInner>`, set after construction.
@@ -727,7 +762,7 @@ impl LsmStorageInner {
                 ),
                 _ => anyhow::bail!(
                     "pre-MVCC directory detected (no format version marker); \
-                     MVCC format (version 2) is required; \
+                     MVCC format (version 3) is required; \
                      please start with a fresh database"
                 ),
             };
@@ -946,8 +981,8 @@ impl LsmStorageInner {
             compaction_filters: Mutex::new(CompactionFilterRegistry {
                 active_filters: recovered_compaction_filters,
                 next_compaction_filter_id,
-                stats: CompactionFilterStats::default(),
             }),
+            filter_stats: Arc::new(CompactionFilterAtomicStats::default()),
             vlog,
             weak_self: std::sync::OnceLock::new(),
             gc_handles: Mutex::new(Vec::new()),
@@ -962,11 +997,14 @@ impl LsmStorageInner {
     }
 
     pub fn add_compaction_filter(&self, compaction_filter: CompactionFilterRequest) -> Result<u64> {
+        // Capture cutoff_ts under the same lock used by add_compaction_filter_with_cutoff,
+        // so no concurrent write can interleave between the cutoff read and validation.
+        let _state_lock = self.state_lock.lock();
         let cutoff_ts = self.mvcc.as_ref().map_or(0, |mvcc| {
             let _write_guard = mvcc.write_lock.lock();
             mvcc.latest_commit_ts()
         });
-        self.add_compaction_filter_with_cutoff(compaction_filter, cutoff_ts)
+        self.add_compaction_filter_inner(&_state_lock, compaction_filter, cutoff_ts)
     }
 
     pub fn add_compaction_filter_with_cutoff(
@@ -984,7 +1022,15 @@ impl LsmStorageInner {
                 mvcc.latest_commit_ts()
             );
         }
+        self.add_compaction_filter_inner(&_state_lock, compaction_filter, cutoff_ts)
+    }
 
+    fn add_compaction_filter_inner(
+        &self,
+        _state_lock: &MutexGuard<'_, ()>,
+        compaction_filter: CompactionFilterRequest,
+        cutoff_ts: u64,
+    ) -> Result<u64> {
         let mut registry = self.compaction_filters.lock();
         let kind = Self::validate_compaction_filter_request(compaction_filter)?;
         anyhow::ensure!(
@@ -1005,13 +1051,13 @@ impl LsmStorageInner {
             .as_ref()
             .expect("manifest initialized")
             .add_record(
-                &_state_lock,
+                _state_lock,
                 ManifestRecord::AddCompactionFilter(installed.clone()),
             )?;
         registry.active_filters.insert(id, installed);
         registry.next_compaction_filter_id = registry.next_compaction_filter_id.saturating_add(1);
         drop(registry);
-        self.maybe_snapshot_manifest(&_state_lock)?;
+        self.maybe_snapshot_manifest(_state_lock)?;
 
         Ok(id)
     }
@@ -1043,7 +1089,8 @@ impl LsmStorageInner {
     }
 
     pub fn compaction_filter_stats(&self) -> CompactionFilterStats {
-        self.compaction_filters.lock().stats()
+        let filters_active = self.compaction_filters.lock().active_filters.len();
+        self.filter_stats.snapshot(filters_active)
     }
 
     fn validate_compaction_filter_request(
@@ -1071,11 +1118,11 @@ impl LsmStorageInner {
     }
 
     pub(crate) fn record_compaction_filter_check(&self) {
-        self.compaction_filters.lock().note_check();
+        self.filter_stats.note_check();
     }
 
     pub(crate) fn record_compaction_filter_drop(&self, bytes_dropped: u64) {
-        self.compaction_filters.lock().note_drop(bytes_dropped);
+        self.filter_stats.note_drop(bytes_dropped);
     }
 
     /// Get a key from the storage.

--- a/kv-engine/src/manifest.rs
+++ b/kv-engine/src/manifest.rs
@@ -9,9 +9,9 @@ use anyhow::{Context, Ok, Result};
 use parking_lot::{Mutex, MutexGuard};
 use serde::{Deserialize, Serialize};
 
-use crate::compact::CompactionTask;
+use crate::{compact::CompactionTask, lsm_storage::InstalledCompactionFilter};
 
-pub struct Manifest {
+pub(crate) struct Manifest {
     file: Arc<Mutex<File>>,
     path: PathBuf,
 }
@@ -23,7 +23,7 @@ pub struct Manifest {
 pub const MANIFEST_FORMAT_VERSION: u32 = 2;
 
 #[derive(Serialize, Deserialize)]
-pub enum ManifestRecord {
+pub(crate) enum ManifestRecord {
     /// Written as the first record in a new database to identify the format
     /// version. Version 2 = MVCC. Absence of this record means pre-MVCC.
     FormatVersion(u32),
@@ -41,6 +41,8 @@ pub enum ManifestRecord {
     DeleteVlogFile(u32),
     /// GC rewrote entries: old_vlog_id, new_vlog_id, keys_rewritten
     GcCompaction(u32, u32, usize),
+    AddCompactionFilter(InstalledCompactionFilter),
+    RemoveCompactionFilter(u64),
     /// A snapshot of the current LSM state for manifest compaction.
     /// Contains the full state needed to reconstruct the engine without
     /// replaying the entire manifest log.
@@ -52,6 +54,10 @@ pub enum ManifestRecord {
         /// IDs of immutable memtables that have not yet been flushed.
         /// Preserved so WAL recovery can rebuild them on restart.
         imm_memtable_ids: Vec<usize>,
+        #[serde(default)]
+        active_compaction_filters: Vec<InstalledCompactionFilter>,
+        #[serde(default)]
+        next_compaction_filter_id: u64,
         /// Manifest format version. 0 = pre-MVCC (legacy/field-absent), 2 = MVCC.
         /// Defaults to 0 when the field is missing from old snapshots written
         /// before this field existed. Version 0 is rejected on open — it is

--- a/kv-engine/src/manifest.rs
+++ b/kv-engine/src/manifest.rs
@@ -18,14 +18,16 @@ pub(crate) struct Manifest {
 
 /// Current manifest format version for MVCC-enabled databases.
 /// Version numbers align with the feature phase: 2 = MVCC Phase 2
-/// (format hardening). Version 0 is reserved to mean "legacy/field-absent"
-/// and must never be assigned as a valid format version.
-pub const MANIFEST_FORMAT_VERSION: u32 = 2;
+/// (format hardening), 3 = compaction filters. Version 0 is reserved to
+/// mean "legacy/field-absent" and must never be assigned as a valid format
+/// version.
+pub const MANIFEST_FORMAT_VERSION: u32 = 3;
 
 #[derive(Serialize, Deserialize)]
 pub(crate) enum ManifestRecord {
     /// Written as the first record in a new database to identify the format
-    /// version. Version 2 = MVCC. Absence of this record means pre-MVCC.
+    /// version. Version 3 = MVCC + compaction filters. Absence of this
+    /// record means pre-MVCC.
     FormatVersion(u32),
     Flush(usize),
     NewMemtable(usize),
@@ -58,7 +60,8 @@ pub(crate) enum ManifestRecord {
         active_compaction_filters: Vec<InstalledCompactionFilter>,
         #[serde(default)]
         next_compaction_filter_id: u64,
-        /// Manifest format version. 0 = pre-MVCC (legacy/field-absent), 2 = MVCC.
+        /// Manifest format version. 0 = pre-MVCC (legacy/field-absent),
+        /// 2 = MVCC, 3 = MVCC + compaction filters.
         /// Defaults to 0 when the field is missing from old snapshots written
         /// before this field existed. Version 0 is rejected on open — it is
         /// not a valid format version, only a sentinel for "field absent".

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -56,6 +56,14 @@ impl LsmMvccInner {
         ts.1.watermark().unwrap_or(ts.0)
     }
 
+    /// Physical deletion by compaction filters is only safe when no active
+    /// readers remain. Readers reload the current LSM state on each access, so
+    /// even readers with read_ts > cutoff_ts could observe disappearing keys if
+    /// deletion were published while they are active.
+    pub(crate) fn can_publish_filter_deletion(&self, _cutoff_ts: u64) -> bool {
+        self.ts.lock().1.watermark().is_none()
+    }
+
     /// Allocate a commit timestamp under the write lock and write to the memtable.
     /// Returns the commit timestamp used.
     pub fn write(
@@ -385,6 +393,18 @@ mod tests {
         // After dropping the guard, watermark advances to latest
         drop(guard);
         assert_eq!(mvcc.watermark(), 102);
+    }
+
+    #[test]
+    fn test_can_publish_filter_deletion_requires_no_active_readers() {
+        let mvcc = Arc::new(LsmMvccInner::new(7));
+        assert!(mvcc.can_publish_filter_deletion(7));
+
+        let guard = mvcc.new_read_guard();
+        assert!(!mvcc.can_publish_filter_deletion(guard.read_ts()));
+        drop(guard);
+
+        assert!(mvcc.can_publish_filter_deletion(7));
     }
 
     #[test]

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -59,8 +59,10 @@ impl LsmMvccInner {
     /// Physical deletion by compaction filters is only safe when no active
     /// readers remain. Readers reload the current LSM state on each access, so
     /// even readers with read_ts > cutoff_ts could observe disappearing keys if
-    /// deletion were published while they are active.
-    pub(crate) fn can_publish_filter_deletion(&self, _cutoff_ts: u64) -> bool {
+    /// deletion were published while they are active. This check is
+    /// intentionally stronger than `watermark > cutoff_ts` — it requires zero
+    /// active readers regardless of their read timestamp.
+    pub(crate) fn can_publish_filter_deletion(&self) -> bool {
         self.ts.lock().1.watermark().is_none()
     }
 
@@ -398,13 +400,13 @@ mod tests {
     #[test]
     fn test_can_publish_filter_deletion_requires_no_active_readers() {
         let mvcc = Arc::new(LsmMvccInner::new(7));
-        assert!(mvcc.can_publish_filter_deletion(7));
+        assert!(mvcc.can_publish_filter_deletion());
 
         let guard = mvcc.new_read_guard();
-        assert!(!mvcc.can_publish_filter_deletion(guard.read_ts()));
+        assert!(!mvcc.can_publish_filter_deletion());
         drop(guard);
 
-        assert!(mvcc.can_publish_filter_deletion(7));
+        assert!(mvcc.can_publish_filter_deletion());
     }
 
     #[test]

--- a/kv-engine/src/tests/compaction.rs
+++ b/kv-engine/src/tests/compaction.rs
@@ -519,3 +519,46 @@ fn test_compaction_filter_non_bottom_compaction_keeps_matching_entries() {
         Some(Bytes::from_static(b"v2"))
     );
 }
+
+#[test]
+fn test_compaction_filter_respects_explicit_cutoff_ts() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(&dir, LsmStorageOptions::default_for_test()).unwrap());
+
+    // Write entries before the cutoff.
+    storage.put(b"old:drop", b"v1").unwrap();
+    sync(&storage);
+
+    // Record the cutoff timestamp explicitly.
+    let cutoff_ts = storage.mvcc.as_ref().unwrap().latest_commit_ts();
+
+    // Write entries after the cutoff — these must survive.
+    storage.put(b"old:keep", b"v2").unwrap();
+    sync(&storage);
+    storage.put(b"live", b"v3").unwrap();
+    sync(&storage);
+
+    // Install filter with explicit cutoff.
+    storage
+        .add_compaction_filter_with_cutoff(
+            CompactionFilterRequest::prefix(Bytes::from_static(b"old:")),
+            cutoff_ts,
+        )
+        .unwrap();
+
+    storage.force_full_compaction().unwrap();
+
+    // Entry written before cutoff is filtered.
+    assert_eq!(storage.get(b"old:drop").unwrap(), None);
+    // Entry written after cutoff survives.
+    assert_eq!(
+        storage.get(b"old:keep").unwrap(),
+        Some(Bytes::from_static(b"v2"))
+    );
+    // Non-matching entry survives.
+    assert_eq!(
+        storage.get(b"live").unwrap(),
+        Some(Bytes::from_static(b"v3"))
+    );
+}

--- a/kv-engine/src/tests/compaction.rs
+++ b/kv-engine/src/tests/compaction.rs
@@ -9,7 +9,7 @@ use super::*;
 use crate::{
     iterators::{StorageIterator, concat_iterator::SstConcatIterator},
     key::{KeySlice, TS_ENABLED},
-    lsm_storage::{LsmStorageInner, LsmStorageOptions},
+    lsm_storage::{CompactionFilterRequest, LsmStorageInner, LsmStorageOptions},
     table::{SsTable, SsTableBuilder},
 };
 
@@ -428,4 +428,94 @@ fn test_watermark_gc_preserves_tombstone_at_non_bottom_level() {
 
     // Tombstone masks the older version — key is deleted.
     assert_eq!(storage.get(b"a").unwrap(), None);
+}
+
+#[test]
+fn test_compaction_filter_respects_cutoff_ts() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(&dir, LsmStorageOptions::default_for_test()).unwrap());
+
+    storage.put(b"old:drop", b"v1").unwrap();
+    sync(&storage);
+
+    storage
+        .add_compaction_filter(CompactionFilterRequest::prefix(Bytes::from_static(b"old:")))
+        .unwrap();
+
+    storage.put(b"old:keep", b"v2").unwrap();
+    sync(&storage);
+    storage.put(b"live", b"v3").unwrap();
+    sync(&storage);
+
+    storage.force_full_compaction().unwrap();
+
+    assert_eq!(storage.get(b"old:drop").unwrap(), None);
+    assert_eq!(
+        storage.get(b"old:keep").unwrap(),
+        Some(Bytes::from_static(b"v2"))
+    );
+    assert_eq!(
+        storage.get(b"live").unwrap(),
+        Some(Bytes::from_static(b"v3"))
+    );
+}
+
+#[test]
+fn test_compaction_filter_keeps_entries_while_reader_is_active() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(&dir, LsmStorageOptions::default_for_test()).unwrap());
+
+    storage.put(b"old:visible", b"v1").unwrap();
+    sync(&storage);
+
+    storage
+        .add_compaction_filter(CompactionFilterRequest::prefix(Bytes::from_static(b"old:")))
+        .unwrap();
+    let _reader = storage.new_txn().unwrap();
+
+    storage.force_full_compaction().unwrap();
+
+    assert_eq!(
+        storage.get(b"old:visible").unwrap(),
+        Some(Bytes::from_static(b"v1"))
+    );
+}
+
+#[test]
+fn test_compaction_filter_non_bottom_compaction_keeps_matching_entries() {
+    use crate::compact::{CompactionOptions, LeveledCompactionOptions};
+
+    let dir = tempdir().unwrap();
+    let options = LsmStorageOptions::default_for_compaction_test(CompactionOptions::Leveled(
+        LeveledCompactionOptions {
+            level_size_multiplier: 2,
+            level0_file_num_compaction_trigger: 1,
+            max_levels: 3,
+            base_level_size_mb: 128,
+        },
+    ));
+    let storage = Arc::new(LsmStorageInner::open(&dir, options).unwrap());
+
+    storage.put(b"old:keep", b"v1").unwrap();
+    sync(&storage);
+    storage.trigger_compaction().unwrap();
+
+    storage
+        .add_compaction_filter(CompactionFilterRequest::prefix(Bytes::from_static(b"old:")))
+        .unwrap();
+    storage.put(b"other", b"v2").unwrap();
+    sync(&storage);
+
+    storage.trigger_compaction().unwrap();
+
+    assert_eq!(
+        storage.get(b"old:keep").unwrap(),
+        Some(Bytes::from_static(b"v1"))
+    );
+    assert_eq!(
+        storage.get(b"other").unwrap(),
+        Some(Bytes::from_static(b"v2"))
+    );
 }

--- a/kv-engine/src/tests/lsm_storage_extra.rs
+++ b/kv-engine/src/tests/lsm_storage_extra.rs
@@ -4,9 +4,174 @@ use tempfile::tempdir;
 use crate::{
     compact::CompactionOptions,
     iterators::StorageIterator,
-    lsm_storage::{KvEngine, LsmStorageOptions, PrefixBloomOptions, WriteBatchRecord},
+    lsm_storage::{
+        CompactionFilterKind, CompactionFilterRequest, KvEngine, LsmStorageOptions,
+        PrefixBloomOptions, WriteBatchRecord,
+    },
     vlog::ValueSeparationOptions,
 };
+
+#[test]
+fn test_compaction_filter_api_add_remove_list_and_stats() {
+    let dir = tempdir().unwrap();
+    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+
+    let first = engine
+        .add_compaction_filter(CompactionFilterRequest::prefix(Bytes::from_static(
+            b"tenant:",
+        )))
+        .unwrap();
+    let second = engine
+        .add_compaction_filter_with_cutoff(
+            CompactionFilterRequest::prefix(Bytes::from_static(b"user:")),
+            0,
+        )
+        .unwrap();
+    assert_eq!(first, 0);
+    assert_eq!(second, 1);
+
+    let listed = engine.list_compaction_filters();
+    assert_eq!(listed.len(), 2);
+    assert_eq!(listed[0].id, first);
+    assert_eq!(
+        listed[0].kind,
+        CompactionFilterKind::Prefix(b"tenant:".to_vec())
+    );
+    assert_eq!(listed[1].id, second);
+    assert_eq!(
+        listed[1].kind,
+        CompactionFilterKind::Prefix(b"user:".to_vec())
+    );
+
+    let removed = engine.remove_compaction_filter(first).unwrap();
+    assert!(removed);
+    assert!(!engine.remove_compaction_filter(first).unwrap());
+    let listed = engine.list_compaction_filters();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].id, second);
+
+    let stats = engine.compaction_filter_stats();
+    assert_eq!(stats.filters_active, 1);
+    assert_eq!(stats.entries_checked, 0);
+    assert_eq!(stats.entries_dropped, 0);
+    assert_eq!(stats.bytes_dropped, 0);
+}
+
+#[test]
+fn test_compaction_filter_api_rejects_invalid_requests() {
+    let dir = tempdir().unwrap();
+    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+
+    let empty = engine.add_compaction_filter(CompactionFilterRequest::prefix(Bytes::new()));
+    assert!(empty.is_err());
+    assert!(empty.unwrap_err().to_string().contains("must not be empty"));
+
+    let oversize_prefix = vec![b'x'; crate::key::MAX_ENCODED_KEY_LEN];
+    let oversize = engine.add_compaction_filter(CompactionFilterRequest::prefix(oversize_prefix));
+    assert!(oversize.is_err());
+    assert!(
+        oversize
+            .unwrap_err()
+            .to_string()
+            .contains("exceeds maximum")
+    );
+
+    let id = engine
+        .add_compaction_filter_with_cutoff(
+            CompactionFilterRequest::prefix(Bytes::from_static(b"dup:")),
+            0,
+        )
+        .unwrap();
+    assert_eq!(id, 0);
+    let duplicate = engine.add_compaction_filter_with_cutoff(
+        CompactionFilterRequest::prefix(Bytes::from_static(b"dup:")),
+        0,
+    );
+    assert!(duplicate.is_err());
+    assert!(duplicate.unwrap_err().to_string().contains("duplicate"));
+}
+
+#[test]
+fn test_compaction_filter_api_rejects_cutoff_above_latest_commit_ts() {
+    let dir = tempdir().unwrap();
+    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+
+    engine.put(b"k1", b"v1").unwrap();
+    let latest = engine.inner.mvcc.as_ref().unwrap().latest_commit_ts();
+
+    let err = engine
+        .add_compaction_filter_with_cutoff(
+            CompactionFilterRequest::prefix(Bytes::from_static(b"k")),
+            latest + 1,
+        )
+        .unwrap_err();
+    assert!(err.to_string().contains("exceeds latest commit ts"));
+}
+
+#[test]
+fn test_compaction_filter_stats_track_drops() {
+    let dir = tempdir().unwrap();
+    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+
+    engine.put(b"old:drop", b"v1").unwrap();
+    engine.force_flush().unwrap();
+    engine
+        .add_compaction_filter(CompactionFilterRequest::prefix(Bytes::from_static(b"old:")))
+        .unwrap();
+    engine.put(b"keep", b"v2").unwrap();
+    engine.force_flush().unwrap();
+    engine.force_full_compaction().unwrap();
+
+    let stats = engine.compaction_filter_stats();
+    assert_eq!(stats.filters_active, 1);
+    assert!(stats.entries_checked >= 2);
+    assert_eq!(stats.entries_dropped, 1);
+    assert!(stats.bytes_dropped > 0);
+}
+
+#[test]
+fn test_compaction_filter_with_value_separation_preserves_unrelated_values() {
+    let dir = tempdir().unwrap();
+    let options = LsmStorageOptions {
+        block_size: 256,
+        target_sst_size: 1 << 20,
+        num_memtable_limit: 2,
+        compaction_options: CompactionOptions::NoCompaction,
+        enable_wal: false,
+        serializable: false,
+        value_separation: Some(ValueSeparationOptions {
+            enabled: true,
+            min_value_size: 16,
+            ..Default::default()
+        }),
+        manifest_snapshot_threshold_bytes: 0,
+        block_cache_capacity: 1024,
+        enable_cache_backfill: true,
+        prefix_bloom: PrefixBloomOptions::default(),
+    };
+    let engine = KvEngine::open(&dir, options).unwrap();
+    let old_value = vec![b'a'; 64];
+    let keep_value = vec![b'b'; 64];
+
+    engine.put(b"old:drop", &old_value).unwrap();
+    engine.force_flush().unwrap();
+    engine
+        .add_compaction_filter(CompactionFilterRequest::prefix(Bytes::from_static(b"old:")))
+        .unwrap();
+    engine.put(b"keep", &keep_value).unwrap();
+    engine.force_flush().unwrap();
+
+    engine.force_full_compaction().unwrap();
+    assert_eq!(engine.get(b"old:drop").unwrap(), None);
+    assert_eq!(
+        engine.get(b"keep").unwrap(),
+        Some(Bytes::from(keep_value.clone()))
+    );
+
+    let _gc_count = engine.trigger_gc().unwrap();
+    assert_eq!(engine.get(b"old:drop").unwrap(), None);
+    assert_eq!(engine.get(b"keep").unwrap(), Some(Bytes::from(keep_value)));
+}
 
 #[test]
 fn test_cache_stats_no_vlog() {

--- a/kv-engine/src/tests/lsm_storage_extra.rs
+++ b/kv-engine/src/tests/lsm_storage_extra.rs
@@ -52,7 +52,7 @@ fn test_compaction_filter_api_add_remove_list_and_stats() {
 
     let stats = engine.compaction_filter_stats();
     assert_eq!(stats.filters_active, 1);
-    assert_eq!(stats.entries_checked, 0);
+    assert_eq!(stats.entries_eligible, 0);
     assert_eq!(stats.entries_dropped, 0);
     assert_eq!(stats.bytes_dropped, 0);
 }
@@ -124,7 +124,7 @@ fn test_compaction_filter_stats_track_drops() {
 
     let stats = engine.compaction_filter_stats();
     assert_eq!(stats.filters_active, 1);
-    assert!(stats.entries_checked >= 2);
+    assert!(stats.entries_eligible >= 2);
     assert_eq!(stats.entries_dropped, 1);
     assert!(stats.bytes_dropped > 0);
 }

--- a/kv-engine/src/tests/manifest.rs
+++ b/kv-engine/src/tests/manifest.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use tempfile::tempdir;
 
 use crate::{
-    lsm_storage::{LsmStorageInner, LsmStorageOptions},
+    lsm_storage::{CompactionFilterRequest, LsmStorageInner, LsmStorageOptions},
     manifest::{MANIFEST_FORMAT_VERSION, Manifest, ManifestRecord},
 };
 
@@ -114,6 +114,8 @@ fn test_accept_snapshot_with_format_version() {
         next_sst_id: 1,
         vlog_references: vec![],
         imm_memtable_ids: vec![],
+        active_compaction_filters: vec![],
+        next_compaction_filter_id: 0,
         format_version: MANIFEST_FORMAT_VERSION,
     };
     std::fs::write(&snapshot_path, serde_json::to_vec(&snapshot).unwrap()).unwrap();
@@ -141,6 +143,8 @@ fn test_snapshot_tmp_crash_recovery() {
         next_sst_id: 1,
         vlog_references: vec![],
         imm_memtable_ids: vec![],
+        active_compaction_filters: vec![],
+        next_compaction_filter_id: 0,
         format_version: MANIFEST_FORMAT_VERSION,
     };
     std::fs::write(&tmp_path, serde_json::to_vec(&snapshot).unwrap()).unwrap();
@@ -197,6 +201,8 @@ fn test_reject_snapshot_without_format_version() {
         next_sst_id: 1,
         vlog_references: vec![],
         imm_memtable_ids: vec![],
+        active_compaction_filters: vec![],
+        next_compaction_filter_id: 0,
         format_version: 0, // old snapshot, no format version
     };
     std::fs::write(&snapshot_path, serde_json::to_vec(&snapshot).unwrap()).unwrap();
@@ -215,4 +221,89 @@ fn test_reject_snapshot_without_format_version() {
         "error should mention pre-MVCC or unsupported, got: {}",
         err
     );
+}
+
+#[test]
+fn test_compaction_filter_recovery_add_remove() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(&dir, LsmStorageOptions::default_for_test()).unwrap());
+    let keep_id = storage
+        .add_compaction_filter(CompactionFilterRequest::prefix(b"keep:".to_vec()))
+        .unwrap();
+    let drop_id = storage
+        .add_compaction_filter(CompactionFilterRequest::prefix(b"drop:".to_vec()))
+        .unwrap();
+    assert!(storage.remove_compaction_filter(drop_id).unwrap());
+    drop(storage);
+
+    let reopened =
+        Arc::new(LsmStorageInner::open(&dir, LsmStorageOptions::default_for_test()).unwrap());
+    let filters = reopened.list_compaction_filters();
+    assert_eq!(filters.len(), 1);
+    assert_eq!(filters[0].id, keep_id);
+    let next_id = reopened
+        .add_compaction_filter(CompactionFilterRequest::prefix(b"later:".to_vec()))
+        .unwrap();
+    assert!(next_id > drop_id);
+}
+
+#[test]
+fn test_manifest_snapshot_preserves_compaction_filters_and_next_id() {
+    let dir = tempdir().unwrap();
+    let options = LsmStorageOptions {
+        manifest_snapshot_threshold_bytes: 1,
+        ..LsmStorageOptions::default_for_test()
+    };
+    let storage = Arc::new(LsmStorageInner::open(&dir, options).unwrap());
+    let first = storage
+        .add_compaction_filter(CompactionFilterRequest::prefix(b"a:".to_vec()))
+        .unwrap();
+    let second = storage
+        .add_compaction_filter(CompactionFilterRequest::prefix(b"b:".to_vec()))
+        .unwrap();
+    let state_lock = storage.state_lock.lock();
+    storage.maybe_snapshot_manifest(&state_lock).unwrap();
+    drop(state_lock);
+    drop(storage);
+
+    let snapshot_path = dir.path().join("MANIFEST_SNAPSHOT");
+    let snapshot: ManifestRecord =
+        serde_json::from_slice(&std::fs::read(snapshot_path).unwrap()).unwrap();
+    match snapshot {
+        ManifestRecord::Snapshot {
+            active_compaction_filters,
+            next_compaction_filter_id,
+            ..
+        } => {
+            assert_eq!(active_compaction_filters.len(), 2);
+            assert_eq!(active_compaction_filters[0].id, first);
+            assert_eq!(active_compaction_filters[1].id, second);
+            assert_eq!(next_compaction_filter_id, second + 1);
+        }
+        _ => panic!("expected snapshot record"),
+    }
+}
+
+#[test]
+fn test_compaction_filter_replay_after_snapshot() {
+    let dir = tempdir().unwrap();
+    let options = LsmStorageOptions {
+        manifest_snapshot_threshold_bytes: 1,
+        ..LsmStorageOptions::default_for_test()
+    };
+    let storage = Arc::new(LsmStorageInner::open(&dir, options.clone()).unwrap());
+    let first = storage
+        .add_compaction_filter(CompactionFilterRequest::prefix(b"a:".to_vec()))
+        .unwrap();
+    let second = storage
+        .add_compaction_filter(CompactionFilterRequest::prefix(b"b:".to_vec()))
+        .unwrap();
+    assert!(storage.remove_compaction_filter(first).unwrap());
+    drop(storage);
+
+    let reopened = Arc::new(LsmStorageInner::open(&dir, options).unwrap());
+    let filters = reopened.list_compaction_filters();
+    assert_eq!(filters.len(), 1);
+    assert_eq!(filters[0].id, second);
 }

--- a/kv-engine/src/tests/manifest.rs
+++ b/kv-engine/src/tests/manifest.rs
@@ -7,7 +7,7 @@ use crate::{
     manifest::{MANIFEST_FORMAT_VERSION, Manifest, ManifestRecord},
 };
 
-/// A fresh database must write FormatVersion(2) as the first manifest record.
+/// A fresh database must write FormatVersion as the first manifest record.
 #[test]
 fn test_fresh_db_writes_format_version() {
     let dir = tempdir().unwrap();
@@ -24,7 +24,7 @@ fn test_fresh_db_writes_format_version() {
     );
     match &records[0] {
         ManifestRecord::FormatVersion(v) => {
-            assert_eq!(*v, MANIFEST_FORMAT_VERSION, "format version should be 2");
+            assert_eq!(*v, MANIFEST_FORMAT_VERSION, "format version should match");
         }
         other => panic!(
             "first record should be FormatVersion, got: {:?}",
@@ -100,8 +100,8 @@ fn test_reject_empty_manifest() {
     );
 }
 
-/// A Snapshot with format_version == 2 must be accepted — this is the
-/// happy path after manifest compaction.
+/// A Snapshot with the current format_version must be accepted — this is
+/// the happy path after manifest compaction.
 #[test]
 fn test_accept_snapshot_with_format_version() {
     let dir = tempdir().unwrap();
@@ -124,7 +124,7 @@ fn test_accept_snapshot_with_format_version() {
     let result = LsmStorageInner::open(&dir, LsmStorageOptions::default_for_test());
     assert!(
         result.is_ok(),
-        "should accept snapshot with format_version=2, got: {:?}",
+        "should accept snapshot with current format_version, got: {:?}",
         result.err()
     );
 }


### PR DESCRIPTION
## Summary

Implement the RFC 009 MVP for persisted, MVCC-safe prefix compaction filters.

## Changes
- add a compaction-filter registry with add/remove/list/stats APIs and validation
- persist filter add/remove state in the manifest and restore it during recovery and snapshots
- apply prefix filters during bottom-level compaction only when no active readers can observe physical deletion
- add coverage for API validation, manifest replay, compaction behavior, MVCC gating, and value-separation regressions

## Verification
- [x] cargo fmt --all --check
- [x] cargo clippy --workspace --all-features --all-targets -- -D warnings
- [x] cargo test -q --package kv-engine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added compaction filter management APIs to register, unregister, and list filters with MVCC-safe deletion.
  * New methods: `add_compaction_filter()`, `add_compaction_filter_with_cutoff()`, `remove_compaction_filter()`, `list_compaction_filters()`, and `compaction_filter_stats()`.
  * Filter statistics now tracked with eligibility and drop metrics.

* **Chores**
  * Manifest format updated to version 3 for compaction filter persistence and recovery support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->