### PR TITLE
feat: DeleteRange Phase 2 — memtable read path and fragmenter

### DIFF
--- a/kv-engine/src/lsm_iterator.rs
+++ b/kv-engine/src/lsm_iterator.rs
@@ -35,6 +35,10 @@ pub struct LsmIterator {
     /// Merged range-tombstone iterator for scan-path visibility checks.
     /// When present, point versions covered by a range tombstone are skipped.
     range_ts_iter: Option<RangeTombstoneIterator>,
+    /// Reusable buffer for encoded user keys — avoids allocation on every `next()`.
+    tmp_encoded_key: Vec<u8>,
+    /// Reusable buffer for decoded user keys — avoids allocation on every `next()`.
+    tmp_decoded_key: Vec<u8>,
 }
 
 impl LsmIterator {
@@ -45,8 +49,16 @@ impl LsmIterator {
         range_ts_iter: Option<RangeTombstoneIterator>,
     ) -> Result<Self> {
         let mut iter = iter;
+        let mut tmp_encoded_key = Vec::new();
+        let mut tmp_decoded_key = Vec::new();
         // Skip tombstones and versions beyond read_ts at the start
-        Self::skip_tombstones(&mut iter, read_ts, range_ts_iter.as_ref())?;
+        Self::skip_tombstones(
+            &mut iter,
+            read_ts,
+            range_ts_iter.as_ref(),
+            &mut tmp_encoded_key,
+            &mut tmp_decoded_key,
+        )?;
 
         let (user_key, encoded_user_key) = if iter.is_valid() && TS_ENABLED {
             (
@@ -64,6 +76,8 @@ impl LsmIterator {
             encoded_user_key,
             read_ts,
             range_ts_iter,
+            tmp_encoded_key,
+            tmp_decoded_key,
         })
     }
 
@@ -81,9 +95,9 @@ impl LsmIterator {
         iter: &mut LsmIteratorInner,
         read_ts: Option<u64>,
         range_ts_iter: Option<&RangeTombstoneIterator>,
+        encoded_user_key: &mut Vec<u8>,
+        decoded_user_key: &mut Vec<u8>,
     ) -> Result<()> {
-        let mut encoded_user_key = Vec::new();
-        let mut decoded_user_key = Vec::new();
         while iter.is_valid() {
             // Extract the current encoded user key once per user-key group
             // and reuse it in both the read_ts filtering and tombstone skip.
@@ -95,7 +109,7 @@ impl LsmIterator {
                 // Range tombstones store raw user keys, not memcomparable form.
                 if range_ts_iter.is_some() {
                     decoded_user_key.clear();
-                    iter.key().decode_user_key_into(&mut decoded_user_key);
+                    iter.key().decode_user_key_into(decoded_user_key);
                 }
             }
             // Skip versions invisible to this snapshot
@@ -139,7 +153,7 @@ impl LsmIterator {
             {
                 let point_ts = crate::key::extract_ts(iter.key().raw_ref()).unwrap_or(0);
                 if rt_iter
-                    .newest_covering_ts(&decoded_user_key, rts)
+                    .newest_covering_ts(decoded_user_key, rts)
                     .is_some_and(|cover_ts| point_ts <= cover_ts)
                 {
                     // Covered — skip all versions of this user key
@@ -196,7 +210,13 @@ impl StorageIterator for LsmIterator {
                 self.inner.next()?;
             }
             // Skip tombstones and invisible versions of the next user key(s)
-            Self::skip_tombstones(&mut self.inner, self.read_ts, self.range_ts_iter.as_ref())?;
+            Self::skip_tombstones(
+                &mut self.inner,
+                self.read_ts,
+                self.range_ts_iter.as_ref(),
+                &mut self.tmp_encoded_key,
+                &mut self.tmp_decoded_key,
+            )?;
             // Update cached user keys (decoded for key(), encoded for next())
             if self.inner.is_valid() {
                 self.inner.key().decode_user_key_into(&mut self.user_key);

--- a/kv-engine/src/lsm_iterator.rs
+++ b/kv-engine/src/lsm_iterator.rs
@@ -94,7 +94,8 @@ impl LsmIterator {
                 // Decode to raw user key only when range tombstones are present.
                 // Range tombstones store raw user keys, not memcomparable form.
                 if range_ts_iter.is_some() {
-                    crate::key::decode_user_key_into(&encoded_user_key, &mut decoded_user_key);
+                    decoded_user_key.clear();
+                    iter.key().decode_user_key_into(&mut decoded_user_key);
                 }
             }
             // Skip versions invisible to this snapshot

--- a/kv-engine/src/lsm_iterator.rs
+++ b/kv-engine/src/lsm_iterator.rs
@@ -195,11 +195,7 @@ impl StorageIterator for LsmIterator {
                 self.inner.next()?;
             }
             // Skip tombstones and invisible versions of the next user key(s)
-            Self::skip_tombstones(
-                &mut self.inner,
-                self.read_ts,
-                self.range_ts_iter.as_ref(),
-            )?;
+            Self::skip_tombstones(&mut self.inner, self.read_ts, self.range_ts_iter.as_ref())?;
             // Update cached user keys (decoded for key(), encoded for next())
             if self.inner.is_valid() {
                 self.inner.key().decode_user_key_into(&mut self.user_key);

--- a/kv-engine/src/lsm_iterator.rs
+++ b/kv-engine/src/lsm_iterator.rs
@@ -108,7 +108,6 @@ impl LsmIterator {
                 // Decode to raw user key only when range tombstones are present.
                 // Range tombstones store raw user keys, not memcomparable form.
                 if range_ts_iter.is_some() {
-                    decoded_user_key.clear();
                     iter.key().decode_user_key_into(decoded_user_key);
                 }
             }

--- a/kv-engine/src/lsm_iterator.rs
+++ b/kv-engine/src/lsm_iterator.rs
@@ -10,6 +10,7 @@ use crate::{
     key::TS_ENABLED,
     mem_table::MemTableIterator,
     mvcc::ReadGuard,
+    range_tombstone::RangeTombstoneIterator,
     table::SsTableIterator,
 };
 
@@ -31,6 +32,9 @@ pub struct LsmIterator {
     /// MVCC read timestamp — if set, versions with `ts > read_ts` are skipped
     /// so the iterator only yields versions visible at this snapshot.
     read_ts: Option<u64>,
+    /// Merged range-tombstone iterator for scan-path visibility checks.
+    /// When present, point versions covered by a range tombstone are skipped.
+    range_ts_iter: Option<RangeTombstoneIterator>,
 }
 
 impl LsmIterator {
@@ -38,10 +42,11 @@ impl LsmIterator {
         iter: LsmIteratorInner,
         upper: Bound<Vec<u8>>,
         read_ts: Option<u64>,
+        range_ts_iter: Option<RangeTombstoneIterator>,
     ) -> Result<Self> {
         let mut iter = iter;
         // Skip tombstones and versions beyond read_ts at the start
-        Self::skip_tombstones(&mut iter, read_ts)?;
+        Self::skip_tombstones(&mut iter, read_ts, range_ts_iter.as_ref())?;
 
         let (user_key, encoded_user_key) = if iter.is_valid() && TS_ENABLED {
             (
@@ -58,6 +63,7 @@ impl LsmIterator {
             user_key,
             encoded_user_key,
             read_ts,
+            range_ts_iter,
         })
     }
 
@@ -69,15 +75,27 @@ impl LsmIterator {
     /// Skip entries with empty values (tombstones) and versions beyond `read_ts`.
     /// When MVCC is enabled, skip all versions of a dead user key, and for
     /// each user key skip versions with `ts > read_ts` (invisible to this
-    /// snapshot) until we find one at or below `read_ts`.
-    fn skip_tombstones(iter: &mut LsmIteratorInner, read_ts: Option<u64>) -> Result<()> {
+    /// snapshot) until we find one at or below `read_ts`. Also skips point
+    /// versions covered by a range tombstone.
+    fn skip_tombstones(
+        iter: &mut LsmIteratorInner,
+        read_ts: Option<u64>,
+        range_ts_iter: Option<&RangeTombstoneIterator>,
+    ) -> Result<()> {
         let mut encoded_user_key = Vec::new();
+        let mut decoded_user_key = Vec::new();
         while iter.is_valid() {
             // Extract the current encoded user key once per user-key group
             // and reuse it in both the read_ts filtering and tombstone skip.
             encoded_user_key.clear();
+            decoded_user_key.clear();
             if TS_ENABLED {
                 encoded_user_key.extend_from_slice(iter.key().encoded_user_key());
+                // Decode to raw user key only when range tombstones are present.
+                // Range tombstones store raw user keys, not memcomparable form.
+                if range_ts_iter.is_some() {
+                    crate::key::decode_user_key_into(&encoded_user_key, &mut decoded_user_key);
+                }
             }
             // Skip versions invisible to this snapshot
             if TS_ENABLED && let Some(rts) = read_ts {
@@ -97,19 +115,42 @@ impl LsmIterator {
                     continue;
                 }
             }
-            if !Self::is_tombstone_value(iter.value()) {
-                return Ok(());
-            }
-            // Tombstone — skip all versions of this dead user key
-            if TS_ENABLED {
-                while iter.is_valid()
-                    && iter.key().encoded_user_key() == encoded_user_key.as_slice()
-                {
+            if Self::is_tombstone_value(iter.value()) {
+                // Point tombstone — skip all versions of this dead user key
+                if TS_ENABLED {
+                    while iter.is_valid()
+                        && iter.key().encoded_user_key() == encoded_user_key.as_slice()
+                    {
+                        iter.next()?;
+                    }
+                } else {
                     iter.next()?;
                 }
-            } else {
-                iter.next()?;
+                continue;
             }
+            // Range tombstone check: if a range tombstone covers this key at
+            // a timestamp >= the point version's timestamp, skip all versions.
+            // Uses decoded_user_key (raw form) because range tombstones store
+            // raw user keys, not memcomparable-encoded form.
+            if TS_ENABLED
+                && let Some(rt_iter) = range_ts_iter
+                && let Some(rts) = read_ts
+            {
+                let point_ts = crate::key::extract_ts(iter.key().raw_ref()).unwrap_or(0);
+                if rt_iter
+                    .newest_covering_ts(&decoded_user_key, rts)
+                    .is_some_and(|cover_ts| point_ts <= cover_ts)
+                {
+                    // Covered — skip all versions of this user key
+                    while iter.is_valid()
+                        && iter.key().encoded_user_key() == encoded_user_key.as_slice()
+                    {
+                        iter.next()?;
+                    }
+                    continue;
+                }
+            }
+            return Ok(());
         }
         Ok(())
     }
@@ -154,7 +195,11 @@ impl StorageIterator for LsmIterator {
                 self.inner.next()?;
             }
             // Skip tombstones and invisible versions of the next user key(s)
-            Self::skip_tombstones(&mut self.inner, self.read_ts)?;
+            Self::skip_tombstones(
+                &mut self.inner,
+                self.read_ts,
+                self.range_ts_iter.as_ref(),
+            )?;
             // Update cached user keys (decoded for key(), encoded for next())
             if self.inner.is_valid() {
                 self.inner.key().decode_user_key_into(&mut self.user_key);

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1188,8 +1188,7 @@ impl LsmStorageInner {
         };
         // Pre-compute the newest range tombstone ts once for both memtable and
         // SST checks — avoids redundant scans of all memtables.
-        let range_ts =
-            mvcc_read_ts.and_then(|rts| self.newest_memtable_range_ts(&state, key, rts));
+        let range_ts = mvcc_read_ts.and_then(|rts| self.newest_memtable_range_ts(&state, key, rts));
         // Check memtable first — route through resolve_vlog_value_bytes for
         // zero-copy inline slicing (refcount bump instead of heap allocation).
         if let Some((value, kind, found_key, value_ts)) =
@@ -1817,8 +1816,7 @@ impl LsmStorageInner {
                     return Ok(Some((val, kind, found_key, vts)));
                 }
                 for m in state.imm_memtables.iter() {
-                    if let Some((raw, found_key)) =
-                        m.get_versioned_raw_with_key(&user_key, read_ts)
+                    if let Some((raw, found_key)) = m.get_versioned_raw_with_key(&user_key, read_ts)
                     {
                         let (val, kind) = Self::parse_value_kind(raw);
                         let vts = crate::key::extract_ts(&found_key).unwrap_or(0);

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1630,7 +1630,8 @@ impl LsmStorageInner {
             } else {
                 Vec::new()
             };
-            let mut lists: Vec<&[crate::range_tombstone::RangeTombstoneFragment]> = Vec::new();
+            let mut lists: Vec<&[crate::range_tombstone::RangeTombstoneFragment]> =
+                Vec::with_capacity(1 + state.imm_memtables.len());
             if !active_frags.is_empty() {
                 lists.push(&active_frags);
             }

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1739,28 +1739,20 @@ impl LsmStorageInner {
         user_key: &[u8],
         read_ts: u64,
     ) -> Option<u64> {
-        let mut best_ts: Option<u64> = None;
-
         // Active memtable: raw scan (no shared fragment cache).
         let active_ts = state
             .memtable
             .range_tombstones()
             .newest_covering_ts(user_key, read_ts);
-        if active_ts.is_some() {
-            best_ts = active_ts;
-        }
 
         // Immutable memtables: cached fragment view.
-        for m in state.imm_memtables.iter() {
-            if let Some(imm) = m.imm_range_tombstones() {
-                let ts = imm.newest_covering_ts(user_key, read_ts);
-                if ts.is_some() && (best_ts.is_none() || ts > best_ts) {
-                    best_ts = ts;
-                }
-            }
-        }
-
-        best_ts
+        // Option<u64> implements Ord, so max correctly handles None cases.
+        state.imm_memtables.iter().fold(active_ts, |best_ts, m| {
+            let imm_ts = m
+                .imm_range_tombstones()
+                .and_then(|imm| imm.newest_covering_ts(user_key, read_ts));
+            best_ts.max(imm_ts)
+        })
     }
 
     /// Shared memtable lookup used by `get()` and `get_with_kind_inner()`.

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1630,19 +1630,16 @@ impl LsmStorageInner {
             } else {
                 Vec::new()
             };
-            // Keep Arc alive for the duration of the merge.
-            let imm_arcs: Vec<Arc<[crate::range_tombstone::RangeTombstoneFragment]>> = state
-                .imm_memtables
-                .iter()
-                .filter_map(|m| m.imm_range_tombstones().map(|imm| imm.fragments().clone()))
-                .collect();
             let mut lists: Vec<&[crate::range_tombstone::RangeTombstoneFragment]> = Vec::new();
             if !active_frags.is_empty() {
                 lists.push(&active_frags);
             }
-            for arc in &imm_arcs {
-                if !arc.is_empty() {
-                    lists.push(arc);
+            for m in &state.imm_memtables {
+                if let Some(imm) = m.imm_range_tombstones() {
+                    let frags = imm.fragments();
+                    if !frags.is_empty() {
+                        lists.push(frags);
+                    }
                 }
             }
             if lists.is_empty() {

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1624,8 +1624,13 @@ impl LsmStorageInner {
         // Build merged range-tombstone fragments from all memtables.
         // Active memtable: private per-scan fragments (no shared cache).
         // Immutable memtables: shared cached fragments (borrowed, not cloned).
-        let range_ts_iter = if mvcc_read_ts.is_some() {
-            let active_frags = if !state.memtable.range_tombstones().is_empty() {
+        let has_active = !state.memtable.range_tombstones().is_empty();
+        let has_imm = state
+            .imm_memtables
+            .iter()
+            .any(|m| m.imm_range_tombstones().is_some());
+        let range_ts_iter = if mvcc_read_ts.is_some() && (has_active || has_imm) {
+            let active_frags = if has_active {
                 crate::range_tombstone::fragment_range(state.memtable.range_tombstones().raw())
             } else {
                 Vec::new()

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1634,7 +1634,7 @@ impl LsmStorageInner {
             let imm_arcs: Vec<Arc<[crate::range_tombstone::RangeTombstoneFragment]>> = state
                 .imm_memtables
                 .iter()
-                .filter_map(|m| m.imm_range_tombstones().map(|imm| imm.fragments()))
+                .filter_map(|m| m.imm_range_tombstones().map(|imm| imm.fragments().clone()))
                 .collect();
             let mut lists: Vec<&[crate::range_tombstone::RangeTombstoneFragment]> = Vec::new();
             if !active_frags.is_empty() {

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1195,10 +1195,11 @@ impl LsmStorageInner {
             self.lookup_memtable(&state, encoded, bloom_hash, mvcc_read_ts)?
         {
             if range_ts.is_some_and(|rt| value_ts <= rt) {
-                // Covered by range tombstone — fall through to SST lookup.
-            } else {
-                return self.resolve_value(&found_key, value, kind);
+                // Covered by range tombstone — any SST version is older and
+                // also covered, so return immediately.
+                return Ok(None);
             }
+            return self.resolve_value(&found_key, value, kind);
         }
         // SST path — delegate to get_with_kind_inner which uses lookup_sst_raw.
         if let Some((value, kind, found_key, value_ts)) =
@@ -1398,10 +1399,9 @@ impl LsmStorageInner {
             self.lookup_memtable(&state, &lookup_key, bloom_hash, Some(read_ts))?
         {
             if range_ts.is_some_and(|rt| value_ts <= rt) {
-                // Covered — fall through to SST lookup.
-            } else {
-                return self.resolve_value(&found_key, value, kind);
+                return Ok(None);
             }
+            return self.resolve_value(&found_key, value, kind);
         }
         if let Some((value, kind, found_key, value_ts)) =
             self.lookup_sst_raw(&state, &lookup_key, bloom_hash, Some(read_ts))?
@@ -1623,23 +1623,32 @@ impl LsmStorageInner {
 
         // Build merged range-tombstone fragments from all memtables.
         // Active memtable: private per-scan fragments (no shared cache).
-        // Immutable memtables: shared cached fragments.
+        // Immutable memtables: shared cached fragments (borrowed, not cloned).
         let range_ts_iter = if mvcc_read_ts.is_some() {
-            let mut all_fragments = Vec::new();
-            if !state.memtable.range_tombstones().is_empty() {
-                let frags =
-                    crate::range_tombstone::fragment_range(state.memtable.range_tombstones().raw());
-                all_fragments.extend(frags);
+            let active_frags = if !state.memtable.range_tombstones().is_empty() {
+                crate::range_tombstone::fragment_range(state.memtable.range_tombstones().raw())
+            } else {
+                Vec::new()
+            };
+            // Keep Arc alive for the duration of the merge.
+            let imm_arcs: Vec<Arc<[crate::range_tombstone::RangeTombstoneFragment]>> = state
+                .imm_memtables
+                .iter()
+                .filter_map(|m| m.imm_range_tombstones().map(|imm| imm.fragments()))
+                .collect();
+            let mut lists: Vec<&[crate::range_tombstone::RangeTombstoneFragment]> = Vec::new();
+            if !active_frags.is_empty() {
+                lists.push(&active_frags);
             }
-            for m in state.imm_memtables.iter() {
-                if let Some(imm) = m.imm_range_tombstones() {
-                    all_fragments.extend(imm.fragments().iter().cloned());
+            for arc in &imm_arcs {
+                if !arc.is_empty() {
+                    lists.push(arc);
                 }
             }
-            if all_fragments.is_empty() {
+            if lists.is_empty() {
                 None
             } else {
-                let merged = crate::range_tombstone::merge_fragment_lists(&[all_fragments]);
+                let merged = crate::range_tombstone::merge_fragment_lists(&lists);
                 Some(crate::range_tombstone::RangeTombstoneIterator::new(
                     Arc::from(merged),
                 ))
@@ -1710,10 +1719,9 @@ impl LsmStorageInner {
             self.lookup_memtable(state, encoded, bloom_hash, mvcc_read_ts)?
         {
             if range_ts.is_some_and(|rt| value_ts <= rt) {
-                // Covered — fall through to SST lookup.
-            } else {
-                return Ok((val, kind));
+                return Ok((None, KvKind::Inline));
             }
+            return Ok((val, kind));
         }
         if let Some((val, kind, _key, value_ts)) =
             self.lookup_sst_raw(state, encoded, bloom_hash, mvcc_read_ts)?

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1188,7 +1188,7 @@ impl LsmStorageInner {
         };
         // Pre-compute the newest range tombstone ts once for both memtable and
         // SST checks — avoids redundant scans of all memtables.
-        let range_ts = mvcc_read_ts.and_then(|rts| self.newest_memtable_range_ts(&state, key, rts));
+        let range_ts = self.newest_memtable_range_ts(&state, key, mvcc_read_ts.unwrap_or(u64::MAX));
         // Check memtable first — route through resolve_vlog_value_bytes for
         // zero-copy inline slicing (refcount bump instead of heap allocation).
         if let Some((value, kind, found_key, value_ts)) =
@@ -1712,7 +1712,7 @@ impl LsmStorageInner {
         } else {
             key
         };
-        let range_ts = mvcc_read_ts.and_then(|rts| self.newest_memtable_range_ts(state, key, rts));
+        let range_ts = self.newest_memtable_range_ts(state, key, mvcc_read_ts.unwrap_or(u64::MAX));
         if let Some((val, kind, _key, value_ts)) =
             self.lookup_memtable(state, encoded, bloom_hash, mvcc_read_ts)?
         {

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -43,8 +43,9 @@ pub type CasEntry = (Vec<u8>, Vec<u8>, KvKind, Vec<u8>, KvKind);
 /// Versioned CAS entry: `(user_key, ts, old_value, old_kind, new_value, new_kind)`.
 pub type VersionedCasEntry = (Vec<u8>, u64, Vec<u8>, KvKind, Vec<u8>, KvKind);
 
-/// Lookup result: `(value, kind, found_internal_key)`.
-type LookupResult = (Option<Bytes>, KvKind, Vec<u8>);
+/// Lookup result: `(value, kind, found_internal_key, version_ts)`.
+/// `version_ts` is the MVCC timestamp of the found version (0 when MVCC disabled).
+type LookupResult = (Option<Bytes>, KvKind, Vec<u8>, u64);
 
 /// Represents the state of the storage engine.
 #[derive(Clone)]
@@ -912,6 +913,7 @@ impl LsmStorageInner {
                         max_commit_ts = wal_max_ts;
                     }
                     if !m.is_empty() {
+                        m.freeze_range_tombstones();
                         state.imm_memtables.insert(0, Arc::new(m));
                     }
                 }
@@ -1184,17 +1186,28 @@ impl LsmStorageInner {
         } else {
             key
         };
+        // Pre-compute the newest range tombstone ts once for both memtable and
+        // SST checks — avoids redundant scans of all memtables.
+        let range_ts =
+            mvcc_read_ts.and_then(|rts| self.newest_memtable_range_ts(&state, key, rts));
         // Check memtable first — route through resolve_vlog_value_bytes for
         // zero-copy inline slicing (refcount bump instead of heap allocation).
-        if let Some((value, kind, found_key)) =
+        if let Some((value, kind, found_key, value_ts)) =
             self.lookup_memtable(&state, encoded, bloom_hash, mvcc_read_ts)?
         {
-            return self.resolve_value(&found_key, value, kind);
+            if range_ts.is_some_and(|rt| value_ts <= rt) {
+                // Covered by range tombstone — fall through to SST lookup.
+            } else {
+                return self.resolve_value(&found_key, value, kind);
+            }
         }
         // SST path — delegate to get_with_kind_inner which uses lookup_sst_raw.
-        if let Some((value, kind, found_key)) =
+        if let Some((value, kind, found_key, value_ts)) =
             self.lookup_sst_raw(&state, encoded, bloom_hash, mvcc_read_ts)?
         {
+            if range_ts.is_some_and(|rt| value_ts <= rt) {
+                return Ok(None);
+            }
             return self.resolve_value(&found_key, value, kind);
         }
 
@@ -1381,14 +1394,22 @@ impl LsmStorageInner {
         let state = self.state.load();
         let bloom_hash = crate::table::bloom::hash_key(key);
         let lookup_key = crate::key::encode_internal_key(key, u64::MAX);
-        if let Some((value, kind, found_key)) =
+        let range_ts = self.newest_memtable_range_ts(&state, key, read_ts);
+        if let Some((value, kind, found_key, value_ts)) =
             self.lookup_memtable(&state, &lookup_key, bloom_hash, Some(read_ts))?
         {
-            return self.resolve_value(&found_key, value, kind);
+            if range_ts.is_some_and(|rt| value_ts <= rt) {
+                // Covered — fall through to SST lookup.
+            } else {
+                return self.resolve_value(&found_key, value, kind);
+            }
         }
-        if let Some((value, kind, found_key)) =
+        if let Some((value, kind, found_key, value_ts)) =
             self.lookup_sst_raw(&state, &lookup_key, bloom_hash, Some(read_ts))?
         {
+            if range_ts.is_some_and(|rt| value_ts <= rt) {
+                return Ok(None);
+            }
             return self.resolve_value(&found_key, value, kind);
         }
 
@@ -1600,7 +1621,35 @@ impl LsmStorageInner {
         }
         let m_iter = MergeIterator::create(concat_iters);
         let two_m = TwoMergeIterator::create(two_l0_iter, m_iter)?;
-        let lit = LsmIterator::new(two_m, Self::into_vec(upper), mvcc_read_ts)?;
+
+        // Build merged range-tombstone fragments from all memtables.
+        // Active memtable: private per-scan fragments (no shared cache).
+        // Immutable memtables: shared cached fragments.
+        let range_ts_iter = if mvcc_read_ts.is_some() {
+            let mut all_fragments = Vec::new();
+            if !state.memtable.range_tombstones().is_empty() {
+                let frags =
+                    crate::range_tombstone::fragment_range(state.memtable.range_tombstones().raw());
+                all_fragments.extend(frags);
+            }
+            for m in state.imm_memtables.iter() {
+                if let Some(imm) = m.imm_range_tombstones() {
+                    all_fragments.extend(imm.fragments().iter().cloned());
+                }
+            }
+            if all_fragments.is_empty() {
+                None
+            } else {
+                let merged = crate::range_tombstone::merge_fragment_lists(&[all_fragments]);
+                Some(crate::range_tombstone::RangeTombstoneIterator::new(
+                    Arc::from(merged),
+                ))
+            }
+        } else {
+            None
+        };
+
+        let lit = LsmIterator::new(two_m, Self::into_vec(upper), mvcc_read_ts, range_ts_iter)?;
 
         Ok(FusedIterator::new(lit))
     }
@@ -1657,18 +1706,69 @@ impl LsmStorageInner {
         } else {
             key
         };
-        if let Some((val, kind, _key)) =
+        if let Some((val, kind, _key, value_ts)) =
             self.lookup_memtable(state, encoded, bloom_hash, mvcc_read_ts)?
         {
-            return Ok((val, kind));
+            if let Some(rts) = mvcc_read_ts {
+                let range_ts = self.newest_memtable_range_ts(state, key, rts);
+                if range_ts.is_some_and(|rt| value_ts <= rt) {
+                    // Covered — fall through to SST lookup.
+                } else {
+                    return Ok((val, kind));
+                }
+            } else {
+                return Ok((val, kind));
+            }
         }
-        if let Some((val, kind, _key)) =
+        if let Some((val, kind, _key, value_ts)) =
             self.lookup_sst_raw(state, encoded, bloom_hash, mvcc_read_ts)?
         {
+            if let Some(rts) = mvcc_read_ts {
+                let range_ts = self.newest_memtable_range_ts(state, key, rts);
+                if range_ts.is_some_and(|rt| value_ts <= rt) {
+                    return Ok((None, KvKind::Inline));
+                }
+            }
             return Ok((val, kind));
         }
 
         Ok((None, KvKind::Inline))
+    }
+
+    /// Find the newest range-tombstone timestamp covering `user_key` across
+    /// all memtables (active + immutable) at `read_ts`.
+    ///
+    /// Returns `Some(ts)` if any memtable range tombstone covers the key.
+    /// The active memtable queries raw tombstones directly (O(R)); immutable
+    /// memtables use their cached fragment view (O(log F)).
+    fn newest_memtable_range_ts(
+        &self,
+        state: &LsmStorageState,
+        user_key: &[u8],
+        read_ts: u64,
+    ) -> Option<u64> {
+        let mut best_ts: Option<u64> = None;
+
+        // Active memtable: raw scan (no shared fragment cache).
+        let active_ts = state
+            .memtable
+            .range_tombstones()
+            .newest_covering_ts(user_key, read_ts);
+        if active_ts.is_some() {
+            best_ts = active_ts;
+        }
+
+        // Immutable memtables: cached fragment view.
+        for m in state.imm_memtables.iter() {
+            if let Some(imm) = m.imm_range_tombstones() {
+                let ts = imm.newest_covering_ts(user_key, read_ts);
+                if ts.is_some() && (best_ts.is_none() || ts > best_ts) {
+                    best_ts = ts;
+                }
+            }
+        }
+
+        best_ts
     }
 
     /// Shared memtable lookup used by `get()` and `get_with_kind_inner()`.
@@ -1694,28 +1794,35 @@ impl LsmStorageInner {
                     .get_versioned_raw_with_key(&user_key, read_ts)
                 {
                     let (val, kind) = Self::parse_value_kind(raw);
-                    return Ok(Some((val, kind, found_key)));
+                    let vts = crate::key::extract_ts(&found_key).unwrap_or(0);
+                    return Ok(Some((val, kind, found_key, vts)));
                 }
                 for m in state.imm_memtables.iter() {
                     if let Some((raw, found_key)) = m.get_versioned_raw_with_key(&user_key, read_ts)
                     {
                         let (val, kind) = Self::parse_value_kind(raw);
-                        return Ok(Some((val, kind, found_key)));
+                        let vts = crate::key::extract_ts(&found_key).unwrap_or(0);
+                        return Ok(Some((val, kind, found_key, vts)));
                     }
                 }
             } else {
-                if let Some(v) = state.memtable.get_versioned(&user_key, read_ts) {
-                    if Self::is_tombstone_value(&v) {
-                        return Ok(Some((None, KvKind::Inline, Vec::new())));
-                    }
-                    return Ok(Some((Some(v), KvKind::Inline, Vec::new())));
+                // Non-vlog MVCC path: use get_versioned_raw_with_key to also
+                // obtain the found key for version timestamp extraction.
+                if let Some((raw, found_key)) = state
+                    .memtable
+                    .get_versioned_raw_with_key(&user_key, read_ts)
+                {
+                    let (val, kind) = Self::parse_value_kind(raw);
+                    let vts = crate::key::extract_ts(&found_key).unwrap_or(0);
+                    return Ok(Some((val, kind, found_key, vts)));
                 }
                 for m in state.imm_memtables.iter() {
-                    if let Some(v) = m.get_versioned(&user_key, read_ts) {
-                        if Self::is_tombstone_value(&v) {
-                            return Ok(Some((None, KvKind::Inline, Vec::new())));
-                        }
-                        return Ok(Some((Some(v), KvKind::Inline, Vec::new())));
+                    if let Some((raw, found_key)) =
+                        m.get_versioned_raw_with_key(&user_key, read_ts)
+                    {
+                        let (val, kind) = Self::parse_value_kind(raw);
+                        let vts = crate::key::extract_ts(&found_key).unwrap_or(0);
+                        return Ok(Some((val, kind, found_key, vts)));
                     }
                 }
             }
@@ -1724,27 +1831,27 @@ impl LsmStorageInner {
             if vlog_enabled {
                 if let Some(raw) = state.memtable.get_raw_with_hash(key, bloom_hash) {
                     let (val, kind) = Self::parse_value_kind(raw);
-                    return Ok(Some((val, kind, key.to_vec())));
+                    return Ok(Some((val, kind, key.to_vec(), 0)));
                 }
                 for m in state.imm_memtables.iter() {
                     if let Some(raw) = m.get_raw_with_hash(key, bloom_hash) {
                         let (val, kind) = Self::parse_value_kind(raw);
-                        return Ok(Some((val, kind, key.to_vec())));
+                        return Ok(Some((val, kind, key.to_vec(), 0)));
                     }
                 }
             } else {
                 if let Some(v) = state.memtable.get_with_hash(key, bloom_hash) {
                     if Self::is_tombstone_value(&v) {
-                        return Ok(Some((None, KvKind::Inline, Vec::new())));
+                        return Ok(Some((None, KvKind::Inline, Vec::new(), 0)));
                     }
-                    return Ok(Some((Some(v), KvKind::Inline, Vec::new())));
+                    return Ok(Some((Some(v), KvKind::Inline, Vec::new(), 0)));
                 }
                 for m in state.imm_memtables.iter() {
                     if let Some(v) = m.get_with_hash(key, bloom_hash) {
                         if Self::is_tombstone_value(&v) {
-                            return Ok(Some((None, KvKind::Inline, Vec::new())));
+                            return Ok(Some((None, KvKind::Inline, Vec::new(), 0)));
                         }
-                        return Ok(Some((Some(v), KvKind::Inline, Vec::new())));
+                        return Ok(Some((Some(v), KvKind::Inline, Vec::new(), 0)));
                     }
                 }
             }
@@ -1755,8 +1862,8 @@ impl LsmStorageInner {
 
     /// Shared SST lookup for `get()` and `get_with_kind_inner()`.
     /// Searches L0 + leveled SSTs. Returns `Ok(None)` if not found.
-    /// Returns `Ok(Some((value, kind, found_key)))` with the parsed value,
-    /// kind, and the full encoded internal key of the matching entry.
+    /// Returns `Ok(Some((value, kind, found_key, version_ts)))` with the parsed
+    /// value, kind, the full encoded internal key, and the version timestamp.
     fn lookup_sst_raw(
         &self,
         state: &LsmStorageState,
@@ -1798,7 +1905,7 @@ impl LsmStorageInner {
                     && let Some(raw) = s.point_get_with_hash(key, bloom_hash)?
                 {
                     let (val, kind) = Self::parse_value_kind(raw);
-                    return Ok(Some((val, kind, key.to_vec())));
+                    return Ok(Some((val, kind, key.to_vec(), 0)));
                 }
             }
         }
@@ -1864,13 +1971,13 @@ impl LsmStorageInner {
                     && let Some(raw) = s.point_get_with_hash(key, bloom_hash)?
                 {
                     let (val, kind) = Self::parse_value_kind(raw);
-                    return Ok(Some((val, kind, key.to_vec())));
+                    return Ok(Some((val, kind, key.to_vec(), 0)));
                 }
             }
         }
-        if let Some((raw, _, found_key)) = best {
+        if let Some((raw, best_ts, found_key)) = best {
             let (val, kind) = Self::parse_value_kind(raw);
-            return Ok(Some((val, kind, found_key)));
+            return Ok(Some((val, kind, found_key, best_ts)));
         }
 
         Ok(None)
@@ -2441,6 +2548,9 @@ impl LsmStorageInner {
         let _guard = self.active_memtable_lock.write();
         let mut state = self.state.load().as_ref().clone();
         let m = std::mem::replace(&mut state.memtable, new_memtable.into());
+        // Build immutable range-tombstone fragment cache before sharing.
+        // OnceLock ensures exactly-once initialization even through &self.
+        m.freeze_range_tombstones();
         // make test happy. but why? kind of wired design decision
         state.imm_memtables.insert(0, m.clone());
         self.state.store(Arc::new(state));

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1705,16 +1705,12 @@ impl LsmStorageInner {
         } else {
             key
         };
+        let range_ts = mvcc_read_ts.and_then(|rts| self.newest_memtable_range_ts(state, key, rts));
         if let Some((val, kind, _key, value_ts)) =
             self.lookup_memtable(state, encoded, bloom_hash, mvcc_read_ts)?
         {
-            if let Some(rts) = mvcc_read_ts {
-                let range_ts = self.newest_memtable_range_ts(state, key, rts);
-                if range_ts.is_some_and(|rt| value_ts <= rt) {
-                    // Covered — fall through to SST lookup.
-                } else {
-                    return Ok((val, kind));
-                }
+            if range_ts.is_some_and(|rt| value_ts <= rt) {
+                // Covered — fall through to SST lookup.
             } else {
                 return Ok((val, kind));
             }
@@ -1722,11 +1718,8 @@ impl LsmStorageInner {
         if let Some((val, kind, _key, value_ts)) =
             self.lookup_sst_raw(state, encoded, bloom_hash, mvcc_read_ts)?
         {
-            if let Some(rts) = mvcc_read_ts {
-                let range_ts = self.newest_memtable_range_ts(state, key, rts);
-                if range_ts.is_some_and(|rt| value_ts <= rt) {
-                    return Ok((None, KvKind::Inline));
-                }
+            if range_ts.is_some_and(|rt| value_ts <= rt) {
+                return Ok((None, KvKind::Inline));
             }
             return Ok((val, kind));
         }

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -60,31 +60,10 @@ impl ImmutableRangeTombstoneSet {
 
     /// Find the newest covering tombstone timestamp for `user_key` at `read_ts`.
     ///
-    /// Uses binary search on the cached fragment view.
+    /// Delegates to `RangeTombstoneIterator::newest_covering_ts` to avoid
+    /// duplicating the binary-search logic.
     pub fn newest_covering_ts(&self, user_key: &[u8], read_ts: u64) -> Option<u64> {
-        let frags = self.fragments();
-        if frags.is_empty() {
-            return None;
-        }
-
-        // Binary search: find the last fragment with start <= user_key.
-        let idx = frags.partition_point(|f| f.start.as_ref() <= user_key);
-        // Check the fragment at idx-1 (if it exists).
-        if idx == 0 {
-            return None;
-        }
-        let frag = &frags[idx - 1];
-        // Verify user_key < end (half-open interval).
-        if user_key >= frag.end.as_ref() {
-            return None;
-        }
-        // Binary search within covering_ts for the newest ts <= read_ts.
-        let ts_idx = frag.covering_ts.partition_point(|&ts| ts <= read_ts);
-        if ts_idx > 0 {
-            Some(frag.covering_ts[ts_idx - 1])
-        } else {
-            None
-        }
+        self.iter().newest_covering_ts(user_key, read_ts)
     }
 
     /// Build a `RangeTombstoneIterator` for scan-path use.

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -59,10 +59,30 @@ impl ImmutableRangeTombstoneSet {
 
     /// Find the newest covering tombstone timestamp for `user_key` at `read_ts`.
     ///
-    /// Delegates to `RangeTombstoneIterator::newest_covering_ts` to avoid
-    /// duplicating the binary-search logic.
+    /// Performs binary search directly on the fragment slice to avoid cloning
+    /// the Arc on the hot point-lookup path.
     pub fn newest_covering_ts(&self, user_key: &[u8], read_ts: u64) -> Option<u64> {
-        self.iter().newest_covering_ts(user_key, read_ts)
+        let frags = self.fragments();
+        if frags.is_empty() {
+            return None;
+        }
+        // Binary search: find the last fragment with start <= user_key.
+        let idx = frags.partition_point(|f| f.start.as_ref() <= user_key);
+        if idx == 0 {
+            return None;
+        }
+        let frag = &frags[idx - 1];
+        // Verify user_key < end (half-open interval).
+        if user_key >= frag.end.as_ref() {
+            return None;
+        }
+        // Binary search within covering_ts for the newest ts <= read_ts.
+        let ts_idx = frag.covering_ts.partition_point(|&ts| ts <= read_ts);
+        if ts_idx > 0 {
+            Some(frag.covering_ts[ts_idx - 1])
+        } else {
+            None
+        }
     }
 
     /// Build a `RangeTombstoneIterator` for scan-path use.

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -59,30 +59,11 @@ impl ImmutableRangeTombstoneSet {
 
     /// Find the newest covering tombstone timestamp for `user_key` at `read_ts`.
     ///
-    /// Performs binary search directly on the fragment slice to avoid cloning
-    /// the Arc on the hot point-lookup path.
+    /// Delegates to [`crate::range_tombstone::find_newest_covering_ts`] to
+    /// avoid duplicating the binary-search logic.
     pub fn newest_covering_ts(&self, user_key: &[u8], read_ts: u64) -> Option<u64> {
         let frags = self.fragments();
-        if frags.is_empty() {
-            return None;
-        }
-        // Binary search: find the last fragment with start <= user_key.
-        let idx = frags.partition_point(|f| f.start.as_ref() <= user_key);
-        if idx == 0 {
-            return None;
-        }
-        let frag = &frags[idx - 1];
-        // Verify user_key < end (half-open interval).
-        if user_key >= frag.end.as_ref() {
-            return None;
-        }
-        // Binary search within covering_ts for the newest ts <= read_ts.
-        let ts_idx = frag.covering_ts.partition_point(|&ts| ts <= read_ts);
-        if ts_idx > 0 {
-            Some(frag.covering_ts[ts_idx - 1])
-        } else {
-            None
-        }
+        crate::range_tombstone::find_newest_covering_ts(frags, user_key, read_ts)
     }
 
     /// Build a `RangeTombstoneIterator` for scan-path use.

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -1,7 +1,7 @@
 use std::{
     ops::Bound,
     path::Path,
-    sync::{Arc, atomic::AtomicUsize},
+    sync::{Arc, OnceLock, atomic::AtomicUsize},
 };
 
 use anyhow::{Context, Ok, Result};
@@ -12,7 +12,10 @@ use ouroboros::self_referencing;
 use crate::{
     iterators::StorageIterator,
     key::{Key, KeySlice, shared_bytes_from_slice},
-    range_tombstone::RangeTombstoneSet,
+    range_tombstone::{
+        RangeTombstoneFragment, RangeTombstoneIterator, RangeTombstoneKey, RangeTombstoneSet,
+        fragment_range,
+    },
     table::{SsTableBuilder, bloom::IncrementalBloom},
     vlog::{KvKind, ValueLog, ValuePointer},
     wal::Wal,
@@ -22,6 +25,73 @@ use crate::{
 /// At 1KB values and 1MB SST target, ~1000 entries. We size generously.
 const BLOOM_EXPECTED_ENTRIES: usize = 4096;
 const BLOOM_FALSE_POSITIVE_RATE: f64 = 0.01;
+
+/// Immutable range-tombstone view for frozen memtables.
+///
+/// After a memtable is frozen, its range-tombstone set becomes read-only.
+/// This wrapper adds a lazily-built fragment cache (`OnceLock`) so that all
+/// readers of the same immutable memtable share the same fragmented view,
+/// avoiding the stale-install race that affects the active memtable.
+pub struct ImmutableRangeTombstoneSet {
+    /// Raw tombstone entries shared with the frozen memtable.
+    raw: Arc<SkipMap<RangeTombstoneKey, Bytes>>,
+    /// Lazily-built non-overlapping fragment view.
+    fragments: OnceLock<Arc<[RangeTombstoneFragment]>>,
+}
+
+impl ImmutableRangeTombstoneSet {
+    /// Wrap a `RangeTombstoneSet`'s raw skipmap into an immutable view.
+    pub fn from_range_tombstone_set(set: &RangeTombstoneSet) -> Self {
+        Self {
+            raw: Arc::clone(set.raw()),
+            fragments: OnceLock::new(),
+        }
+    }
+
+    /// Return the fragmented view, building it lazily on first access.
+    pub fn fragments(&self) -> Arc<[RangeTombstoneFragment]> {
+        self.fragments
+            .get_or_init(|| {
+                let frags = fragment_range(&self.raw);
+                Arc::from(frags)
+            })
+            .clone()
+    }
+
+    /// Find the newest covering tombstone timestamp for `user_key` at `read_ts`.
+    ///
+    /// Uses binary search on the cached fragment view.
+    pub fn newest_covering_ts(&self, user_key: &[u8], read_ts: u64) -> Option<u64> {
+        let frags = self.fragments();
+        if frags.is_empty() {
+            return None;
+        }
+
+        // Binary search: find the last fragment with start <= user_key.
+        let idx = frags.partition_point(|f| f.start.as_ref() <= user_key);
+        // Check the fragment at idx-1 (if it exists).
+        if idx == 0 {
+            return None;
+        }
+        let frag = &frags[idx - 1];
+        // Verify user_key < end (half-open interval).
+        if user_key >= frag.end.as_ref() {
+            return None;
+        }
+        // Binary search within covering_ts for the newest ts <= read_ts.
+        let ts_idx = frag.covering_ts.partition_point(|&ts| ts <= read_ts);
+        if ts_idx > 0 {
+            Some(frag.covering_ts[ts_idx - 1])
+        } else {
+            None
+        }
+    }
+
+    /// Build a `RangeTombstoneIterator` for scan-path use.
+    pub fn iter(&self) -> RangeTombstoneIterator {
+        RangeTombstoneIterator::new(self.fragments())
+    }
+}
 
 /// A basic mem-table based on crossbeam-skiplist.
 ///
@@ -38,6 +108,10 @@ pub struct MemTable {
     bloom: IncrementalBloom,
     /// Range tombstones stored in this memtable.
     range_tombstones: RangeTombstoneSet,
+    /// Immutable range-tombstone view with cached fragments, set after freeze.
+    /// Uses `OnceLock` for interior mutability so it can be initialized through
+    /// `&self` (the memtable may already be inside an `Arc` when frozen).
+    immutable_range_tombstones: OnceLock<ImmutableRangeTombstoneSet>,
 }
 
 /// Create a bound of `Bytes` from a bound of `&[u8]`.
@@ -60,6 +134,7 @@ impl MemTable {
             vlog_enabled: false,
             bloom: IncrementalBloom::new(BLOOM_EXPECTED_ENTRIES, BLOOM_FALSE_POSITIVE_RATE),
             range_tombstones: RangeTombstoneSet::new(),
+            immutable_range_tombstones: OnceLock::new(),
         }
     }
 
@@ -73,6 +148,7 @@ impl MemTable {
             vlog_enabled: true,
             bloom: IncrementalBloom::new(BLOOM_EXPECTED_ENTRIES, BLOOM_FALSE_POSITIVE_RATE),
             range_tombstones: RangeTombstoneSet::new(),
+            immutable_range_tombstones: OnceLock::new(),
         }
     }
 
@@ -625,6 +701,25 @@ impl MemTable {
     /// Access the range tombstone set for this memtable.
     pub fn range_tombstones(&self) -> &RangeTombstoneSet {
         &self.range_tombstones
+    }
+
+    /// Freeze the range tombstones into an immutable view with cached fragments.
+    ///
+    /// Called once when the memtable transitions from active to immutable.
+    /// Uses `OnceLock` for interior mutability so it can be called through `&self`
+    /// (the memtable may already be inside an `Arc` when frozen). Safe to call
+    /// multiple times; only the first call has any effect.
+    pub fn freeze_range_tombstones(&self) {
+        if !self.range_tombstones.is_empty() {
+            self.immutable_range_tombstones.get_or_init(|| {
+                ImmutableRangeTombstoneSet::from_range_tombstone_set(&self.range_tombstones)
+            });
+        }
+    }
+
+    /// Access the immutable range-tombstone view (available after freeze).
+    pub fn imm_range_tombstones(&self) -> Option<&ImmutableRangeTombstoneSet> {
+        self.immutable_range_tombstones.get()
     }
 
     #[must_use]

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -48,14 +48,13 @@ impl ImmutableRangeTombstoneSet {
         }
     }
 
-    /// Return the fragmented view, building it lazily on first access.
-    pub fn fragments(&self) -> Arc<[RangeTombstoneFragment]> {
-        self.fragments
-            .get_or_init(|| {
-                let frags = fragment_range(&self.raw);
-                Arc::from(frags)
-            })
-            .clone()
+    /// Return a reference to the fragmented view, building it lazily on first
+    /// access. Returns `&Arc` to avoid cloning on the hot point-lookup path.
+    pub fn fragments(&self) -> &Arc<[RangeTombstoneFragment]> {
+        self.fragments.get_or_init(|| {
+            let frags = fragment_range(&self.raw);
+            Arc::from(frags)
+        })
     }
 
     /// Find the newest covering tombstone timestamp for `user_key` at `read_ts`.
@@ -68,7 +67,7 @@ impl ImmutableRangeTombstoneSet {
 
     /// Build a `RangeTombstoneIterator` for scan-path use.
     pub fn iter(&self) -> RangeTombstoneIterator {
-        RangeTombstoneIterator::new(self.fragments())
+        RangeTombstoneIterator::new(self.fragments().clone())
     }
 }
 

--- a/kv-engine/src/range_tombstone.rs
+++ b/kv-engine/src/range_tombstone.rs
@@ -252,8 +252,12 @@ pub fn fragment_range(raw: &Arc<SkipMap<RangeTombstoneKey, Bytes>>) -> Vec<Range
     let mut ends_at: Vec<Vec<(usize, u64)>> = vec![Vec::new(); endpoints.len()];
 
     for (idx, (start, end, ts)) in tombstones.iter().enumerate() {
-        let start_pos = endpoints.binary_search(start).unwrap();
-        let end_pos = endpoints.binary_search(end).unwrap();
+        let start_pos = endpoints
+            .binary_search(start)
+            .expect("start endpoint must exist in collected endpoints");
+        let end_pos = endpoints
+            .binary_search(end)
+            .expect("end endpoint must exist in collected endpoints");
         starts_at[start_pos].push((idx, *ts));
         ends_at[end_pos].push((idx, *ts));
     }
@@ -345,8 +349,12 @@ pub fn merge_fragment_lists(lists: &[Vec<RangeTombstoneFragment>]) -> Vec<RangeT
     let mut ends_at: Vec<Vec<usize>> = vec![Vec::new(); endpoints.len()];
 
     for (idx, f) in all.iter().enumerate() {
-        let start_pos = endpoints.binary_search(&f.start).unwrap();
-        let end_pos = endpoints.binary_search(&f.end).unwrap();
+        let start_pos = endpoints
+            .binary_search(&f.start)
+            .expect("start endpoint must exist in collected endpoints");
+        let end_pos = endpoints
+            .binary_search(&f.end)
+            .expect("end endpoint must exist in collected endpoints");
         starts_at[start_pos].push(idx);
         ends_at[end_pos].push(idx);
     }

--- a/kv-engine/src/range_tombstone.rs
+++ b/kv-engine/src/range_tombstone.rs
@@ -322,9 +322,7 @@ pub fn fragment_range(raw: &Arc<SkipMap<RangeTombstoneKey, Bytes>>) -> Vec<Range
 /// The output is sorted by `start`, non-overlapping, with `covering_ts` being
 /// the union of all input sources for each span. Adjacent fragments with
 /// identical `covering_ts` are coalesced.
-pub fn merge_fragment_lists(
-    lists: &[Vec<RangeTombstoneFragment>],
-) -> Vec<RangeTombstoneFragment> {
+pub fn merge_fragment_lists(lists: &[Vec<RangeTombstoneFragment>]) -> Vec<RangeTombstoneFragment> {
     // Collect all fragments and sort by start.
     let all: Vec<&RangeTombstoneFragment> = lists.iter().flatten().collect();
     if all.is_empty() {

--- a/kv-engine/src/range_tombstone.rs
+++ b/kv-engine/src/range_tombstone.rs
@@ -215,6 +215,38 @@ pub struct RangeTombstoneFragment {
     pub covering_ts: Vec<u64>,
 }
 
+/// Find the newest covering tombstone timestamp for `user_key` at `read_ts`
+/// within a sorted, non-overlapping fragment slice.
+///
+/// O(log F + log T) where F is the fragment count and T is the max covering_ts
+/// length per fragment.
+pub fn find_newest_covering_ts(
+    fragments: &[RangeTombstoneFragment],
+    user_key: &[u8],
+    read_ts: u64,
+) -> Option<u64> {
+    if fragments.is_empty() {
+        return None;
+    }
+    // Binary search: find the last fragment with start <= user_key.
+    let idx = fragments.partition_point(|f| f.start.as_ref() <= user_key);
+    if idx == 0 {
+        return None;
+    }
+    let frag = &fragments[idx - 1];
+    // Verify user_key < end (half-open interval).
+    if user_key >= frag.end.as_ref() {
+        return None;
+    }
+    // Binary search within covering_ts for the newest ts <= read_ts.
+    let ts_idx = frag.covering_ts.partition_point(|&ts| ts <= read_ts);
+    if ts_idx > 0 {
+        Some(frag.covering_ts[ts_idx - 1])
+    } else {
+        None
+    }
+}
+
 /// Fragment raw tombstones from a skipmap into non-overlapping spans.
 ///
 /// Implements a sweep-line algorithm over sorted endpoints. Each unique
@@ -247,19 +279,19 @@ pub fn fragment_range(raw: &Arc<SkipMap<RangeTombstoneKey, Bytes>>) -> Vec<Range
     // two tombstones sharing the same ts don't lose coverage when one ends
     // before the other.
     let mut active: BTreeMap<u64, u32> = BTreeMap::new();
-    // Pre-index: for each endpoint, which tombstones start / end here.
-    let mut starts_at: Vec<Vec<(usize, u64)>> = vec![Vec::new(); endpoints.len()];
-    let mut ends_at: Vec<Vec<(usize, u64)>> = vec![Vec::new(); endpoints.len()];
+    // Pre-index: for each endpoint, which tombstone timestamps start / end here.
+    let mut starts_at: Vec<Vec<u64>> = vec![Vec::new(); endpoints.len()];
+    let mut ends_at: Vec<Vec<u64>> = vec![Vec::new(); endpoints.len()];
 
-    for (idx, (start, end, ts)) in tombstones.iter().enumerate() {
+    for (start, end, ts) in &tombstones {
         let start_pos = endpoints
             .binary_search(start)
             .expect("start endpoint must exist in collected endpoints");
         let end_pos = endpoints
             .binary_search(end)
             .expect("end endpoint must exist in collected endpoints");
-        starts_at[start_pos].push((idx, *ts));
-        ends_at[end_pos].push((idx, *ts));
+        starts_at[start_pos].push(*ts);
+        ends_at[end_pos].push(*ts);
     }
 
     let mut fragments: Vec<RangeTombstoneFragment> = Vec::new();
@@ -269,7 +301,7 @@ pub fn fragment_range(raw: &Arc<SkipMap<RangeTombstoneKey, Bytes>>) -> Vec<Range
         // Process ends BEFORE starts so that adjacent intervals [a,b) and [b,c)
         // with the same timestamp produce a continuous [a,c) fragment rather than
         // two separate fragments with a gap at b.
-        for &(_, ts) in &ends_at[i] {
+        for &ts in &ends_at[i] {
             if let Some(cnt) = active.get_mut(&ts) {
                 *cnt -= 1;
                 if *cnt == 0 {
@@ -277,7 +309,7 @@ pub fn fragment_range(raw: &Arc<SkipMap<RangeTombstoneKey, Bytes>>) -> Vec<Range
                 }
             }
         }
-        for &(_, ts) in &starts_at[i] {
+        for &ts in &starts_at[i] {
             *active.entry(ts).or_insert(0) += 1;
         }
 
@@ -437,33 +469,10 @@ impl RangeTombstoneIterator {
 
     /// Find the newest covering tombstone timestamp for `user_key` at `read_ts`.
     ///
-    /// Uses binary search on the sorted fragment list, then binary search on
-    /// `covering_ts` within the matching fragment. O(log F + log T) where F
-    /// is the fragment count and T is the max tombstone count per fragment.
+    /// Delegates to [`find_newest_covering_ts`] — O(log F + log T) where F is
+    /// the fragment count and T is the max covering_ts length per fragment.
     pub fn newest_covering_ts(&self, user_key: &[u8], read_ts: u64) -> Option<u64> {
-        if self.fragments.is_empty() {
-            return None;
-        }
-
-        // Binary search: find the last fragment with start <= user_key.
-        let idx = self
-            .fragments
-            .partition_point(|f| f.start.as_ref() <= user_key);
-        if idx == 0 {
-            return None;
-        }
-        let frag = &self.fragments[idx - 1];
-        // Verify user_key < end (half-open interval).
-        if user_key >= frag.end.as_ref() {
-            return None;
-        }
-        // Binary search within covering_ts for the newest ts <= read_ts.
-        let ts_idx = frag.covering_ts.partition_point(|&ts| ts <= read_ts);
-        if ts_idx > 0 {
-            Some(frag.covering_ts[ts_idx - 1])
-        } else {
-            None
-        }
+        find_newest_covering_ts(&self.fragments, user_key, read_ts)
     }
 }
 

--- a/kv-engine/src/range_tombstone.rs
+++ b/kv-engine/src/range_tombstone.rs
@@ -326,9 +326,9 @@ pub fn fragment_range(raw: &Arc<SkipMap<RangeTombstoneKey, Bytes>>) -> Vec<Range
 /// The output is sorted by `start`, non-overlapping, with `covering_ts` being
 /// the union of all input sources for each span. Adjacent fragments with
 /// identical `covering_ts` are coalesced.
-pub fn merge_fragment_lists(lists: &[Vec<RangeTombstoneFragment>]) -> Vec<RangeTombstoneFragment> {
+pub fn merge_fragment_lists(lists: &[&[RangeTombstoneFragment]]) -> Vec<RangeTombstoneFragment> {
     // Collect all fragments and sort by start.
-    let all: Vec<&RangeTombstoneFragment> = lists.iter().flatten().collect();
+    let all: Vec<&RangeTombstoneFragment> = lists.iter().copied().flatten().collect();
     if all.is_empty() {
         return Vec::new();
     }
@@ -768,7 +768,7 @@ mod tests {
             covering_ts: vec![20],
         }];
 
-        let merged = merge_fragment_lists(&[frags1, frags2]);
+        let merged = merge_fragment_lists(&[&frags1, &frags2]);
         // Adjacent with different ts — should NOT coalesce.
         assert_eq!(merged.len(), 2);
         assert_eq!(merged[0].covering_ts, vec![10]);
@@ -789,7 +789,7 @@ mod tests {
             covering_ts: vec![20],
         }];
 
-        let merged = merge_fragment_lists(&[frags1, frags2]);
+        let merged = merge_fragment_lists(&[&frags1, &frags2]);
         assert_eq!(merged.len(), 3);
         assert_eq!(merged[0].start.as_ref(), b"a");
         assert_eq!(merged[0].end.as_ref(), b"m");
@@ -816,7 +816,7 @@ mod tests {
             covering_ts: vec![10],
         }];
 
-        let merged = merge_fragment_lists(&[frags1, frags2]);
+        let merged = merge_fragment_lists(&[&frags1, &frags2]);
         assert_eq!(merged.len(), 1);
         assert_eq!(merged[0].start.as_ref(), b"a");
         assert_eq!(merged[0].end.as_ref(), b"z");

--- a/kv-engine/src/range_tombstone.rs
+++ b/kv-engine/src/range_tombstone.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::sync::{
     Arc,
     atomic::{AtomicUsize, Ordering},
@@ -192,6 +193,270 @@ impl Default for RangeTombstoneSet {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Range tombstone fragmentation
+//
+// Raw tombstones may overlap. The fragmenter converts them into non-overlapping
+// spans, each carrying the sorted set of tombstone timestamps that cover every
+// key in that span. This enables O(log F) per-key lookups during scans and
+// compaction instead of O(R) raw scans.
+// ---------------------------------------------------------------------------
+
+/// A non-overlapping range-tombstone span with all covering timestamps.
+///
+/// `covering_ts` is sorted ascending (oldest first). For any key `k` in
+/// `[start, end)`, every timestamp in `covering_ts` covers `k`. Use
+/// `partition_point(|ts| ts <= read_ts)` to find the newest visible covering
+/// timestamp.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RangeTombstoneFragment {
+    pub start: Bytes,
+    pub end: Bytes,
+    pub covering_ts: Vec<u64>,
+}
+
+/// Fragment raw tombstones from a skipmap into non-overlapping spans.
+///
+/// Implements a sweep-line algorithm over sorted endpoints. Each unique
+/// endpoint becomes a potential fragment boundary. Adjacent fragments with
+/// identical `covering_ts` are coalesced.
+pub fn fragment_range(raw: &Arc<SkipMap<RangeTombstoneKey, Bytes>>) -> Vec<RangeTombstoneFragment> {
+    // Collect all (start, end, ts) triples.
+    let mut tombstones: Vec<(Bytes, Bytes, u64)> = Vec::new();
+    for entry in raw.iter() {
+        let key = entry.key();
+        let end = entry.value();
+        tombstones.push((key.start.clone(), end.clone(), key.ts));
+    }
+
+    if tombstones.is_empty() {
+        return Vec::new();
+    }
+
+    // Collect all unique endpoints and sort.
+    let mut endpoints: Vec<Bytes> = Vec::with_capacity(tombstones.len() * 2);
+    for (start, end, _) in &tombstones {
+        endpoints.push(start.clone());
+        endpoints.push(end.clone());
+    }
+    endpoints.sort();
+    endpoints.dedup();
+
+    // Sweep-line: walk adjacent endpoint pairs, track active tombstone timestamps.
+    // BTreeMap<u64, u32> acts as a multiset — refcount per timestamp — so that
+    // two tombstones sharing the same ts don't lose coverage when one ends
+    // before the other.
+    let mut active: BTreeMap<u64, u32> = BTreeMap::new();
+    // Pre-index: for each endpoint, which tombstones start / end here.
+    let mut starts_at: Vec<Vec<(usize, u64)>> = vec![Vec::new(); endpoints.len()];
+    let mut ends_at: Vec<Vec<(usize, u64)>> = vec![Vec::new(); endpoints.len()];
+
+    for (idx, (start, end, ts)) in tombstones.iter().enumerate() {
+        let start_pos = endpoints.binary_search(start).unwrap();
+        let end_pos = endpoints.binary_search(end).unwrap();
+        starts_at[start_pos].push((idx, *ts));
+        ends_at[end_pos].push((idx, *ts));
+    }
+
+    let mut fragments: Vec<RangeTombstoneFragment> = Vec::new();
+
+    for i in 0..endpoints.len() - 1 {
+        // Update active set at this endpoint.
+        // Process ends BEFORE starts so that adjacent intervals [a,b) and [b,c)
+        // with the same timestamp produce a continuous [a,c) fragment rather than
+        // two separate fragments with a gap at b.
+        for &(_, ts) in &ends_at[i] {
+            if let Some(cnt) = active.get_mut(&ts) {
+                *cnt -= 1;
+                if *cnt == 0 {
+                    active.remove(&ts);
+                }
+            }
+        }
+        for &(_, ts) in &starts_at[i] {
+            *active.entry(ts).or_insert(0) += 1;
+        }
+
+        if active.is_empty() {
+            continue;
+        }
+
+        let frag_start = endpoints[i].clone();
+        let frag_end = endpoints[i + 1].clone();
+
+        // Skip empty spans (shouldn't happen with deduped endpoints, but guard).
+        if frag_start >= frag_end {
+            continue;
+        }
+
+        // Coalesce with previous fragment if covering_ts are identical.
+        // Compare iterators to avoid allocating a Vec when coalescing.
+        if let Some(last) = fragments.last_mut()
+            && last.end == frag_start
+            && last.covering_ts.len() == active.len()
+            && last
+                .covering_ts
+                .iter()
+                .zip(active.keys())
+                .all(|(a, b)| a == b)
+        {
+            last.end = frag_end;
+            continue;
+        }
+
+        let covering_ts: Vec<u64> = active.keys().copied().collect();
+
+        fragments.push(RangeTombstoneFragment {
+            start: frag_start,
+            end: frag_end,
+            covering_ts,
+        });
+    }
+
+    fragments
+}
+
+/// Merge multiple sorted fragment lists into a single non-overlapping list.
+///
+/// Each input list must be sorted by `start` and non-overlapping within itself.
+/// The output is sorted by `start`, non-overlapping, with `covering_ts` being
+/// the union of all input sources for each span. Adjacent fragments with
+/// identical `covering_ts` are coalesced.
+pub fn merge_fragment_lists(
+    lists: &[Vec<RangeTombstoneFragment>],
+) -> Vec<RangeTombstoneFragment> {
+    // Collect all fragments and sort by start.
+    let all: Vec<&RangeTombstoneFragment> = lists.iter().flatten().collect();
+    if all.is_empty() {
+        return Vec::new();
+    }
+
+    // Collect all unique endpoints and sort.
+    let mut endpoints: Vec<Bytes> = Vec::with_capacity(all.len() * 2);
+    for f in &all {
+        endpoints.push(f.start.clone());
+        endpoints.push(f.end.clone());
+    }
+    endpoints.sort();
+    endpoints.dedup();
+
+    // Pre-index: for each endpoint position, which fragments start / end here.
+    // Store (fragment_idx, covering_ts_slice_idx) but since we need all ts
+    // from a fragment, store the fragment index and expand later.
+    let mut starts_at: Vec<Vec<usize>> = vec![Vec::new(); endpoints.len()];
+    let mut ends_at: Vec<Vec<usize>> = vec![Vec::new(); endpoints.len()];
+
+    for (idx, f) in all.iter().enumerate() {
+        let start_pos = endpoints.binary_search(&f.start).unwrap();
+        let end_pos = endpoints.binary_search(&f.end).unwrap();
+        starts_at[start_pos].push(idx);
+        ends_at[end_pos].push(idx);
+    }
+
+    // Sweep-line: track active timestamps with a refcount multiset.
+    let mut active: BTreeMap<u64, u32> = BTreeMap::new();
+    let mut fragments: Vec<RangeTombstoneFragment> = Vec::new();
+
+    for i in 0..endpoints.len() - 1 {
+        // Process ends BEFORE starts for correct adjacent-interval handling.
+        for &frag_idx in &ends_at[i] {
+            for &ts in &all[frag_idx].covering_ts {
+                if let Some(cnt) = active.get_mut(&ts) {
+                    *cnt -= 1;
+                    if *cnt == 0 {
+                        active.remove(&ts);
+                    }
+                }
+            }
+        }
+        for &frag_idx in &starts_at[i] {
+            for &ts in &all[frag_idx].covering_ts {
+                *active.entry(ts).or_insert(0) += 1;
+            }
+        }
+
+        if active.is_empty() {
+            continue;
+        }
+
+        let frag_start = endpoints[i].clone();
+        let frag_end = endpoints[i + 1].clone();
+
+        if frag_start >= frag_end {
+            continue;
+        }
+
+        // Coalesce with previous fragment if covering_ts are identical.
+        if let Some(last) = fragments.last_mut()
+            && last.end == frag_start
+            && last.covering_ts.len() == active.len()
+            && last
+                .covering_ts
+                .iter()
+                .zip(active.keys())
+                .all(|(a, b)| a == b)
+        {
+            last.end = frag_end;
+            continue;
+        }
+
+        let covering_ts: Vec<u64> = active.keys().copied().collect();
+        fragments.push(RangeTombstoneFragment {
+            start: frag_start,
+            end: frag_end,
+            covering_ts,
+        });
+    }
+
+    fragments
+}
+
+/// Iterator over sorted range-tombstone fragments for scan-path visibility checks.
+///
+/// Wraps a pre-built fragment list and provides O(log F + log T) per-key
+/// lookups via binary search on fragments and their covering timestamps.
+pub struct RangeTombstoneIterator {
+    fragments: Arc<[RangeTombstoneFragment]>,
+}
+
+impl RangeTombstoneIterator {
+    /// Create a new iterator over sorted, non-overlapping fragments.
+    pub fn new(fragments: Arc<[RangeTombstoneFragment]>) -> Self {
+        Self { fragments }
+    }
+
+    /// Find the newest covering tombstone timestamp for `user_key` at `read_ts`.
+    ///
+    /// Uses binary search on the sorted fragment list, then binary search on
+    /// `covering_ts` within the matching fragment. O(log F + log T) where F
+    /// is the fragment count and T is the max tombstone count per fragment.
+    pub fn newest_covering_ts(&self, user_key: &[u8], read_ts: u64) -> Option<u64> {
+        if self.fragments.is_empty() {
+            return None;
+        }
+
+        // Binary search: find the last fragment with start <= user_key.
+        let idx = self
+            .fragments
+            .partition_point(|f| f.start.as_ref() <= user_key);
+        if idx == 0 {
+            return None;
+        }
+        let frag = &self.fragments[idx - 1];
+        // Verify user_key < end (half-open interval).
+        if user_key >= frag.end.as_ref() {
+            return None;
+        }
+        // Binary search within covering_ts for the newest ts <= read_ts.
+        let ts_idx = frag.covering_ts.partition_point(|&ts| ts <= read_ts);
+        if ts_idx > 0 {
+            Some(frag.covering_ts[ts_idx - 1])
+        } else {
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -355,5 +620,300 @@ mod tests {
         assert_eq!(set.newest_covering_ts(b"a", 100), Some(10));
         // end == key: NOT covered (key < end).
         assert_eq!(set.newest_covering_ts(b"z", 100), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // Fragmenter tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_fragment_empty_input() {
+        let set = RangeTombstoneSet::new();
+        let frags = fragment_range(set.raw());
+        assert!(frags.is_empty());
+    }
+
+    #[test]
+    fn test_fragment_single_tombstone() {
+        let set = RangeTombstoneSet::new();
+        set.add(ts(b"a", b"z", 10), 0);
+
+        let frags = fragment_range(set.raw());
+        assert_eq!(frags.len(), 1);
+        assert_eq!(frags[0].start.as_ref(), b"a");
+        assert_eq!(frags[0].end.as_ref(), b"z");
+        assert_eq!(frags[0].covering_ts, vec![10]);
+    }
+
+    #[test]
+    fn test_fragment_non_overlapping() {
+        let set = RangeTombstoneSet::new();
+        set.add(ts(b"a", b"m", 10), 0);
+        set.add(ts(b"p", b"z", 20), 1);
+
+        let frags = fragment_range(set.raw());
+        assert_eq!(frags.len(), 2);
+        assert_eq!(frags[0].start.as_ref(), b"a");
+        assert_eq!(frags[0].end.as_ref(), b"m");
+        assert_eq!(frags[0].covering_ts, vec![10]);
+        assert_eq!(frags[1].start.as_ref(), b"p");
+        assert_eq!(frags[1].end.as_ref(), b"z");
+        assert_eq!(frags[1].covering_ts, vec![20]);
+    }
+
+    #[test]
+    fn test_fragment_overlapping() {
+        // [a, z) @ 10 and [m, p) @ 20
+        // Should produce: [a, m)@[10], [m, p)@[10, 20], [p, z)@[10]
+        let set = RangeTombstoneSet::new();
+        set.add(ts(b"a", b"z", 10), 0);
+        set.add(ts(b"m", b"p", 20), 1);
+
+        let frags = fragment_range(set.raw());
+        assert_eq!(frags.len(), 3);
+        assert_eq!(frags[0].start.as_ref(), b"a");
+        assert_eq!(frags[0].end.as_ref(), b"m");
+        assert_eq!(frags[0].covering_ts, vec![10]);
+        assert_eq!(frags[1].start.as_ref(), b"m");
+        assert_eq!(frags[1].end.as_ref(), b"p");
+        assert_eq!(frags[1].covering_ts, vec![10, 20]);
+        assert_eq!(frags[2].start.as_ref(), b"p");
+        assert_eq!(frags[2].end.as_ref(), b"z");
+        assert_eq!(frags[2].covering_ts, vec![10]);
+    }
+
+    #[test]
+    fn test_fragment_coalesce() {
+        // Adjacent tombstones with same ts should coalesce.
+        let set = RangeTombstoneSet::new();
+        set.add(ts(b"a", b"m", 10), 0);
+        set.add(ts(b"m", b"z", 10), 1);
+
+        let frags = fragment_range(set.raw());
+        assert_eq!(frags.len(), 1);
+        assert_eq!(frags[0].start.as_ref(), b"a");
+        assert_eq!(frags[0].end.as_ref(), b"z");
+        assert_eq!(frags[0].covering_ts, vec![10]);
+    }
+
+    #[test]
+    fn test_fragment_nested() {
+        // Inner tombstone with newer ts: [a, z)@10, [c, x)@20
+        let set = RangeTombstoneSet::new();
+        set.add(ts(b"a", b"z", 10), 0);
+        set.add(ts(b"c", b"x", 20), 1);
+
+        let frags = fragment_range(set.raw());
+        assert_eq!(frags.len(), 3);
+        assert_eq!(frags[0].start.as_ref(), b"a");
+        assert_eq!(frags[0].end.as_ref(), b"c");
+        assert_eq!(frags[0].covering_ts, vec![10]);
+        assert_eq!(frags[1].start.as_ref(), b"c");
+        assert_eq!(frags[1].end.as_ref(), b"x");
+        assert_eq!(frags[1].covering_ts, vec![10, 20]);
+        assert_eq!(frags[2].start.as_ref(), b"x");
+        assert_eq!(frags[2].end.as_ref(), b"z");
+        assert_eq!(frags[2].covering_ts, vec![10]);
+    }
+
+    #[test]
+    fn test_fragment_overlapping_same_ts() {
+        // Two tombstones with the same ts that partially overlap: [a,m)@10 and [f,z)@10.
+        // Together they cover [a,z) — the fragmenter must NOT lose coverage at [m,z).
+        let set = RangeTombstoneSet::new();
+        set.add(ts(b"a", b"m", 10), 0);
+        set.add(ts(b"f", b"z", 10), 1);
+
+        let frags = fragment_range(set.raw());
+        // Should coalesce into a single [a,z)@[10] fragment.
+        assert_eq!(frags.len(), 1);
+        assert_eq!(frags[0].start.as_ref(), b"a");
+        assert_eq!(frags[0].end.as_ref(), b"z");
+        assert_eq!(frags[0].covering_ts, vec![10]);
+    }
+
+    #[test]
+    fn test_fragment_overlapping_same_ts_different_endpoints() {
+        // [a,m)@10, [f,p)@10, [h,z)@10 — all same ts, varying endpoints.
+        // Together they cover [a,z).
+        let set = RangeTombstoneSet::new();
+        set.add(ts(b"a", b"m", 10), 0);
+        set.add(ts(b"f", b"p", 10), 1);
+        set.add(ts(b"h", b"z", 10), 2);
+
+        let frags = fragment_range(set.raw());
+        assert_eq!(frags.len(), 1);
+        assert_eq!(frags[0].start.as_ref(), b"a");
+        assert_eq!(frags[0].end.as_ref(), b"z");
+        assert_eq!(frags[0].covering_ts, vec![10]);
+    }
+
+    #[test]
+    fn test_merge_fragment_lists() {
+        // Two non-overlapping fragment lists from different sources.
+        let frags1 = vec![RangeTombstoneFragment {
+            start: Bytes::from_static(b"a"),
+            end: Bytes::from_static(b"m"),
+            covering_ts: vec![10],
+        }];
+        let frags2 = vec![RangeTombstoneFragment {
+            start: Bytes::from_static(b"m"),
+            end: Bytes::from_static(b"z"),
+            covering_ts: vec![20],
+        }];
+
+        let merged = merge_fragment_lists(&[frags1, frags2]);
+        // Adjacent with different ts — should NOT coalesce.
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].covering_ts, vec![10]);
+        assert_eq!(merged[1].covering_ts, vec![20]);
+    }
+
+    #[test]
+    fn test_merge_fragment_lists_overlapping() {
+        // Overlapping fragments from two sources.
+        let frags1 = vec![RangeTombstoneFragment {
+            start: Bytes::from_static(b"a"),
+            end: Bytes::from_static(b"z"),
+            covering_ts: vec![10],
+        }];
+        let frags2 = vec![RangeTombstoneFragment {
+            start: Bytes::from_static(b"m"),
+            end: Bytes::from_static(b"p"),
+            covering_ts: vec![20],
+        }];
+
+        let merged = merge_fragment_lists(&[frags1, frags2]);
+        assert_eq!(merged.len(), 3);
+        assert_eq!(merged[0].start.as_ref(), b"a");
+        assert_eq!(merged[0].end.as_ref(), b"m");
+        assert_eq!(merged[0].covering_ts, vec![10]);
+        assert_eq!(merged[1].start.as_ref(), b"m");
+        assert_eq!(merged[1].end.as_ref(), b"p");
+        assert_eq!(merged[1].covering_ts, vec![10, 20]);
+        assert_eq!(merged[2].start.as_ref(), b"p");
+        assert_eq!(merged[2].end.as_ref(), b"z");
+        assert_eq!(merged[2].covering_ts, vec![10]);
+    }
+
+    #[test]
+    fn test_merge_coalesce_same_ts() {
+        // Adjacent fragments with identical ts from different sources coalesce.
+        let frags1 = vec![RangeTombstoneFragment {
+            start: Bytes::from_static(b"a"),
+            end: Bytes::from_static(b"m"),
+            covering_ts: vec![10],
+        }];
+        let frags2 = vec![RangeTombstoneFragment {
+            start: Bytes::from_static(b"m"),
+            end: Bytes::from_static(b"z"),
+            covering_ts: vec![10],
+        }];
+
+        let merged = merge_fragment_lists(&[frags1, frags2]);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].start.as_ref(), b"a");
+        assert_eq!(merged[0].end.as_ref(), b"z");
+        assert_eq!(merged[0].covering_ts, vec![10]);
+    }
+
+    // -----------------------------------------------------------------------
+    // RangeTombstoneIterator tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_iterator_empty() {
+        let iter = RangeTombstoneIterator::new(Arc::from([]));
+        assert_eq!(iter.newest_covering_ts(b"m", 100), None);
+    }
+
+    #[test]
+    fn test_iterator_basic_lookup() {
+        let frags = vec![
+            RangeTombstoneFragment {
+                start: Bytes::from_static(b"a"),
+                end: Bytes::from_static(b"m"),
+                covering_ts: vec![10],
+            },
+            RangeTombstoneFragment {
+                start: Bytes::from_static(b"m"),
+                end: Bytes::from_static(b"z"),
+                covering_ts: vec![10, 20],
+            },
+        ];
+        let iter = RangeTombstoneIterator::new(Arc::from(frags));
+
+        // Key in first fragment.
+        assert_eq!(iter.newest_covering_ts(b"b", 100), Some(10));
+        // Key in second fragment — newest ts=20.
+        assert_eq!(iter.newest_covering_ts(b"n", 100), Some(20));
+        // Key at boundary.
+        assert_eq!(iter.newest_covering_ts(b"m", 100), Some(20));
+        // Key not covered.
+        assert_eq!(iter.newest_covering_ts(b"z", 100), None);
+        assert_eq!(iter.newest_covering_ts(b"a", 100), Some(10));
+    }
+
+    #[test]
+    fn test_iterator_read_ts_visibility() {
+        let frags = vec![RangeTombstoneFragment {
+            start: Bytes::from_static(b"a"),
+            end: Bytes::from_static(b"z"),
+            covering_ts: vec![10, 20, 30],
+        }];
+        let iter = RangeTombstoneIterator::new(Arc::from(frags));
+
+        // read_ts < all covering timestamps.
+        assert_eq!(iter.newest_covering_ts(b"m", 5), None);
+        // read_ts == first covering timestamp.
+        assert_eq!(iter.newest_covering_ts(b"m", 10), Some(10));
+        // read_ts between covering timestamps.
+        assert_eq!(iter.newest_covering_ts(b"m", 15), Some(10));
+        // read_ts == last covering timestamp.
+        assert_eq!(iter.newest_covering_ts(b"m", 30), Some(30));
+        // read_ts > all covering timestamps.
+        assert_eq!(iter.newest_covering_ts(b"m", 100), Some(30));
+    }
+
+    #[test]
+    fn test_iterator_key_before_all_fragments() {
+        let frags = vec![RangeTombstoneFragment {
+            start: Bytes::from_static(b"m"),
+            end: Bytes::from_static(b"z"),
+            covering_ts: vec![10],
+        }];
+        let iter = RangeTombstoneIterator::new(Arc::from(frags));
+        assert_eq!(iter.newest_covering_ts(b"a", 100), None);
+    }
+
+    #[test]
+    fn test_iterator_key_after_all_fragments() {
+        let frags = vec![RangeTombstoneFragment {
+            start: Bytes::from_static(b"a"),
+            end: Bytes::from_static(b"m"),
+            covering_ts: vec![10],
+        }];
+        let iter = RangeTombstoneIterator::new(Arc::from(frags));
+        assert_eq!(iter.newest_covering_ts(b"z", 100), None);
+    }
+
+    #[test]
+    fn test_iterator_key_at_fragment_boundary() {
+        // Fragments [a, m)@[10] and [m, z)@[20].
+        // Key "m" is NOT in [a, m) but IS in [m, z).
+        let frags = vec![
+            RangeTombstoneFragment {
+                start: Bytes::from_static(b"a"),
+                end: Bytes::from_static(b"m"),
+                covering_ts: vec![10],
+            },
+            RangeTombstoneFragment {
+                start: Bytes::from_static(b"m"),
+                end: Bytes::from_static(b"z"),
+                covering_ts: vec![20],
+            },
+        ];
+        let iter = RangeTombstoneIterator::new(Arc::from(frags));
+        assert_eq!(iter.newest_covering_ts(b"m", 100), Some(20));
     }
 }

--- a/kv-engine/src/range_tombstone.rs
+++ b/kv-engine/src/range_tombstone.rs
@@ -327,6 +327,10 @@ pub fn fragment_range(raw: &Arc<SkipMap<RangeTombstoneKey, Bytes>>) -> Vec<Range
 /// the union of all input sources for each span. Adjacent fragments with
 /// identical `covering_ts` are coalesced.
 pub fn merge_fragment_lists(lists: &[&[RangeTombstoneFragment]]) -> Vec<RangeTombstoneFragment> {
+    // Short-circuit: empty input or single list (already sorted, non-overlapping).
+    if lists.len() <= 1 {
+        return lists.first().map_or_else(Vec::new, |l| l.to_vec());
+    }
     // Collect all fragments and sort by start.
     let all: Vec<&RangeTombstoneFragment> = lists.iter().copied().flatten().collect();
     if all.is_empty() {

--- a/kv-engine/src/tests/memtable.rs
+++ b/kv-engine/src/tests/memtable.rs
@@ -1,8 +1,10 @@
+use std::ops::Bound;
 use std::sync::Arc;
 
 use tempfile::tempdir;
 
 use crate::{
+    iterators::StorageIterator,
     lsm_storage::{LsmStorageInner, LsmStorageOptions},
     mem_table::MemTable,
 };
@@ -707,4 +709,347 @@ fn test_range_tombstone_set_len() {
         1,
     );
     assert_eq!(set.len(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2: Read-path integration tests
+// ---------------------------------------------------------------------------
+
+/// Helper to collect scan results from a `ScanIterator` (which implements
+/// `StorageIterator`, not `std::iter::Iterator`).
+fn collect_scan_keys(
+    iter: crate::lsm_iterator::ScanIterator,
+) -> Vec<Vec<u8>> {
+    let mut results = Vec::new();
+    let mut iter = iter;
+    while iter.is_valid() {
+        results.push(iter.key().to_vec());
+        iter.next().unwrap();
+    }
+    results
+}
+
+fn collect_scan_kv(
+    iter: crate::lsm_iterator::ScanIterator,
+) -> Vec<(Vec<u8>, Vec<u8>)> {
+    let mut results = Vec::new();
+    let mut iter = iter;
+    while iter.is_valid() {
+        results.push((iter.key().to_vec(), iter.value().to_vec()));
+        iter.next().unwrap();
+    }
+    results
+}
+
+#[test]
+fn test_get_hides_range_deleted_key() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+    storage.put(b"key1", b"val1").unwrap();
+    storage.put(b"key2", b"val2").unwrap();
+    storage.put(b"key3", b"val3").unwrap();
+
+    // Delete range [key1, key3) — hides key1 and key2.
+    storage.delete_range_internal(b"key1", b"key3").unwrap();
+
+    assert!(storage.get(b"key1").unwrap().is_none());
+    assert!(storage.get(b"key2").unwrap().is_none());
+    // key3 is at the end boundary — NOT covered (half-open).
+    assert_eq!(&storage.get(b"key3").unwrap().unwrap()[..], b"val3");
+}
+
+#[test]
+fn test_get_preserves_key_at_end_boundary() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+    storage.put(b"z", b"val").unwrap();
+    storage.delete_range_internal(b"a", b"z").unwrap();
+
+    // key == end is NOT covered (half-open [start, end)).
+    assert_eq!(&storage.get(b"z").unwrap().unwrap()[..], b"val");
+}
+
+#[test]
+fn test_get_later_put_recreates_key() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+    storage.put(b"key1", b"old").unwrap();
+    storage.delete_range_internal(b"key1", b"key2").unwrap();
+    assert!(storage.get(b"key1").unwrap().is_none());
+
+    // Later put recreates the key.
+    storage.put(b"key1", b"new").unwrap();
+    assert_eq!(&storage.get(b"key1").unwrap().unwrap()[..], b"new");
+}
+
+#[test]
+fn test_scan_skips_range_deleted_keys() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+    storage.put(b"a", b"1").unwrap();
+    storage.put(b"b", b"2").unwrap();
+    storage.put(b"c", b"3").unwrap();
+    storage.put(b"d", b"4").unwrap();
+
+    // Delete [b, d) — hides b and c.
+    storage.delete_range_internal(b"b", b"d").unwrap();
+
+    let results = collect_scan_kv(storage.scan(Bound::Unbounded, Bound::Unbounded).unwrap());
+
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].0, b"a");
+    assert_eq!(results[1].0, b"d");
+}
+
+#[test]
+fn test_scan_preserves_uncovered_keys() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+    storage.put(b"a", b"1").unwrap();
+    storage.put(b"m", b"2").unwrap();
+    storage.put(b"z", b"3").unwrap();
+
+    // Delete [d, f) — no keys are in this range.
+    storage.delete_range_internal(b"d", b"f").unwrap();
+
+    let results = collect_scan_keys(storage.scan(Bound::Unbounded, Bound::Unbounded).unwrap());
+
+    // All keys are outside [d, f), so all are visible.
+    assert_eq!(results.len(), 3);
+    assert_eq!(results[0], b"a");
+    assert_eq!(results[1], b"m");
+    assert_eq!(results[2], b"z");
+}
+
+#[test]
+fn test_prefix_scan_respects_range_tombstones() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+    storage.put(b"user:1:name", b"alice").unwrap();
+    storage.put(b"user:2:name", b"bob").unwrap();
+    storage.put(b"user:3:name", b"carol").unwrap();
+
+    // Delete user:2's range.
+    storage
+        .delete_range_internal(b"user:2:", b"user:3:")
+        .unwrap();
+
+    let results = collect_scan_keys(storage.prefix_scan(b"user:").unwrap());
+
+    // user:2:name should be hidden, user:1:name and user:3:name visible.
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0], b"user:1:name");
+    assert_eq!(results[1], b"user:3:name");
+}
+
+#[test]
+fn test_get_immutable_memtable_range_tombstone() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+    storage.put(b"key1", b"val1").unwrap();
+    storage.put(b"key2", b"val2").unwrap();
+
+    // Delete range then freeze the memtable.
+    storage.delete_range_internal(b"key1", b"key3").unwrap();
+    storage
+        .force_freeze_memtable(&storage.state_lock.lock())
+        .unwrap();
+
+    // Both keys should still be hidden from the immutable memtable.
+    assert!(storage.get(b"key1").unwrap().is_none());
+    assert!(storage.get(b"key2").unwrap().is_none());
+}
+
+#[test]
+fn test_scan_immutable_memtable_range_tombstone() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+    storage.put(b"a", b"1").unwrap();
+    storage.put(b"b", b"2").unwrap();
+    storage.put(b"c", b"3").unwrap();
+
+    // Delete range then freeze.
+    storage.delete_range_internal(b"b", b"c").unwrap();
+    storage
+        .force_freeze_memtable(&storage.state_lock.lock())
+        .unwrap();
+
+    let results = collect_scan_keys(storage.scan(Bound::Unbounded, Bound::Unbounded).unwrap());
+
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0], b"a");
+    assert_eq!(results[1], b"c");
+}
+
+#[test]
+fn test_get_snapshot_before_delete_range() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+    storage.put(b"key1", b"val1").unwrap();
+
+    // Pin a read guard BEFORE the delete_range.
+    let read_guard = storage.mvcc.as_ref().map(|m| m.new_read_guard());
+    let read_ts = read_guard.as_ref().map(|g| g.read_ts());
+
+    storage.delete_range_internal(b"key1", b"key2").unwrap();
+
+    // The snapshot before delete_range should still see the key.
+    // We can't directly use the snapshot with get() (which always uses latest),
+    // but we verify the tombstone is visible to new readers.
+    assert!(storage.get(b"key1").unwrap().is_none());
+
+    drop(read_guard);
+    let _ = read_ts;
+}
+
+#[test]
+fn test_fragmenter_with_storage() {
+    // Verify that fragments are correctly built from storage range tombstones.
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+    storage.put(b"a", b"1").unwrap();
+    storage.put(b"m", b"2").unwrap();
+    storage.put(b"z", b"3").unwrap();
+
+    storage.delete_range_internal(b"a", b"m").unwrap();
+    storage.delete_range_internal(b"f", b"z").unwrap();
+
+    // Active memtable should have range tombstones.
+    let state = storage.state.load();
+    let frags = crate::range_tombstone::fragment_range(state.memtable.range_tombstones().raw());
+    assert!(!frags.is_empty());
+
+    // Verify fragments cover [a, m) and [f, z).
+    // Should have fragments covering the union of [a, m) and [f, z).
+    assert!(frags
+        .iter()
+        .any(|f| f.start.as_ref() == b"a" && f.end.as_ref() <= b"m".as_slice()));
+    assert!(frags
+        .iter()
+        .any(|f| f.start.as_ref() >= b"f".as_slice() && f.end.as_ref() <= b"z".as_slice()));
+}
+
+#[test]
+fn test_range_tombstone_with_point_tombstone_compose() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+    storage.put(b"a", b"1").unwrap();
+    storage.put(b"b", b"2").unwrap();
+    storage.put(b"c", b"3").unwrap();
+
+    // Point delete b.
+    storage.delete(b"b").unwrap();
+    // Range delete [a, c) — hides a (b is already point-deleted).
+    storage.delete_range_internal(b"a", b"c").unwrap();
+
+    assert!(storage.get(b"a").unwrap().is_none());
+    assert!(storage.get(b"b").unwrap().is_none());
+    // c is at end boundary — NOT covered.
+    assert_eq!(&storage.get(b"c").unwrap().unwrap()[..], b"3");
+}
+
+#[test]
+fn test_get_with_ts_range_tombstone() {
+    // Transaction point lookups must respect range tombstones.
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+    storage.put(b"key1", b"val1").unwrap();
+    storage.put(b"key2", b"val2").unwrap();
+    storage.put(b"key3", b"val3").unwrap();
+
+    storage.delete_range_internal(b"key1", b"key3").unwrap();
+
+    // get_with_ts (transaction path) must also hide range-deleted keys.
+    // Use a large read_ts to see all committed data.
+    let read_ts = u64::MAX - 1;
+    assert!(storage.get_with_ts(b"key1", read_ts).unwrap().is_none());
+    assert!(storage.get_with_ts(b"key2", read_ts).unwrap().is_none());
+    // key3 is at end boundary — NOT covered (half-open).
+    assert!(storage.get_with_ts(b"key3", read_ts).unwrap().is_some());
+}
+
+#[test]
+fn test_flush_rejects_memtable_with_range_tombstones() {
+    let memtable = MemTable::create(0);
+    memtable.for_testing_put_slice(b"key1", b"val1").unwrap();
+    memtable.put_range_tombstone(b"a", b"z", 10, 0).unwrap();
+
+    let mut builder = crate::table::SsTableBuilder::new(4096);
+    let result = memtable.flush(&mut builder);
+    assert!(result.is_err());
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("range tombstones"),
+        "error should mention range tombstones"
+    );
+}
+
+#[test]
+fn test_scan_range_tombstone_hides_older_not_newer_version() {
+    // A range tombstone at ts=T should hide point versions with ts <= T,
+    // but NOT newer versions with ts > T.
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+
+    storage.put(b"k", b"old").unwrap();
+    storage.delete_range_internal(b"k", b"l").unwrap();
+    storage.put(b"k", b"new").unwrap();
+
+    // Scan should yield "new" (the put after the range tombstone).
+    let mut scan = storage.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    assert!(scan.is_valid());
+    assert_eq!(scan.key(), b"k");
+    assert_eq!(scan.value(), b"new");
+    scan.next().unwrap();
+    assert!(!scan.is_valid());
+}
+
+#[test]
+fn test_get_put_in_imm_range_delete_and_put_in_active() {
+    // Put in imm_memtable, range delete + new put in active memtable.
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+
+    storage.put(b"k", b"old").unwrap();
+    // Force freeze — moves current memtable to imm_memtables.
+    let state_lock = storage.state_lock.lock();
+    storage.force_freeze_memtable(&state_lock).unwrap();
+    drop(state_lock);
+
+    storage.delete_range_internal(b"k", b"l").unwrap();
+    storage.put(b"k", b"new").unwrap();
+
+    // get should return "new" — the put after the range tombstone.
+    assert_eq!(&storage.get(b"k").unwrap().unwrap()[..], b"new");
+}
+
+#[test]
+fn test_get_key_outside_range_tombstones() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+
+    storage.put(b"a", b"1").unwrap();
+    storage.put(b"z", b"2").unwrap();
+    storage.delete_range_internal(b"m", b"n").unwrap();
+
+    // Keys outside the tombstone range should be visible.
+    assert_eq!(&storage.get(b"a").unwrap().unwrap()[..], b"1");
+    assert_eq!(&storage.get(b"z").unwrap().unwrap()[..], b"2");
 }

--- a/kv-engine/src/tests/memtable.rs
+++ b/kv-engine/src/tests/memtable.rs
@@ -902,12 +902,11 @@ fn test_get_snapshot_before_delete_range() {
     assert!(storage.get(b"key1").unwrap().is_none());
 
     // The snapshot pinned BEFORE delete_range should still see the key.
-    if let Some(ts) = read_ts {
-        assert!(
-            storage.get_with_ts(b"key1", ts).unwrap().is_some(),
-            "snapshot before delete_range should still see key1"
-        );
-    }
+    let ts = read_ts.expect("MVCC must be enabled for snapshot visibility test");
+    assert!(
+        storage.get_with_ts(b"key1", ts).unwrap().is_some(),
+        "snapshot before delete_range should still see key1"
+    );
 
     drop(read_guard);
 }

--- a/kv-engine/src/tests/memtable.rs
+++ b/kv-engine/src/tests/memtable.rs
@@ -898,13 +898,18 @@ fn test_get_snapshot_before_delete_range() {
 
     storage.delete_range_internal(b"key1", b"key2").unwrap();
 
-    // The snapshot before delete_range should still see the key.
-    // We can't directly use the snapshot with get() (which always uses latest),
-    // but we verify the tombstone is visible to new readers.
+    // New readers should not see the key.
     assert!(storage.get(b"key1").unwrap().is_none());
 
+    // The snapshot pinned BEFORE delete_range should still see the key.
+    if let Some(ts) = read_ts {
+        assert!(
+            storage.get_with_ts(b"key1", ts).unwrap().is_some(),
+            "snapshot before delete_range should still see key1"
+        );
+    }
+
     drop(read_guard);
-    let _ = read_ts;
 }
 
 #[test]

--- a/kv-engine/src/tests/memtable.rs
+++ b/kv-engine/src/tests/memtable.rs
@@ -717,9 +717,7 @@ fn test_range_tombstone_set_len() {
 
 /// Helper to collect scan results from a `ScanIterator` (which implements
 /// `StorageIterator`, not `std::iter::Iterator`).
-fn collect_scan_keys(
-    iter: crate::lsm_iterator::ScanIterator,
-) -> Vec<Vec<u8>> {
+fn collect_scan_keys(iter: crate::lsm_iterator::ScanIterator) -> Vec<Vec<u8>> {
     let mut results = Vec::new();
     let mut iter = iter;
     while iter.is_valid() {
@@ -729,9 +727,7 @@ fn collect_scan_keys(
     results
 }
 
-fn collect_scan_kv(
-    iter: crate::lsm_iterator::ScanIterator,
-) -> Vec<(Vec<u8>, Vec<u8>)> {
+fn collect_scan_kv(iter: crate::lsm_iterator::ScanIterator) -> Vec<(Vec<u8>, Vec<u8>)> {
     let mut results = Vec::new();
     let mut iter = iter;
     while iter.is_valid() {
@@ -931,12 +927,16 @@ fn test_fragmenter_with_storage() {
 
     // Verify fragments cover [a, m) and [f, z).
     // Should have fragments covering the union of [a, m) and [f, z).
-    assert!(frags
-        .iter()
-        .any(|f| f.start.as_ref() == b"a" && f.end.as_ref() <= b"m".as_slice()));
-    assert!(frags
-        .iter()
-        .any(|f| f.start.as_ref() >= b"f".as_slice() && f.end.as_ref() <= b"z".as_slice()));
+    assert!(
+        frags
+            .iter()
+            .any(|f| f.start.as_ref() == b"a" && f.end.as_ref() <= b"m".as_slice())
+    );
+    assert!(
+        frags
+            .iter()
+            .any(|f| f.start.as_ref() >= b"f".as_slice() && f.end.as_ref() <= b"z".as_slice())
+    );
 }
 
 #[test]
@@ -990,10 +990,7 @@ fn test_flush_rejects_memtable_with_range_tombstones() {
     let result = memtable.flush(&mut builder);
     assert!(result.is_err());
     assert!(
-        result
-            .unwrap_err()
-            .to_string()
-            .contains("range tombstones"),
+        result.unwrap_err().to_string().contains("range tombstones"),
         "error should mention range tombstones"
     );
 }


### PR DESCRIPTION
## Summary

Implements Phase 2 of the DeleteRange feature ([RFC 010](https://github.com/ben1009/toy-kv-engine/blob/main/rfcs/010-delete-range.md)).

## Changes

### Fragmenter (`range_tombstone.rs`)
- `fragment_range()` — sweep-line algorithm converting raw tombstones to non-overlapping fragments. Uses `BTreeMap<u64, u32>` refcount multiset for correct handling of duplicate timestamps.
- `merge_fragment_lists()` — O(F log F) sweep-line merge of fragment lists from multiple sources with timestamp union and coalescing.
- `RangeTombstoneIterator` — binary-search based lookup over sorted fragments for O(log F + log T) per-key coverage checks.
- 5 new unit tests (duplicate ts, iterator boundaries).

### Memtable (`mem_table.rs`)
- `ImmutableRangeTombstoneSet` — wraps raw `SkipMap` with `OnceLock<Arc<[RangeTombstoneFragment]>>` for lazy fragment cache on frozen memtables.
- `freeze_range_tombstones()` — interior mutability via `OnceLock` (works through `&self` since memtable is already in `Arc`).

### Read Path (`lsm_storage.rs`)
- `get()` — checks range tombstones across all memtables after finding point candidate; hides key if `value_ts <= range_ts`. Pre-computes `newest_memtable_range_ts` once for both memtable and SST checks.
- `get_with_ts()` — added range tombstone check for transaction point lookups (was missing, snapshot isolation violation).
- `get_with_kind_inner()` — added range tombstone check for CAS operations.
- `scan_inner()` — builds merged `RangeTombstoneIterator` from active + immutable memtables, passes to `LsmIterator`.

### Iterator (`lsm_iterator.rs`)
- `skip_tombstones()` — decodes user key from memcomparable form only when range tombstones are present; checks coverage after finding visible point version.

### Tests (`tests/memtable.rs`)
- 8 new integration tests: get/scan with range tombstones, get_with_ts visibility, flush guard, multi-version key interaction, cross-layer resurrection.

## Verification
- [x] 512 tests pass
- [x] 0 clippy warnings
- [x] 3-round adversarial review completed and issues fixed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Range tombstones now filter key visibility for both point lookups and scans.
  * MVCC reads now account for range-tombstone coverage using the read timestamp.
  * Scan operations efficiently skip keys hidden by `[start, end)` deletions, including correct half-open end behavior.
* **Bug Fixes**
  * Reads now consistently short-circuit covered versions to ensure expected deletion semantics.
* **Tests**
  * Added extensive integration coverage for range-tombstone behavior across reads, freezes into immutable state, and timestamp/visibility edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->