### PR TITLE
feat: DeleteRange Phase 3 — SST v4 format, durable range tombstone reads

### DIFF
--- a/kv-engine/src/bin/compaction-simulator.rs
+++ b/kv-engine/src/bin/compaction-simulator.rs
@@ -160,16 +160,28 @@ impl MockStorage {
                 for id in 0..(files.len() - 1) {
                     let this_file = self.snapshot.sstables[&files[id]].clone();
                     let next_file = self.snapshot.sstables[&files[id + 1]].clone();
-                    if this_file.last_key() >= next_file.first_key() {
+                    if this_file.last_key_or_panic() >= next_file.first_key_or_panic() {
                         panic!(
                             "invalid file arrangement in L{}: id={}, range={:x}..={:x}; id={}, range={:x}..={:x}",
                             level,
                             this_file.sst_id(),
-                            this_file.first_key().for_testing_key_ref().get_u64(),
-                            this_file.last_key().for_testing_key_ref().get_u64(),
+                            this_file
+                                .first_key_or_panic()
+                                .for_testing_key_ref()
+                                .get_u64(),
+                            this_file
+                                .last_key_or_panic()
+                                .for_testing_key_ref()
+                                .get_u64(),
                             next_file.sst_id(),
-                            next_file.first_key().for_testing_key_ref().get_u64(),
-                            next_file.last_key().for_testing_key_ref().get_u64()
+                            next_file
+                                .first_key_or_panic()
+                                .for_testing_key_ref()
+                                .get_u64(),
+                            next_file
+                                .last_key_or_panic()
+                                .for_testing_key_ref()
+                                .get_u64()
                         );
                     }
                 }
@@ -535,8 +547,9 @@ fn main() {
                         .iter()
                         .chain(task.lower_level_sst_ids.iter())
                     {
-                        first_keys.push(storage.snapshot.sstables[file].first_key().clone());
-                        last_keys.push(storage.snapshot.sstables[file].last_key().clone());
+                        first_keys
+                            .push(storage.snapshot.sstables[file].first_key_or_panic().clone());
+                        last_keys.push(storage.snapshot.sstables[file].last_key_or_panic().clone());
                     }
                     let begin = first_keys.into_iter().min().unwrap();
                     let end = last_keys.into_iter().max().unwrap();
@@ -570,11 +583,11 @@ fn main() {
                                 "{}.sst {:x}..={:x}",
                                 id,
                                 storage.snapshot.sstables[id]
-                                    .first_key()
+                                    .first_key_or_panic()
                                     .for_testing_key_ref()
                                     .get_u64(),
                                 storage.snapshot.sstables[id]
-                                    .last_key()
+                                    .last_key_or_panic()
                                     .for_testing_key_ref()
                                     .get_u64()
                             ))
@@ -590,11 +603,11 @@ fn main() {
                                 "{}.sst {:x}..={:x}",
                                 id,
                                 storage.snapshot.sstables[id]
-                                    .first_key()
+                                    .first_key_or_panic()
                                     .for_testing_key_ref()
                                     .get_u64(),
                                 storage.snapshot.sstables[id]
-                                    .last_key()
+                                    .last_key_or_panic()
                                     .for_testing_key_ref()
                                     .get_u64()
                             ))
@@ -609,11 +622,11 @@ fn main() {
                                 "{}.sst {:x}..={:x}",
                                 id,
                                 storage.snapshot.sstables[id]
-                                    .first_key()
+                                    .first_key_or_panic()
                                     .for_testing_key_ref()
                                     .get_u64(),
                                 storage.snapshot.sstables[id]
-                                    .last_key()
+                                    .last_key_or_panic()
                                     .for_testing_key_ref()
                                     .get_u64()
                             ))

