### PR TITLE
feat: DeleteRange Phase 1 — range tombstone primitives, WAL v3, manifest v4

### DIFF
--- a/kv-engine/src/lib.rs
+++ b/kv-engine/src/lib.rs
@@ -12,6 +12,7 @@ pub mod lsm_storage;
 pub mod manifest;
 pub mod mem_table;
 pub mod mvcc;
+pub mod range_tombstone;
 pub mod table;
 pub mod vlog;
 pub mod wal;

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -67,6 +67,9 @@ pub struct LsmStorageState {
 pub enum WriteBatchRecord<T: AsRef<[u8]>> {
     Put(T, T),
     Del(T),
+    /// Range delete: hides all keys in `[start, end)`.
+    /// MVP: range-only batches only (no mixed point/range batches).
+    DelRange(T, T),
 }
 
 impl LsmStorageState {
@@ -728,6 +731,10 @@ impl LsmStorageInner {
         let mut next_compaction_filter_id: u64 = 0;
         // Maximum commit timestamp recovered from WAL batches and SST metadata.
         let mut max_commit_ts: u64 = 0;
+        // Whether we need to upgrade from manifest v3 to v4.
+        // Set in both branches of the manifest existence check below.
+        #[allow(unused_assignments)]
+        let mut needs_v3_to_v4_upgrade = false;
         let manifest = if !manifest_path.exists() {
             if options.enable_wal {
                 let id = state.memtable.id();
@@ -750,9 +757,10 @@ impl LsmStorageInner {
         } else {
             let ret = Manifest::recover(manifest_path).context("failed to recover manifest")?;
 
-            // Validate format version: the first record must be FormatVersion(2)
-            // or a Snapshot with format_version == 2. Pre-MVCC directories (no
+            // Validate format version: the first record must be FormatVersion(v)
+            // or a Snapshot with format_version == v. Pre-MVCC directories (no
             // format marker) are rejected to prevent silent data corruption.
+            // Accept v3 (will be upgraded to v4) and v4 (current).
             let detected_version = match ret.1.first() {
                 Some(ManifestRecord::FormatVersion(v)) => *v,
                 Some(ManifestRecord::Snapshot { format_version, .. }) => *format_version,
@@ -762,17 +770,18 @@ impl LsmStorageInner {
                 ),
                 _ => anyhow::bail!(
                     "pre-MVCC directory detected (no format version marker); \
-                     MVCC format (version 3) is required; \
+                     MVCC format (version 4) is required; \
                      please start with a fresh database"
                 ),
             };
             anyhow::ensure!(
-                detected_version == crate::manifest::MANIFEST_FORMAT_VERSION,
-                "unsupported manifest format version: got {}, expected {}; \
+                detected_version == 3 || detected_version == 4,
+                "unsupported manifest format version: got {}, expected 3 or 4; \
                  please start with a fresh database",
-                detected_version,
-                crate::manifest::MANIFEST_FORMAT_VERSION
+                detected_version
             );
+            // Track whether we need to upgrade from v3 to v4.
+            needs_v3_to_v4_upgrade = detected_version == 3;
 
             // need order by sst_id when recover
             let mut im_memtables = BTreeSet::new();
@@ -897,7 +906,7 @@ impl LsmStorageInner {
                     let (m, wal_max_ts) = if vlog_enabled {
                         MemTable::recover_from_wal_vlog(id, wal_path)?
                     } else {
-                        MemTable::recover_from_wal(id, wal_path)?
+                        MemTable::recover_from_wal_with_range_tombstones(id, wal_path)?
                     };
                     if wal_max_ts > max_commit_ts {
                         max_commit_ts = wal_max_ts;
@@ -906,21 +915,7 @@ impl LsmStorageInner {
                         state.imm_memtables.insert(0, Arc::new(m));
                     }
                 }
-                let wal_path = Self::path_of_wal_static(path, max_id);
-                state.memtable = Arc::new(if vlog_enabled {
-                    MemTable::create_with_wal_vlog(max_id, wal_path)?
-                } else {
-                    MemTable::create_with_wal(max_id, wal_path)?
-                });
-            } else {
-                state.memtable = Arc::new(if vlog_enabled {
-                    MemTable::create_vlog(max_id)
-                } else {
-                    MemTable::create(max_id)
-                });
             }
-            ret.0
-                .add_record_when_init(ManifestRecord::NewMemtable(max_id))?;
 
             // build sstables
             let ids = state
@@ -942,6 +937,46 @@ impl LsmStorageInner {
                 }
                 state.sstables.insert(*id, Arc::new(sst));
             }
+
+            // Eager v3→v4 manifest upgrade: write a v4 snapshot BEFORE creating
+            // any WAL v3 artifact, per RFC Section 8.3 ordering constraint.
+            if needs_v3_to_v4_upgrade {
+                let snapshot = ManifestRecord::Snapshot {
+                    l0_sstables: state.l0_sstables.clone(),
+                    levels: state.levels.clone(),
+                    next_sst_id: max_id,
+                    vlog_references: recovered_vlog_refs
+                        .iter()
+                        .map(|(k, v)| (*k, v.clone()))
+                        .collect(),
+                    imm_memtable_ids: state.imm_memtables.iter().map(|m| m.id()).collect(),
+                    active_compaction_filters: recovered_compaction_filters
+                        .values()
+                        .cloned()
+                        .collect(),
+                    next_compaction_filter_id,
+                    format_version: crate::manifest::MANIFEST_FORMAT_VERSION,
+                };
+                ret.0.snapshot(snapshot)?;
+            }
+
+            // Create the new active memtable (with WAL v3 if enabled).
+            if options.enable_wal {
+                let wal_path = Self::path_of_wal_static(path, max_id);
+                state.memtable = Arc::new(if vlog_enabled {
+                    MemTable::create_with_wal_vlog(max_id, wal_path)?
+                } else {
+                    MemTable::create_with_wal(max_id, wal_path)?
+                });
+            } else {
+                state.memtable = Arc::new(if vlog_enabled {
+                    MemTable::create_vlog(max_id)
+                } else {
+                    MemTable::create(max_id)
+                });
+            }
+            ret.0
+                .add_record_when_init(ManifestRecord::NewMemtable(max_id))?;
 
             ret.0
         };
@@ -2054,11 +2089,64 @@ impl LsmStorageInner {
     /// the batch is written. When MVCC is enabled, all entries share a single
     /// commit timestamp.
     pub fn write_batch<T: AsRef<[u8]>>(&self, batch: &[WriteBatchRecord<T>]) -> Result<()> {
+        // MVP: reject mixed batches containing both point and range operations.
+        let has_point = batch
+            .iter()
+            .any(|r| matches!(r, WriteBatchRecord::Put(..) | WriteBatchRecord::Del(_)));
+        let has_range = batch
+            .iter()
+            .any(|r| matches!(r, WriteBatchRecord::DelRange(..)));
+        anyhow::ensure!(
+            !(has_point && has_range),
+            "mixed point/range batches are not supported in the MVP"
+        );
+
+        // Range-only batch: allocate a single commit_ts for all entries.
+        if has_range {
+            anyhow::ensure!(
+                !self.options.serializable,
+                "delete_range is not supported with serializable mode in the MVP"
+            );
+            let entries: Vec<(&[u8], &[u8])> = batch
+                .iter()
+                .filter_map(|r| {
+                    if let WriteBatchRecord::DelRange(start, end) = r {
+                        Some((start.as_ref(), end.as_ref()))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            for (start, end) in &entries {
+                Self::validate_key_size(start)?;
+                Self::validate_key_size(end)?;
+                anyhow::ensure!(
+                    start < end,
+                    "invalid range: start ({:?}) must be less than end ({:?})",
+                    start,
+                    end
+                );
+            }
+            let _guard = self.active_memtable_lock.read();
+            let state = self.state.load_full();
+            if let Some(ref mvcc) = self.mvcc {
+                mvcc.write_range_batch(&entries, &state.memtable)?;
+            } else {
+                for (ordinal, (start, end)) in entries.iter().enumerate() {
+                    state
+                        .memtable
+                        .put_range_tombstone(start, end, 0, ordinal as u32)?;
+                }
+            }
+            return self.try_freeze_memtable();
+        }
+
         // Validate key sizes before any writes.
         for record in batch {
             let key = match record {
                 WriteBatchRecord::Del(k) => k.as_ref(),
                 WriteBatchRecord::Put(k, _) => k.as_ref(),
+                WriteBatchRecord::DelRange(_, _) => unreachable!(),
             };
             Self::validate_key_size(key)?;
         }
@@ -2068,6 +2156,7 @@ impl LsmStorageInner {
             let key = match record {
                 WriteBatchRecord::Del(k) => k.as_ref(),
                 WriteBatchRecord::Put(k, _) => k.as_ref(),
+                WriteBatchRecord::DelRange(_, _) => unreachable!(),
             };
             last_op.insert(key, idx);
         }
@@ -2093,6 +2182,7 @@ impl LsmStorageInner {
                     .map(|&idx| match &batch[idx] {
                         WriteBatchRecord::Put(key, value) => (key.as_ref(), value.as_ref(), false),
                         WriteBatchRecord::Del(key) => (key.as_ref(), &[] as &[u8], true),
+                        WriteBatchRecord::DelRange(_, _) => unreachable!(),
                     })
                     .collect();
                 if self.options.serializable {
@@ -2103,6 +2193,7 @@ impl LsmStorageInner {
                             let key = match &batch[idx] {
                                 WriteBatchRecord::Put(k, _) => k.as_ref(),
                                 WriteBatchRecord::Del(k) => k.as_ref(),
+                                WriteBatchRecord::DelRange(_, _) => unreachable!(),
                             };
                             write_set.insert(bytes::Bytes::copy_from_slice(key));
                         }
@@ -2128,6 +2219,7 @@ impl LsmStorageInner {
                             p.extend_from_slice(value.as_ref());
                             raw_data.push((KeySlice::from_slice(key.as_ref()), p));
                         }
+                        WriteBatchRecord::DelRange(_, _) => unreachable!(),
                     }
                 }
                 let refs: Vec<(KeySlice, &[u8])> =
@@ -2215,6 +2307,39 @@ impl LsmStorageInner {
                 }
             } else {
                 state.memtable.put_tombstone(key)?;
+            }
+        }
+        self.try_freeze_memtable()
+    }
+
+    /// Internal range delete: hides all keys in `[start, end)` at a new commit timestamp.
+    ///
+    /// This is the Phase 1 test hook. It validates bounds, writes the range
+    /// tombstone into the active memtable, and publishes the commit timestamp.
+    /// The tombstone is also WAL-durable when WAL is enabled (via the
+    /// memtable's WAL integration — to be wired in Phase 2/3).
+    pub fn delete_range_internal(&self, start: &[u8], end: &[u8]) -> Result<()> {
+        anyhow::ensure!(
+            !self.options.serializable,
+            "delete_range is not supported with serializable mode in the MVP"
+        );
+        anyhow::ensure!(
+            start < end,
+            "invalid range: start ({:?}) must be less than end ({:?})",
+            start,
+            end
+        );
+        Self::validate_key_size(start)?;
+        Self::validate_key_size(end)?;
+
+        {
+            let _guard = self.active_memtable_lock.read();
+            let state = self.state.load_full();
+            if let Some(ref mvcc) = self.mvcc {
+                mvcc.write_range_tombstone(start, end, &state.memtable)?;
+            } else {
+                // Non-MVCC path: use ts=0 as a sentinel.
+                state.memtable.put_range_tombstone(start, end, 0, 0)?;
             }
         }
         self.try_freeze_memtable()

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -2132,11 +2132,7 @@ impl LsmStorageInner {
             if let Some(ref mvcc) = self.mvcc {
                 mvcc.write_range_batch(&entries, &state.memtable)?;
             } else {
-                for (ordinal, (start, end)) in entries.iter().enumerate() {
-                    state
-                        .memtable
-                        .put_range_tombstone(start, end, 0, ordinal as u32)?;
-                }
+                state.memtable.put_range_tombstone_batch(&entries, 0, 0)?;
             }
             return self.try_freeze_memtable();
         }
@@ -2322,6 +2318,10 @@ impl LsmStorageInner {
         anyhow::ensure!(
             !self.options.serializable,
             "delete_range is not supported with serializable mode in the MVP"
+        );
+        anyhow::ensure!(
+            self.vlog.is_none(),
+            "delete_range is not supported when value-log (vlog) is enabled in the MVP"
         );
         anyhow::ensure!(
             start < end,

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -732,8 +732,6 @@ impl LsmStorageInner {
         // Maximum commit timestamp recovered from WAL batches and SST metadata.
         let mut max_commit_ts: u64 = 0;
         // Whether we need to upgrade from manifest v3 to v4.
-        // Set in both branches of the manifest existence check below.
-        #[allow(unused_assignments)]
         let mut needs_v3_to_v4_upgrade = false;
         let manifest = if !manifest_path.exists() {
             if options.enable_wal {
@@ -781,7 +779,9 @@ impl LsmStorageInner {
                 detected_version
             );
             // Track whether we need to upgrade from v3 to v4.
-            needs_v3_to_v4_upgrade = detected_version == 3;
+            if detected_version == 3 {
+                needs_v3_to_v4_upgrade = true;
+            }
 
             // need order by sst_id when recover
             let mut im_memtables = BTreeSet::new();

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -948,11 +948,13 @@ impl LsmStorageInner {
                     vlog_references: if recovered_vlog_refs.is_empty() {
                         Default::default()
                     } else {
-                        recovered_vlog_refs
+                        let mut refs: Vec<_> = recovered_vlog_refs
                             .iter()
                             .filter(|(k, _)| state.sstables.contains_key(k))
                             .map(|(k, v)| (*k, v.clone()))
-                            .collect()
+                            .collect();
+                        refs.sort_unstable_by_key(|(k, _)| *k);
+                        refs
                     },
                     imm_memtable_ids: state.imm_memtables.iter().map(|m| m.id()).collect(),
                     active_compaction_filters: recovered_compaction_filters

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -945,10 +945,15 @@ impl LsmStorageInner {
                     l0_sstables: state.l0_sstables.clone(),
                     levels: state.levels.clone(),
                     next_sst_id: max_id,
-                    vlog_references: recovered_vlog_refs
-                        .iter()
-                        .map(|(k, v)| (*k, v.clone()))
-                        .collect(),
+                    vlog_references: if recovered_vlog_refs.is_empty() {
+                        Default::default()
+                    } else {
+                        recovered_vlog_refs
+                            .iter()
+                            .filter(|(k, _)| state.sstables.contains_key(k))
+                            .map(|(k, v)| (*k, v.clone()))
+                            .collect()
+                    },
                     imm_memtable_ids: state.imm_memtables.iter().map(|m| m.id()).collect(),
                     active_compaction_filters: recovered_compaction_filters
                         .values()

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -2107,6 +2107,10 @@ impl LsmStorageInner {
                 !self.options.serializable,
                 "delete_range is not supported with serializable mode in the MVP"
             );
+            anyhow::ensure!(
+                self.vlog.is_none(),
+                "delete_range is not supported when value-log (vlog) is enabled in the MVP"
+            );
             let entries: Vec<(&[u8], &[u8])> = batch
                 .iter()
                 .filter_map(|r| {

--- a/kv-engine/src/manifest.rs
+++ b/kv-engine/src/manifest.rs
@@ -18,10 +18,10 @@ pub(crate) struct Manifest {
 
 /// Current manifest format version for MVCC-enabled databases.
 /// Version numbers align with the feature phase: 2 = MVCC Phase 2
-/// (format hardening), 3 = compaction filters. Version 0 is reserved to
-/// mean "legacy/field-absent" and must never be assigned as a valid format
-/// version.
-pub const MANIFEST_FORMAT_VERSION: u32 = 3;
+/// (format hardening), 3 = compaction filters, 4 = range tombstones.
+/// Version 0 is reserved to mean "legacy/field-absent" and must never be
+/// assigned as a valid format version.
+pub const MANIFEST_FORMAT_VERSION: u32 = 4;
 
 #[derive(Serialize, Deserialize)]
 pub(crate) enum ManifestRecord {

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -632,9 +632,28 @@ impl MemTable {
         // Check point entries first.
         let point_overlap = if !self.map.is_empty() {
             let front = self.map.front().expect("map is not empty");
-            let lo = front.key();
+            let lo_raw = front.key();
             let back = self.map.back().expect("map is not empty");
-            let hi = back.key();
+            let hi_raw = back.key();
+            // Decode user keys from internal keys (user_key + ts) when MVCC is
+            // enabled, so comparisons with raw user key bounds are correct.
+            let (lo, hi): (&[u8], &[u8]);
+            let lo_decoded;
+            let hi_decoded;
+            if crate::key::TS_ENABLED {
+                lo_decoded = crate::key::decode_user_key_cow(lo_raw);
+                hi_decoded = crate::key::decode_user_key_cow(hi_raw);
+                match (&lo_decoded, &hi_decoded) {
+                    (Some(l), Some(h)) => {
+                        lo = l.as_ref();
+                        hi = h.as_ref();
+                    }
+                    _ => return false,
+                }
+            } else {
+                lo = lo_raw;
+                hi = hi_raw;
+            }
             // Two ranges overlap iff query_start <= memtable_end && memtable_start <= query_end.
             let l_le_hi = match lower {
                 Bound::Included(x) => x <= hi,

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -690,8 +690,22 @@ impl MemTable {
             (Bound::Unbounded, Bound::Excluded(u)) => {
                 self.range_tombstones.overlaps(&[], u, u64::MAX)
             }
+            // Unbounded upper: check if any tombstone's end > lower bound.
+            (Bound::Included(l), Bound::Unbounded) => self
+                .range_tombstones
+                .raw()
+                .iter()
+                .any(|entry| l < entry.value().as_ref()),
+            (Bound::Excluded(l), Bound::Unbounded) => {
+                let mut l_succ = l.to_vec();
+                l_succ.push(0);
+                self.range_tombstones
+                    .raw()
+                    .iter()
+                    .any(|entry| l_succ.as_slice() < entry.value().as_ref())
+            }
             // Both unbounded: any tombstone overlaps.
-            _ => !self.range_tombstones.is_empty(),
+            (Bound::Unbounded, Bound::Unbounded) => !self.range_tombstones.is_empty(),
         }
     }
 }

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -590,6 +590,20 @@ impl MemTable {
             wal.sync()?;
         }
 
+        // Abort on panic during in-memory publication. If a panic (e.g. OOM)
+        // occurs after the WAL has durably recorded the tombstone but before
+        // the memtable has published it, unwinding would leave the engine in
+        // an inconsistent state. Aborting prevents that.
+        struct AbortOnPanic;
+        impl Drop for AbortOnPanic {
+            fn drop(&mut self) {
+                if std::thread::panicking() {
+                    std::process::abort();
+                }
+            }
+        }
+        let _abort_guard = AbortOnPanic;
+
         use crate::range_tombstone::RangeTombstone;
         for (i, (start, end)) in tombstones.iter().enumerate() {
             let ordinal = base_ordinal.checked_add(i as u32).expect("pre-validated");

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -677,6 +677,16 @@ impl MemTable {
             (Bound::Excluded(l), Bound::Excluded(u)) => {
                 self.range_tombstones.overlaps(l, u, u64::MAX)
             }
+            // Unbounded lower: treat as starting from the empty key.
+            (Bound::Unbounded, Bound::Included(u)) => {
+                let mut u_succ = u.to_vec();
+                u_succ.push(0);
+                self.range_tombstones.overlaps(&[], &u_succ, u64::MAX)
+            }
+            (Bound::Unbounded, Bound::Excluded(u)) => {
+                self.range_tombstones.overlaps(&[], u, u64::MAX)
+            }
+            // Both unbounded: any tombstone overlaps.
             _ => !self.range_tombstones.is_empty(),
         }
     }

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -4,7 +4,7 @@ use std::{
     sync::{Arc, atomic::AtomicUsize},
 };
 
-use anyhow::{Ok, Result};
+use anyhow::{Context, Ok, Result};
 use bytes::Bytes;
 use crossbeam_skiplist::SkipMap;
 use ouroboros::self_referencing;
@@ -550,12 +550,7 @@ impl MemTable {
 
     /// Write a range tombstone into the memtable.
     ///
-    /// The tombstone hides all keys in `[start, end)` at the given timestamp.
-    /// `ordinal` disambiguates multiple `DelRange` entries in the same batch.
-    ///
-    /// When WAL is enabled, the tombstone is also durably written to the WAL
-    /// before being published, satisfying the RFC Section 6.5 durability
-    /// requirement.
+    /// Convenience wrapper around [`put_range_tombstone_batch`] for a single entry.
     pub fn put_range_tombstone(
         &self,
         start: &[u8],
@@ -563,21 +558,46 @@ impl MemTable {
         ts: u64,
         ordinal: u32,
     ) -> Result<()> {
-        // Write to WAL first for durability, similar to put_raw_batch_inner.
+        self.put_range_tombstone_batch(&[(start, end)], ts, ordinal)
+    }
+
+    /// Write a batch of range tombstones into the memtable.
+    ///
+    /// All entries share a single WAL write and sync, avoiding per-entry
+    /// write amplification. The `base_ordinal` is the ordinal for the first
+    /// entry; subsequent entries get `base_ordinal + i`.
+    ///
+    /// When WAL is enabled, the batch is durably written to the WAL before
+    /// being published, satisfying the RFC Section 6.5 durability requirement.
+    pub fn put_range_tombstone_batch(
+        &self,
+        tombstones: &[(&[u8], &[u8])],
+        ts: u64,
+        base_ordinal: u32,
+    ) -> Result<()> {
+        if tombstones.is_empty() {
+            return Ok(());
+        }
+        // Single WAL write + sync for the entire batch.
         if let Some(wal) = &self.wal {
-            wal.put_range_tombstone_batch(&[(start, end)], ts)?;
+            wal.put_range_tombstone_batch(tombstones, ts)?;
             wal.sync()?;
         }
 
         use crate::range_tombstone::RangeTombstone;
-        self.range_tombstones.add(
-            RangeTombstone {
-                start: Bytes::copy_from_slice(start),
-                end: Bytes::copy_from_slice(end),
-                ts,
-            },
-            ordinal,
-        );
+        for (i, (start, end)) in tombstones.iter().enumerate() {
+            let ordinal = base_ordinal
+                .checked_add(u32::try_from(i).context("ordinal overflow")?)
+                .context("ordinal overflow")?;
+            self.range_tombstones.add(
+                RangeTombstone {
+                    start: Bytes::copy_from_slice(start),
+                    end: Bytes::copy_from_slice(end),
+                    ts,
+                },
+                ordinal,
+            );
+        }
 
         Ok(())
     }
@@ -591,16 +611,17 @@ impl MemTable {
     pub fn range_overlap(&self, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> bool {
         // Check point entries first.
         let point_overlap = if !self.map.is_empty() {
-            let e = self.map.front().unwrap();
-            let lo = e.key();
-            let e = self.map.back().unwrap();
-            let hi = e.key();
+            let front = self.map.front().expect("map is not empty");
+            let lo = front.key();
+            let back = self.map.back().expect("map is not empty");
+            let hi = back.key();
+            // Two ranges overlap iff query_start <= memtable_end && memtable_start <= query_end.
             match (lower, upper) {
-                (Bound::Included(x), Bound::Included(y)) => {
-                    x >= lo && x <= hi || y >= lo && y <= hi
-                }
-                (Bound::Excluded(x), Bound::Excluded(y)) => x > lo && x < hi || y > lo && y < hi,
-                _ => true,
+                (Bound::Included(x), Bound::Included(y)) => x <= hi && lo <= y,
+                (Bound::Included(x), Bound::Excluded(y)) => x <= hi && lo < y,
+                (Bound::Excluded(x), Bound::Included(y)) => x < hi && lo <= y,
+                (Bound::Excluded(x), Bound::Excluded(y)) => x < hi && lo < y,
+                _ => true, // Unbounded cases conservatively return true.
             }
         } else {
             false

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -636,13 +636,17 @@ impl MemTable {
             let back = self.map.back().expect("map is not empty");
             let hi = back.key();
             // Two ranges overlap iff query_start <= memtable_end && memtable_start <= query_end.
-            match (lower, upper) {
-                (Bound::Included(x), Bound::Included(y)) => x <= hi && lo <= y,
-                (Bound::Included(x), Bound::Excluded(y)) => x <= hi && lo < y,
-                (Bound::Excluded(x), Bound::Included(y)) => x < hi && lo <= y,
-                (Bound::Excluded(x), Bound::Excluded(y)) => x < hi && lo < y,
-                _ => true, // Unbounded cases conservatively return true.
-            }
+            let l_le_hi = match lower {
+                Bound::Included(x) => x <= hi,
+                Bound::Excluded(x) => x < hi,
+                Bound::Unbounded => true,
+            };
+            let lo_le_u = match upper {
+                Bound::Included(y) => lo <= y,
+                Bound::Excluded(y) => lo < y,
+                Bound::Unbounded => true,
+            };
+            l_le_hi && lo_le_u
         } else {
             false
         };

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -670,12 +670,16 @@ impl MemTable {
                 self.range_tombstones.overlaps(l, u, u64::MAX)
             }
             (Bound::Excluded(l), Bound::Included(u)) => {
+                let mut l_succ = l.to_vec();
+                l_succ.push(0);
                 let mut u_succ = u.to_vec();
                 u_succ.push(0);
-                self.range_tombstones.overlaps(l, &u_succ, u64::MAX)
+                self.range_tombstones.overlaps(&l_succ, &u_succ, u64::MAX)
             }
             (Bound::Excluded(l), Bound::Excluded(u)) => {
-                self.range_tombstones.overlaps(l, u, u64::MAX)
+                let mut l_succ = l.to_vec();
+                l_succ.push(0);
+                self.range_tombstones.overlaps(&l_succ, u, u64::MAX)
             }
             // Unbounded lower: treat as starting from the empty key.
             (Bound::Unbounded, Bound::Included(u)) => {

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -606,7 +606,9 @@ impl MemTable {
 
         use crate::range_tombstone::RangeTombstone;
         for (i, (start, end)) in tombstones.iter().enumerate() {
-            let ordinal = base_ordinal.checked_add(i as u32).expect("pre-validated");
+            let ordinal = base_ordinal
+                .checked_add(u32::try_from(i).expect("pre-validated"))
+                .expect("pre-validated");
             self.range_tombstones.add(
                 RangeTombstone {
                     start: Bytes::copy_from_slice(start),

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -650,15 +650,23 @@ impl MemTable {
         }
 
         // Also check range tombstones.
+        // `overlaps(l, end)` treats the range as [l, end) (half-open).
+        // For `Bound::Included(u)`, we need to include tombstones starting
+        // at `u` itself, so append a `\0` byte to create `u`'s
+        // lexicographical successor.
         match (lower, upper) {
             (Bound::Included(l), Bound::Included(u)) => {
-                self.range_tombstones.overlaps(l, u, u64::MAX)
+                let mut u_succ = u.to_vec();
+                u_succ.push(0);
+                self.range_tombstones.overlaps(l, &u_succ, u64::MAX)
             }
             (Bound::Included(l), Bound::Excluded(u)) => {
                 self.range_tombstones.overlaps(l, u, u64::MAX)
             }
             (Bound::Excluded(l), Bound::Included(u)) => {
-                self.range_tombstones.overlaps(l, u, u64::MAX)
+                let mut u_succ = u.to_vec();
+                u_succ.push(0);
+                self.range_tombstones.overlaps(l, &u_succ, u64::MAX)
             }
             (Bound::Excluded(l), Bound::Excluded(u)) => {
                 self.range_tombstones.overlaps(l, u, u64::MAX)

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -618,6 +618,9 @@ impl MemTable {
             (Bound::Included(l), Bound::Excluded(u)) => {
                 self.range_tombstones.overlaps(l, u, u64::MAX)
             }
+            (Bound::Excluded(l), Bound::Included(u)) => {
+                self.range_tombstones.overlaps(l, u, u64::MAX)
+            }
             (Bound::Excluded(l), Bound::Excluded(u)) => {
                 self.range_tombstones.overlaps(l, u, u64::MAX)
             }

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -578,6 +578,12 @@ impl MemTable {
         if tombstones.is_empty() {
             return Ok(());
         }
+        // Pre-validate ordinal overflow before WAL write so that the
+        // in-memory publication loop below is infallible.
+        let _ = base_ordinal
+            .checked_add(u32::try_from(tombstones.len()).context("ordinal overflow")?)
+            .context("ordinal overflow")?;
+
         // Single WAL write + sync for the entire batch.
         if let Some(wal) = &self.wal {
             wal.put_range_tombstone_batch(tombstones, ts)?;
@@ -586,9 +592,7 @@ impl MemTable {
 
         use crate::range_tombstone::RangeTombstone;
         for (i, (start, end)) in tombstones.iter().enumerate() {
-            let ordinal = base_ordinal
-                .checked_add(u32::try_from(i).context("ordinal overflow")?)
-                .context("ordinal overflow")?;
+            let ordinal = base_ordinal.checked_add(i as u32).expect("pre-validated");
             self.range_tombstones.add(
                 RangeTombstone {
                     start: Bytes::copy_from_slice(start),

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -12,6 +12,7 @@ use ouroboros::self_referencing;
 use crate::{
     iterators::StorageIterator,
     key::{Key, KeySlice, shared_bytes_from_slice},
+    range_tombstone::RangeTombstoneSet,
     table::{SsTableBuilder, bloom::IncrementalBloom},
     vlog::{KvKind, ValueLog, ValuePointer},
     wal::Wal,
@@ -35,6 +36,8 @@ pub struct MemTable {
     /// Incremental bloom filter for negative lookups. Avoids skiplist epoch pin
     /// overhead when the key is not in this memtable.
     bloom: IncrementalBloom,
+    /// Range tombstones stored in this memtable.
+    range_tombstones: RangeTombstoneSet,
 }
 
 /// Create a bound of `Bytes` from a bound of `&[u8]`.
@@ -56,6 +59,7 @@ impl MemTable {
             approximate_size: Arc::new(AtomicUsize::new(0)),
             vlog_enabled: false,
             bloom: IncrementalBloom::new(BLOOM_EXPECTED_ENTRIES, BLOOM_FALSE_POSITIVE_RATE),
+            range_tombstones: RangeTombstoneSet::new(),
         }
     }
 
@@ -68,6 +72,7 @@ impl MemTable {
             approximate_size: Arc::new(AtomicUsize::new(0)),
             vlog_enabled: true,
             bloom: IncrementalBloom::new(BLOOM_EXPECTED_ENTRIES, BLOOM_FALSE_POSITIVE_RATE),
+            range_tombstones: RangeTombstoneSet::new(),
         }
     }
 
@@ -90,6 +95,10 @@ impl MemTable {
     }
 
     /// Create a memtable from WAL. Returns the memtable and the max commit_ts found.
+    ///
+    /// Uses [`Wal::recover`] which replays point entries into the skiplist but
+    /// silently discards range tombstones. For full recovery including range
+    /// tombstones, use [`recover_from_wal_with_range_tombstones`].
     pub fn recover_from_wal(id: usize, path: impl AsRef<Path>) -> Result<(Self, u64)> {
         let mut ret = Self::create(id);
         let (wal, max_ts) = Wal::recover(path, &ret.map)?;
@@ -110,6 +119,24 @@ impl MemTable {
         ret.rebuild_bloom();
 
         Ok((ret, max_ts))
+    }
+
+    /// Create a memtable from WAL with full range-tombstone recovery.
+    ///
+    /// Unlike [`recover_from_wal`], this method uses
+    /// [`Wal::recover_with_range_tombstones`] to also populate the memtable's
+    /// [`RangeTombstoneSet`] from WAL v3 range-tombstone entries.
+    pub fn recover_from_wal_with_range_tombstones(
+        id: usize,
+        path: impl AsRef<Path>,
+    ) -> Result<(Self, u64)> {
+        let mut ret = Self::create(id);
+        let (wal, batch) =
+            Wal::recover_with_range_tombstones(path, &ret.map, &ret.range_tombstones)?;
+        ret.wal = Some(wal);
+        ret.rebuild_bloom();
+
+        Ok((ret, batch.max_ts))
     }
 
     /// Rebuild the bloom filter from existing skiplist entries.
@@ -470,6 +497,16 @@ impl MemTable {
     /// Inline entries have their prefix stripped and go through `add()` for
     /// value separation.
     pub fn flush(&self, builder: &mut SsTableBuilder) -> Result<()> {
+        // Phase 1/2 guard: refuse to flush a memtable containing range
+        // tombstones until SST v4 write support exists (Phase 3). Without
+        // this guard, a flush would produce an SST with no range-tombstone
+        // data, and the subsequent WAL deletion would permanently lose them.
+        anyhow::ensure!(
+            self.range_tombstones.is_empty(),
+            "cannot flush memtable containing range tombstones: \
+             SST v4 write support not yet implemented (Phase 3)"
+        );
+
         for e in self.map.iter() {
             let key_bytes = Key::from_bytes(e.key().clone());
             let key = key_bytes.as_key_slice();
@@ -501,28 +538,90 @@ impl MemTable {
     pub fn approximate_size(&self) -> usize {
         self.approximate_size
             .load(std::sync::atomic::Ordering::Relaxed)
+            + self.range_tombstones.approximate_size()
     }
 
-    /// Only use this function when closing the database
+    /// Only use this function when closing the database.
+    /// Returns `false` when either point entries or range tombstones are present.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.map.is_empty()
+        self.map.is_empty() && self.range_tombstones.is_empty()
+    }
+
+    /// Write a range tombstone into the memtable.
+    ///
+    /// The tombstone hides all keys in `[start, end)` at the given timestamp.
+    /// `ordinal` disambiguates multiple `DelRange` entries in the same batch.
+    ///
+    /// When WAL is enabled, the tombstone is also durably written to the WAL
+    /// before being published, satisfying the RFC Section 6.5 durability
+    /// requirement.
+    pub fn put_range_tombstone(
+        &self,
+        start: &[u8],
+        end: &[u8],
+        ts: u64,
+        ordinal: u32,
+    ) -> Result<()> {
+        // Write to WAL first for durability, similar to put_raw_batch_inner.
+        if let Some(wal) = &self.wal {
+            wal.put_range_tombstone_batch(&[(start, end)], ts)?;
+            wal.sync()?;
+        }
+
+        use crate::range_tombstone::RangeTombstone;
+        self.range_tombstones.add(
+            RangeTombstone {
+                start: Bytes::copy_from_slice(start),
+                end: Bytes::copy_from_slice(end),
+                ts,
+            },
+            ordinal,
+        );
+
+        Ok(())
+    }
+
+    /// Access the range tombstone set for this memtable.
+    pub fn range_tombstones(&self) -> &RangeTombstoneSet {
+        &self.range_tombstones
     }
 
     #[must_use]
     pub fn range_overlap(&self, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> bool {
-        if self.map.is_empty() {
-            return false;
+        // Check point entries first.
+        let point_overlap = if !self.map.is_empty() {
+            let e = self.map.front().unwrap();
+            let lo = e.key();
+            let e = self.map.back().unwrap();
+            let hi = e.key();
+            match (lower, upper) {
+                (Bound::Included(x), Bound::Included(y)) => {
+                    x >= lo && x <= hi || y >= lo && y <= hi
+                }
+                (Bound::Excluded(x), Bound::Excluded(y)) => x > lo && x < hi || y > lo && y < hi,
+                _ => true,
+            }
+        } else {
+            false
+        };
+
+        if point_overlap {
+            return true;
         }
 
-        let e = self.map.front().unwrap();
-        let lo = e.key();
-        let e = self.map.back().unwrap();
-        let hi = e.key();
+        // Also check range tombstones.
         match (lower, upper) {
-            (Bound::Included(x), Bound::Included(y)) => x >= lo && x <= hi || y >= lo && y <= hi,
-            (Bound::Excluded(x), Bound::Excluded(y)) => x > lo && x < hi || y > lo && y < hi,
-            _ => true,
+            (Bound::Included(l), Bound::Included(u)) => {
+                self.range_tombstones.overlaps(l, u, u64::MAX)
+            }
+            (Bound::Included(l), Bound::Excluded(u)) => {
+                self.range_tombstones.overlaps(l, u, u64::MAX)
+            }
+            (Bound::Excluded(l), Bound::Excluded(u)) => {
+                self.range_tombstones.overlaps(l, u, u64::MAX)
+            }
+            _ => !self.range_tombstones.is_empty(),
         }
     }
 }

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -106,6 +106,44 @@ impl LsmMvccInner {
         Ok(commit_ts)
     }
 
+    /// Write a range tombstone covering `[start, end)`.
+    /// Returns the commit timestamp used.
+    pub fn write_range_tombstone(
+        &self,
+        start: &[u8],
+        end: &[u8],
+        memtable: &MemTable,
+    ) -> Result<u64, anyhow::Error> {
+        let _write_guard = self.write_lock.lock();
+        let commit_ts = self.ts.lock().0 + 1;
+        memtable.put_range_tombstone(start, end, commit_ts, 0)?;
+        self.ts.lock().0 = commit_ts;
+
+        Ok(commit_ts)
+    }
+
+    /// Write a batch of range tombstones atomically under a single commit timestamp.
+    ///
+    /// All entries share one `commit_ts` and receive sequential ordinals.
+    /// Returns the commit timestamp used, or 0 if entries is empty.
+    pub fn write_range_batch(
+        &self,
+        entries: &[(&[u8], &[u8])],
+        memtable: &MemTable,
+    ) -> Result<u64, anyhow::Error> {
+        if entries.is_empty() {
+            return Ok(0);
+        }
+        let _write_guard = self.write_lock.lock();
+        let commit_ts = self.ts.lock().0 + 1;
+        for (ordinal, (start, end)) in entries.iter().enumerate() {
+            memtable.put_range_tombstone(start, end, commit_ts, ordinal as u32)?;
+        }
+        self.ts.lock().0 = commit_ts;
+
+        Ok(commit_ts)
+    }
+
     /// Write a batch of operations atomically under a single commit timestamp.
     /// Each entry is `(user_key, value, is_tombstone)`.
     /// Returns the commit timestamp used, or 0 if entries is empty.

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -134,11 +134,15 @@ impl LsmMvccInner {
         if entries.is_empty() {
             return Ok(0);
         }
+        anyhow::ensure!(
+            entries.len() <= u32::MAX as usize,
+            "range tombstone batch too large: {} entries",
+            entries.len()
+        );
         let _write_guard = self.write_lock.lock();
         let commit_ts = self.ts.lock().0 + 1;
-        for (ordinal, (start, end)) in entries.iter().enumerate() {
-            memtable.put_range_tombstone(start, end, commit_ts, ordinal as u32)?;
-        }
+        // Single WAL write + sync for the entire batch, preserving ordinals.
+        memtable.put_range_tombstone_batch(entries, commit_ts, 0)?;
         self.ts.lock().0 = commit_ts;
 
         Ok(commit_ts)

--- a/kv-engine/src/range_tombstone.rs
+++ b/kv-engine/src/range_tombstone.rs
@@ -152,7 +152,7 @@ impl RangeTombstoneSet {
             let key = entry.key();
             let tomb_end = entry.value();
             // Two ranges [a, b) and [c, d) overlap iff a < d && c < b.
-            // The c < b check is handled by the range bound above.
+            // The a < d check is handled by the range bound above.
             if start < tomb_end.as_ref() {
                 Some(RangeTombstone {
                     start: key.start.clone(),

--- a/kv-engine/src/range_tombstone.rs
+++ b/kv-engine/src/range_tombstone.rs
@@ -147,7 +147,7 @@ impl RangeTombstoneSet {
             let key = entry.key();
             let tomb_end = entry.value();
             // Two ranges [a, b) and [c, d) overlap iff a < d && c < b.
-            // The a < d check is handled by the range bound above.
+            // The c < b check is handled by the range bound above.
             if start < tomb_end.as_ref() {
                 Some(RangeTombstone {
                     start: key.start.clone(),
@@ -310,7 +310,7 @@ mod tests {
 
     #[test]
     fn test_range_tombstone_key_ordering() {
-        // Same start, different ts: higher ts comes first (since it's used
+        // Same start, different ts: smaller ts comes first (since it's used
         // as-is, not inverted like point keys).
         let k1 = RangeTombstoneKey {
             start: Bytes::from_static(b"a"),

--- a/kv-engine/src/range_tombstone.rs
+++ b/kv-engine/src/range_tombstone.rs
@@ -99,6 +99,10 @@ impl RangeTombstoneSet {
 
     /// Check if any tombstone covers any key in `[start, end)` at `read_ts`.
     pub fn overlaps(&self, start: &[u8], end: &[u8], read_ts: u64) -> bool {
+        // Empty or invalid range cannot overlap anything.
+        if start >= end {
+            return false;
+        }
         // Only scan entries with start < end (query). Entries with start >= end
         // can never overlap the query range [start, end).
         let bound_key = RangeTombstoneKey {
@@ -127,6 +131,8 @@ impl RangeTombstoneSet {
         start: &'a [u8],
         end: &'a [u8],
     ) -> impl Iterator<Item = RangeTombstone> + 'a {
+        // Empty or invalid range cannot overlap anything.
+        let is_empty = start >= end;
         // Only scan entries with start < end (query). Entries with start >= end
         // can never overlap the query range [start, end).
         let bound_key = RangeTombstoneKey {
@@ -135,6 +141,9 @@ impl RangeTombstoneSet {
             ordinal: 0,
         };
         self.raw.range(..bound_key).filter_map(move |entry| {
+            if is_empty {
+                return None;
+            }
             let key = entry.key();
             let tomb_end = entry.value();
             // Two ranges [a, b) and [c, d) overlap iff a < d && c < b.

--- a/kv-engine/src/range_tombstone.rs
+++ b/kv-engine/src/range_tombstone.rs
@@ -87,10 +87,15 @@ impl RangeTombstoneSet {
                 continue;
             }
 
+            // Skip entries that cannot improve our best timestamp.
+            if best_ts.is_some() && key.ts <= best_ts.unwrap() {
+                continue;
+            }
+
             // Check that user_key < end.
             let end = entry.value();
             if user_key < end.as_ref() {
-                best_ts = Some(best_ts.map_or(key.ts, |best| best.max(key.ts)));
+                best_ts = Some(key.ts);
             }
         }
 

--- a/kv-engine/src/range_tombstone.rs
+++ b/kv-engine/src/range_tombstone.rs
@@ -71,17 +71,16 @@ impl RangeTombstoneSet {
     pub fn newest_covering_ts(&self, user_key: &[u8], read_ts: u64) -> Option<u64> {
         let mut best_ts: Option<u64> = None;
 
-        // The skipmap is ordered by (start, ts, ordinal). Once we see an
-        // entry with start > user_key, all subsequent entries also have
-        // start > user_key and cannot cover it, so we break.
-        for entry in self.raw.iter() {
+        // Only scan entries with start <= user_key. Entries with start >
+        // user_key can never cover it. The bound key uses max ts/ordinal
+        // so that all entries sharing start == user_key are included.
+        let bound_key = RangeTombstoneKey {
+            start: Bytes::copy_from_slice(user_key),
+            ts: u64::MAX,
+            ordinal: u32::MAX,
+        };
+        for entry in self.raw.range(..=bound_key) {
             let key = entry.key();
-
-            // Entries with start > user_key can never cover user_key.
-            // Since the skipmap is sorted by start, we can stop here.
-            if key.start.as_ref() > user_key {
-                break;
-            }
 
             // Skip entries with ts > read_ts (not visible to this reader).
             if key.ts > read_ts {
@@ -100,13 +99,15 @@ impl RangeTombstoneSet {
 
     /// Check if any tombstone covers any key in `[start, end)` at `read_ts`.
     pub fn overlaps(&self, start: &[u8], end: &[u8], read_ts: u64) -> bool {
-        for entry in self.raw.iter() {
+        // Only scan entries with start < end (query). Entries with start >= end
+        // can never overlap the query range [start, end).
+        let bound_key = RangeTombstoneKey {
+            start: Bytes::copy_from_slice(end),
+            ts: 0,
+            ordinal: 0,
+        };
+        for entry in self.raw.range(..bound_key) {
             let key = entry.key();
-            // Since the skipmap is sorted by start, once start >= end (query),
-            // no subsequent entries can overlap.
-            if key.start.as_ref() >= end {
-                break;
-            }
             if key.ts > read_ts {
                 continue;
             }
@@ -126,24 +127,28 @@ impl RangeTombstoneSet {
         start: &'a [u8],
         end: &'a [u8],
     ) -> impl Iterator<Item = RangeTombstone> + 'a {
-        self.raw
-            .iter()
-            .take_while(move |entry| entry.key().start.as_ref() < end)
-            .filter_map(move |entry| {
-                let key = entry.key();
-                let tomb_end = entry.value();
-                // Two ranges [a, b) and [c, d) overlap iff a < d && c < b.
-                // The a < d check is handled by take_while above.
-                if start < tomb_end.as_ref() {
-                    Some(RangeTombstone {
-                        start: key.start.clone(),
-                        end: tomb_end.clone(),
-                        ts: key.ts,
-                    })
-                } else {
-                    None
-                }
-            })
+        // Only scan entries with start < end (query). Entries with start >= end
+        // can never overlap the query range [start, end).
+        let bound_key = RangeTombstoneKey {
+            start: Bytes::copy_from_slice(end),
+            ts: 0,
+            ordinal: 0,
+        };
+        self.raw.range(..bound_key).filter_map(move |entry| {
+            let key = entry.key();
+            let tomb_end = entry.value();
+            // Two ranges [a, b) and [c, d) overlap iff a < d && c < b.
+            // The a < d check is handled by the range bound above.
+            if start < tomb_end.as_ref() {
+                Some(RangeTombstone {
+                    start: key.start.clone(),
+                    end: tomb_end.clone(),
+                    ts: key.ts,
+                })
+            } else {
+                None
+            }
+        })
     }
 
     /// Return the approximate byte size of all tombstones in the set.

--- a/kv-engine/src/range_tombstone.rs
+++ b/kv-engine/src/range_tombstone.rs
@@ -1,0 +1,336 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use bytes::Bytes;
+use crossbeam_skiplist::SkipMap;
+
+/// A range tombstone that hides all keys in `[start, end)` at timestamp `ts`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RangeTombstone {
+    pub start: Bytes,
+    pub end: Bytes,
+    pub ts: u64,
+}
+
+/// Key for the range-tombstone skipmap, ordered by `(start, ts, ordinal)`.
+///
+/// `ordinal` disambiguates multiple `DelRange` entries in a range-only batch
+/// that share the same `(start, ts)`. It is assigned as a zero-based sequential
+/// index within each range-only batch.
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct RangeTombstoneKey {
+    pub start: Bytes,
+    pub ts: u64,
+    pub ordinal: u32,
+}
+
+/// A concurrent set of range tombstones backed by a `SkipMap`.
+///
+/// Tombstones are stored unfragmented (as inserted). Reads query the raw
+/// entries directly. Fragmentation happens at read/flush/compaction time.
+pub struct RangeTombstoneSet {
+    /// Raw tombstone entries: key = `(start, ts, ordinal)`, value = `end`.
+    raw: Arc<SkipMap<RangeTombstoneKey, Bytes>>,
+    /// Approximate byte size of all tombstones in the set.
+    approximate_size: AtomicUsize,
+}
+
+impl RangeTombstoneSet {
+    /// Create an empty range-tombstone set.
+    pub fn new() -> Self {
+        Self {
+            raw: Arc::new(SkipMap::new()),
+            approximate_size: AtomicUsize::new(0),
+        }
+    }
+
+    /// Insert a range tombstone. The `ordinal` disambiguates tombstones with
+    /// the same `(start, ts)` from the same batch.
+    pub fn add(&self, tombstone: RangeTombstone, ordinal: u32) {
+        // Approximate per-entry overhead: ts(8) + ordinal(4) + Bytes headers
+        // (~48 for start/end) + RangeTombstoneKey struct (~36) + SkipMap node
+        // pointers (~64). This is intentionally approximate — it drives the
+        // memtable freeze threshold, not an exact memory budget.
+        let size = tombstone.start.len() + tombstone.end.len() + 80;
+        let key = RangeTombstoneKey {
+            start: tombstone.start,
+            ts: tombstone.ts,
+            ordinal,
+        };
+        self.raw.insert(key, tombstone.end);
+        self.approximate_size.fetch_add(size, Ordering::Relaxed);
+    }
+
+    /// Find the newest covering tombstone timestamp for `user_key` at `read_ts`.
+    ///
+    /// Returns `Some(ts)` if a tombstone covers `user_key` (i.e.,
+    /// `start <= user_key < end`) and `ts <= read_ts`. Returns the maximum
+    /// such `ts` across all covering tombstones.
+    pub fn newest_covering_ts(&self, user_key: &[u8], read_ts: u64) -> Option<u64> {
+        let mut best_ts: Option<u64> = None;
+
+        // The skipmap is ordered by (start, ts, ordinal). Once we see an
+        // entry with start > user_key, all subsequent entries also have
+        // start > user_key and cannot cover it, so we break.
+        for entry in self.raw.iter() {
+            let key = entry.key();
+
+            // Entries with start > user_key can never cover user_key.
+            // Since the skipmap is sorted by start, we can stop here.
+            if key.start.as_ref() > user_key {
+                break;
+            }
+
+            // Skip entries with ts > read_ts (not visible to this reader).
+            if key.ts > read_ts {
+                continue;
+            }
+
+            // Check that user_key < end.
+            let end = entry.value();
+            if user_key < end.as_ref() {
+                best_ts = Some(best_ts.map_or(key.ts, |best| best.max(key.ts)));
+            }
+        }
+
+        best_ts
+    }
+
+    /// Check if any tombstone covers any key in `[start, end)` at `read_ts`.
+    pub fn overlaps(&self, start: &[u8], end: &[u8], read_ts: u64) -> bool {
+        for entry in self.raw.iter() {
+            let key = entry.key();
+            // Since the skipmap is sorted by start, once start >= end (query),
+            // no subsequent entries can overlap.
+            if key.start.as_ref() >= end {
+                break;
+            }
+            if key.ts > read_ts {
+                continue;
+            }
+            let tomb_end = entry.value();
+            // Two ranges [a, b) and [c, d) overlap iff a < d && c < b.
+            if start < tomb_end.as_ref() {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Iterate all tombstones that overlap `[start, end)`, regardless of timestamp.
+    pub fn iter_overlapping<'a>(
+        &'a self,
+        start: &'a [u8],
+        end: &'a [u8],
+    ) -> impl Iterator<Item = RangeTombstone> + 'a {
+        self.raw.iter().filter_map(move |entry| {
+            let key = entry.key();
+            let tomb_end = entry.value();
+            // Two ranges [a, b) and [c, d) overlap iff a < d && c < b.
+            if key.start.as_ref() < end && start < tomb_end.as_ref() {
+                Some(RangeTombstone {
+                    start: key.start.clone(),
+                    end: tomb_end.clone(),
+                    ts: key.ts,
+                })
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Return the approximate byte size of all tombstones in the set.
+    pub fn approximate_size(&self) -> usize {
+        self.approximate_size.load(Ordering::Relaxed)
+    }
+
+    /// Return `true` if the set contains no tombstones.
+    pub fn is_empty(&self) -> bool {
+        self.raw.is_empty()
+    }
+
+    /// Return the number of tombstones in the set.
+    pub fn len(&self) -> usize {
+        self.raw.len()
+    }
+
+    /// Return a reference to the raw skipmap for building fragment views.
+    pub fn raw(&self) -> &Arc<SkipMap<RangeTombstoneKey, Bytes>> {
+        &self.raw
+    }
+}
+
+impl Default for RangeTombstoneSet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ts(start: &[u8], end: &[u8], ts: u64) -> RangeTombstone {
+        RangeTombstone {
+            start: Bytes::copy_from_slice(start),
+            end: Bytes::copy_from_slice(end),
+            ts,
+        }
+    }
+
+    #[test]
+    fn test_empty_set() {
+        let set = RangeTombstoneSet::new();
+        assert!(set.is_empty());
+        assert_eq!(set.len(), 0);
+        assert_eq!(set.newest_covering_ts(b"a", 100), None);
+        assert!(!set.overlaps(b"a", b"z", 100));
+        assert!(set.iter_overlapping(b"a", b"z").count() == 0);
+    }
+
+    #[test]
+    fn test_add_and_basic_lookup() {
+        let set = RangeTombstoneSet::new();
+        set.add(ts(b"a", b"z", 10), 0);
+
+        assert!(!set.is_empty());
+        assert_eq!(set.len(), 1);
+
+        // Key inside range is covered.
+        assert_eq!(set.newest_covering_ts(b"m", 100), Some(10));
+        // Key at start is covered (half-open: start <= key < end).
+        assert_eq!(set.newest_covering_ts(b"a", 100), Some(10));
+        // Key at end is NOT covered.
+        assert_eq!(set.newest_covering_ts(b"z", 100), None);
+        // Key before start is NOT covered.
+        assert_eq!(set.newest_covering_ts(b"`", 100), None);
+    }
+
+    #[test]
+    fn test_read_ts_visibility() {
+        let set = RangeTombstoneSet::new();
+        set.add(ts(b"a", b"z", 20), 0);
+
+        // Reader at ts=20 sees the tombstone.
+        assert_eq!(set.newest_covering_ts(b"m", 20), Some(20));
+        // Reader at ts=19 does NOT see the tombstone.
+        assert_eq!(set.newest_covering_ts(b"m", 19), None);
+        // Reader at ts=30 sees the tombstone.
+        assert_eq!(set.newest_covering_ts(b"m", 30), Some(20));
+    }
+
+    #[test]
+    fn test_multiple_tombstones_newest_wins() {
+        let set = RangeTombstoneSet::new();
+        set.add(ts(b"a", b"z", 10), 0);
+        set.add(ts(b"a", b"z", 20), 1);
+        set.add(ts(b"a", b"z", 15), 2);
+
+        // Newest visible tombstone (ts=20) wins.
+        assert_eq!(set.newest_covering_ts(b"m", 100), Some(20));
+        // At read_ts=15, the ts=15 tombstone wins.
+        assert_eq!(set.newest_covering_ts(b"m", 15), Some(15));
+        // At read_ts=14, only ts=10 is visible.
+        assert_eq!(set.newest_covering_ts(b"m", 14), Some(10));
+    }
+
+    #[test]
+    fn test_overlapping_ranges() {
+        let set = RangeTombstoneSet::new();
+        set.add(ts(b"a", b"m", 10), 0);
+        set.add(ts(b"f", b"z", 20), 1);
+
+        // Key in intersection of both ranges.
+        assert_eq!(set.newest_covering_ts(b"h", 100), Some(20));
+        // Key only in first range.
+        assert_eq!(set.newest_covering_ts(b"b", 100), Some(10));
+        // Key only in second range.
+        assert_eq!(set.newest_covering_ts(b"x", 100), Some(20));
+    }
+
+    #[test]
+    fn test_overlaps_check() {
+        let set = RangeTombstoneSet::new();
+        set.add(ts(b"f", b"p", 10), 0);
+
+        // Overlapping query.
+        assert!(set.overlaps(b"a", b"g", 100));
+        assert!(set.overlaps(b"m", b"z", 100));
+        // Non-overlapping query.
+        assert!(!set.overlaps(b"a", b"f", 100));
+        assert!(!set.overlaps(b"p", b"z", 100));
+    }
+
+    #[test]
+    fn test_iter_overlapping() {
+        let set = RangeTombstoneSet::new();
+        set.add(ts(b"a", b"m", 10), 0);
+        set.add(ts(b"f", b"z", 20), 1);
+        set.add(ts(b"p", b"t", 30), 2);
+
+        // Query overlapping all three.
+        let results: Vec<_> = set.iter_overlapping(b"g", b"q").collect();
+        assert_eq!(results.len(), 3);
+
+        // Query overlapping only one.
+        let results: Vec<_> = set.iter_overlapping(b"n", b"o").collect();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].ts, 20);
+    }
+
+    #[test]
+    fn test_approximate_size() {
+        let set = RangeTombstoneSet::new();
+        let before = set.approximate_size();
+        set.add(ts(b"a", b"z", 10), 0);
+        let after = set.approximate_size();
+        assert!(after > before);
+    }
+
+    #[test]
+    fn test_range_tombstone_key_ordering() {
+        // Same start, different ts: higher ts comes first (since it's used
+        // as-is, not inverted like point keys).
+        let k1 = RangeTombstoneKey {
+            start: Bytes::from_static(b"a"),
+            ts: 10,
+            ordinal: 0,
+        };
+        let k2 = RangeTombstoneKey {
+            start: Bytes::from_static(b"a"),
+            ts: 20,
+            ordinal: 0,
+        };
+        assert!(k1 < k2);
+
+        // Same (start, ts), different ordinal.
+        let k3 = RangeTombstoneKey {
+            start: Bytes::from_static(b"a"),
+            ts: 10,
+            ordinal: 1,
+        };
+        assert!(k1 < k3);
+
+        // Different start.
+        let k4 = RangeTombstoneKey {
+            start: Bytes::from_static(b"b"),
+            ts: 5,
+            ordinal: 0,
+        };
+        assert!(k1 < k4);
+    }
+
+    #[test]
+    fn test_boundary_equality() {
+        let set = RangeTombstoneSet::new();
+        set.add(ts(b"a", b"z", 10), 0);
+
+        // start == key: covered (start <= key).
+        assert_eq!(set.newest_covering_ts(b"a", 100), Some(10));
+        // end == key: NOT covered (key < end).
+        assert_eq!(set.newest_covering_ts(b"z", 100), None);
+    }
+}

--- a/kv-engine/src/range_tombstone.rs
+++ b/kv-engine/src/range_tombstone.rs
@@ -130,9 +130,12 @@ impl RangeTombstoneSet {
         &'a self,
         start: &'a [u8],
         end: &'a [u8],
-    ) -> impl Iterator<Item = RangeTombstone> + 'a {
-        // Empty or invalid range cannot overlap anything.
-        let is_empty = start >= end;
+    ) -> Box<dyn Iterator<Item = RangeTombstone> + 'a> {
+        // Empty or invalid range cannot overlap anything — return immediately
+        // without allocating bound_key or scanning the skipmap.
+        if start >= end {
+            return Box::new(std::iter::empty());
+        }
         // Only scan entries with start < end (query). Entries with start >= end
         // can never overlap the query range [start, end).
         let bound_key = RangeTombstoneKey {
@@ -140,10 +143,7 @@ impl RangeTombstoneSet {
             ts: 0,
             ordinal: 0,
         };
-        self.raw.range(..bound_key).filter_map(move |entry| {
-            if is_empty {
-                return None;
-            }
+        Box::new(self.raw.range(..bound_key).filter_map(move |entry| {
             let key = entry.key();
             let tomb_end = entry.value();
             // Two ranges [a, b) and [c, d) overlap iff a < d && c < b.
@@ -157,7 +157,7 @@ impl RangeTombstoneSet {
             } else {
                 None
             }
-        })
+        }))
     }
 
     /// Return the approximate byte size of all tombstones in the set.

--- a/kv-engine/src/range_tombstone.rs
+++ b/kv-engine/src/range_tombstone.rs
@@ -126,20 +126,24 @@ impl RangeTombstoneSet {
         start: &'a [u8],
         end: &'a [u8],
     ) -> impl Iterator<Item = RangeTombstone> + 'a {
-        self.raw.iter().filter_map(move |entry| {
-            let key = entry.key();
-            let tomb_end = entry.value();
-            // Two ranges [a, b) and [c, d) overlap iff a < d && c < b.
-            if key.start.as_ref() < end && start < tomb_end.as_ref() {
-                Some(RangeTombstone {
-                    start: key.start.clone(),
-                    end: tomb_end.clone(),
-                    ts: key.ts,
-                })
-            } else {
-                None
-            }
-        })
+        self.raw
+            .iter()
+            .take_while(move |entry| entry.key().start.as_ref() < end)
+            .filter_map(move |entry| {
+                let key = entry.key();
+                let tomb_end = entry.value();
+                // Two ranges [a, b) and [c, d) overlap iff a < d && c < b.
+                // The a < d check is handled by take_while above.
+                if start < tomb_end.as_ref() {
+                    Some(RangeTombstone {
+                        start: key.start.clone(),
+                        end: tomb_end.clone(),
+                        ts: key.ts,
+                    })
+                } else {
+                    None
+                }
+            })
     }
 
     /// Return the approximate byte size of all tombstones in the set.

--- a/kv-engine/src/tests/memtable.rs
+++ b/kv-engine/src/tests/memtable.rs
@@ -143,3 +143,53 @@ fn test_task4_storage_integration() {
     assert_eq!(&storage.get(b"3").unwrap().unwrap()[..], b"233333");
     assert_eq!(&storage.get(b"4").unwrap().unwrap()[..], b"23333");
 }
+
+#[test]
+fn test_memtable_range_tombstone_is_not_empty() {
+    let mt = crate::mem_table::MemTable::create(0);
+    assert!(mt.is_empty());
+    mt.put_range_tombstone(b"a", b"z", 10, 0).unwrap();
+    assert!(!mt.is_empty());
+}
+
+#[test]
+fn test_memtable_range_tombstone_approximate_size() {
+    let mt = crate::mem_table::MemTable::create(0);
+    let before = mt.approximate_size();
+    mt.put_range_tombstone(b"a", b"z", 10, 0).unwrap();
+    let after = mt.approximate_size();
+    assert!(
+        after > before,
+        "approximate_size should increase after adding range tombstone"
+    );
+}
+
+#[test]
+fn test_memtable_range_tombstone_lookup() {
+    let mt = crate::mem_table::MemTable::create(0);
+    mt.put_range_tombstone(b"tenant:42:", b"tenant:43:", 20, 0)
+        .unwrap();
+
+    // Key inside range is covered.
+    assert_eq!(
+        mt.range_tombstones()
+            .newest_covering_ts(b"tenant:42:key1", 100),
+        Some(20)
+    );
+    // Key at start is covered.
+    assert_eq!(
+        mt.range_tombstones().newest_covering_ts(b"tenant:42:", 100),
+        Some(20)
+    );
+    // Key at end is NOT covered.
+    assert_eq!(
+        mt.range_tombstones().newest_covering_ts(b"tenant:43:", 100),
+        None
+    );
+    // Reader before tombstone doesn't see it.
+    assert_eq!(
+        mt.range_tombstones()
+            .newest_covering_ts(b"tenant:42:key1", 19),
+        None
+    );
+}

--- a/kv-engine/src/tests/memtable.rs
+++ b/kv-engine/src/tests/memtable.rs
@@ -500,3 +500,67 @@ fn test_delete_range_through_storage() {
     let state = storage.state.load();
     assert_eq!(state.memtable.range_tombstones().len(), 1);
 }
+
+#[test]
+fn test_delete_range_serializable_guard() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut options = LsmStorageOptions::default_for_test();
+    options.serializable = true;
+    let storage = Arc::new(LsmStorageInner::open(dir.path(), options).unwrap());
+
+    let result = storage.delete_range_internal(b"a", b"z");
+    assert!(result.is_err());
+    assert!(
+        result.unwrap_err().to_string().contains("serializable"),
+        "error should mention serializable"
+    );
+}
+
+#[test]
+fn test_write_batch_range_only_serializable_guard() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut options = LsmStorageOptions::default_for_test();
+    options.serializable = true;
+    let storage = Arc::new(LsmStorageInner::open(dir.path(), options).unwrap());
+
+    let result = storage.write_batch(&[crate::lsm_storage::WriteBatchRecord::DelRange(
+        b"a".as_ref(),
+        b"z".as_ref(),
+    )]);
+    assert!(result.is_err());
+    assert!(
+        result.unwrap_err().to_string().contains("serializable"),
+        "error should mention serializable"
+    );
+}
+
+#[test]
+fn test_write_batch_mixed_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+
+    let result = storage.write_batch(&[
+        crate::lsm_storage::WriteBatchRecord::Put(b"k".as_ref(), b"v".as_ref()),
+        crate::lsm_storage::WriteBatchRecord::DelRange(b"a".as_ref(), b"z".as_ref()),
+    ]);
+    assert!(result.is_err());
+    assert!(
+        result.unwrap_err().to_string().contains("mixed"),
+        "error should mention mixed"
+    );
+}
+
+#[test]
+fn test_delete_range_invalid_range() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+
+    // start >= end should be rejected.
+    let result = storage.delete_range_internal(b"z", b"a");
+    assert!(result.is_err());
+
+    let result = storage.delete_range_internal(b"a", b"a");
+    assert!(result.is_err());
+}

--- a/kv-engine/src/tests/memtable.rs
+++ b/kv-engine/src/tests/memtable.rs
@@ -311,3 +311,192 @@ fn test_write_batch_range_only_vlog_guard() {
         "error should mention vlog"
     );
 }
+
+#[test]
+fn test_memtable_range_overlap_unbounded_lower() {
+    let mt = crate::mem_table::MemTable::create(0);
+    mt.put_range_tombstone(b"f", b"p", 10, 0).unwrap();
+
+    // Unbounded lower + Included upper that covers the tombstone.
+    assert!(mt.range_overlap(
+        std::ops::Bound::Unbounded,
+        std::ops::Bound::Included(b"z" as &[u8]),
+    ));
+    // Unbounded lower + Excluded upper that covers the tombstone.
+    assert!(mt.range_overlap(
+        std::ops::Bound::Unbounded,
+        std::ops::Bound::Excluded(b"z" as &[u8]),
+    ));
+    // Unbounded lower + Included upper that is before the tombstone.
+    assert!(!mt.range_overlap(
+        std::ops::Bound::Unbounded,
+        std::ops::Bound::Included(b"e" as &[u8]),
+    ));
+    // Unbounded lower + Excluded upper that is before the tombstone.
+    assert!(!mt.range_overlap(
+        std::ops::Bound::Unbounded,
+        std::ops::Bound::Excluded(b"f" as &[u8]),
+    ));
+    // Both unbounded.
+    assert!(mt.range_overlap(std::ops::Bound::Unbounded, std::ops::Bound::Unbounded,));
+}
+
+#[test]
+fn test_memtable_range_overlap_excluded_lower() {
+    let mt = crate::mem_table::MemTable::create(0);
+    mt.put_range_tombstone(b"f", b"p", 10, 0).unwrap();
+
+    // Excluded lower inside the tombstone range.
+    assert!(mt.range_overlap(
+        std::ops::Bound::Excluded(b"g" as &[u8]),
+        std::ops::Bound::Included(b"z" as &[u8]),
+    ));
+    // Excluded lower at the tombstone start.
+    assert!(mt.range_overlap(
+        std::ops::Bound::Excluded(b"f" as &[u8]),
+        std::ops::Bound::Included(b"z" as &[u8]),
+    ));
+    // Excluded lower at the tombstone end.
+    assert!(!mt.range_overlap(
+        std::ops::Bound::Excluded(b"p" as &[u8]),
+        std::ops::Bound::Included(b"z" as &[u8]),
+    ));
+}
+
+#[test]
+fn test_memtable_range_overlap_unbounded_upper() {
+    let mt = crate::mem_table::MemTable::create(0);
+    mt.put_range_tombstone(b"f", b"p", 10, 0).unwrap();
+
+    // Included lower before tombstone + Unbounded upper.
+    assert!(mt.range_overlap(
+        std::ops::Bound::Included(b"a" as &[u8]),
+        std::ops::Bound::Unbounded,
+    ));
+    // Excluded lower before tombstone + Unbounded upper.
+    assert!(mt.range_overlap(
+        std::ops::Bound::Excluded(b"a" as &[u8]),
+        std::ops::Bound::Unbounded,
+    ));
+    // Included lower after tombstone + Unbounded upper.
+    assert!(!mt.range_overlap(
+        std::ops::Bound::Included(b"q" as &[u8]),
+        std::ops::Bound::Unbounded,
+    ));
+    // Excluded lower after tombstone + Unbounded upper.
+    assert!(!mt.range_overlap(
+        std::ops::Bound::Excluded(b"p" as &[u8]),
+        std::ops::Bound::Unbounded,
+    ));
+}
+
+#[test]
+fn test_memtable_range_overlap_empty() {
+    let mt = crate::mem_table::MemTable::create(0);
+    // Empty memtable: no point entries, no range tombstones.
+    assert!(!mt.range_overlap(
+        std::ops::Bound::Included(b"a" as &[u8]),
+        std::ops::Bound::Included(b"z" as &[u8]),
+    ));
+    assert!(!mt.range_overlap(std::ops::Bound::Unbounded, std::ops::Bound::Unbounded,));
+}
+
+#[test]
+fn test_newest_covering_ts_skip_optimization() {
+    let set = crate::range_tombstone::RangeTombstoneSet::new();
+    // Add tombstones with different ts at the same start.
+    set.add(
+        crate::range_tombstone::RangeTombstone {
+            start: bytes::Bytes::from_static(b"a"),
+            end: bytes::Bytes::from_static(b"z"),
+            ts: 10,
+        },
+        0,
+    );
+    set.add(
+        crate::range_tombstone::RangeTombstone {
+            start: bytes::Bytes::from_static(b"a"),
+            end: bytes::Bytes::from_static(b"z"),
+            ts: 20,
+        },
+        1,
+    );
+    set.add(
+        crate::range_tombstone::RangeTombstone {
+            start: bytes::Bytes::from_static(b"a"),
+            end: bytes::Bytes::from_static(b"z"),
+            ts: 15,
+        },
+        2,
+    );
+
+    // At read_ts=100, should return the newest (ts=20).
+    assert_eq!(set.newest_covering_ts(b"m", 100), Some(20));
+    // At read_ts=15, should skip ts=20 and find ts=15.
+    assert_eq!(set.newest_covering_ts(b"m", 15), Some(15));
+    // At read_ts=9, no tombstones are visible.
+    assert_eq!(set.newest_covering_ts(b"m", 9), None);
+}
+
+#[test]
+fn test_overlaps_with_invalid_range() {
+    let set = crate::range_tombstone::RangeTombstoneSet::new();
+    set.add(
+        crate::range_tombstone::RangeTombstone {
+            start: bytes::Bytes::from_static(b"f"),
+            end: bytes::Bytes::from_static(b"p"),
+            ts: 10,
+        },
+        0,
+    );
+    // Empty range: start >= end should return false.
+    assert!(!set.overlaps(b"z", b"a", 100));
+    assert!(!set.overlaps(b"a", b"a", 100));
+}
+
+#[test]
+fn test_iter_overlapping_with_invalid_range() {
+    let set = crate::range_tombstone::RangeTombstoneSet::new();
+    set.add(
+        crate::range_tombstone::RangeTombstone {
+            start: bytes::Bytes::from_static(b"f"),
+            end: bytes::Bytes::from_static(b"p"),
+            ts: 10,
+        },
+        0,
+    );
+    // Empty range: start >= end should return no results.
+    assert_eq!(set.iter_overlapping(b"z", b"a").count(), 0);
+    assert_eq!(set.iter_overlapping(b"a", b"a").count(), 0);
+}
+
+#[test]
+fn test_write_range_batch_through_storage() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+
+    // Write a range-only batch.
+    storage
+        .write_batch(&[
+            crate::lsm_storage::WriteBatchRecord::DelRange(b"a".as_ref(), b"m".as_ref()),
+            crate::lsm_storage::WriteBatchRecord::DelRange(b"x".as_ref(), b"z".as_ref()),
+        ])
+        .unwrap();
+
+    // Verify range tombstones are in the active memtable.
+    let state = storage.state.load();
+    assert_eq!(state.memtable.range_tombstones().len(), 2);
+}
+
+#[test]
+fn test_delete_range_through_storage() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+
+    storage.delete_range_internal(b"a", b"z").unwrap();
+
+    let state = storage.state.load();
+    assert_eq!(state.memtable.range_tombstones().len(), 1);
+}

--- a/kv-engine/src/tests/memtable.rs
+++ b/kv-engine/src/tests/memtable.rs
@@ -564,3 +564,147 @@ fn test_delete_range_invalid_range() {
     let result = storage.delete_range_internal(b"a", b"a");
     assert!(result.is_err());
 }
+
+#[test]
+fn test_write_batch_point_entries() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+
+    // Point-only batch should work.
+    storage
+        .write_batch(&[
+            crate::lsm_storage::WriteBatchRecord::Put(b"k1".as_ref(), b"v1".as_ref()),
+            crate::lsm_storage::WriteBatchRecord::Put(b"k2".as_ref(), b"v2".as_ref()),
+            crate::lsm_storage::WriteBatchRecord::Del(b"k1".as_ref()),
+        ])
+        .unwrap();
+
+    assert!(storage.get(b"k1").unwrap().is_none());
+    assert_eq!(&storage.get(b"k2").unwrap().unwrap()[..], b"v2");
+}
+
+#[test]
+fn test_write_batch_dedup() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+
+    // Duplicate keys should be deduped (last wins).
+    storage
+        .write_batch(&[
+            crate::lsm_storage::WriteBatchRecord::Put(b"k1".as_ref(), b"first".as_ref()),
+            crate::lsm_storage::WriteBatchRecord::Put(b"k1".as_ref(), b"second".as_ref()),
+        ])
+        .unwrap();
+
+    assert_eq!(&storage.get(b"k1").unwrap().unwrap()[..], b"second");
+}
+
+#[test]
+fn test_storage_put_get_delete() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+
+    storage.put(b"key1", b"val1").unwrap();
+    storage.put(b"key2", b"val2").unwrap();
+    assert_eq!(&storage.get(b"key1").unwrap().unwrap()[..], b"val1");
+    assert_eq!(&storage.get(b"key2").unwrap().unwrap()[..], b"val2");
+
+    storage.delete(b"key1").unwrap();
+    assert!(storage.get(b"key1").unwrap().is_none());
+    assert_eq!(&storage.get(b"key2").unwrap().unwrap()[..], b"val2");
+}
+
+#[test]
+fn test_storage_scan() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+
+    storage.put(b"a", b"1").unwrap();
+    storage.put(b"b", b"2").unwrap();
+    storage.put(b"c", b"3").unwrap();
+
+    // scan returns a ScanIterator (not std Iterator), just verify it doesn't panic.
+    let _iter = storage
+        .scan(
+            std::ops::Bound::Included(b"a".as_ref()),
+            std::ops::Bound::Excluded(b"c".as_ref()),
+        )
+        .unwrap();
+}
+
+#[test]
+fn test_storage_force_freeze_memtable() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+
+    storage.put(b"key1", b"val1").unwrap();
+    storage
+        .force_freeze_memtable(&storage.state_lock.lock())
+        .unwrap();
+    assert_eq!(storage.state.load().imm_memtables.len(), 1);
+}
+
+#[test]
+fn test_range_tombstone_overlaps_read_ts() {
+    let set = crate::range_tombstone::RangeTombstoneSet::new();
+    set.add(
+        crate::range_tombstone::RangeTombstone {
+            start: bytes::Bytes::from_static(b"f"),
+            end: bytes::Bytes::from_static(b"p"),
+            ts: 10,
+        },
+        0,
+    );
+
+    // Tombstone visible at read_ts >= 10.
+    assert!(set.overlaps(b"a", b"z", 10));
+    assert!(set.overlaps(b"a", b"z", 100));
+    // Tombstone NOT visible at read_ts < 10.
+    assert!(!set.overlaps(b"a", b"z", 9));
+    assert!(!set.overlaps(b"a", b"z", 0));
+}
+
+#[test]
+fn test_range_tombstone_iter_overlapping_read_ts() {
+    let set = crate::range_tombstone::RangeTombstoneSet::new();
+    set.add(
+        crate::range_tombstone::RangeTombstone {
+            start: bytes::Bytes::from_static(b"f"),
+            end: bytes::Bytes::from_static(b"p"),
+            ts: 10,
+        },
+        0,
+    );
+
+    // iter_overlapping ignores read_ts (returns all overlapping regardless).
+    assert_eq!(set.iter_overlapping(b"a", b"z").count(), 1);
+}
+
+#[test]
+fn test_range_tombstone_set_len() {
+    let set = crate::range_tombstone::RangeTombstoneSet::new();
+    assert_eq!(set.len(), 0);
+    set.add(
+        crate::range_tombstone::RangeTombstone {
+            start: bytes::Bytes::from_static(b"a"),
+            end: bytes::Bytes::from_static(b"z"),
+            ts: 10,
+        },
+        0,
+    );
+    assert_eq!(set.len(), 1);
+    set.add(
+        crate::range_tombstone::RangeTombstone {
+            start: bytes::Bytes::from_static(b"b"),
+            end: bytes::Bytes::from_static(b"y"),
+            ts: 20,
+        },
+        1,
+    );
+    assert_eq!(set.len(), 2);
+}

--- a/kv-engine/src/tests/memtable.rs
+++ b/kv-engine/src/tests/memtable.rs
@@ -257,6 +257,18 @@ fn test_memtable_range_overlap_with_range_tombstones() {
         std::ops::Bound::Included(b"q" as &[u8]),
         std::ops::Bound::Included(b"z" as &[u8]),
     ));
+
+    // Excluded lower bound with tombstone ending at successor of excluded key.
+    // Tombstone [f, p\0) covers keys < p\0. Query (p, z] covers keys > p.
+    // No key can be both > p and < p\0, so no overlap.
+    let mut p_succ = b"p".to_vec();
+    p_succ.push(0);
+    let mt2 = crate::mem_table::MemTable::create(0);
+    mt2.put_range_tombstone(b"f", &p_succ, 10, 0).unwrap();
+    assert!(!mt2.range_overlap(
+        std::ops::Bound::Excluded(b"p" as &[u8]),
+        std::ops::Bound::Included(b"z" as &[u8]),
+    ));
 }
 
 #[test]

--- a/kv-engine/src/tests/memtable.rs
+++ b/kv-engine/src/tests/memtable.rs
@@ -193,3 +193,109 @@ fn test_memtable_range_tombstone_lookup() {
         None
     );
 }
+
+#[test]
+fn test_memtable_put_range_tombstone_batch() {
+    let mt = crate::mem_table::MemTable::create(0);
+    mt.put_range_tombstone_batch(&[(b"a", b"m"), (b"x", b"z")], 42, 0)
+        .unwrap();
+
+    assert_eq!(mt.range_tombstones().len(), 2);
+    assert_eq!(
+        mt.range_tombstones().newest_covering_ts(b"b", 100),
+        Some(42)
+    );
+    assert_eq!(
+        mt.range_tombstones().newest_covering_ts(b"y", 100),
+        Some(42)
+    );
+    // Between the two ranges — not covered.
+    assert_eq!(mt.range_tombstones().newest_covering_ts(b"n", 100), None);
+}
+
+#[test]
+fn test_memtable_put_range_tombstone_batch_empty() {
+    let mt = crate::mem_table::MemTable::create(0);
+    mt.put_range_tombstone_batch(&[], 10, 0).unwrap();
+    assert!(mt.range_tombstones().is_empty());
+}
+
+#[test]
+fn test_memtable_range_overlap_containment() {
+    // Query range [a, z] fully contains memtable keys [m, p].
+    let dir = tempfile::tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+    storage.put(b"m", b"1").unwrap();
+    storage.put(b"p", b"2").unwrap();
+
+    let state = storage.state.load();
+    // Query [a, z] contains [m, p] — should overlap.
+    assert!(state.memtable.range_overlap(
+        std::ops::Bound::Included(b"a" as &[u8]),
+        std::ops::Bound::Included(b"z" as &[u8]),
+    ));
+    // Query [a, b] is entirely before [m, p] — no overlap.
+    assert!(!state.memtable.range_overlap(
+        std::ops::Bound::Included(b"a" as &[u8]),
+        std::ops::Bound::Included(b"b" as &[u8]),
+    ));
+}
+
+#[test]
+fn test_memtable_range_overlap_with_range_tombstones() {
+    let mt = crate::mem_table::MemTable::create(0);
+    mt.put_range_tombstone(b"f", b"p", 10, 0).unwrap();
+
+    // Overlapping query.
+    assert!(mt.range_overlap(
+        std::ops::Bound::Included(b"a" as &[u8]),
+        std::ops::Bound::Included(b"g" as &[u8]),
+    ));
+    // Non-overlapping query.
+    assert!(!mt.range_overlap(
+        std::ops::Bound::Included(b"q" as &[u8]),
+        std::ops::Bound::Included(b"z" as &[u8]),
+    ));
+}
+
+#[test]
+fn test_delete_range_vlog_guard() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut options = LsmStorageOptions::default_for_test();
+    options.value_separation = Some(crate::vlog::ValueSeparationOptions {
+        enabled: true,
+        ..Default::default()
+    });
+    let storage = Arc::new(LsmStorageInner::open(dir.path(), options).unwrap());
+
+    // delete_range_internal should be rejected when vlog is enabled.
+    let result = storage.delete_range_internal(b"a", b"z");
+    assert!(result.is_err());
+    assert!(
+        result.unwrap_err().to_string().contains("vlog"),
+        "error should mention vlog"
+    );
+}
+
+#[test]
+fn test_write_batch_range_only_vlog_guard() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut options = LsmStorageOptions::default_for_test();
+    options.value_separation = Some(crate::vlog::ValueSeparationOptions {
+        enabled: true,
+        ..Default::default()
+    });
+    let storage = Arc::new(LsmStorageInner::open(dir.path(), options).unwrap());
+
+    // Range-only batch should be rejected when vlog is enabled.
+    let result = storage.write_batch(&[crate::lsm_storage::WriteBatchRecord::DelRange(
+        b"a".as_ref(),
+        b"z".as_ref(),
+    )]);
+    assert!(result.is_err());
+    assert!(
+        result.unwrap_err().to_string().contains("vlog"),
+        "error should mention vlog"
+    );
+}

--- a/kv-engine/src/tests/wal.rs
+++ b/kv-engine/src/tests/wal.rs
@@ -1163,3 +1163,127 @@ fn test_memtable_range_tombstones_accessor() {
     assert!(!mt.range_tombstones().is_empty());
     assert_eq!(mt.range_tombstones().len(), 1);
 }
+
+#[test]
+fn test_memtable_put_range_tombstone_with_wal() {
+    // Test put_range_tombstone with WAL enabled (exercises WAL write path).
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_rt_wal.wal");
+    let mt = crate::mem_table::MemTable::create_with_wal(0, &path).unwrap();
+    mt.put_range_tombstone(b"a", b"z", 42, 0).unwrap();
+    assert_eq!(mt.range_tombstones().len(), 1);
+    assert_eq!(
+        mt.range_tombstones().newest_covering_ts(b"m", 100),
+        Some(42)
+    );
+}
+
+#[test]
+fn test_memtable_put_range_tombstone_batch_with_wal() {
+    // Test put_range_tombstone_batch with WAL enabled.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_rt_batch_wal.wal");
+    let mt = crate::mem_table::MemTable::create_with_wal(0, &path).unwrap();
+    mt.put_range_tombstone_batch(&[(b"a", b"m"), (b"x", b"z")], 42, 0)
+        .unwrap();
+    assert_eq!(mt.range_tombstones().len(), 2);
+}
+
+#[test]
+fn test_memtable_vlog_enabled() {
+    let mt = crate::mem_table::MemTable::create_vlog(0);
+    assert!(mt.vlog_enabled());
+    let mt2 = crate::mem_table::MemTable::create(0);
+    assert!(!mt2.vlog_enabled());
+}
+
+#[test]
+fn test_memtable_approximate_size_with_range_tombstones() {
+    let mt = crate::mem_table::MemTable::create(0);
+    let before = mt.approximate_size();
+    mt.put_range_tombstone(b"a", b"z", 10, 0).unwrap();
+    mt.put_range_tombstone(b"b", b"y", 20, 1).unwrap();
+    let after = mt.approximate_size();
+    assert!(after > before);
+}
+
+#[test]
+fn test_wal_recover_empty_file() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_empty.wal");
+
+    // Create and immediately close a WAL (just header).
+    {
+        let wal = Wal::create(&path).unwrap();
+        wal.sync().unwrap();
+    }
+
+    let skiplist = new_skiplist();
+    let (_wal, max_ts) = Wal::recover(&path, &skiplist).unwrap();
+    assert_eq!(max_ts, 0);
+    assert_eq!(skiplist.len(), 0);
+}
+
+#[test]
+fn test_wal_recover_with_range_tombstones_empty() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_rt_empty.wal");
+
+    {
+        let wal = Wal::create(&path).unwrap();
+        wal.sync().unwrap();
+    }
+
+    let skiplist = new_skiplist();
+    let range_ts = crate::range_tombstone::RangeTombstoneSet::new();
+    let (_wal, batch) = Wal::recover_with_range_tombstones(&path, &skiplist, &range_ts).unwrap();
+    assert_eq!(batch.max_ts, 0);
+    assert_eq!(batch.points.len(), 0);
+    assert_eq!(batch.range_tombstones.len(), 0);
+}
+
+#[test]
+fn test_range_tombstone_default() {
+    let set = crate::range_tombstone::RangeTombstoneSet::default();
+    assert!(set.is_empty());
+}
+
+#[test]
+fn test_range_tombstone_key_ordering_different_starts() {
+    use crate::range_tombstone::RangeTombstoneKey;
+    let k1 = RangeTombstoneKey {
+        start: bytes::Bytes::from_static(b"a"),
+        ts: 100,
+        ordinal: 0,
+    };
+    let k2 = RangeTombstoneKey {
+        start: bytes::Bytes::from_static(b"b"),
+        ts: 1,
+        ordinal: 0,
+    };
+    // Different start: "a" < "b" regardless of ts.
+    assert!(k1 < k2);
+}
+
+#[test]
+fn test_storage_open_and_close() {
+    let dir = tempdir().unwrap();
+    {
+        let _storage =
+            LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap();
+    }
+    // Reopen should work.
+    {
+        let _storage =
+            LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap();
+    }
+}
+
+#[test]
+fn test_storage_delete_nonexistent() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+    // Deleting a non-existent key should succeed silently.
+    storage.delete(b"nonexistent").unwrap();
+}

--- a/kv-engine/src/tests/wal.rs
+++ b/kv-engine/src/tests/wal.rs
@@ -238,11 +238,14 @@ fn test_wal_crc_mismatch_stops_recovery() {
             .unwrap()
             .read_to_end(&mut raw)
             .unwrap();
-        // Layout: [6-byte header][16-byte batch1 header][6-byte batch1 entries]
-        //         [16-byte batch2 header][6-byte batch2 entries]
-        // Batch2 CRC is at offset 6 + 16 + 6 + 8 + 4 = 40, bytes 40..44.
-        assert_eq!(raw.len(), 6 + 16 + 6 + 16 + 6);
-        raw[40] ^= 0xFF; // corrupt one byte of batch2's CRC
+        // v3 layout: [6-byte header][16-byte batch1 header][7-byte batch1 entries]
+        //            [16-byte batch2 header][7-byte batch2 entries]
+        // Each entry: kind(1) + key_len(2) + key(1) + val_len(2) + val(1) = 7 bytes
+        // Batch2 CRC is at offset 6 + 16 + 7 + 8 + 4 = 41, bytes 41..45.
+        let entry_size = 7usize; // v3: kind(1) + key_len(2) + key(1) + val_len(2) + val(1)
+        assert_eq!(raw.len(), 6 + 16 + entry_size + 16 + entry_size);
+        let crc_offset = 6 + 16 + entry_size + 8 + 4;
+        raw[crc_offset] ^= 0xFF; // corrupt one byte of batch2's CRC
         let mut f = OpenOptions::new()
             .write(true)
             .truncate(true)
@@ -369,16 +372,14 @@ fn test_wal_legacy_data_coincidentally_matching_magic() {
 
     // Construct a legacy-format WAL where the first 4 bytes happen to be
     // 0x57414C32 (the MVCC magic 'WAL2'). This is a false positive test.
-    // key_len=0x5741 (22337) would be huge, so instead we craft bytes that
-    // match the magic but are followed by a version that doesn't match.
-    // Recovery validates version == WAL_FORMAT_VERSION (2), so version=0x0003
+    // Recovery validates version == 2 or 3, so version=0x0004
     // must return an "unsupported WAL version" error (no legacy fallback).
     {
         use std::io::Write;
         let mut f = std::fs::File::create(&path).unwrap();
         // Manually write bytes that spell 'WAL2' but with wrong version.
         f.write_all(&[0x57, 0x41, 0x4C, 0x32]).unwrap(); // magic = WAL2
-        f.write_all(&[0x00, 0x03]).unwrap(); // version = 3 (not 2)
+        f.write_all(&[0x00, 0x04]).unwrap(); // version = 4 (unsupported)
         // The rest is a valid legacy entry: key=[1], value=[2]
         f.write_all(&[0x00, 0x01]).unwrap(); // key_len = 1
         f.write_all(&[0x01]).unwrap(); // key
@@ -674,5 +675,88 @@ fn test_wal_legacy_put_batch_writes_flat_format() {
             .unwrap()
             .value(),
         &Bytes::from(vec![b'v', b'1'])
+    );
+}
+
+#[test]
+fn test_wal_v3_range_tombstone_batch_round_trip() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_v3.wal");
+    let skiplist = new_skiplist();
+    let range_ts = crate::range_tombstone::RangeTombstoneSet::new();
+
+    // Create WAL and write a range tombstone batch.
+    let wal = Wal::create(&path).unwrap();
+    wal.put_range_tombstone_batch(
+        &[
+            (b"a" as &[u8], b"m" as &[u8]),
+            (b"x" as &[u8], b"z" as &[u8]),
+        ],
+        42,
+    )
+    .unwrap();
+    wal.sync().unwrap();
+    drop(wal);
+
+    // Recover with range tombstone support.
+    let (_wal, batch) = Wal::recover_with_range_tombstones(&path, &skiplist, &range_ts).unwrap();
+    assert_eq!(batch.max_ts, 42);
+    assert_eq!(batch.range_tombstones.len(), 2);
+    assert_eq!(batch.range_tombstones[0].start, Bytes::from_static(b"a"));
+    assert_eq!(batch.range_tombstones[0].end, Bytes::from_static(b"m"));
+    assert_eq!(batch.range_tombstones[0].ts, 42);
+    assert_eq!(batch.range_tombstones[1].start, Bytes::from_static(b"x"));
+    assert_eq!(batch.range_tombstones[1].end, Bytes::from_static(b"z"));
+    // Range tombstones should also be in the set.
+    assert_eq!(range_ts.newest_covering_ts(b"f", 100), Some(42));
+}
+
+#[test]
+fn test_wal_v3_mixed_point_and_range_recovery() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_v3_mixed.wal");
+    let skiplist = new_skiplist();
+    let range_ts = crate::range_tombstone::RangeTombstoneSet::new();
+
+    let wal = Wal::create(&path).unwrap();
+    // Write a point batch.
+    wal.put_batch(&[(b"key1", b"val1")], 10).unwrap();
+    // Write a range tombstone batch.
+    wal.put_range_tombstone_batch(&[(b"a", b"z")], 20).unwrap();
+    // Write another point batch.
+    wal.put_batch(&[(b"key2", b"val2")], 30).unwrap();
+    wal.sync().unwrap();
+    drop(wal);
+
+    let (_wal, batch) = Wal::recover_with_range_tombstones(&path, &skiplist, &range_ts).unwrap();
+    assert_eq!(batch.max_ts, 30);
+    assert_eq!(batch.points.len(), 2);
+    assert_eq!(batch.range_tombstones.len(), 1);
+    assert_eq!(batch.range_tombstones[0].ts, 20);
+    // Skiplist should have point entries.
+    assert_eq!(skiplist.len(), 2);
+    // Range tombstone set should have the range.
+    assert_eq!(range_ts.newest_covering_ts(b"m", 100), Some(20));
+}
+
+#[test]
+fn test_wal_v3_point_batch_backward_compat() {
+    // v3 point batches should still be readable.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_v3_compat.wal");
+    let skiplist = new_skiplist();
+
+    let wal = Wal::create(&path).unwrap();
+    wal.put_batch(&[(b"key1", b"val1"), (b"key2", b"val2")], 42)
+        .unwrap();
+    wal.sync().unwrap();
+    drop(wal);
+
+    let (_wal, max_ts) = Wal::recover(&path, &skiplist).unwrap();
+    assert_eq!(max_ts, 42);
+    assert_eq!(skiplist.len(), 2);
+    assert_eq!(
+        skiplist.get(&Bytes::from_static(b"key1")).unwrap().value(),
+        &Bytes::from_static(b"val1")
     );
 }

--- a/kv-engine/src/tests/wal.rs
+++ b/kv-engine/src/tests/wal.rs
@@ -4,7 +4,10 @@ use bytes::{BufMut, Bytes};
 use crossbeam_skiplist::SkipMap;
 use tempfile::tempdir;
 
-use crate::wal::Wal;
+use crate::{
+    lsm_storage::{LsmStorageInner, LsmStorageOptions},
+    wal::Wal,
+};
 
 fn new_skiplist() -> Arc<SkipMap<Bytes, Bytes>> {
     Arc::new(SkipMap::new())
@@ -758,5 +761,161 @@ fn test_wal_v3_point_batch_backward_compat() {
     assert_eq!(
         skiplist.get(&Bytes::from_static(b"key1")).unwrap().value(),
         &Bytes::from_static(b"val1")
+    );
+}
+
+#[test]
+fn test_wal_v3_recover_with_tombstones() {
+    // v3 point tombstones should be recovered correctly.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_v3_tomb.wal");
+    let skiplist = new_skiplist();
+
+    let wal = Wal::create(&path).unwrap();
+    wal.put_batch(&[(b"key1", b"val1")], 10).unwrap();
+    // Write a tombstone batch (delete key1).
+    wal.put_batch(&[(b"key1", &[] as &[u8])], 20).unwrap();
+    wal.put_batch(&[(b"key2", b"val2")], 30).unwrap();
+    wal.sync().unwrap();
+    drop(wal);
+
+    let (_wal, max_ts) = Wal::recover(&path, &skiplist).unwrap();
+    assert_eq!(max_ts, 30);
+    // key1 has put then tombstone — tombstone overwrites, so 2 entries remain.
+    assert_eq!(skiplist.len(), 2);
+}
+
+#[test]
+fn test_wal_v3_recover_with_range_tombstones_skipped() {
+    // When using recover() (not recover_with_range_tombstones),
+    // range tombstone entries should be silently skipped.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_v3_skip.wal");
+    let skiplist = new_skiplist();
+
+    let wal = Wal::create(&path).unwrap();
+    wal.put_batch(&[(b"key1", b"val1")], 10).unwrap();
+    wal.put_range_tombstone_batch(&[(b"a", b"z")], 20).unwrap();
+    wal.put_batch(&[(b"key2", b"val2")], 30).unwrap();
+    wal.sync().unwrap();
+    drop(wal);
+
+    let (_wal, max_ts) = Wal::recover(&path, &skiplist).unwrap();
+    assert_eq!(max_ts, 30);
+    // Only point entries in skiplist, range tombstones skipped.
+    assert_eq!(skiplist.len(), 2);
+}
+
+#[test]
+fn test_wal_v3_multiple_range_tombstone_batches() {
+    // Multiple range tombstone batches should recover with correct ordinals.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_v3_multi_rt.wal");
+    let skiplist = new_skiplist();
+    let range_ts = crate::range_tombstone::RangeTombstoneSet::new();
+
+    let wal = Wal::create(&path).unwrap();
+    wal.put_range_tombstone_batch(&[(b"a", b"m")], 10).unwrap();
+    wal.put_range_tombstone_batch(&[(b"x", b"z")], 20).unwrap();
+    wal.sync().unwrap();
+    drop(wal);
+
+    let (_wal, batch) = Wal::recover_with_range_tombstones(&path, &skiplist, &range_ts).unwrap();
+    assert_eq!(batch.max_ts, 20);
+    assert_eq!(batch.range_tombstones.len(), 2);
+    // Each batch has ordinal 0 (single-entry batches).
+    assert_eq!(range_ts.newest_covering_ts(b"f", 100), Some(10));
+    assert_eq!(range_ts.newest_covering_ts(b"y", 100), Some(20));
+}
+
+#[test]
+fn test_wal_v3_empty_batch_recovery() {
+    // An empty WAL file should recover cleanly.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_v3_empty.wal");
+    let skiplist = new_skiplist();
+
+    let wal = Wal::create(&path).unwrap();
+    wal.sync().unwrap();
+    drop(wal);
+
+    let (_wal, max_ts) = Wal::recover(&path, &skiplist).unwrap();
+    assert_eq!(max_ts, 0);
+    assert_eq!(skiplist.len(), 0);
+}
+
+#[test]
+fn test_wal_v3_truncated_batch_recovery() {
+    // A truncated batch should be detected and recovery should stop.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_v3_trunc.wal");
+    let skiplist = new_skiplist();
+
+    let wal = Wal::create(&path).unwrap();
+    wal.put_batch(&[(b"key1", b"val1")], 10).unwrap();
+    wal.put_batch(&[(b"key2", b"val2")], 20).unwrap();
+    wal.sync().unwrap();
+    drop(wal);
+
+    // Truncate the file to corrupt the last batch.
+    let metadata = std::fs::metadata(&path).unwrap();
+    let truncated_len = metadata.len() - 5; // Remove last 5 bytes.
+    let f = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
+    f.set_len(truncated_len).unwrap();
+    drop(f);
+
+    let skiplist2 = new_skiplist();
+    let (_wal, max_ts) = Wal::recover(&path, &skiplist2).unwrap();
+    // First batch should still be recovered.
+    assert_eq!(max_ts, 10);
+    assert_eq!(skiplist2.len(), 1);
+}
+
+#[test]
+fn test_memtable_recover_from_wal_with_range_tombstones() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_mt_recover.wal");
+
+    // Create a memtable with WAL and write range tombstones.
+    {
+        let mt = crate::mem_table::MemTable::create_with_wal(0, &path).unwrap();
+        mt.put_range_tombstone(b"a", b"z", 42, 0).unwrap();
+        // Force WAL write via a point entry.
+        mt.for_testing_put_slice(b"key1", b"val1").unwrap();
+    }
+
+    // Recover from WAL.
+    let (mt, max_ts) =
+        crate::mem_table::MemTable::recover_from_wal_with_range_tombstones(0, &path).unwrap();
+    assert_eq!(max_ts, 42);
+    // Range tombstone should be recovered.
+    assert_eq!(
+        mt.range_tombstones().newest_covering_ts(b"m", 100),
+        Some(42)
+    );
+}
+
+#[test]
+fn test_write_range_batch_mvcc_path() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+
+    // Write a range-only batch through the MVCC path.
+    storage
+        .write_batch(&[crate::lsm_storage::WriteBatchRecord::DelRange(
+            b"a".as_ref(),
+            b"z".as_ref(),
+        )])
+        .unwrap();
+
+    let state = storage.state.load();
+    assert_eq!(state.memtable.range_tombstones().len(), 1);
+    assert_eq!(
+        state
+            .memtable
+            .range_tombstones()
+            .newest_covering_ts(b"m", u64::MAX),
+        Some(1)
     );
 }

--- a/kv-engine/src/tests/wal.rs
+++ b/kv-engine/src/tests/wal.rs
@@ -919,3 +919,90 @@ fn test_write_range_batch_mvcc_path() {
         Some(1)
     );
 }
+
+#[test]
+fn test_memtable_recover_from_wal_vlog() {
+    // Test recover_from_wal_vlog path (vlog-enabled recovery).
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_vlog_recover.wal");
+
+    // Write entries directly to WAL since for_testing_put_slice doesn't write to WAL.
+    {
+        let wal = Wal::create(&path).unwrap();
+        wal.put_batch(&[(b"key1", b"val1")], 10).unwrap();
+        wal.put_batch(&[(b"key2", b"val2")], 20).unwrap();
+        wal.sync().unwrap();
+    }
+
+    // Recover using vlog recovery path.
+    let (mt, max_ts) = crate::mem_table::MemTable::recover_from_wal_vlog(0, &path).unwrap();
+    assert_eq!(max_ts, 20);
+    assert!(!mt.is_empty());
+}
+
+#[test]
+fn test_memtable_recover_from_wal_plain() {
+    // Test recover_from_wal path (non-vlog, non-range-tombstone).
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_plain_recover.wal");
+
+    {
+        let wal = Wal::create(&path).unwrap();
+        wal.put_batch(&[(b"key1", b"val1")], 10).unwrap();
+        wal.put_batch(&[(b"key2", b"val2")], 20).unwrap();
+        wal.sync().unwrap();
+    }
+
+    let (mt, max_ts) = crate::mem_table::MemTable::recover_from_wal(0, &path).unwrap();
+    assert_eq!(max_ts, 20);
+    assert!(!mt.is_empty());
+}
+
+#[test]
+fn test_manifest_v3_to_v4_upgrade() {
+    // Create a database, then reopen to verify manifest recovery works.
+    let dir = tempdir().unwrap();
+
+    // First open: creates fresh manifest (v4).
+    {
+        let storage =
+            LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap();
+        storage.put(b"key1", b"val1").unwrap();
+    }
+
+    // Reopen: should recover from v4 manifest successfully.
+    let storage = LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap();
+    // Just verify it opens without error — manifest recovery worked.
+}
+
+#[test]
+fn test_range_overlap_with_point_entries_excluded_bounds() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+    storage.put(b"m", b"1").unwrap();
+    storage.put(b"p", b"2").unwrap();
+
+    let state = storage.state.load();
+
+    // Excluded lower before first key + Unbounded upper.
+    assert!(state.memtable.range_overlap(
+        std::ops::Bound::Excluded(b"a" as &[u8]),
+        std::ops::Bound::Unbounded,
+    ));
+    // Excluded lower at first key + Unbounded upper.
+    assert!(state.memtable.range_overlap(
+        std::ops::Bound::Excluded(b"m" as &[u8]),
+        std::ops::Bound::Unbounded,
+    ));
+    // Included lower at last key + Excluded upper after last key.
+    assert!(state.memtable.range_overlap(
+        std::ops::Bound::Included(b"p" as &[u8]),
+        std::ops::Bound::Excluded(b"z" as &[u8]),
+    ));
+    // Excluded lower at last key + Included upper after last key.
+    assert!(!state.memtable.range_overlap(
+        std::ops::Bound::Excluded(b"p" as &[u8]),
+        std::ops::Bound::Included(b"z" as &[u8]),
+    ));
+}

--- a/kv-engine/src/tests/wal.rs
+++ b/kv-engine/src/tests/wal.rs
@@ -1006,3 +1006,160 @@ fn test_range_overlap_with_point_entries_excluded_bounds() {
         std::ops::Bound::Included(b"z" as &[u8]),
     ));
 }
+
+#[test]
+fn test_wal_put_batch_key_too_large() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_large_key.wal");
+    let wal = Wal::create(&path).unwrap();
+
+    // Key larger than u16::MAX should be rejected.
+    let large_key = vec![0u8; u16::MAX as usize + 1];
+    let result = wal.put_batch(&[(&large_key, b"val")], 10);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_wal_put_batch_value_too_large() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_large_val.wal");
+    let wal = Wal::create(&path).unwrap();
+
+    // Value larger than u16::MAX should be rejected.
+    let large_val = vec![0u8; u16::MAX as usize + 1];
+    let result = wal.put_batch(&[(b"key", &large_val)], 10);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_wal_put_range_tombstone_batch_key_too_large() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_large_rt.wal");
+    let wal = Wal::create(&path).unwrap();
+
+    let large_key = vec![0u8; u16::MAX as usize + 1];
+    let result = wal.put_range_tombstone_batch(&[(&large_key, b"z")], 10);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_wal_put_range_tombstone_batch_requires_mvcc() {
+    // Non-MVCC WAL should reject range tombstone batches.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_no_mvcc.wal");
+    let wal = Wal::create(&path).unwrap();
+
+    // Default WAL is MVCC-enabled, so this should work.
+    let result = wal.put_range_tombstone_batch(&[(b"a", b"z")], 10);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_wal_put_key_too_large() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_put_large.wal");
+    let wal = Wal::create(&path).unwrap();
+
+    let large_key = vec![0u8; u16::MAX as usize + 1];
+    let result = wal.put(&large_key, b"val");
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_wal_put_value_too_large() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_put_large_val.wal");
+    let wal = Wal::create(&path).unwrap();
+
+    let large_val = vec![0u8; u16::MAX as usize + 1];
+    let result = wal.put(b"key", &large_val);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_wal_recover_corrupted_magic() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_corrupt_magic.wal");
+
+    // Write a valid WAL.
+    {
+        let wal = Wal::create(&path).unwrap();
+        wal.put_batch(&[(b"key1", b"val1")], 10).unwrap();
+        wal.sync().unwrap();
+    }
+
+    // Corrupt the magic bytes.
+    let mut data = std::fs::read(&path).unwrap();
+    data[0] = 0xFF;
+    std::fs::write(&path, &data).unwrap();
+
+    let skiplist = new_skiplist();
+    // Corrupted magic means recovery sees an empty/legacy file.
+    let (_wal, max_ts) = Wal::recover(&path, &skiplist).unwrap();
+    assert_eq!(max_ts, 0);
+}
+
+#[test]
+fn test_wal_recover_corrupted_crc() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_corrupt_crc.wal");
+
+    // Write a valid WAL.
+    {
+        let wal = Wal::create(&path).unwrap();
+        wal.put_batch(&[(b"key1", b"val1")], 10).unwrap();
+        wal.sync().unwrap();
+    }
+
+    // Corrupt a byte in the data area (after header + batch header).
+    let mut data = std::fs::read(&path).unwrap();
+    if data.len() > 20 {
+        data[20] ^= 0xFF;
+    }
+    std::fs::write(&path, &data).unwrap();
+
+    let skiplist = new_skiplist();
+    // Should still recover (corrupted batch is skipped).
+    let (_wal, max_ts) = Wal::recover(&path, &skiplist).unwrap();
+    assert_eq!(max_ts, 0);
+    assert_eq!(skiplist.len(), 0);
+}
+
+#[test]
+fn test_memtable_create_with_wal() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_create_wal.wal");
+    let mt = crate::mem_table::MemTable::create_with_wal(0, &path).unwrap();
+    assert!(!mt.vlog_enabled());
+}
+
+#[test]
+fn test_memtable_create_with_wal_vlog() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test_create_wal_vlog.wal");
+    let mt = crate::mem_table::MemTable::create_with_wal_vlog(0, &path).unwrap();
+    assert!(mt.vlog_enabled());
+}
+
+#[test]
+fn test_memtable_create_vlog() {
+    let mt = crate::mem_table::MemTable::create_vlog(0);
+    assert!(mt.vlog_enabled());
+}
+
+#[test]
+fn test_memtable_is_empty() {
+    let mt = crate::mem_table::MemTable::create(0);
+    assert!(mt.is_empty());
+    mt.for_testing_put_slice(b"key", b"val").unwrap();
+    assert!(!mt.is_empty());
+}
+
+#[test]
+fn test_memtable_range_tombstones_accessor() {
+    let mt = crate::mem_table::MemTable::create(0);
+    assert!(mt.range_tombstones().is_empty());
+    mt.put_range_tombstone(b"a", b"z", 10, 0).unwrap();
+    assert!(!mt.range_tombstones().is_empty());
+    assert_eq!(mt.range_tombstones().len(), 1);
+}

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -637,16 +637,16 @@ impl Wal {
             }
         }
 
-        // Insert recovered range tombstones into the set.
-        for (start, end, ts, ordinal) in &range_ts {
-            range_tombstones.add(
-                RangeTombstone {
-                    start: start.clone(),
-                    end: end.clone(),
-                    ts: *ts,
-                },
-                *ordinal,
-            );
+        // Insert recovered range tombstones into the set and build the batch
+        // list in a single pass, avoiding a separate iteration.
+        let mut recovered_range_tombstones = Vec::with_capacity(range_ts.len());
+        for (start, end, ts, ordinal) in range_ts {
+            recovered_range_tombstones.push(RangeTombstone {
+                start: start.clone(),
+                end: end.clone(),
+                ts,
+            });
+            range_tombstones.add(RangeTombstone { start, end, ts }, ordinal);
         }
 
         Ok((
@@ -657,10 +657,7 @@ impl Wal {
             RecoveredWalBatch {
                 points,
                 point_tombstones,
-                range_tombstones: range_ts
-                    .into_iter()
-                    .map(|(start, end, ts, _)| RangeTombstone { start, end, ts })
-                    .collect(),
+                range_tombstones: recovered_range_tombstones,
                 max_ts,
             },
         ))

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -146,8 +146,10 @@ impl Wal {
 
                 // Compute the expected size of all entries.
                 let entries_start = data.remaining();
-                // Each entry is at least 4 bytes: key_len(u16) + value_len(u16).
-                if entry_count > entries_start / 4 {
+                // v3 PointTombstone is only 3 bytes (kind:1 + key_len:2);
+                // v2 entries are at least 4 bytes (key_len:2 + value_len:2).
+                let min_entry_size = if is_v3 { 3 } else { 4 };
+                if entry_count > entries_start / min_entry_size {
                     data = before_batch;
                     break;
                 }
@@ -542,7 +544,8 @@ impl Wal {
                 }
 
                 let mut entry_buf = data.split_to(expected_size);
-                for i in 0..entry_count {
+                let mut range_tombstone_idx: u32 = 0;
+                for _ in 0..entry_count {
                     if is_v3 {
                         let kind = entry_buf.get_u8();
                         match kind {
@@ -571,12 +574,10 @@ impl Wal {
                                 let start = entry_buf.split_to(start_size);
                                 let end_size = entry_buf.get_u16() as usize;
                                 let end = entry_buf.split_to(end_size);
-                                range_ts.push((
-                                    start,
-                                    end,
-                                    commit_ts,
-                                    u32::try_from(i).context("ordinal overflow")?,
-                                ));
+                                range_ts.push((start, end, commit_ts, range_tombstone_idx));
+                                range_tombstone_idx = range_tombstone_idx
+                                    .checked_add(1)
+                                    .context("ordinal overflow")?;
                             }
                             _ => unreachable!(),
                         }

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -436,7 +436,10 @@ impl Wal {
                 let data_crc32 = data.get_u32();
 
                 let entries_start = data.remaining();
-                if entry_count > entries_start / 4 {
+                // v3 PointTombstone is only 3 bytes (kind:1 + key_len:2);
+                // v2 entries are at least 4 bytes (key_len:2 + value_len:2).
+                let min_entry_size = if is_v3 { 3 } else { 4 };
+                if entry_count > entries_start / min_entry_size {
                     data = before_batch;
                     break;
                 }

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -568,7 +568,12 @@ impl Wal {
                                 let start = entry_buf.split_to(start_size);
                                 let end_size = entry_buf.get_u16() as usize;
                                 let end = entry_buf.split_to(end_size);
-                                range_ts.push((start, end, commit_ts, i as u32));
+                                range_ts.push((
+                                    start,
+                                    end,
+                                    commit_ts,
+                                    u32::try_from(i).context("ordinal overflow")?,
+                                ));
                             }
                             _ => unreachable!(),
                         }

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -10,16 +10,45 @@ use bytes::{Buf, BufMut, Bytes};
 use crossbeam_skiplist::SkipMap;
 use parking_lot::Mutex;
 
+use crate::range_tombstone::RangeTombstone;
+
+/// Result of recovering a WAL file, containing both point entries and range tombstones.
+pub struct RecoveredWalBatch {
+    /// Point key-value entries recovered from the WAL.
+    pub points: Vec<(Bytes, Bytes)>,
+    /// Point tombstones recovered from the WAL.
+    pub point_tombstones: Vec<Bytes>,
+    /// Range tombstones recovered from the WAL.
+    pub range_tombstones: Vec<RangeTombstone>,
+    /// Maximum commit_ts found across all batches.
+    pub max_ts: u64,
+}
+
 /// Magic number for MVCC-format WAL files: "WAL2" in ASCII.
 const WAL_MVCC_MAGIC: u32 = 0x5741_4C32;
-/// MVCC WAL format version.
-const WAL_FORMAT_VERSION: u16 = 2;
+/// MVCC WAL format version 2: untyped entries (key_len, key, val_len, val).
+const WAL_FORMAT_VERSION_V2: u16 = 2;
+/// MVCC WAL format version 3: typed entries with kind prefix.
+const WAL_FORMAT_VERSION_V3: u16 = 3;
+/// Current WAL format version written by new files.
+const WAL_FORMAT_VERSION: u16 = WAL_FORMAT_VERSION_V3;
 /// Size of the WAL file header: magic (4) + version (2) = 6 bytes.
 const WAL_HEADER_SIZE: usize = 6;
 /// Size of a batch header: commit_ts (8) + entry_count (4) + data_crc32 (4) = 16 bytes.
 const BATCH_HEADER_SIZE: usize = 16;
 /// Maximum WAL file size to prevent unbounded allocation during recovery (1 GB).
 const MAX_WAL_FILE_SIZE: u64 = 1 << 30;
+
+/// Entry kind tags for WAL v3 typed entries.
+#[repr(u8)]
+enum WalEntryKind {
+    /// A point key-value put.
+    Put = 0,
+    /// A point tombstone (deletion marker).
+    PointTombstone = 1,
+    /// A range tombstone covering `[start, end)`.
+    RangeTombstone = 2,
+}
 
 pub struct Wal {
     pub(crate) file: Arc<Mutex<BufWriter<File>>>,
@@ -72,20 +101,29 @@ impl Wal {
         let mut data = buf_bytes.clone();
 
         // Detect MVCC format by checking the magic number AND version field.
+        // Accept both v2 (untyped entries) and v3 (typed entries).
         let mvcc_format = if data.len() >= WAL_HEADER_SIZE {
             let magic = (&data[..4]).get_u32();
             let version = (&data[4..6]).get_u16();
             if magic == WAL_MVCC_MAGIC {
                 anyhow::ensure!(
-                    version == WAL_FORMAT_VERSION,
-                    "unsupported WAL version: got {}, expected {}",
+                    version == WAL_FORMAT_VERSION_V2 || version == WAL_FORMAT_VERSION_V3,
+                    "unsupported WAL version: got {}, expected {} or {}",
                     version,
-                    WAL_FORMAT_VERSION
+                    WAL_FORMAT_VERSION_V2,
+                    WAL_FORMAT_VERSION_V3
                 );
                 true
             } else {
                 false
             }
+        } else {
+            false
+        };
+
+        // Determine if this is v3 (typed entries) or v2 (untyped entries).
+        let is_v3 = if data.len() >= WAL_HEADER_SIZE {
+            (&data[4..6]).get_u16() == WAL_FORMAT_VERSION_V3
         } else {
             false
         };
@@ -117,21 +155,80 @@ impl Wal {
                 let mut ok = true;
                 // Peek ahead to check if we have enough data for all entries.
                 for _ in 0..entry_count {
-                    if entries_start - expected_size < 4 {
-                        // Not enough data for key_len + value_len.
-                        ok = false;
-                        break;
+                    if is_v3 {
+                        // v3: [kind:1][...]
+                        if entries_start - expected_size < 1 {
+                            ok = false;
+                            break;
+                        }
+                        let kind = data[expected_size];
+                        expected_size += 1;
+                        match kind {
+                            0 => {
+                                // Put: [key_len:2][key][value_len:2][value]
+                                if entries_start - expected_size < 4 {
+                                    ok = false;
+                                    break;
+                                }
+                                let pos = expected_size;
+                                let key_size = (&data[pos..pos + 2]).get_u16() as usize;
+                                if entries_start - expected_size < 4 + key_size {
+                                    ok = false;
+                                    break;
+                                }
+                                let val_size = (&data[pos + 2 + key_size..pos + 4 + key_size])
+                                    .get_u16()
+                                    as usize;
+                                expected_size += 4 + key_size + val_size;
+                            }
+                            1 => {
+                                // PointTombstone: [key_len:2][key]
+                                if entries_start - expected_size < 2 {
+                                    ok = false;
+                                    break;
+                                }
+                                let pos = expected_size;
+                                let key_size = (&data[pos..pos + 2]).get_u16() as usize;
+                                expected_size += 2 + key_size;
+                            }
+                            2 => {
+                                // RangeTombstone: [start_len:2][start][end_len:2][end]
+                                if entries_start - expected_size < 4 {
+                                    ok = false;
+                                    break;
+                                }
+                                let pos = expected_size;
+                                let start_size = (&data[pos..pos + 2]).get_u16() as usize;
+                                if entries_start - expected_size < 4 + start_size {
+                                    ok = false;
+                                    break;
+                                }
+                                let end_size = (&data[pos + 2 + start_size..pos + 4 + start_size])
+                                    .get_u16()
+                                    as usize;
+                                expected_size += 4 + start_size + end_size;
+                            }
+                            _ => {
+                                ok = false;
+                                break;
+                            }
+                        }
+                    } else {
+                        // v2: [key_len:2][key][value_len:2][value]
+                        if entries_start - expected_size < 4 {
+                            ok = false;
+                            break;
+                        }
+                        let pos = expected_size;
+                        let key_size = (&data[pos..pos + 2]).get_u16() as usize;
+                        if entries_start - expected_size < 4 + key_size {
+                            ok = false;
+                            break;
+                        }
+                        let val_size =
+                            (&data[pos + 2 + key_size..pos + 4 + key_size]).get_u16() as usize;
+                        expected_size += 4 + key_size + val_size;
                     }
-                    let pos = expected_size;
-                    let key_size = (&data[pos..pos + 2]).get_u16() as usize;
-                    // Ensure key bytes + val_len u16 are within bounds before reading.
-                    if entries_start - expected_size < 4 + key_size {
-                        ok = false;
-                        break;
-                    }
-                    let val_size =
-                        (&data[pos + 2 + key_size..pos + 4 + key_size]).get_u16() as usize;
-                    expected_size += 4 + key_size + val_size;
                     if expected_size > entries_start {
                         ok = false;
                         break;
@@ -157,13 +254,51 @@ impl Wal {
                 // Replay entries into skiplist using zero-copy Bytes slices.
                 let mut entry_buf = data.split_to(expected_size);
                 for _ in 0..entry_count {
-                    let key_size = entry_buf.get_u16() as usize;
-                    let key = entry_buf.split_to(key_size);
-
-                    let value_size = entry_buf.get_u16() as usize;
-                    let value = entry_buf.split_to(value_size);
-
-                    skiplist.insert(key, value);
+                    if is_v3 {
+                        // v3: typed entries with kind prefix.
+                        let kind = entry_buf.get_u8();
+                        match kind {
+                            0 => {
+                                // Put: [kind:1][key_len:2][key][value_len:2][value]
+                                let key_size = entry_buf.get_u16() as usize;
+                                let key = entry_buf.split_to(key_size);
+                                let value_size = entry_buf.get_u16() as usize;
+                                let value = entry_buf.split_to(value_size);
+                                skiplist.insert(key, value);
+                            }
+                            1 => {
+                                // PointTombstone: [kind:1][key_len:2][key]
+                                let key_size = entry_buf.get_u16() as usize;
+                                let key = entry_buf.split_to(key_size);
+                                // Store tombstone as key -> KvKind::Tombstone byte.
+                                skiplist.insert(
+                                    key,
+                                    Bytes::from_static(&[crate::vlog::KvKind::Tombstone as u8]),
+                                );
+                            }
+                            2 => {
+                                // RangeTombstone: [kind:1][start_len:2][start][end_len:2][end]
+                                let start_size = entry_buf.get_u16() as usize;
+                                let start = entry_buf.split_to(start_size);
+                                let end_size = entry_buf.get_u16() as usize;
+                                let _end = entry_buf.split_to(end_size);
+                                // Range tombstones are not replayed into the skiplist;
+                                // they are recovered via recover_with_range_tombstones().
+                                // Track max_ts from the batch header (already done above).
+                                let _ = start;
+                            }
+                            _ => {
+                                anyhow::bail!("unknown WAL v3 entry kind: {}", kind);
+                            }
+                        }
+                    } else {
+                        // v2: untyped entries [key_len:2][key][value_len:2][value].
+                        let key_size = entry_buf.get_u16() as usize;
+                        let key = entry_buf.split_to(key_size);
+                        let value_size = entry_buf.get_u16() as usize;
+                        let value = entry_buf.split_to(value_size);
+                        skiplist.insert(key, value);
+                    }
                 }
                 if commit_ts > max_ts {
                     max_ts = commit_ts;
@@ -229,6 +364,300 @@ impl Wal {
                 mvcc_format,
             },
             max_ts,
+        ))
+    }
+
+    /// Recover a WAL file with full range-tombstone support.
+    ///
+    /// Returns a [`RecoveredWalBatch`] containing point entries, point tombstones,
+    /// range tombstones, and the maximum commit_ts. Point entries and tombstones
+    /// are also replayed into the provided skiplist for backward compatibility.
+    pub fn recover_with_range_tombstones(
+        path: impl AsRef<Path>,
+        skiplist: &SkipMap<Bytes, Bytes>,
+        range_tombstones: &crate::range_tombstone::RangeTombstoneSet,
+    ) -> Result<(Self, RecoveredWalBatch)> {
+        let mut f = File::options()
+            .read(true)
+            .append(true)
+            .open(path.as_ref())
+            .context("failed to recover from WAL")?;
+        let file_len = f.metadata()?.len();
+        anyhow::ensure!(
+            file_len <= MAX_WAL_FILE_SIZE,
+            "WAL file too large: {} bytes (max {})",
+            file_len,
+            MAX_WAL_FILE_SIZE
+        );
+        let mut buf = Vec::with_capacity(file_len as usize);
+        f.read_to_end(&mut buf)?;
+
+        let buf_bytes = Bytes::from(buf);
+        let mut max_ts: u64 = 0;
+        let mut data = buf_bytes.clone();
+        let mut points = Vec::new();
+        let mut point_tombstones = Vec::new();
+        let mut range_ts = Vec::new();
+
+        // Detect MVCC format.
+        let mvcc_format = if data.len() >= WAL_HEADER_SIZE {
+            let magic = (&data[..4]).get_u32();
+            let version = (&data[4..6]).get_u16();
+            if magic == WAL_MVCC_MAGIC {
+                anyhow::ensure!(
+                    version == WAL_FORMAT_VERSION_V2 || version == WAL_FORMAT_VERSION_V3,
+                    "unsupported WAL version: got {}, expected {} or {}",
+                    version,
+                    WAL_FORMAT_VERSION_V2,
+                    WAL_FORMAT_VERSION_V3
+                );
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+
+        let is_v3 = if data.len() >= WAL_HEADER_SIZE {
+            (&data[4..6]).get_u16() == WAL_FORMAT_VERSION_V3
+        } else {
+            false
+        };
+
+        if mvcc_format {
+            data.advance(WAL_HEADER_SIZE);
+            let data_len = data.len();
+
+            while data.remaining() >= BATCH_HEADER_SIZE {
+                let before_batch = data.clone();
+                let commit_ts = data.get_u64();
+                let entry_count = data.get_u32() as usize;
+                let data_crc32 = data.get_u32();
+
+                let entries_start = data.remaining();
+                if entry_count > entries_start / 4 {
+                    data = before_batch;
+                    break;
+                }
+
+                // For v3, we need to scan entries to compute expected size
+                // because entry sizes vary by kind.
+                let mut expected_size: usize = 0;
+                let mut ok = true;
+                for _ in 0..entry_count {
+                    if is_v3 {
+                        // v3: [kind:1][...]
+                        if entries_start - expected_size < 1 {
+                            ok = false;
+                            break;
+                        }
+                        let kind = data[expected_size];
+                        expected_size += 1;
+                        match kind {
+                            0 => {
+                                // Put: [key_len:2][key][value_len:2][value]
+                                if entries_start - expected_size < 4 {
+                                    ok = false;
+                                    break;
+                                }
+                                let pos = expected_size;
+                                let key_size = (&data[pos..pos + 2]).get_u16() as usize;
+                                if entries_start - expected_size < 4 + key_size {
+                                    ok = false;
+                                    break;
+                                }
+                                let val_size = (&data[pos + 2 + key_size..pos + 4 + key_size])
+                                    .get_u16()
+                                    as usize;
+                                expected_size += 4 + key_size + val_size;
+                            }
+                            1 => {
+                                // PointTombstone: [key_len:2][key]
+                                if entries_start - expected_size < 2 {
+                                    ok = false;
+                                    break;
+                                }
+                                let pos = expected_size;
+                                let key_size = (&data[pos..pos + 2]).get_u16() as usize;
+                                expected_size += 2 + key_size;
+                            }
+                            2 => {
+                                // RangeTombstone: [start_len:2][start][end_len:2][end]
+                                if entries_start - expected_size < 4 {
+                                    ok = false;
+                                    break;
+                                }
+                                let pos = expected_size;
+                                let start_size = (&data[pos..pos + 2]).get_u16() as usize;
+                                if entries_start - expected_size < 4 + start_size {
+                                    ok = false;
+                                    break;
+                                }
+                                let end_size = (&data[pos + 2 + start_size..pos + 4 + start_size])
+                                    .get_u16()
+                                    as usize;
+                                expected_size += 4 + start_size + end_size;
+                            }
+                            _ => {
+                                ok = false;
+                                break;
+                            }
+                        }
+                    } else {
+                        // v2: [key_len:2][key][value_len:2][value]
+                        if entries_start - expected_size < 4 {
+                            ok = false;
+                            break;
+                        }
+                        let pos = expected_size;
+                        let key_size = (&data[pos..pos + 2]).get_u16() as usize;
+                        if entries_start - expected_size < 4 + key_size {
+                            ok = false;
+                            break;
+                        }
+                        let val_size =
+                            (&data[pos + 2 + key_size..pos + 4 + key_size]).get_u16() as usize;
+                        expected_size += 4 + key_size + val_size;
+                    }
+                    if expected_size > entries_start {
+                        ok = false;
+                        break;
+                    }
+                }
+
+                if !ok || expected_size > entries_start {
+                    data = before_batch;
+                    break;
+                }
+
+                let entry_data = &data[..expected_size];
+                let computed_crc = crc32fast::hash(entry_data);
+                if computed_crc != data_crc32 {
+                    data = before_batch;
+                    break;
+                }
+
+                let mut entry_buf = data.split_to(expected_size);
+                for i in 0..entry_count {
+                    if is_v3 {
+                        let kind = entry_buf.get_u8();
+                        match kind {
+                            0 => {
+                                // Put
+                                let key_size = entry_buf.get_u16() as usize;
+                                let key = entry_buf.split_to(key_size);
+                                let value_size = entry_buf.get_u16() as usize;
+                                let value = entry_buf.split_to(value_size);
+                                points.push((key.clone(), value.clone()));
+                                skiplist.insert(key, value);
+                            }
+                            1 => {
+                                // PointTombstone
+                                let key_size = entry_buf.get_u16() as usize;
+                                let key = entry_buf.split_to(key_size);
+                                point_tombstones.push(key.clone());
+                                skiplist.insert(
+                                    key,
+                                    Bytes::from_static(&[crate::vlog::KvKind::Tombstone as u8]),
+                                );
+                            }
+                            2 => {
+                                // RangeTombstone
+                                let start_size = entry_buf.get_u16() as usize;
+                                let start = entry_buf.split_to(start_size);
+                                let end_size = entry_buf.get_u16() as usize;
+                                let end = entry_buf.split_to(end_size);
+                                range_ts.push((start, end, commit_ts, i as u32));
+                            }
+                            _ => unreachable!(),
+                        }
+                    } else {
+                        // v2: untyped entries
+                        let key_size = entry_buf.get_u16() as usize;
+                        let key = entry_buf.split_to(key_size);
+                        let value_size = entry_buf.get_u16() as usize;
+                        let value = entry_buf.split_to(value_size);
+                        points.push((key.clone(), value.clone()));
+                        skiplist.insert(key, value);
+                    }
+                }
+
+                if commit_ts > max_ts {
+                    max_ts = commit_ts;
+                }
+            }
+
+            let valid_data = data_len - data.remaining();
+            let valid_file = WAL_HEADER_SIZE + valid_data;
+            if (valid_file as u64) < file_len {
+                f.set_len(valid_file as u64)?;
+            }
+        } else {
+            // Legacy format: flat entries.
+            let data_len = data.len();
+            while data.has_remaining() {
+                let before_entry = data.clone();
+                if data.remaining() < 4 {
+                    data = before_entry;
+                    break;
+                }
+                let key_size = data.get_u16() as usize;
+                if data.remaining() < key_size + 2 {
+                    data = before_entry;
+                    break;
+                }
+                let key = data.split_to(key_size);
+                if data.remaining() < 2 {
+                    data = before_entry;
+                    break;
+                }
+                let value_size = data.get_u16() as usize;
+                if data.remaining() < value_size {
+                    data = before_entry;
+                    break;
+                }
+                let value = data.split_to(value_size);
+                if let Some(ts) = crate::key::extract_ts(&key)
+                    && ts > max_ts
+                {
+                    max_ts = ts;
+                }
+                points.push((key.clone(), value.clone()));
+                skiplist.insert(key, value);
+            }
+            let valid_len = data_len - data.remaining();
+            if (valid_len as u64) < file_len {
+                f.set_len(valid_len as u64)?;
+            }
+        }
+
+        // Insert recovered range tombstones into the set.
+        for (start, end, ts, ordinal) in &range_ts {
+            range_tombstones.add(
+                RangeTombstone {
+                    start: start.clone(),
+                    end: end.clone(),
+                    ts: *ts,
+                },
+                *ordinal,
+            );
+        }
+
+        Ok((
+            Self {
+                file: Arc::new(Mutex::new(BufWriter::new(f))),
+                mvcc_format,
+            },
+            RecoveredWalBatch {
+                points,
+                point_tombstones,
+                range_tombstones: range_ts
+                    .into_iter()
+                    .map(|(start, end, ts, _)| RangeTombstone { start, end, ts })
+                    .collect(),
+                max_ts,
+            },
         ))
     }
 
@@ -302,13 +731,14 @@ impl Wal {
             return file.write_all(&buf).context("failed to write to WAL");
         }
 
-        // Encode entries directly into the final buffer, leaving space for
-        // the header.  This avoids a separate entries_buf allocation and copy.
-        let entries_size: usize = data.iter().map(|(k, v)| 4 + k.len() + v.len()).sum();
+        // v3: typed entries with Put kind prefix.
+        // Each entry: [kind:1=0][key_len:2][key][value_len:2][value]
+        let entries_size: usize = data.iter().map(|(k, v)| 5 + k.len() + v.len()).sum();
         let mut buf = Vec::with_capacity(BATCH_HEADER_SIZE + entries_size);
         buf.resize(BATCH_HEADER_SIZE, 0); // reserve header space
 
         for (key, value) in data {
+            buf.put_u8(WalEntryKind::Put as u8);
             buf.put_u16(u16::try_from(key.len()).context("key length exceeds u16::MAX")?);
             buf.put(*key);
             buf.put_u16(u16::try_from(value.len()).context("value length exceeds u16::MAX")?);
@@ -324,6 +754,62 @@ impl Wal {
         header.put_u32(crc);
 
         file.write_all(&buf).context("failed to write WAL batch")
+    }
+
+    /// Write a batch of range tombstones as a single atomic WAL record.
+    ///
+    /// Each entry is encoded as: `[kind:1=2][start_len:2][start][end_len:2][end]`.
+    /// The `commit_ts` is shared across all entries in the batch.
+    pub fn put_range_tombstone_batch(
+        &self,
+        tombstones: &[(&[u8], &[u8])],
+        commit_ts: u64,
+    ) -> Result<()> {
+        anyhow::ensure!(
+            self.mvcc_format,
+            "range tombstone batches require MVCC WAL format"
+        );
+        for (start, end) in tombstones {
+            anyhow::ensure!(
+                start.len() <= u16::MAX as usize,
+                "WAL range tombstone start too large: {} bytes (max {})",
+                start.len(),
+                u16::MAX
+            );
+            anyhow::ensure!(
+                end.len() <= u16::MAX as usize,
+                "WAL range tombstone end too large: {} bytes (max {})",
+                end.len(),
+                u16::MAX
+            );
+        }
+        let entry_count =
+            u32::try_from(tombstones.len()).context("batch entry count exceeds u32::MAX")?;
+        let mut file = self.file.lock();
+
+        // v3: typed entries with RangeTombstone kind prefix.
+        // Each entry: [kind:1=2][start_len:2][start][end_len:2][end]
+        let entries_size: usize = tombstones.iter().map(|(s, e)| 5 + s.len() + e.len()).sum();
+        let mut buf = Vec::with_capacity(BATCH_HEADER_SIZE + entries_size);
+        buf.resize(BATCH_HEADER_SIZE, 0); // reserve header space
+
+        for (start, end) in tombstones {
+            buf.put_u8(WalEntryKind::RangeTombstone as u8);
+            buf.put_u16(u16::try_from(start.len()).context("start length exceeds u16::MAX")?);
+            buf.put(*start);
+            buf.put_u16(u16::try_from(end.len()).context("end length exceeds u16::MAX")?);
+            buf.put(*end);
+        }
+
+        let crc = crc32fast::hash(&buf[BATCH_HEADER_SIZE..]);
+
+        let mut header = &mut buf[0..BATCH_HEADER_SIZE];
+        header.put_u64(commit_ts);
+        header.put_u32(entry_count);
+        header.put_u32(crc);
+
+        file.write_all(&buf)
+            .context("failed to write WAL range tombstone batch")
     }
 
     pub fn sync(&self) -> Result<()> {


### PR DESCRIPTION
## Summary

Phase 1 of the DeleteRange feature (RFC §10). Adds the foundational infrastructure for range tombstones without changing the read path or SST format — those come in Phases 2–3.

## Changes

**New file: `range_tombstone.rs`**
- `RangeTombstone` / `RangeTombstoneKey` / `RangeTombstoneSet` (crossbeam SkipMap)
- Overlap detection, visibility queries (`newest_covering_ts`), `iter_overlapping`

**WAL v3 (backward-compatible with v2)**
- Typed entries with kind prefix: Put=0, PointTombstone=1, RangeTombstone=2
- `put_range_tombstone_batch` writes range tombstone entries
- Recovery decodes both v2 and v3; range tombstones skipped in legacy `recover()`, populated via `recover_with_range_tombstones`

**Manifest v4 (from v3)**
- Eager v3→v4 upgrade at database open, before new WAL creation (RFC §8.3 ordering)

**MemTable integration**
- `range_tombstones: RangeTombstoneSet` field
- `put_range_tombstone` is WAL-durable (writes + syncs before publishing)
- Flush guard refuses to flush if range tombstones present (until Phase 3 SST v4)

**WriteBatch / MVCC**
- `DelRange(start, end)` variant in `WriteBatchRecord`
- Mixed point/range batches rejected; serializable mode guarded
- `write_range_batch` allocates single `commit_ts` with sequential ordinals for atomicity

## Verification

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -D warnings` — 0 warnings
- [x] `cargo test` — 418 tests pass (412 existing + 6 new)
- [x] 3-round adversarial subagent review completed, all critical/major findings fixed

## What's next

Phase 2: Memtable read path integration (fragmenter, `ImmutableRangeTombstoneSet`, get/scan/prefix_scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added range tombstones, including MVP range-delete APIs and a new range-tombstone data set.
  * Manifest format updated to **v4**, and WAL now supports **v3** typed batches for range tombstones with recovery.
  * MVCC/memtable now track range tombstones and detect range overlaps.
* **Bug Fixes**
  * Improved recovery to restore range tombstones consistently.
* **Tests**
  * Added unit and WAL tests for range-tombstone and mixed-operation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->