### PR TITLE
feat: DeleteRange Phase 5 — public API, CLI commands, observability stats

### DIFF
--- a/kv-engine/src/bin/kv-engine-cli.rs
+++ b/kv-engine/src/bin/kv-engine-cli.rs
@@ -65,6 +65,15 @@ impl ReplHandler {
                 self.lsm.delete(key.as_bytes())?;
                 println!("{} deleted", key);
             }
+            Command::Delrange { start, end } => {
+                if start >= end {
+                    return Err(anyhow::anyhow!(
+                        "invalid range: start must be less than end"
+                    ));
+                }
+                self.lsm.delete_range(start.as_bytes(), end.as_bytes())?;
+                println!("range deleted: [{}, {})", start, end);
+            }
             Command::Get { key } => {
                 if let Some(value) = self.lsm.get(key.as_bytes())? {
                     println!("{}={:?}", key, value);
@@ -160,6 +169,19 @@ impl ReplHandler {
                     println!("Value cache: disabled or no activity");
                 }
             }
+            Command::RtStats => {
+                let rs = self.lsm.range_tombstone_stats();
+                println!("Range tombstones:");
+                println!("  active:          {}", rs.active_count);
+                println!("  immutable:       {}", rs.immutable_count);
+                println!("  SSTs:            {}", rs.sst_count);
+                println!("  fragments:       {}", rs.total_sst_fragment_count);
+                println!("  metadata bytes:  {}", rs.metadata_bytes);
+                println!("  covering lookups: {}", rs.covering_lookups);
+                println!("  covering hits:    {}", rs.covering_hits);
+                println!("  covered drops:    {}", rs.covered_point_drops);
+                println!("  tombstone drops:  {}", rs.tombstone_drops);
+            }
         };
 
         self.epoch += 1;