--- a/kv-engine/src/compact/leveled.rs
+++ b/kv-engine/src/compact/leveled.rs
@@ -35,16 +35,17 @@ impl LeveledCompactionController {
         sst_ids: &[usize],
         in_level: usize,
     ) -> Vec<usize> {
+        // Filter out range-only SSTs (no point data) when computing key range.
         let Some(first_key) = sst_ids
             .iter()
-            .map(|id| snapshot.sstables[id].first_key())
+            .filter_map(|id| snapshot.sstables[id].first_key())
             .min()
         else {
             return vec![];
         };
         let Some(last_key) = sst_ids
             .iter()
-            .map(|id| snapshot.sstables[id].last_key())
+            .filter_map(|id| snapshot.sstables[id].last_key())
             .max()
         else {
             return vec![];
@@ -53,7 +54,11 @@ impl LeveledCompactionController {
         let mut ret = vec![];
         for sst_id in &snapshot.levels[in_level - 1].1 {
             let sst = &snapshot.sstables[sst_id];
-            if !(sst.first_key() > last_key || sst.last_key() < first_key) {
+            // Skip range-only SSTs — they have no point data to compact.
+            let (Some(fk), Some(lk)) = (sst.first_key(), sst.last_key()) else {
+                continue;
+            };
+            if !(fk > last_key || lk < first_key) {
                 ret.push(*sst_id);
             }
         }
@@ -155,9 +160,11 @@ impl LeveledCompactionController {
             .1
             .retain(|x| !task.lower_level_sst_ids.contains(x));
         snapshot.levels[task.lower_level - 1].1.extend(new_sst_ids);
-        snapshot.levels[task.lower_level - 1]
-            .1
-            .sort_by_key(|x| snapshot.sstables[x].first_key());
+        snapshot.levels[task.lower_level - 1].1.sort_by(|a, b| {
+            snapshot.sstables[a]
+                .first_key()
+                .cmp(&snapshot.sstables[b].first_key())
+        });
 
         let mut rm_ids =
             Vec::with_capacity(task.upper_level_sst_ids.len() + task.lower_level_sst_ids.len());

--- a/kv-engine/src/iterators/concat_iterator.rs
+++ b/kv-engine/src/iterators/concat_iterator.rs
@@ -34,6 +34,12 @@ impl SstConcatIterator {
         sstables: Vec<Arc<SsTable>>,
         vlog: Option<Arc<ValueLog>>,
     ) -> Result<Self> {
+        // Filter out range-only SSTs (no point data) — their range tombstones
+        // are handled separately by the read path.
+        let sstables: Vec<_> = sstables
+            .into_iter()
+            .filter(|sst| sst.first_key().is_some())
+            .collect();
         if sstables.is_empty() {
             return Ok(Self {
                 current: None,
@@ -74,6 +80,11 @@ impl SstConcatIterator {
         key: KeySlice,
         vlog: Option<Arc<ValueLog>>,
     ) -> Result<Self> {
+        // Filter out range-only SSTs (no point data).
+        let sstables: Vec<_> = sstables
+            .into_iter()
+            .filter(|sst| sst.first_key().is_some())
+            .collect();
         if sstables.is_empty() {
             return Ok(Self {
                 current: None,
@@ -82,7 +93,11 @@ impl SstConcatIterator {
                 vlog,
             });
         }
-        if key > sstables[sstables.len() - 1].last_key().as_key_slice() {
+        if key
+            > sstables[sstables.len() - 1]
+                .last_key_or_panic()
+                .as_key_slice()
+        {
             return Ok(Self {
                 current: None,
                 next_sst_idx: 0,
@@ -96,17 +111,19 @@ impl SstConcatIterator {
         while lo <= hi {
             let mid = lo + (hi - lo) / 2;
             let s = sstables[mid].clone();
-            if key >= s.first_key().as_key_slice() && key <= s.last_key().as_key_slice() {
+            if key >= s.first_key_or_panic().as_key_slice()
+                && key <= s.last_key_or_panic().as_key_slice()
+            {
                 lo = mid;
                 break;
             }
-            if key < s.first_key().as_key_slice() {
+            if key < s.first_key_or_panic().as_key_slice() {
                 if mid == 0 {
                     lo = 0;
                     break;
                 }
                 hi = mid - 1;
-            } else if key > s.last_key().as_key_slice() {
+            } else if key > s.last_key_or_panic().as_key_slice() {
                 if mid == sstables.len() - 1 {
                     lo = sstables.len() - 1;
                     break;

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1412,7 +1412,12 @@ impl LsmStorageInner {
             return self.resolve_value(&found_key, value, kind);
         }
         // Only compute SST range tombstone ts when we fall through to SSTs.
-        let range_ts = memtable_range_ts.max(self.newest_sst_range_ts(&state, key, read_ts));
+        // Skip entirely if memtable already covers at read_ts.
+        let range_ts = if memtable_range_ts.is_some_and(|ts| ts >= read_ts) {
+            memtable_range_ts
+        } else {
+            memtable_range_ts.max(self.newest_sst_range_ts(&state, key, read_ts))
+        };
         if let Some((value, kind, found_key, value_ts)) =
             self.lookup_sst_raw(&state, &lookup_key, bloom_hash, Some(read_ts))?
         {
@@ -1831,6 +1836,11 @@ impl LsmStorageInner {
             {
                 let ts = crate::range_tombstone::find_newest_covering_ts(frags, user_key, read_ts);
                 best_ts = best_ts.max(ts);
+                // find_newest_covering_ts only returns timestamps <= read_ts,
+                // so best_ts can never exceed read_ts. Early exit.
+                if best_ts == Some(read_ts) {
+                    return best_ts;
+                }
             }
         }
         best_ts

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1186,25 +1186,24 @@ impl LsmStorageInner {
         } else {
             key
         };
-        // Pre-compute the newest range tombstone ts once for both memtable and
-        // SST checks — avoids redundant scans of all memtables and SSTs.
-        let read_ts_for_range = mvcc_read_ts.unwrap_or(u64::MAX);
-        let range_ts = self
-            .newest_memtable_range_ts(&state, key, read_ts_for_range)
-            .max(self.newest_sst_range_ts(&state, key, read_ts_for_range));
         // Check memtable first — route through resolve_vlog_value_bytes for
         // zero-copy inline slicing (refcount bump instead of heap allocation).
+        let read_ts_for_range = mvcc_read_ts.unwrap_or(u64::MAX);
+        let memtable_range_ts = self.newest_memtable_range_ts(&state, key, read_ts_for_range);
         if let Some((value, kind, found_key, value_ts)) =
             self.lookup_memtable(&state, encoded, bloom_hash, mvcc_read_ts)?
         {
-            if range_ts.is_some_and(|rt| value_ts <= rt) {
+            if memtable_range_ts.is_some_and(|rt| value_ts <= rt) {
                 // Covered by range tombstone — any SST version is older and
                 // also covered, so return immediately.
                 return Ok(None);
             }
             return self.resolve_value(&found_key, value, kind);
         }
-        // SST path — delegate to get_with_kind_inner which uses lookup_sst_raw.
+        // SST path — only compute SST range tombstone ts when we actually
+        // need it (deferred from the hot memtable-hit path).
+        let range_ts =
+            memtable_range_ts.max(self.newest_sst_range_ts(&state, key, read_ts_for_range));
         if let Some((value, kind, found_key, value_ts)) =
             self.lookup_sst_raw(&state, encoded, bloom_hash, mvcc_read_ts)?
         {
@@ -1747,17 +1746,18 @@ impl LsmStorageInner {
             key
         };
         let read_ts_for_range = mvcc_read_ts.unwrap_or(u64::MAX);
-        let range_ts = self
-            .newest_memtable_range_ts(state, key, read_ts_for_range)
-            .max(self.newest_sst_range_ts(state, key, read_ts_for_range));
+        let memtable_range_ts = self.newest_memtable_range_ts(state, key, read_ts_for_range);
         if let Some((val, kind, _key, value_ts)) =
             self.lookup_memtable(state, encoded, bloom_hash, mvcc_read_ts)?
         {
-            if range_ts.is_some_and(|rt| value_ts <= rt) {
+            if memtable_range_ts.is_some_and(|rt| value_ts <= rt) {
                 return Ok((None, KvKind::Inline));
             }
             return Ok((val, kind));
         }
+        // Only compute SST range tombstone ts when we fall through to the SST path.
+        let range_ts =
+            memtable_range_ts.max(self.newest_sst_range_ts(state, key, read_ts_for_range));
         if let Some((val, kind, _key, value_ts)) =
             self.lookup_sst_raw(state, encoded, bloom_hash, mvcc_read_ts)?
         {

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1201,9 +1201,12 @@ impl LsmStorageInner {
             return self.resolve_value(&found_key, value, kind);
         }
         // SST path — only compute SST range tombstone ts when we actually
-        // need it (deferred from the hot memtable-hit path).
-        let range_ts =
-            memtable_range_ts.max(self.newest_sst_range_ts(&state, key, read_ts_for_range));
+        // need it. Skip entirely if memtable already covers at read_ts.
+        let range_ts = if memtable_range_ts.is_some_and(|ts| ts >= read_ts_for_range) {
+            memtable_range_ts
+        } else {
+            memtable_range_ts.max(self.newest_sst_range_ts(&state, key, read_ts_for_range))
+        };
         if let Some((value, kind, found_key, value_ts)) =
             self.lookup_sst_raw(&state, encoded, bloom_hash, mvcc_read_ts)?
         {
@@ -1397,17 +1400,19 @@ impl LsmStorageInner {
         let state = self.state.load();
         let bloom_hash = crate::table::bloom::hash_key(key);
         let lookup_key = crate::key::encode_internal_key(key, u64::MAX);
-        let range_ts = self
-            .newest_memtable_range_ts(&state, key, read_ts)
-            .max(self.newest_sst_range_ts(&state, key, read_ts));
+        let memtable_range_ts = self.newest_memtable_range_ts(&state, key, read_ts);
         if let Some((value, kind, found_key, value_ts)) =
             self.lookup_memtable(&state, &lookup_key, bloom_hash, Some(read_ts))?
         {
-            if range_ts.is_some_and(|rt| value_ts <= rt) {
+            if memtable_range_ts.is_some_and(|rt| value_ts <= rt) {
+                // Covered by memtable range tombstone — SST versions are older
+                // and also covered, so return immediately.
                 return Ok(None);
             }
             return self.resolve_value(&found_key, value, kind);
         }
+        // Only compute SST range tombstone ts when we fall through to SSTs.
+        let range_ts = memtable_range_ts.max(self.newest_sst_range_ts(&state, key, read_ts));
         if let Some((value, kind, found_key, value_ts)) =
             self.lookup_sst_raw(&state, &lookup_key, bloom_hash, Some(read_ts))?
         {
@@ -1644,7 +1649,8 @@ impl LsmStorageInner {
                     .get(id)
                     .is_some_and(|s| s.has_range_tombstones())
             });
-        let range_ts_iter = if mvcc_read_ts.is_some() && (has_active || has_imm || has_sst_rt) {
+        let read_ts_for_range = mvcc_read_ts.unwrap_or(u64::MAX);
+        let range_ts_iter = if has_active || has_imm || has_sst_rt {
             let active_frags = if has_active {
                 crate::range_tombstone::fragment_range(state.memtable.range_tombstones().raw())
             } else {
@@ -1756,8 +1762,12 @@ impl LsmStorageInner {
             return Ok((val, kind));
         }
         // Only compute SST range tombstone ts when we fall through to the SST path.
-        let range_ts =
-            memtable_range_ts.max(self.newest_sst_range_ts(state, key, read_ts_for_range));
+        // Skip entirely if memtable already covers at read_ts.
+        let range_ts = if memtable_range_ts.is_some_and(|ts| ts >= read_ts_for_range) {
+            memtable_range_ts
+        } else {
+            memtable_range_ts.max(self.newest_sst_range_ts(state, key, read_ts_for_range))
+        };
         if let Some((val, kind, _key, value_ts)) =
             self.lookup_sst_raw(state, encoded, bloom_hash, mvcc_read_ts)?
         {

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1187,8 +1187,11 @@ impl LsmStorageInner {
             key
         };
         // Pre-compute the newest range tombstone ts once for both memtable and
-        // SST checks — avoids redundant scans of all memtables.
-        let range_ts = self.newest_memtable_range_ts(&state, key, mvcc_read_ts.unwrap_or(u64::MAX));
+        // SST checks — avoids redundant scans of all memtables and SSTs.
+        let read_ts_for_range = mvcc_read_ts.unwrap_or(u64::MAX);
+        let range_ts = self
+            .newest_memtable_range_ts(&state, key, read_ts_for_range)
+            .max(self.newest_sst_range_ts(&state, key, read_ts_for_range));
         // Check memtable first — route through resolve_vlog_value_bytes for
         // zero-copy inline slicing (refcount bump instead of heap allocation).
         if let Some((value, kind, found_key, value_ts)) =
@@ -1364,17 +1367,18 @@ impl LsmStorageInner {
             let user_key_prefix = crate::key::encoded_user_key_prefix(&encoded)
                 .expect("encoded key must have valid user key prefix");
             let idx = sst_ids.partition_point(|id| {
-                state
-                    .sstables
-                    .get(id)
-                    .expect("SST must exist")
-                    .first_key()
-                    .encoded_user_key()
-                    <= user_key_prefix
+                let sst = state.sstables.get(id).expect("SST must exist");
+                match sst.first_key() {
+                    Some(fk) => fk.encoded_user_key() <= user_key_prefix,
+                    None => false, // range-only SST: sort before all others
+                }
             });
             for i in (0..idx).rev() {
                 let sst = state.sstables.get(&sst_ids[i]).expect("SST must exist");
-                if sst.last_key().encoded_user_key() < user_key_prefix {
+                let Some(last_key) = sst.last_key() else {
+                    continue; // range-only SST, no point data
+                };
+                if last_key.encoded_user_key() < user_key_prefix {
                     break;
                 }
                 if let Some((raw, found_key)) =
@@ -1394,7 +1398,9 @@ impl LsmStorageInner {
         let state = self.state.load();
         let bloom_hash = crate::table::bloom::hash_key(key);
         let lookup_key = crate::key::encode_internal_key(key, u64::MAX);
-        let range_ts = self.newest_memtable_range_ts(&state, key, read_ts);
+        let range_ts = self
+            .newest_memtable_range_ts(&state, key, read_ts)
+            .max(self.newest_sst_range_ts(&state, key, read_ts));
         if let Some((value, kind, found_key, value_ts)) =
             self.lookup_memtable(&state, &lookup_key, bloom_hash, Some(read_ts))?
         {
@@ -1629,7 +1635,17 @@ impl LsmStorageInner {
             .imm_memtables
             .iter()
             .any(|m| m.imm_range_tombstones().is_some());
-        let range_ts_iter = if mvcc_read_ts.is_some() && (has_active || has_imm) {
+        let has_sst_rt = state
+            .l0_sstables
+            .iter()
+            .chain(state.levels.iter().flat_map(|(_, ids)| ids))
+            .any(|id| {
+                state
+                    .sstables
+                    .get(id)
+                    .is_some_and(|s| s.has_range_tombstones())
+            });
+        let range_ts_iter = if mvcc_read_ts.is_some() && (has_active || has_imm || has_sst_rt) {
             let active_frags = if has_active {
                 crate::range_tombstone::fragment_range(state.memtable.range_tombstones().raw())
             } else {
@@ -1646,6 +1662,19 @@ impl LsmStorageInner {
                     if !frags.is_empty() {
                         lists.push(frags);
                     }
+                }
+            }
+            // Collect SST range-tombstone fragments.
+            for id in state
+                .l0_sstables
+                .iter()
+                .chain(state.levels.iter().flat_map(|(_, ids)| ids))
+            {
+                if let Some(sst) = state.sstables.get(id)
+                    && let Some(frags) = sst.range_tombstone_fragments()
+                    && !frags.is_empty()
+                {
+                    lists.push(frags);
                 }
             }
             if lists.is_empty() {
@@ -1717,7 +1746,10 @@ impl LsmStorageInner {
         } else {
             key
         };
-        let range_ts = self.newest_memtable_range_ts(state, key, mvcc_read_ts.unwrap_or(u64::MAX));
+        let read_ts_for_range = mvcc_read_ts.unwrap_or(u64::MAX);
+        let range_ts = self
+            .newest_memtable_range_ts(state, key, read_ts_for_range)
+            .max(self.newest_sst_range_ts(state, key, read_ts_for_range));
         if let Some((val, kind, _key, value_ts)) =
             self.lookup_memtable(state, encoded, bloom_hash, mvcc_read_ts)?
         {
@@ -1764,6 +1796,34 @@ impl LsmStorageInner {
                 .and_then(|imm| imm.newest_covering_ts(user_key, read_ts));
             best_ts.max(imm_ts)
         })
+    }
+
+    /// Find the newest range-tombstone timestamp across all SSTs that cover
+    /// `user_key` at `read_ts`.
+    ///
+    /// Iterates L0 + leveled SSTs and checks each SST's cached range-tombstone
+    /// fragments. Returns the maximum covering timestamp, or `None` if no SST
+    /// tombstone covers the key.
+    fn newest_sst_range_ts(
+        &self,
+        state: &LsmStorageState,
+        user_key: &[u8],
+        read_ts: u64,
+    ) -> Option<u64> {
+        let mut best_ts: Option<u64> = None;
+        let all_ssts = state
+            .l0_sstables
+            .iter()
+            .chain(state.levels.iter().flat_map(|(_, ids)| ids));
+        for id in all_ssts {
+            if let Some(sst) = state.sstables.get(id)
+                && let Some(frags) = sst.range_tombstone_fragments()
+            {
+                let ts = crate::range_tombstone::find_newest_covering_ts(frags, user_key, read_ts);
+                best_ts = best_ts.max(ts);
+            }
+        }
+        best_ts
     }
 
     /// Shared memtable lookup used by `get()` and `get_with_kind_inner()`.
@@ -1919,20 +1979,24 @@ impl LsmStorageInner {
                 let search_prefix =
                     search_prefix.expect("search_prefix must be present when mvcc_read_ts is Some");
                 let idx = sst_ids.partition_point(|id| {
-                    state
+                    let sst = state
                         .sstables
                         .get(id)
-                        .expect("SST must exist in sstables map")
-                        .first_key()
-                        .encoded_user_key()
-                        <= search_prefix
+                        .expect("SST must exist in sstables map");
+                    match sst.first_key() {
+                        Some(fk) => fk.encoded_user_key() <= search_prefix,
+                        None => false,
+                    }
                 });
                 for i in (0..idx).rev() {
                     let sst = state
                         .sstables
                         .get(&sst_ids[i])
                         .expect("SST must exist in sstables map");
-                    if sst.last_key().encoded_user_key() < search_prefix {
+                    let Some(last_key) = sst.last_key() else {
+                        continue;
+                    };
+                    if last_key.encoded_user_key() < search_prefix {
                         break;
                     }
                     // Remaining SSTs are sorted descending by key prefix;
@@ -1955,8 +2019,10 @@ impl LsmStorageInner {
                     }
                 }
             } else {
-                let idx =
-                    sst_ids.partition_point(|id| state.sstables[id].first_key().raw_ref() <= key);
+                let idx = sst_ids.partition_point(|id| match state.sstables[id].first_key() {
+                    Some(fk) => fk.raw_ref() <= key,
+                    None => false,
+                });
                 if idx == 0 {
                     continue;
                 }

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -552,16 +552,6 @@ impl MemTable {
     /// Inline entries have their prefix stripped and go through `add()` for
     /// value separation.
     pub fn flush(&self, builder: &mut SsTableBuilder) -> Result<()> {
-        // Phase 1/2 guard: refuse to flush a memtable containing range
-        // tombstones until SST v4 write support exists (Phase 3). Without
-        // this guard, a flush would produce an SST with no range-tombstone
-        // data, and the subsequent WAL deletion would permanently lose them.
-        anyhow::ensure!(
-            self.range_tombstones.is_empty(),
-            "cannot flush memtable containing range tombstones: \
-             SST v4 write support not yet implemented (Phase 3)"
-        );
-
         for e in self.map.iter() {
             let key_bytes = Key::from_bytes(e.key().clone());
             let key = key_bytes.as_key_slice();
@@ -581,6 +571,12 @@ impl MemTable {
                 };
                 builder.add(key, raw)?;
             }
+        }
+
+        // Write range tombstones into the SST v4 range-tombstone block.
+        if !self.range_tombstones.is_empty() {
+            let frags = crate::range_tombstone::fragment_range(self.range_tombstones.raw());
+            builder.add_range_tombstones(frags);
         }
 
         Ok(())

--- a/kv-engine/src/range_tombstone.rs
+++ b/kv-engine/src/range_tombstone.rs
@@ -280,6 +280,11 @@ impl RangeTombstoneFragment {
             let start_len = cursor.get_u16() as usize;
             let end_len = cursor.get_u16() as usize;
             let ts_count = cursor.get_u32() as usize;
+            // Division-based check prevents overflow on 32-bit platforms.
+            anyhow::ensure!(
+                cursor.remaining() / 8 >= ts_count,
+                "ts_count {ts_count} exceeds remaining payload"
+            );
             let total_data = start_len + end_len + ts_count * 8;
             anyhow::ensure!(
                 cursor.remaining() >= total_data,

--- a/kv-engine/src/range_tombstone.rs
+++ b/kv-engine/src/range_tombstone.rs
@@ -215,6 +215,94 @@ pub struct RangeTombstoneFragment {
     pub covering_ts: Vec<u64>,
 }
 
+impl RangeTombstoneFragment {
+    /// Encode fragments into the SST v4 range-tombstone block format.
+    ///
+    /// ```text
+    /// record_count: u32
+    /// repeated:
+    ///   start_len: u16 | end_len: u16 | ts_count: u32
+    ///   start: [u8]    | end: [u8]     | repeated ts: u64
+    /// crc32
+    /// ```
+    pub fn encode_block(fragments: &[Self], buf: &mut Vec<u8>) {
+        use bytes::BufMut;
+
+        let start = buf.len();
+        buf.put_u32(fragments.len() as u32);
+        for frag in fragments {
+            buf.put_u16(frag.start.len() as u16);
+            buf.put_u16(frag.end.len() as u16);
+            buf.put_u32(frag.covering_ts.len() as u32);
+            buf.extend_from_slice(&frag.start);
+            buf.extend_from_slice(&frag.end);
+            for &ts in &frag.covering_ts {
+                buf.put_u64(ts);
+            }
+        }
+        let crc = crc32fast::hash(&buf[start..]);
+        buf.put_u32(crc);
+    }
+
+    /// Decode fragments from the SST v4 range-tombstone block format.
+    ///
+    /// Returns `Err` if the data is truncated or the CRC32 check fails.
+    pub fn decode_block(data: &[u8]) -> anyhow::Result<Vec<Self>> {
+        use bytes::Buf;
+
+        anyhow::ensure!(data.len() >= 8, "range-tombstone block too short");
+        // Last 4 bytes are CRC32.
+        let (payload, crc_bytes) = data.split_at(data.len() - 4);
+        let expected_crc = (&crc_bytes[..]).get_u32();
+        let actual_crc = crc32fast::hash(payload);
+        anyhow::ensure!(
+            actual_crc == expected_crc,
+            "range-tombstone block CRC mismatch: expected {expected_crc:#010x}, got {actual_crc:#010x}"
+        );
+
+        let mut cursor = payload;
+        anyhow::ensure!(cursor.remaining() >= 4, "block too short for record_count");
+        let record_count = cursor.get_u32() as usize;
+
+        // Each record needs at minimum 8 bytes (start_len:2 + end_len:2 + ts_count:4).
+        anyhow::ensure!(
+            cursor.remaining() >= record_count * 8,
+            "record_count {} exceeds available data ({} bytes)",
+            record_count,
+            cursor.remaining()
+        );
+        let mut fragments = Vec::with_capacity(record_count);
+        for _ in 0..record_count {
+            anyhow::ensure!(
+                cursor.remaining() >= 8,
+                "block truncated at fragment header"
+            );
+            let start_len = cursor.get_u16() as usize;
+            let end_len = cursor.get_u16() as usize;
+            let ts_count = cursor.get_u32() as usize;
+            let total_data = start_len + end_len + ts_count * 8;
+            anyhow::ensure!(
+                cursor.remaining() >= total_data,
+                "block truncated at fragment data"
+            );
+            let start = Bytes::copy_from_slice(&cursor[..start_len]);
+            cursor.advance(start_len);
+            let end = Bytes::copy_from_slice(&cursor[..end_len]);
+            cursor.advance(end_len);
+            let mut covering_ts = Vec::with_capacity(ts_count);
+            for _ in 0..ts_count {
+                covering_ts.push(cursor.get_u64());
+            }
+            fragments.push(RangeTombstoneFragment {
+                start,
+                end,
+                covering_ts,
+            });
+        }
+        Ok(fragments)
+    }
+}
+
 /// Find the newest covering tombstone timestamp for `user_key` at `read_ts`
 /// within a sorted, non-overlapping fragment slice.
 ///
@@ -934,5 +1022,54 @@ mod tests {
         ];
         let iter = RangeTombstoneIterator::new(Arc::from(frags));
         assert_eq!(iter.newest_covering_ts(b"m", 100), Some(20));
+    }
+
+    #[test]
+    fn test_encode_decode_block_roundtrip() {
+        let frags = vec![
+            RangeTombstoneFragment {
+                start: Bytes::from_static(b"a"),
+                end: Bytes::from_static(b"m"),
+                covering_ts: vec![10, 20],
+            },
+            RangeTombstoneFragment {
+                start: Bytes::from_static(b"m"),
+                end: Bytes::from_static(b"z"),
+                covering_ts: vec![20],
+            },
+        ];
+        let mut buf = Vec::new();
+        RangeTombstoneFragment::encode_block(&frags, &mut buf);
+        let decoded = RangeTombstoneFragment::decode_block(&buf).unwrap();
+        assert_eq!(frags, decoded);
+    }
+
+    #[test]
+    fn test_encode_decode_empty_block() {
+        let frags: Vec<RangeTombstoneFragment> = vec![];
+        let mut buf = Vec::new();
+        RangeTombstoneFragment::encode_block(&frags, &mut buf);
+        let decoded = RangeTombstoneFragment::decode_block(&buf).unwrap();
+        assert!(decoded.is_empty());
+    }
+
+    #[test]
+    fn test_decode_block_crc_mismatch() {
+        let frags = vec![RangeTombstoneFragment {
+            start: Bytes::from_static(b"a"),
+            end: Bytes::from_static(b"z"),
+            covering_ts: vec![10],
+        }];
+        let mut buf = Vec::new();
+        RangeTombstoneFragment::encode_block(&frags, &mut buf);
+        // Corrupt the CRC.
+        let last = buf.len() - 1;
+        buf[last] ^= 0xff;
+        assert!(RangeTombstoneFragment::decode_block(&buf).is_err());
+    }
+
+    #[test]
+    fn test_decode_block_truncated() {
+        assert!(RangeTombstoneFragment::decode_block(&[0, 0, 0, 1]).is_err());
     }
 }

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -25,6 +25,8 @@ const SST_MVCC_MAGIC: u32 = 0x4D56_4343;
 const SST_FOOTER_VERSION_V2: u8 = 2;
 /// Footer version for SSTs with prefix bloom filters.
 const SST_FOOTER_VERSION_V3: u8 = 3;
+/// Footer version for SSTs with range-tombstone blocks.
+const SST_FOOTER_VERSION_V4: u8 = 4;
 /// Size of the MVCC footer extension: max_ts (8) + magic (4) + version (1) = 13 bytes.
 const MVCC_FOOTER_EXTRA: u64 = (SIZE_OF_U64 + SIZE_OF_U32 + 1) as u64;
 
@@ -187,13 +189,17 @@ pub struct SsTable {
     pub(crate) block_meta_offset: usize,
     id: usize,
     block_cache: Option<Arc<BlockCache>>,
-    first_key: KeyBytes,
-    last_key: KeyBytes,
+    /// First point key. `None` for range-only SSTs.
+    first_key: Option<KeyBytes>,
+    /// Last point key. `None` for range-only SSTs.
+    last_key: Option<KeyBytes>,
     pub(crate) bloom: Option<Bloom>,
     /// The maximum timestamp stored in this SST, implemented in MVCC.
     max_ts: u64,
-    /// Prefix bloom filters for prefix scan pruning. Present only in v3 SSTs.
+    /// Prefix bloom filters for prefix scan pruning. Present only in v3+ SSTs.
     pub(crate) prefix_blooms: Option<PrefixBloomSet>,
+    /// Cached range-tombstone fragments. Present in v4 SSTs with range tombstones.
+    range_tombstones: Option<Arc<[crate::range_tombstone::RangeTombstoneFragment]>>,
 }
 
 impl SsTable {
@@ -219,24 +225,74 @@ impl SsTable {
         let tail = file.read(tail_start, file.size() - tail_start)?;
 
         // Detect MVCC footer by checking magic AND version at their expected
-        // positions. Version can be 2 (no prefix bloom) or 3 (with prefix bloom).
+        // positions. Version can be 2 (no prefix bloom), 3 (with prefix bloom),
+        // or 4 (with range-tombstone block).
         let version = tail[tail.len() - 1];
         let has_mvcc_magic = tail.len() >= (MVCC_FOOTER_EXTRA as usize + SIZE_OF_U32)
             && (&tail[tail.len() - 5..tail.len() - 1]).get_u32() == SST_MVCC_MAGIC;
-        if has_mvcc_magic && version != SST_FOOTER_VERSION_V2 && version != SST_FOOTER_VERSION_V3 {
+        if has_mvcc_magic
+            && version != SST_FOOTER_VERSION_V2
+            && version != SST_FOOTER_VERSION_V3
+            && version != SST_FOOTER_VERSION_V4
+        {
             anyhow::bail!(
-                "unsupported MVCC footer version: {} (expected {} or {})",
+                "unsupported MVCC footer version: {} (expected {}, {} or {})",
                 version,
                 SST_FOOTER_VERSION_V2,
-                SST_FOOTER_VERSION_V3
+                SST_FOOTER_VERSION_V3,
+                SST_FOOTER_VERSION_V4
             );
         }
         let is_mvcc = has_mvcc_magic
-            && (version == SST_FOOTER_VERSION_V2 || version == SST_FOOTER_VERSION_V3);
+            && (version == SST_FOOTER_VERSION_V2
+                || version == SST_FOOTER_VERSION_V3
+                || version == SST_FOOTER_VERSION_V4);
 
-        let (bloom_offset_base, max_ts, bloom_offset, prefix_bloom_set) = if is_mvcc
-            && version == SST_FOOTER_VERSION_V3
+        // v4 footer is 25 bytes: [bloom_offset:4][prefix_bloom_offset:4]
+        // [range_tombstone_offset:4][max_ts:8][magic:4][version:1].
+        // Need to re-read with a larger tail if v4 detected.
+        let (bloom_offset_base, mut max_ts, bloom_offset, prefix_bloom_set, v4_rt_off) = if is_mvcc
+            && version == SST_FOOTER_VERSION_V4
         {
+            let v4_tail_size = SIZE_OF_U32 + SIZE_OF_U32 + SIZE_OF_U32 + MVCC_FOOTER_EXTRA as usize;
+            let v4_tail = file.read(
+                file.size().saturating_sub(v4_tail_size as u64),
+                v4_tail_size as u64,
+            )?;
+            // Layout in the 25-byte tail:
+            //   [0..4]   bloom_offset
+            //   [4..8]   prefix_bloom_offset
+            //   [8..12]  range_tombstone_offset
+            //   [12..20] max_ts
+            //   [20..24] magic
+            //   [24]     version
+            let bloom_off = (&v4_tail[0..4]).get_u32() as u64;
+            let prefix_bloom_off = (&v4_tail[4..8]).get_u32() as u64;
+            let rt_off = (&v4_tail[8..12]).get_u32() as u64;
+            let max_ts_val = (&v4_tail[12..20]).get_u64();
+            let footer_start = file.size() - 25;
+            // On-disk layout (v4):
+            //   [bloom_data][bloom_offset:
+            // 4][prefix_bloom_section][range_tombstone_block][v4_footer:25] section_end
+            // for prefix bloom is rt_off if present, otherwise footer_start.
+            let prefix_set = if prefix_bloom_off > 0 {
+                let section_end = if rt_off > 0 { rt_off } else { footer_start };
+                Self::decode_prefix_blooms(&file, prefix_bloom_off, section_end)?
+            } else {
+                None
+            };
+            // bloom_offset_base: start of prefix bloom section if present,
+            // otherwise start of range-tombstone block if present,
+            // otherwise start of v4 footer.
+            let base = if prefix_bloom_off > 0 {
+                prefix_bloom_off
+            } else if rt_off > 0 {
+                rt_off
+            } else {
+                footer_start
+            };
+            (base, max_ts_val, bloom_off, prefix_set, Some(rt_off))
+        } else if is_mvcc && version == SST_FOOTER_VERSION_V3 {
             // v3 file layout (from end of file):
             //   [version:1][magic:4][max_ts:8][prefix_bloom_offset:4]
             //   [prefix_bloom_section (variable size)]
@@ -279,7 +335,7 @@ impl SsTable {
 
             // bloom_offset_base = start of prefix bloom section (bloom data
             // ends right before it).
-            (prefix_bloom_off, max_ts, bloom_off, prefix_blooms)
+            (prefix_bloom_off, max_ts, bloom_off, prefix_blooms, None)
         } else if is_mvcc {
             // v2 tail layout: [bloom_offset: u32][max_ts: u64][magic: u32][version: u8]
             //                 bytes 0..4    bytes 4..12   bytes 12..16  byte 16
@@ -289,11 +345,11 @@ impl SsTable {
             let bloom_off = (&tail[tail.len() - MVCC_FOOTER_EXTRA as usize - SIZE_OF_U32
                 ..tail.len() - MVCC_FOOTER_EXTRA as usize])
                 .get_u32() as u64;
-            (footer_start, max_ts, bloom_off, None)
+            (footer_start, max_ts, bloom_off, None, None)
         } else {
             // Legacy footer: last 4 bytes are bloom_offset.
             let bloom_off = (&tail[tail.len() - SIZE_OF_U32..]).get_u32() as u64;
-            (file.size(), 0, bloom_off, None)
+            (file.size(), 0, bloom_off, None, None)
         };
         anyhow::ensure!(
             bloom_offset >= SIZE_OF_U32 as u64
@@ -327,33 +383,70 @@ impl SsTable {
             file.read(meta_offset, bloom_offset - SIZE_OF_U32 as u64 - meta_offset)?
                 .as_slice(),
         );
-        anyhow::ensure!(!block_meta.is_empty(), "SST has no block metadata");
-        let first_key = block_meta[0].first_key.clone();
-        let last_key = block_meta[block_meta.len() - 1].last_key.clone();
-        // Reject footer-less MVCC SSTs: scanning only first_key/last_key per
-        // block cannot recover the true max_ts (a middle key may carry a higher
-        // timestamp). Underestimating max_ts would allow commit timestamp reuse
-        // after restart, violating MVCC safety. Require the v2 footer.
-        // Keys with ts=0 are the default for non-MVCC usage and are not a concern.
-        if max_ts == 0 {
-            // Validate both the key structure (decode_user_key) and timestamp
-            // (extract_ts) to reduce false positives on legacy binary keys
-            // that coincidentally contain a timestamp-shaped suffix.
-            let looks_like_mvcc_key = |raw: &[u8]| {
-                crate::key::decode_user_key(raw).is_some()
-                    && crate::key::extract_ts(raw).is_some_and(|ts| ts > 0)
-            };
-            for meta in &block_meta {
-                if looks_like_mvcc_key(meta.first_key.raw_ref())
-                    || looks_like_mvcc_key(meta.last_key.raw_ref())
-                {
-                    anyhow::bail!(
-                        "SST contains MVCC-encoded keys but has no v2 footer; \
-                         re-flush or compact to add the footer before upgrading"
-                    );
+        // Decode range-tombstone block (v4 only).
+        let range_tombstones = if let Some(rt_off) = v4_rt_off {
+            if rt_off > 0 {
+                // Range-tombstone block extends from rt_off to the start of
+                // the 25-byte v4 footer.
+                let footer_start = file.size() - 25;
+                anyhow::ensure!(
+                    rt_off <= footer_start,
+                    "range tombstone offset ({rt_off}) exceeds footer start ({footer_start})"
+                );
+                let rt_data = file.read(rt_off, footer_start - rt_off)?;
+                let frags = crate::range_tombstone::RangeTombstoneFragment::decode_block(
+                    rt_data.as_slice(),
+                )?;
+                // Update max_ts from range-tombstone timestamps.
+                for frag in &frags {
+                    for &ts in &frag.covering_ts {
+                        if ts > max_ts {
+                            max_ts = ts;
+                        }
+                    }
+                }
+                Some(Arc::from(frags))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        // Decode block metadata. Range-only SSTs may have empty block_meta.
+        let (first_key, last_key) = if block_meta.is_empty() {
+            anyhow::ensure!(
+                range_tombstones.is_some(),
+                "SST has no block metadata and no range-tombstone block"
+            );
+            (None, None)
+        } else {
+            // Reject footer-less MVCC SSTs: scanning only first_key/last_key per
+            // block cannot recover the true max_ts (a middle key may carry a higher
+            // timestamp). Underestimating max_ts would allow commit timestamp reuse
+            // after restart, violating MVCC safety. Require the v2 footer.
+            // Keys with ts=0 are the default for non-MVCC usage and are not a concern.
+            if max_ts == 0 {
+                let looks_like_mvcc_key = |raw: &[u8]| {
+                    crate::key::decode_user_key(raw).is_some()
+                        && crate::key::extract_ts(raw).is_some_and(|ts| ts > 0)
+                };
+                for meta in &block_meta {
+                    if looks_like_mvcc_key(meta.first_key.raw_ref())
+                        || looks_like_mvcc_key(meta.last_key.raw_ref())
+                    {
+                        anyhow::bail!(
+                            "SST contains MVCC-encoded keys but has no v2 footer; \
+                             re-flush or compact to add the footer before upgrading"
+                        );
+                    }
                 }
             }
-        }
+            (
+                Some(block_meta[0].first_key.clone()),
+                Some(block_meta[block_meta.len() - 1].last_key.clone()),
+            )
+        };
         Ok(Self {
             file,
             block_meta,
@@ -365,6 +458,7 @@ impl SsTable {
             bloom: Some(bloom),
             max_ts,
             prefix_blooms: prefix_bloom_set,
+            range_tombstones,
         })
     }
 
@@ -513,11 +607,12 @@ impl SsTable {
             block_meta_offset: 0,
             id,
             block_cache: None,
-            first_key,
-            last_key,
+            first_key: Some(first_key),
+            last_key: Some(last_key),
             bloom: None,
             max_ts: 0,
             prefix_blooms: None,
+            range_tombstones: None,
         }
     }
 
@@ -656,7 +751,11 @@ impl SsTable {
         // With MVCC, the search key uses ts=u64::MAX (smallest encoded form for the
         // user key), so it may sort before the SST's first_key. We skip the range
         // check in MVCC mode and rely on the bloom filter for fast rejection.
-        if !TS_ENABLED && (key < self.first_key.raw_ref() || key > self.last_key.raw_ref()) {
+        // Range-only SSTs have no point keys, so skip the range check.
+        if !TS_ENABLED
+            && let (Some(first), Some(last)) = (self.first_key.as_ref(), self.last_key.as_ref())
+            && (key < first.raw_ref() || key > last.raw_ref())
+        {
             return Ok(None);
         }
         // Bloom filter check.  The caller precomputes hash_key(raw_user_key),
@@ -750,13 +849,45 @@ impl SsTable {
     }
 
     #[must_use]
-    pub fn first_key(&self) -> &KeyBytes {
-        &self.first_key
+    pub fn first_key(&self) -> Option<&KeyBytes> {
+        self.first_key.as_ref()
     }
 
     #[must_use]
-    pub fn last_key(&self) -> &KeyBytes {
-        &self.last_key
+    pub fn last_key(&self) -> Option<&KeyBytes> {
+        self.last_key.as_ref()
+    }
+
+    /// Returns the first point key, panicking if this is a range-only SST.
+    ///
+    /// Use this in compaction/iterator code that cannot handle range-only SSTs.
+    #[must_use]
+    pub fn first_key_or_panic(&self) -> &KeyBytes {
+        self.first_key
+            .as_ref()
+            .expect("range-only SST has no point keys")
+    }
+
+    /// Returns the last point key, panicking if this is a range-only SST.
+    #[must_use]
+    pub fn last_key_or_panic(&self) -> &KeyBytes {
+        self.last_key
+            .as_ref()
+            .expect("range-only SST has no point keys")
+    }
+
+    /// Returns `true` if this SST contains range-tombstone fragments.
+    #[must_use]
+    pub fn has_range_tombstones(&self) -> bool {
+        self.range_tombstones.is_some()
+    }
+
+    /// Returns the cached range-tombstone fragments, if any.
+    #[must_use]
+    pub fn range_tombstone_fragments(
+        &self,
+    ) -> Option<&Arc<[crate::range_tombstone::RangeTombstoneFragment]>> {
+        self.range_tombstones.as_ref()
     }
 
     /// Get table size in bytes
@@ -774,8 +905,12 @@ impl SsTable {
     }
 
     pub fn range_overlap(&self, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> bool {
-        let lo = self.first_key.as_key_slice();
-        let hi = self.last_key.as_key_slice();
+        // Range-only SSTs always overlap (they cover a range with tombstones).
+        let (Some(first), Some(last)) = (self.first_key.as_ref(), self.last_key.as_ref()) else {
+            return true;
+        };
+        let lo = first.as_key_slice();
+        let hi = last.as_key_slice();
 
         // Both TS_ENABLED and non-TS paths compare encoded keys directly
         // since the encoding preserves byte order.

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -11,6 +11,7 @@ use crate::{
     block::{Block, BlockBuilder},
     key::{KeyBytes, KeySlice, TS_ENABLED},
     lsm_storage::{BlockCache, PrefixBloomOptions},
+    range_tombstone::RangeTombstoneFragment,
     vlog::{KvKind, ValueLogBuilder, ValuePointer, ValueSeparationOptions, index::VlogIndexEntry},
 };
 
@@ -45,6 +46,8 @@ pub struct SsTableBuilder {
     /// as the full-key bloom filter) to avoid false negatives from
     /// hash collisions in a HashSet.
     prefix_hash_sets: HashMap<usize, Vec<u32>>,
+    /// Range-tombstone fragments to write into the SST v4 range-tombstone block.
+    range_tombstones: Vec<RangeTombstoneFragment>,
 }
 
 impl SsTableBuilder {
@@ -66,6 +69,7 @@ impl SsTableBuilder {
             user_key_buf: Vec::new(),
             prefix_bloom_options: None,
             prefix_hash_sets: HashMap::new(),
+            range_tombstones: Vec::new(),
         }
     }
 
@@ -92,6 +96,7 @@ impl SsTableBuilder {
             user_key_buf: Vec::new(),
             prefix_bloom_options: None,
             prefix_hash_sets: HashMap::new(),
+            range_tombstones: Vec::new(),
         }
     }
 
@@ -115,7 +120,22 @@ impl SsTableBuilder {
     }
 
     pub fn is_empty(&self) -> bool {
-        !self.has_data
+        !self.has_data && self.range_tombstones.is_empty()
+    }
+
+    /// Add pre-fragmented range-tombstone spans to the SST.
+    ///
+    /// Call after all point entries have been added. The fragments are written
+    /// into the SST v4 range-tombstone block during `build_with_backfill()`.
+    pub fn add_range_tombstones(&mut self, fragments: Vec<RangeTombstoneFragment>) {
+        for frag in &fragments {
+            for &ts in &frag.covering_ts {
+                if ts > self.max_ts {
+                    self.max_ts = ts;
+                }
+            }
+        }
+        self.range_tombstones = fragments;
     }
 
     /// Adds a key-value pair to SSTable.
@@ -432,19 +452,45 @@ impl SsTableBuilder {
         bloom.encode(&mut buf);
         buf.put_u32(u32::try_from(bloom_offset).context("bloom offset exceeds u32::MAX")?);
 
-        if let Some(ref prefix_set) = prefix_bloom_set {
-            // Write v3 footer with prefix bloom section.
-            let prefix_bloom_offset = buf.len();
+        // Write prefix bloom section if present (v3+).
+        let prefix_bloom_offset = if let Some(ref prefix_set) = prefix_bloom_set {
+            let off = buf.len();
             Self::encode_prefix_bloom_section(prefix_set, &mut buf)?;
-            buf.put_u32(
-                u32::try_from(prefix_bloom_offset)
-                    .context("prefix bloom offset exceeds u32::MAX")?,
-            );
+            Some(u32::try_from(off).context("prefix bloom offset exceeds u32::MAX")?)
+        } else {
+            None
+        };
+
+        // Write range-tombstone block if present (v4).
+        let has_range_tombstones = !self.range_tombstones.is_empty();
+        let range_tombstone_offset = if has_range_tombstones {
+            let off =
+                u32::try_from(buf.len()).context("range tombstone offset exceeds u32::MAX")?;
+            RangeTombstoneFragment::encode_block(&self.range_tombstones, &mut buf);
+            Some(off)
+        } else {
+            None
+        };
+
+        if has_range_tombstones {
+            // Write v4 footer: 25 bytes fixed.
+            // Layout (reversed from disk):
+            //   bloom_offset:4 | prefix_bloom_offset:4 | range_tombstone_offset:4 | max_ts:8 |
+            // magic:4 | version:1
+            buf.put_u32(u32::try_from(bloom_offset).context("bloom offset exceeds u32::MAX")?);
+            buf.put_u32(prefix_bloom_offset.unwrap_or(0));
+            buf.put_u32(range_tombstone_offset.unwrap_or(0));
+            buf.put_u64(self.max_ts);
+            buf.put_u32(super::SST_MVCC_MAGIC);
+            buf.put_u8(super::SST_FOOTER_VERSION_V4);
+        } else if prefix_bloom_offset.is_some() {
+            // Write v3 footer with prefix bloom section.
+            buf.put_u32(prefix_bloom_offset.unwrap());
             buf.put_u64(self.max_ts);
             buf.put_u32(super::SST_MVCC_MAGIC);
             buf.put_u8(super::SST_FOOTER_VERSION_V3);
         } else {
-            // Write v2 footer (no prefix bloom metadata).
+            // Write v2 footer (no prefix bloom, no range tombstones).
             buf.put_u64(self.max_ts);
             buf.put_u32(super::SST_MVCC_MAGIC);
             buf.put_u8(super::SST_FOOTER_VERSION_V2);
@@ -463,8 +509,21 @@ impl SsTableBuilder {
         }
 
         let meta = mem::take(&mut self.meta);
-        let first_key = meta[0].first_key.clone();
-        let last_key = meta[meta.len() - 1].last_key.clone();
+        // For range-only SSTs (no point entries), first_key/last_key are None.
+        let (first_key, last_key) = if self.has_data {
+            (
+                Some(meta[0].first_key.clone()),
+                Some(meta[meta.len() - 1].last_key.clone()),
+            )
+        } else {
+            (None, None)
+        };
+
+        let range_tombstones = if self.range_tombstones.is_empty() {
+            None
+        } else {
+            Some(Arc::from(self.range_tombstones))
+        };
 
         let sst = SsTable {
             file,
@@ -477,6 +536,7 @@ impl SsTableBuilder {
             bloom: Some(bloom),
             max_ts: self.max_ts,
             prefix_blooms: prefix_bloom_set,
+            range_tombstones,
         };
         Ok((sst, self.collected_blocks))
     }

--- a/kv-engine/src/tests/memtable.rs
+++ b/kv-engine/src/tests/memtable.rs
@@ -985,18 +985,28 @@ fn test_get_with_ts_range_tombstone() {
 }
 
 #[test]
-fn test_flush_rejects_memtable_with_range_tombstones() {
+fn test_flush_writes_range_tombstones_to_sst() {
+    let dir = tempdir().unwrap();
     let memtable = MemTable::create(0);
     memtable.for_testing_put_slice(b"key1", b"val1").unwrap();
     memtable.put_range_tombstone(b"a", b"z", 10, 0).unwrap();
 
     let mut builder = crate::table::SsTableBuilder::new(4096);
-    let result = memtable.flush(&mut builder);
-    assert!(result.is_err());
+    memtable.flush(&mut builder).unwrap();
+    let sst = builder
+        .build_for_test(dir.path().join("test_flush_rt.sst"))
+        .unwrap();
+
+    // SST should contain the range tombstones in v4 format.
     assert!(
-        result.unwrap_err().to_string().contains("range tombstones"),
-        "error should mention range tombstones"
+        sst.has_range_tombstones(),
+        "SST should have range tombstones"
     );
+    let frags = sst.range_tombstone_fragments().unwrap();
+    assert!(!frags.is_empty(), "fragments should not be empty");
+    // The tombstone [a, z)@10 should cover key "key1".
+    let ts = crate::range_tombstone::find_newest_covering_ts(frags, b"key1", 100);
+    assert_eq!(ts, Some(10));
 }
 
 #[test]
@@ -1053,4 +1063,117 @@ fn test_get_key_outside_range_tombstones() {
     // Keys outside the tombstone range should be visible.
     assert_eq!(&storage.get(b"a").unwrap().unwrap()[..], b"1");
     assert_eq!(&storage.get(b"z").unwrap().unwrap()[..], b"2");
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3: SST v4 range-tombstone tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_flush_with_range_tombstone_sst_read() {
+    // put → delete_range → flush → get should return None for covered keys.
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+
+    storage.put(b"key1", b"val1").unwrap();
+    storage.put(b"key2", b"val2").unwrap();
+    storage.delete_range_internal(b"key1", b"key3").unwrap();
+
+    // Force flush — the memtable now has both point entries and range tombstones.
+    let state_lock = storage.state_lock.lock();
+    storage.force_freeze_memtable(&state_lock).unwrap();
+    drop(state_lock);
+    storage.force_flush_next_imm_memtable().unwrap();
+
+    // Both keys should be hidden by the SST range tombstone.
+    assert!(storage.get(b"key1").unwrap().is_none());
+    assert!(storage.get(b"key2").unwrap().is_none());
+
+    // Key outside the range should still be visible if present.
+    storage.put(b"key4", b"val4").unwrap();
+    assert_eq!(&storage.get(b"key4").unwrap().unwrap()[..], b"val4");
+}
+
+#[test]
+fn test_range_only_sst_flush() {
+    // delete_range with no point entries → flush → verify SST opens and
+    // range tombstones are readable.
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+
+    storage.delete_range_internal(b"a", b"z").unwrap();
+
+    let state_lock = storage.state_lock.lock();
+    storage.force_freeze_memtable(&state_lock).unwrap();
+    drop(state_lock);
+    storage.force_flush_next_imm_memtable().unwrap();
+
+    // The SST should have been created and contain range tombstones.
+    let state = storage.state.load();
+    assert!(!state.l0_sstables.is_empty(), "should have flushed an SST");
+    let sst_id = state.l0_sstables.last().unwrap();
+    let sst = state.sstables.get(sst_id).unwrap();
+    assert!(
+        sst.has_range_tombstones(),
+        "SST should have range tombstones"
+    );
+}
+
+#[test]
+fn test_recovery_preserves_range_tombstones() {
+    // put → delete_range → flush → close → reopen → verify tombstones survive.
+    let dir = tempdir().unwrap();
+
+    {
+        let storage =
+            LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap();
+        storage.put(b"key1", b"val1").unwrap();
+        storage.delete_range_internal(b"key1", b"key2").unwrap();
+
+        let state_lock = storage.state_lock.lock();
+        storage.force_freeze_memtable(&state_lock).unwrap();
+        drop(state_lock);
+        storage.force_flush_next_imm_memtable().unwrap();
+    }
+
+    // Reopen — the range tombstone should have been recovered from the SST.
+    {
+        let storage =
+            LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap();
+        assert!(
+            storage.get(b"key1").unwrap().is_none(),
+            "key1 should be hidden by recovered range tombstone"
+        );
+    }
+}
+
+#[test]
+fn test_scan_hides_keys_covered_by_sst_range_tombstone() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+
+    storage.put(b"a", b"1").unwrap();
+    storage.put(b"b", b"2").unwrap();
+    storage.put(b"c", b"3").unwrap();
+    storage.delete_range_internal(b"a", b"c").unwrap();
+
+    let state_lock = storage.state_lock.lock();
+    storage.force_freeze_memtable(&state_lock).unwrap();
+    drop(state_lock);
+    storage.force_flush_next_imm_memtable().unwrap();
+
+    // Scan — "a" and "b" should be hidden, "c" should be visible.
+    let mut iter = storage
+        .scan(Bound::Included(b"a"), Bound::Included(b"z"))
+        .unwrap();
+    let mut keys = Vec::new();
+    while iter.is_valid() {
+        keys.push(iter.key().to_vec());
+        iter.next().unwrap();
+    }
+    assert_eq!(keys.len(), 1, "expected only 'c', got {:?}", keys);
+    assert_eq!(&keys[0], b"c");
 }

--- a/kv-engine/src/tests/sst.rs
+++ b/kv-engine/src/tests/sst.rs
@@ -134,11 +134,11 @@ fn test_sst_decode() {
     let new_sst = SsTable::open_for_test(sst.file).unwrap();
     assert_eq!(new_sst.block_meta, meta);
     assert_eq!(
-        new_sst.first_key().for_testing_key_ref(),
+        new_sst.first_key().unwrap().for_testing_key_ref(),
         key_of(0).for_testing_key_ref()
     );
     assert_eq!(
-        new_sst.last_key().for_testing_key_ref(),
+        new_sst.last_key().unwrap().for_testing_key_ref(),
         key_of(num_of_keys() - 1).for_testing_key_ref()
     );
 }


### PR DESCRIPTION
## Summary

Implements Phase 3 of the DeleteRange RFC: range tombstones are now written to SSTs during flush and consulted during reads, making range deletions durable across restarts.

## Changes

### Range-tombstone block codec ()
- `encode_block` / `decode_block` with CRC32 integrity check
- Input validation: `record_count` checked against available data before allocation

### SST v4 format (, `table/builder.rs`)
- v4 footer (25 bytes): adds `range_tombstone_offset:4` field
- Builder writes range-tombstone block and v4 footer when range tombstones present
- Reader decodes range-tombstone block eagerly on open, caches fragments in `Arc<[RangeTombstoneFragment]>`
- Range-only SSTs (no point entries) supported: `first_key`/`last_key` are `None`

### Flush integration (`mem_table.rs`)
- Removed flush guard; flush now fragments and writes range tombstones to SST builder

### Read path (`lsm_storage.rs`)
- `get` / `get_with_ts` / `get_with_kind_inner`: consult `newest_sst_range_ts` alongside memtable range tombstones
- `scan_inner`: merges SST range-tombstone fragments into the scan iterator
- Binary-search SST lookup sites handle `None` keys from range-only SSTs

### Compaction safety (`compact/leveled.rs`, `iterators/concat_iterator.rs`)
- `SstConcatIterator` filters out range-only SSTs at construction
- `find_overlapping_ssts` skips range-only SSTs when computing key ranges
- `apply_compaction_result` sort handles `None` first keys

## Known Limitation

Compaction does not yet propagate range tombstones to output SSTs (Phase 4: Compaction GC).

## Verification
- [x] 520 tests passing
- [x] 0 clippy warnings
- [x] cargo fmt clean
- [x] 3-round adversarial review completed, all critical/major bugs fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SST-backed range tombstones using the v4 SST format. Key-range deletions now persist in SSTs and correctly affect point reads and range scans.

* **Improvements**
  * Memtable flush now preserves range tombstones into SSTs.
  * Handling of range-only SSTs was improved to ensure correct visibility and overlap behavior during reads, scans, and compaction.

* **Tests**
  * Added/updated coverage for range-tombstone flush, SST recovery after restart, range-only SST behavior, and scan visibility semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->