@@ -176,6 +198,10 @@ enum Command {
     },
     Del {
         key: String,
+    },
+    Delrange {
+        start: String,
+        end: String,
     },
     Get {
         key: String,
@@ -194,6 +220,7 @@ enum Command {
     Quit,
     Close,
     Stats,
+    RtStats,
 }
 
 impl Command {
@@ -232,6 +259,13 @@ impl Command {
             )(i)
         };
 
+        let delrange = |i| {
+            map(
+                tuple((tag_no_case("delrange"), space1, string, space1, string)),
+                |(_, _, start, _, end)| Command::Delrange { start, end },
+            )(i)
+        };
+
         let get = |i| {
             map(
                 tuple((tag_no_case("get"), space1, string)),
@@ -263,6 +297,7 @@ impl Command {
         let command = |i| {
             alt((
                 fill,
+                delrange,
                 del,
                 get,
                 scan,
@@ -273,6 +308,7 @@ impl Command {
                 map(tag_no_case("quit"), |_| Command::Quit),
                 map(tag_no_case("close"), |_| Command::Close),
                 map(tag_no_case("stats"), |_| Command::Stats),
+                map(tag_no_case("rt_stats"), |_| Command::RtStats),
             ))(i)
         };
 

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -26,7 +26,8 @@ use crate::{
 
 /// Return type for `compact_from_iter` and friends:
 /// (point_ssts, vlog_ids, applied_filters, output_point_ranges)
-type CompactIterResult = Result<(Vec<Arc<SsTable>>, Vec<u32>, bool, Vec<(Vec<u8>, Vec<u8>)>)>;
+/// (point_ssts, vlog_ids, filter_deletion, output_ranges, gc_dropped_fragments)
+type CompactIterResult = Result<(Vec<Arc<SsTable>>, Vec<u32>, bool, Vec<(Vec<u8>, Vec<u8>)>, u64)>;
 
 /// Return type for `compact`:
 /// (point_ssts, range_only_ssts, vlog_ids, applied_filters)
@@ -348,20 +349,17 @@ impl LsmStorageInner {
         } else {
             Vec::new()
         };
-        let merged_fragments = if compact_to_bottom_level {
+        let (merged_fragments, gc_dropped_fragments) = if compact_to_bottom_level {
             if let Some(wm) = watermark {
                 let before = merged_fragments.len();
                 let after = gc_range_fragments(merged_fragments, wm);
-                let dropped = before.saturating_sub(after.len());
-                if dropped > 0 {
-                    self.rt_stats.note_tombstone_drops_n(dropped as u64);
-                }
-                after
+                let dropped = before.saturating_sub(after.len()) as u64;
+                (after, dropped)
             } else {
-                merged_fragments
+                (merged_fragments, 0)
             }
         } else {
-            merged_fragments
+            (merged_fragments, 0)
         };
 
         // Track state for watermark-aware version dropping. Keys iterate
@@ -533,6 +531,7 @@ impl LsmStorageInner {
             all_vlog_ids,
             can_publish_filter_deletion,
             output_point_ranges,
+            gc_dropped_fragments,
         ))
     }
 
@@ -754,7 +753,7 @@ impl LsmStorageInner {
         };
 
         // Dispatch to variant-specific compaction logic
-        let (point_ssts, vlog_ids, apply_filters, output_ranges) = match task {
+        let (point_ssts, vlog_ids, apply_filters, output_ranges, gc_dropped_fragments) = match task {
             CompactionTask::Simple(SimpleLeveledCompactionTask {
                 upper_level,
                 upper_level_sst_ids,
@@ -858,6 +857,13 @@ impl LsmStorageInner {
         } else {
             self.build_range_only_ssts(&merged_fragments, &output_ranges)?
         };
+
+        // Only count tombstone drops when fragments are truly removed (no
+        // range-only SSTs written). When range-only SSTs are produced the
+        // GC'd fragments are re-persisted there, so they are not reclaimed.
+        if gc_dropped_fragments > 0 && range_only_ssts.is_empty() {
+            self.rt_stats.note_tombstone_drops_n(gc_dropped_fragments);
+        }
 
         Ok((point_ssts, range_only_ssts, vlog_ids, apply_filters))
     }

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -350,7 +350,13 @@ impl LsmStorageInner {
         };
         let merged_fragments = if compact_to_bottom_level {
             if let Some(wm) = watermark {
-                gc_range_fragments(merged_fragments, wm)
+                let before = merged_fragments.len();
+                let after = gc_range_fragments(merged_fragments, wm);
+                let dropped = before.saturating_sub(after.len());
+                if dropped > 0 {
+                    self.rt_stats.note_tombstone_drops_n(dropped as u64);
+                }
+                after
             } else {
                 merged_fragments
             }
@@ -445,6 +451,7 @@ impl LsmStorageInner {
                             .is_some_and(|rt_ts| ts <= rt_ts)
                     {
                         // Covered by a permanent range tombstone — safe to drop
+                        self.rt_stats.note_covered_drop();
                         false
                     } else {
                         true

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -27,7 +27,13 @@ use crate::{
 /// Return type for `compact_from_iter` and friends:
 /// (point_ssts, vlog_ids, applied_filters, output_point_ranges)
 /// (point_ssts, vlog_ids, filter_deletion, output_ranges, gc_dropped_fragments)
-type CompactIterResult = Result<(Vec<Arc<SsTable>>, Vec<u32>, bool, Vec<(Vec<u8>, Vec<u8>)>, u64)>;
+type CompactIterResult = Result<(
+    Vec<Arc<SsTable>>,
+    Vec<u32>,
+    bool,
+    Vec<(Vec<u8>, Vec<u8>)>,
+    u64,
+)>;
 
 /// Return type for `compact`:
 /// (point_ssts, range_only_ssts, vlog_ids, applied_filters)
@@ -753,7 +759,8 @@ impl LsmStorageInner {
         };
 
         // Dispatch to variant-specific compaction logic
-        let (point_ssts, vlog_ids, apply_filters, output_ranges, gc_dropped_fragments) = match task {
+        let (point_ssts, vlog_ids, apply_filters, output_ranges, gc_dropped_fragments) = match task
+        {
             CompactionTask::Simple(SimpleLeveledCompactionTask {
                 upper_level,
                 upper_level_sst_ids,

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1500,6 +1500,13 @@ impl LsmStorageInner {
             return self.resolve_value(&found_key, value, kind);
         }
 
+        // No point entry found, but a range tombstone covers this key —
+        // after compaction removed the covered point entry, the key is
+        // effectively hidden by range-tombstone metadata alone.
+        if range_ts.is_some() {
+            self.rt_stats.note_hit();
+        }
+
         Ok(None)
     }
 
@@ -1712,6 +1719,10 @@ impl LsmStorageInner {
                 return Ok(None);
             }
             return self.resolve_value(&found_key, value, kind);
+        }
+
+        if range_ts.is_some() {
+            self.rt_stats.note_hit();
         }
 
         Ok(None)
@@ -2072,6 +2083,10 @@ impl LsmStorageInner {
                 return Ok((None, KvKind::Inline));
             }
             return Ok((val, kind));
+        }
+
+        if range_ts.is_some() {
+            self.rt_stats.note_hit();
         }
 
         Ok((None, KvKind::Inline))

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -271,6 +271,32 @@ pub struct CacheStats {
     pub value_cache_miss_count: u64,
 }
 
+/// Range tombstone statistics for the storage engine.
+///
+/// Memtable counts (`active_count`, `immutable_count`) are raw tombstones;
+/// SST counts (`sst_count`, `total_sst_fragment_count`) are post-fragmentation.
+#[derive(Clone, Copy, Debug)]
+pub struct RangeTombstoneStats {
+    /// Number of range tombstones in the active (mutable) memtable.
+    pub active_count: u64,
+    /// Total range tombstones across all immutable memtables.
+    pub immutable_count: u64,
+    /// Number of SSTs that contain range-tombstone metadata (including range-only SSTs).
+    pub sst_count: u64,
+    /// Total range-tombstone fragment count across all SSTs.
+    pub total_sst_fragment_count: u64,
+    /// Approximate bytes of range-tombstone metadata across all SSTs.
+    pub metadata_bytes: u64,
+    /// Number of point lookups that consulted range-tombstone metadata.
+    pub covering_lookups: u64,
+    /// Number of point lookups where a range tombstone covered the key.
+    pub covering_hits: u64,
+    /// Number of point entries dropped by compaction due to range-tombstone coverage.
+    pub covered_point_drops: u64,
+    /// Number of range-tombstone fragments dropped by compaction (obsolete).
+    pub tombstone_drops: u64,
+}
+
 #[derive(Clone, Debug)]
 pub enum CompactionFilterRequest {
     Prefix(Bytes),
@@ -334,6 +360,60 @@ pub(crate) struct CompactionFilterAtomicStats {
     entries_eligible: AtomicU64,
     entries_dropped: AtomicU64,
     bytes_dropped: AtomicU64,
+}
+
+/// Atomic counters for range-tombstone runtime observability.
+pub(crate) struct RangeTombstoneAtomicStats {
+    covering_lookups: AtomicU64,
+    covering_hits: AtomicU64,
+    covered_point_drops: AtomicU64,
+    tombstone_drops: AtomicU64,
+}
+
+impl Default for RangeTombstoneAtomicStats {
+    fn default() -> Self {
+        Self {
+            covering_lookups: AtomicU64::new(0),
+            covering_hits: AtomicU64::new(0),
+            covered_point_drops: AtomicU64::new(0),
+            tombstone_drops: AtomicU64::new(0),
+        }
+    }
+}
+
+impl RangeTombstoneAtomicStats {
+    pub(crate) fn note_lookup(&self) {
+        self.covering_lookups
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub(crate) fn note_hit(&self) {
+        self.covering_hits
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub(crate) fn note_covered_drop(&self) {
+        self.covered_point_drops
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub(crate) fn note_tombstone_drops_n(&self, n: u64) {
+        self.tombstone_drops
+            .fetch_add(n, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn snapshot(&self) -> (u64, u64, u64, u64) {
+        (
+            self.covering_lookups
+                .load(std::sync::atomic::Ordering::Relaxed),
+            self.covering_hits
+                .load(std::sync::atomic::Ordering::Relaxed),
+            self.covered_point_drops
+                .load(std::sync::atomic::Ordering::Relaxed),
+            self.tombstone_drops
+                .load(std::sync::atomic::Ordering::Relaxed),
+        )
+    }
 }
 
 impl Default for CompactionFilterAtomicStats {
@@ -438,6 +518,7 @@ pub(crate) struct LsmStorageInner {
     pub(crate) mvcc: Option<Arc<LsmMvccInner>>,
     compaction_filters: Mutex<CompactionFilterRegistry>,
     filter_stats: Arc<CompactionFilterAtomicStats>,
+    pub(crate) rt_stats: Arc<RangeTombstoneAtomicStats>,
     /// Value Log manager for key-value separation. `None` if value separation is disabled.
     pub(crate) vlog: Option<Arc<ValueLog>>,
     /// Weak reference to the owning `Arc<LsmStorageInner>`, set after construction.
@@ -576,6 +657,20 @@ impl KvEngine {
         self.inner.delete(key)
     }
 
+    /// Delete all keys in the half-open range `[start, end)`.
+    ///
+    /// The range tombstone is immediately visible to readers at newer
+    /// timestamps. Older snapshots continue to see pre-existing data.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `start >= end`, if either key exceeds the maximum
+    /// key size, or if the engine is in serializable mode or has value
+    /// separation enabled (not supported in the MVP).
+    pub fn delete_range(&self, start: &[u8], end: &[u8]) -> Result<()> {
+        self.inner.delete_range_internal(start, end)
+    }
+
     pub fn sync(&self) -> Result<()> {
         self.inner.sync()
     }
@@ -683,6 +778,53 @@ impl KvEngine {
             block_cache_entry_count: self.inner.block_cache.entry_count(),
             value_cache_hit_count: vc_hits,
             value_cache_miss_count: vc_misses,
+        }
+    }
+
+    /// Get range tombstone statistics for the storage engine.
+    ///
+    /// Note: iterates SST metadata and may be non-trivial for large LSM states.
+    /// Not intended for hot-path use.
+    pub fn range_tombstone_stats(&self) -> RangeTombstoneStats {
+        let state = self.inner.state.load();
+        let active_count = state.memtable.range_tombstones().len() as u64;
+        let immutable_count: u64 = state
+            .imm_memtables
+            .iter()
+            .map(|mt| mt.range_tombstones().len() as u64)
+            .sum();
+        let mut sst_count: u64 = 0;
+        let mut total_sst_fragment_count: u64 = 0;
+        let mut metadata_bytes: u64 = 0;
+        for sst in state.sstables.values() {
+            if sst.has_range_tombstones() {
+                sst_count += 1;
+                if let Some(fragments) = sst.range_tombstone_fragments() {
+                    total_sst_fragment_count += fragments.len() as u64;
+                    // Estimate: each fragment ≈ 2 (start_len) + 2 (end_len) + 4 (ts_count)
+                    // + start.len() + end.len() + covering_ts.len() * 8
+                    for f in fragments.iter() {
+                        metadata_bytes += 8
+                            + f.start.len() as u64
+                            + f.end.len() as u64
+                            + f.covering_ts.len() as u64 * 8;
+                    }
+                }
+            }
+        }
+        let (covering_lookups, covering_hits, covered_point_drops, tombstone_drops) =
+            self.inner.rt_stats.snapshot();
+
+        RangeTombstoneStats {
+            active_count,
+            immutable_count,
+            sst_count,
+            total_sst_fragment_count,
+            metadata_bytes,
+            covering_lookups,
+            covering_hits,
+            covered_point_drops,
+            tombstone_drops,
         }
     }
 }
@@ -1165,6 +1307,7 @@ impl LsmStorageInner {
                 next_compaction_filter_id,
             }),
             filter_stats: Arc::new(CompactionFilterAtomicStats::default()),
+            rt_stats: Arc::new(RangeTombstoneAtomicStats::default()),
             vlog,
             weak_self: std::sync::OnceLock::new(),
             gc_handles: Mutex::new(Vec::new()),
@@ -1328,12 +1471,14 @@ impl LsmStorageInner {
         // zero-copy inline slicing (refcount bump instead of heap allocation).
         let read_ts_for_range = mvcc_read_ts.unwrap_or(u64::MAX);
         let memtable_range_ts = self.newest_memtable_range_ts(&state, key, read_ts_for_range);
+        self.rt_stats.note_lookup();
         if let Some((value, kind, found_key, value_ts)) =
             self.lookup_memtable(&state, encoded, bloom_hash, mvcc_read_ts)?
         {
             if memtable_range_ts.is_some_and(|rt| value_ts <= rt) {
                 // Covered by range tombstone — any SST version is older and
                 // also covered, so return immediately.
+                self.rt_stats.note_hit();
                 return Ok(None);
             }
             return self.resolve_value(&found_key, value, kind);
@@ -1349,6 +1494,7 @@ impl LsmStorageInner {
             self.lookup_sst_raw(&state, encoded, bloom_hash, mvcc_read_ts)?
         {
             if range_ts.is_some_and(|rt| value_ts <= rt) {
+                self.rt_stats.note_hit();
                 return Ok(None);
             }
             return self.resolve_value(&found_key, value, kind);
@@ -1539,12 +1685,14 @@ impl LsmStorageInner {
         let bloom_hash = crate::table::bloom::hash_key(key);
         let lookup_key = crate::key::encode_internal_key(key, u64::MAX);
         let memtable_range_ts = self.newest_memtable_range_ts(&state, key, read_ts);
+        self.rt_stats.note_lookup();
         if let Some((value, kind, found_key, value_ts)) =
             self.lookup_memtable(&state, &lookup_key, bloom_hash, Some(read_ts))?
         {
             if memtable_range_ts.is_some_and(|rt| value_ts <= rt) {
                 // Covered by memtable range tombstone — SST versions are older
                 // and also covered, so return immediately.
+                self.rt_stats.note_hit();
                 return Ok(None);
             }
             return self.resolve_value(&found_key, value, kind);
@@ -1560,6 +1708,7 @@ impl LsmStorageInner {
             self.lookup_sst_raw(&state, &lookup_key, bloom_hash, Some(read_ts))?
         {
             if range_ts.is_some_and(|rt| value_ts <= rt) {
+                self.rt_stats.note_hit();
                 return Ok(None);
             }
             return self.resolve_value(&found_key, value, kind);
@@ -1898,10 +2047,12 @@ impl LsmStorageInner {
         };
         let read_ts_for_range = mvcc_read_ts.unwrap_or(u64::MAX);
         let memtable_range_ts = self.newest_memtable_range_ts(state, key, read_ts_for_range);
+        self.rt_stats.note_lookup();
         if let Some((val, kind, _key, value_ts)) =
             self.lookup_memtable(state, encoded, bloom_hash, mvcc_read_ts)?
         {
             if memtable_range_ts.is_some_and(|rt| value_ts <= rt) {
+                self.rt_stats.note_hit();
                 return Ok((None, KvKind::Inline));
             }
             return Ok((val, kind));
@@ -1917,6 +2068,7 @@ impl LsmStorageInner {
             self.lookup_sst_raw(state, encoded, bloom_hash, mvcc_read_ts)?
         {
             if range_ts.is_some_and(|rt| value_ts <= rt) {
+                self.rt_stats.note_hit();
                 return Ok((None, KvKind::Inline));
             }
             return Ok((val, kind));

--- a/kv-engine/src/tests/memtable.rs
+++ b/kv-engine/src/tests/memtable.rs
@@ -5,7 +5,7 @@ use tempfile::tempdir;
 
 use crate::{
     iterators::StorageIterator,
-    lsm_storage::{LsmStorageInner, LsmStorageOptions},
+    lsm_storage::{KvEngine, LsmStorageInner, LsmStorageOptions},
     mem_table::MemTable,
 };
 
@@ -1176,4 +1176,81 @@ fn test_scan_hides_keys_covered_by_sst_range_tombstone() {
     }
     assert_eq!(keys.len(), 1, "expected only 'c', got {:?}", keys);
     assert_eq!(&keys[0], b"c");
+}
+
+#[test]
+fn test_public_delete_range_api() {
+    let dir = tempdir().unwrap();
+    let storage = KvEngine::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap();
+
+    storage.put(b"a", b"1").unwrap();
+    storage.put(b"b", b"2").unwrap();
+    storage.put(b"c", b"3").unwrap();
+
+    // Exercise the public KvEngine::delete_range path.
+    storage.delete_range(b"a", b"c").unwrap();
+
+    // "a" and "b" should be hidden, "c" should be visible.
+    assert!(storage.get(b"a").unwrap().is_none());
+    assert!(storage.get(b"b").unwrap().is_none());
+    assert_eq!(storage.get(b"c").unwrap().unwrap().as_ref(), b"3");
+}
+
+#[test]
+fn test_delete_range_invalid_bounds() {
+    let dir = tempdir().unwrap();
+    let storage = KvEngine::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap();
+    // start > end
+    assert!(storage.delete_range(b"c", b"a").is_err());
+    // start == end
+    assert!(storage.delete_range(b"a", b"a").is_err());
+}
+
+#[test]
+fn test_range_tombstone_stats() {
+    let dir = tempdir().unwrap();
+    let storage = KvEngine::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap();
+
+    // Initially no range tombstones.
+    let stats = storage.range_tombstone_stats();
+    assert_eq!(stats.active_count, 0);
+    assert_eq!(stats.immutable_count, 0);
+    assert_eq!(stats.sst_count, 0);
+    assert_eq!(stats.covering_lookups, 0);
+    assert_eq!(stats.covering_hits, 0);
+
+    // Add some keys and a range tombstone.
+    storage.put(b"m", b"val").unwrap();
+    storage.delete_range(b"a", b"z").unwrap();
+
+    let stats = storage.range_tombstone_stats();
+    assert_eq!(stats.active_count, 1);
+    assert_eq!(stats.immutable_count, 0);
+
+    // Flush — tombstone moves from active to SST.
+    storage.force_flush().unwrap();
+
+    let stats = storage.range_tombstone_stats();
+    assert_eq!(stats.active_count, 0);
+    assert_eq!(stats.immutable_count, 0);
+    // The range-only SST should exist with fragments.
+    assert!(stats.sst_count >= 1);
+    assert!(stats.total_sst_fragment_count >= 1);
+
+    // Exercise runtime counters: get on a covered key.
+    let result = storage.get(b"m").unwrap();
+    assert!(
+        result.is_none(),
+        "key 'm' should be hidden by range tombstone"
+    );
+
+    let stats = storage.range_tombstone_stats();
+    assert!(
+        stats.covering_lookups >= 1,
+        "should have counted at least one lookup"
+    );
+    assert!(
+        stats.covering_hits >= 1,
+        "should have counted at least one hit"
+    );
 }


### PR DESCRIPTION
## Summary

Final phase (§15) of the DeleteRange feature (RFC 010). Adds the public `delete_range` API, CLI commands, and range-tombstone observability stats.

## Changes

**Public API** (`lsm_storage.rs`):
- `KvEngine::delete_range(start, end)` — validates bounds, delegates to memtable
- `KvEngine::range_tombstone_stats()` — returns snapshot of all range-tombstone counters

**Stats** (`lsm_storage.rs`):
- `RangeTombstoneStats` — 8 RFC §12.4 fields + 1 bonus (`metadata_bytes`)
- `RangeTombstoneAtomicStats` — 4 runtime `AtomicU64` counters: `covering_lookups`, `covering_hits`, `covered_point_drops`, `tombstone_drops`

**Counter wiring** (`compact.rs`, `lsm_storage.rs`):
- `covering_lookups` / `covering_hits` — incremented on every `get` / `get_with_ts` / `get_for_txn_inner`
- `covered_point_drops` — incremented in compaction when point entry dropped by range tombstone
- `tombstone_drops` — incremented in compaction when `gc_range_fragments` removes fragments

**CLI** (`kv-engine-cli.rs`):
- `delrange <start> <end>` — with `start >= end` validation
- `rt_stats` — prints all 9 stats fields

**Tests** (`tests/memtable.rs`):
- `test_public_delete_range_api` — basic hide/reveal
- `test_delete_range_invalid_bounds` — error paths
- `test_range_tombstone_stats` — counter correctness

## Verification

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — 528 passed, 0 failed
- [x] 9 rounds of subagent review — final verdict: PASS

## RFC coverage

All 8 §12.4 `RangeTombstoneStats` fields present. All 4 runtime counters wired. Public API with `# Errors` doc. CLI commands match RFC naming. Only deferred item: benchmark coverage (§12.5, P2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `delrange` CLI command for deleting ranges of keys with boundary validation
  * Added `rt_stats` CLI command to view range-tombstone coverage statistics and metrics
  * Introduced `delete_range()` API method for range deletion operations
  * Added `range_tombstone_stats()` method to observe tombstone coverage, lookup hits, and drop counters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->