### PR TITLE
feat: DeleteRange benchmark gates (RFC 010 §12.5)

### DIFF
--- a/docs/bench-report-deleterange.md
+++ b/docs/bench-report-deleterange.md
@@ -1,0 +1,103 @@
+# DeleteRange Performance Report
+
+Date: 2026-06-18
+RFC: 010 §12.5
+Hardware: (fill in)
+Rust: stable
+Criterion: 0.5
+
+## Benchmark Results
+
+### get_noncovering — point lookup with N non-covering tombstones in active memtable
+
+| Tombstones | Time | vs Baseline |
+|---|---|---|
+| 0 | 321 ns | baseline |
+| 1 | 386 ns | +20% |
+| 100 | 3.29 µs | +925% |
+| 10,000 | 293 µs | +91,200% |
+
+Bottleneck: O(R) linear scan over all tombstones in the active memtable
+per `get()` call. Each tombstone = 2 key comparisons.
+
+### get_covering — single covering tombstone at different levels
+
+| Level | Time | Notes |
+|---|---|---|
+| active_memtable | 374 ns | tombstone in write buffer |
+| immutable_memtable | 466 ns | tombstone frozen, not flushed |
+| L0 | 366 ns | tombstone flushed to L0 SST |
+| lower_level (L1+) | 171 ns | binary search on sorted SSTs |
+
+L1+ is fastest: non-overlapping SSTs with smaller search space.
+L0 is slower: many overlapping SSTs to scan.
+
+### scan_dense_deleted_range — scan [1000, 2000) where all entries hidden
+
+| Case | Time | Notes |
+|---|---|---|
+| deleted (0 results) | 47.8 µs | tombstone filters all entries |
+| baseline (1000 results) | 52.7 µs | full iteration + value copy |
+
+Deleted scan is faster: merge iterator skips entries without copying values.
+
+### scan_noncovering_tombstones — scan 0..4000 with 100 non-covering tombstones
+
+| Case | Time | vs Baseline |
+|---|---|---|
+| 100 non-covering | 484 µs | +135% |
+| baseline | 206 µs | — |
+
+4000 entries × 100 tombstone checks = 400k comparisons per scan.
+
+### prefix_scan_tombstones — prefix "pre0025" (50 entries)
+
+| Case | Time | vs Baseline |
+|---|---|---|
+| non_overlapping | 4.01 µs | +29% |
+| overlapping | 3.12 µs | +1% |
+| 100 non-covering | 42.4 µs | +1,270% |
+| baseline | 3.09 µs | — |
+
+50 entries × 100 tombstone checks = 5k comparisons per prefix lookup.
+
+### flush_compaction_tombstones
+
+| Operation | Time |
+|---|---|
+| flush mixed (1000 entries + 1 tombstone) | 505 µs |
+| flush range-only (tombstone only) | 449 µs |
+| compaction mixed (5000 entries + 1 tombstone) | 1.36 ms |
+| compaction range-only (tombstone fragments only) | 606 µs |
+
+## Acceptance Gates (RFC 010 §12.5)
+
+| Gate | Target | Actual | Status |
+|---|---|---|---|
+| get ≤10% regression at 100 non-covering | ≤353 ns | 3.29 µs | ❌ |
+| scan ≤15% regression at 100 non-covering | ≤237 µs | 484 µs | ❌ |
+| prefix_scan ≤15% regression at 100 non-covering | ≤3.55 µs | 42.4 µs | ❌ |
+
+## Root Cause
+
+**O(R) linear scan in the active memtable** for range tombstones.
+
+- `get` path: `find_sst_with_range_ts()` scans all R tombstones in the active memtable linearly.
+- `scan` path: merge iterator checks every candidate entry against all R tombstones.
+- `prefix_scan` path: same as scan but per-prefix.
+
+At 100 tombstones, this adds ~3 µs overhead per get, ~280 µs overhead per scan,
+and ~39 µs overhead per prefix scan.
+
+## Optimization Direction (RFC §12.2 deferred)
+
+Replace the `Vec<RangeTombstone>` linear scan with an interval tree or sorted structure,
+reducing per-entry check from O(R) to O(log R + K) where K is the number of covering
+tombstones for a given key.
+
+Expected improvement:
+- get at 100 tombstones: 3.29 µs → ~350 ns (back to ~baseline)
+- scan at 100 tombstones: 484 µs → ~230 µs (back to ~baseline)
+- prefix_scan at 100 tombstones: 42.4 µs → ~3.5 µs (back to ~baseline)
+
+These benchmarks establish the baseline for that optimization.

--- a/docs/bench-report-deleterange.md
+++ b/docs/bench-report-deleterange.md
@@ -3,7 +3,7 @@
 Date: 2026-06-18
 RFC: 010 §12.5
 Hardware: (fill in)
-Rust: stable
+Rust: nightly-2026-05-28 (1.98.0-nightly)
 Criterion: 0.5
 
 ## Methodology

--- a/docs/bench-report-deleterange.md
+++ b/docs/bench-report-deleterange.md
@@ -6,6 +6,15 @@ Hardware: (fill in)
 Rust: stable
 Criterion: 0.5
 
+## Methodology
+
+- **Framework**: Criterion 0.5, `harness = false`
+- **Sample size**: 100 for `get`, 50 for `scan`/`prefix_scan`, 20 for flush/compaction/recovery
+- **Warmup**: 3 seconds per benchmark
+- **Setup pattern**: `iter_batched` — setup closure creates fresh data, measured closure runs the operation
+- **Keys**: `keyNNNNNN` format with 100-byte values
+- **Tombstones**: `delNNNNNN-delNNNNN1` (4-byte disjoint ranges, non-covering unless stated)
+
 ## Benchmark Results
 
 ### get_noncovering — point lookup with N non-covering tombstones in active memtable
@@ -70,6 +79,19 @@ Deleted scan is faster: merge iterator skips entries without copying values.
 | compaction mixed (5000 entries + 1 tombstone) | 1.36 ms |
 | compaction range-only (tombstone fragments only) | 606 µs |
 
+### recovery_tombstones — KvEngine::open with N tombstones
+
+| Case | Time | Notes |
+|---|---|---|
+| SST 0 tombstones | 83 µs | baseline |
+| SST 1 | 82 µs | no overhead |
+| SST 100 | 109 µs | +31% — fragment metadata scan |
+| SST 10,000 | 6.74 ms | +81x — pathological |
+| WAL 100 | 2.06 ms | WAL replay + tombstone recovery |
+
+Recovery measures `open()` only (no `close()`). 10k tombstones causes ~6.7ms
+from reading range fragment blocks during SST metadata scan.
+
 ## Acceptance Gates (RFC 010 §12.5)
 
 | Gate | Target | Actual | Status |
@@ -95,9 +117,9 @@ Replace the `Vec<RangeTombstone>` linear scan with an interval tree or sorted st
 reducing per-entry check from O(R) to O(log R + K) where K is the number of covering
 tombstones for a given key.
 
-Expected improvement:
-- get at 100 tombstones: 3.29 µs → ~350 ns (back to ~baseline)
-- scan at 100 tombstones: 484 µs → ~230 µs (back to ~baseline)
-- prefix_scan at 100 tombstones: 42.4 µs → ~3.5 µs (back to ~baseline)
+Expected improvement (conservative, includes constant-factor overhead from tree lookup):
+- get at 100 tombstones: 3.29 µs → ~400 ns (slightly above 321 ns baseline)
+- scan at 100 tombstones: 484 µs → ~250 µs (slightly above 206 µs baseline)
+- prefix_scan at 100 tombstones: 42.4 µs → ~5 µs (above 3.09 µs baseline)
 
 These benchmarks establish the baseline for that optimization.

--- a/docs/bench-report-deleterange.md
+++ b/docs/bench-report-deleterange.md
@@ -2,7 +2,7 @@
 
 Date: 2026-06-18
 RFC: 010 §12.5
-Hardware: (fill in)
+Hardware: Intel i9-13900T (24 cores / 32 threads), 64 GB RAM, x86_64
 Rust: nightly-2026-05-28 (1.98.0-nightly)
 Criterion: 0.5
 

--- a/kv-engine/Cargo.toml
+++ b/kv-engine/Cargo.toml
@@ -38,3 +38,7 @@ harness = false
 [[bench]]
 name = "vlog_index_benchmarks"
 harness = false
+
+[[bench]]
+name = "deleterange_benchmarks"
+harness = false

--- a/kv-engine/benches/deleterange_benchmarks.rs
+++ b/kv-engine/benches/deleterange_benchmarks.rs
@@ -100,7 +100,6 @@ fn bench_get_noncovering(c: &mut Criterion) {
 
         // Add tombstones after compaction so they live in memtable/imm
         insert_noncovering_tombstones(&lsm, n_tombstones);
-        flush_all(&lsm);
 
         let label = format!("tombstones={}", n_tombstones);
         group.bench_function(BenchmarkId::new("get", &label), |b| {
@@ -192,19 +191,20 @@ fn bench_get_covering(c: &mut Criterion) {
         lsm.close().unwrap();
     }
 
-    // Lower level: tombstone present without compacting it away.
-    // Write tombstone into memtable and flush to L0; do NOT compact
-    // further so the tombstone survives GC.
+    // Lower level: tombstone compacted to L1+.
+    // Pin the MVCC watermark with a transaction to prevent GC of the
+    // tombstone and covered entries during compaction.
     {
         let dir = tempfile::tempdir().unwrap();
         let lsm = KvEngine::open(dir.path(), make_options()).unwrap();
         load_entries(&lsm, 5000);
         flush_all(&lsm);
         lsm.force_full_compaction().unwrap();
-        // Add covering tombstone and flush to SST (L0).
-        // Do NOT force_full_compaction — that would GC the tombstone.
         lsm.delete_range(b"key002500", b"key002501").unwrap();
         flush_all(&lsm);
+        // Pin watermark before compaction to prevent GC
+        let _txn = lsm.new_txn().unwrap();
+        lsm.force_full_compaction().unwrap();
 
         group.bench_function("lower_level", |b| {
             b.iter(|| {

--- a/kv-engine/benches/deleterange_benchmarks.rs
+++ b/kv-engine/benches/deleterange_benchmarks.rs
@@ -38,6 +38,13 @@ fn make_options() -> LsmStorageOptions {
     }
 }
 
+fn make_options_wal() -> LsmStorageOptions {
+    LsmStorageOptions {
+        enable_wal: true,
+        ..make_options()
+    }
+}
+
 fn flush_all(lsm: &KvEngine) {
     for _ in 0..5 {
         if lsm.force_flush().is_err() {
@@ -142,11 +149,7 @@ fn bench_get_covering(c: &mut Criterion) {
     // Fill active memtable with data to trigger a freeze (num_memtable_limit=2).
     {
         let dir = tempfile::tempdir().unwrap();
-        let opts = LsmStorageOptions {
-            target_sst_size: 2 << 20,
-            ..make_options()
-        };
-        let lsm = KvEngine::open(dir.path(), opts).unwrap();
+        let lsm = KvEngine::open(dir.path(), make_options()).unwrap();
         load_entries(&lsm, 5000);
         flush_all(&lsm);
         lsm.force_full_compaction().unwrap();
@@ -191,16 +194,19 @@ fn bench_get_covering(c: &mut Criterion) {
         lsm.close().unwrap();
     }
 
-    // Lower level: tombstone compacted to lower level
+    // Lower level: tombstone present without compacting it away.
+    // Write tombstone into memtable and flush to L0; do NOT compact
+    // further so the tombstone survives GC.
     {
         let dir = tempfile::tempdir().unwrap();
         let lsm = KvEngine::open(dir.path(), make_options()).unwrap();
         load_entries(&lsm, 5000);
         flush_all(&lsm);
         lsm.force_full_compaction().unwrap();
+        // Add covering tombstone and flush to SST (L0).
+        // Do NOT force_full_compaction — that would GC the tombstone.
         lsm.delete_range(b"key002500", b"key002501").unwrap();
         flush_all(&lsm);
-        lsm.force_full_compaction().unwrap();
 
         group.bench_function("lower_level", |b| {
             b.iter(|| {
@@ -222,17 +228,15 @@ fn bench_scan_dense_deleted(c: &mut Criterion) {
     let mut group = c.benchmark_group("scan_dense_deleted_range");
     group.sample_size(50);
 
+    // Deleted range: tombstone in memtable, point entries in SSTs.
+    // Do NOT compact after adding the tombstone — compaction would GC
+    // both the tombstone and the covered entries, making the scan trivial.
     let dir = tempfile::tempdir().unwrap();
     let lsm = KvEngine::open(dir.path(), make_options()).unwrap();
-
     load_entries(&lsm, 5000);
     flush_all(&lsm);
     lsm.force_full_compaction().unwrap();
-
-    // Delete key1000..key2000 (1000 entries)
     lsm.delete_range(b"key001000", b"key002000").unwrap();
-    flush_all(&lsm);
-    lsm.force_full_compaction().unwrap();
 
     group.bench_function("scan_deleted_1000", |b| {
         b.iter(|| {
@@ -322,6 +326,29 @@ fn bench_prefix_scan_tombstones(c: &mut Criterion) {
         lsm.close().unwrap();
     }
 
+    // 100 non-covering tombstones (§12.5 gate workload)
+    {
+        let dir = tempfile::tempdir().unwrap();
+        let lsm = KvEngine::open(dir.path(), make_options()).unwrap();
+        let value = vec![0xABu8; 100];
+        for i in 0..5000 {
+            let key = format!("pre{:04}item{:04}", i / 50, i % 50);
+            lsm.put(key.as_bytes(), &value).unwrap();
+        }
+        flush_all(&lsm);
+        lsm.force_full_compaction().unwrap();
+        insert_noncovering_tombstones(&lsm, 100);
+
+        group.bench_function("non_overlapping_100", |b| {
+            b.iter(|| {
+                let iter = lsm.prefix_scan(b"pre0025").unwrap();
+                let count = count_scan(iter);
+                black_box(count);
+            })
+        });
+        lsm.close().unwrap();
+    }
+
     group.finish();
 }
 
@@ -333,7 +360,7 @@ fn bench_flush_compaction(c: &mut Criterion) {
     let mut group = c.benchmark_group("flush_compaction_tombstones");
     group.sample_size(20);
 
-    // Mixed: point entries + range tombstone
+    // Mixed flush: point entries + range tombstone
     group.bench_function("flush_mixed", |b| {
         b.iter_batched(
             || {
@@ -356,7 +383,7 @@ fn bench_flush_compaction(c: &mut Criterion) {
         )
     });
 
-    // Range-only: just a tombstone, no point entries
+    // Range-only flush: just a tombstone, no point entries
     group.bench_function("flush_range_only", |b| {
         b.iter_batched(
             || {
@@ -398,6 +425,34 @@ fn bench_flush_compaction(c: &mut Criterion) {
         )
     });
 
+    // Compaction with range-only data (§12.5 range-only compaction path)
+    group.bench_function("compaction_range_only", |b| {
+        b.iter_batched(
+            || {
+                let dir = tempfile::tempdir().unwrap();
+                let lsm = KvEngine::open(dir.path(), make_options()).unwrap();
+                // Write some entries first so there's a lower level to compact into
+                let value = vec![0xABu8; 100];
+                for i in 0..1000 {
+                    let key = format!("key{:06}", i);
+                    lsm.put(key.as_bytes(), &value).unwrap();
+                }
+                flush_all(&lsm);
+                lsm.force_full_compaction().unwrap();
+                // Now add a range-only tombstone and flush
+                lsm.delete_range(b"key000500", b"key000800").unwrap();
+                flush_all(&lsm);
+                (dir, lsm)
+            },
+            |(dir, lsm)| {
+                lsm.force_full_compaction().unwrap();
+                lsm.close().unwrap();
+                drop(dir);
+            },
+            criterion::BatchSize::SmallInput,
+        )
+    });
+
     group.finish();
 }
 
@@ -410,7 +465,7 @@ fn bench_recovery(c: &mut Criterion) {
     group.sample_size(20);
 
     for n_tombstones in [0, 1, 100, 10_000] {
-        // Prepare data directory with tombstones
+        // Prepare data directory with tombstones (WAL disabled, flushed)
         let dir = tempfile::tempdir().unwrap();
         {
             let lsm = KvEngine::open(dir.path(), make_options()).unwrap();
@@ -422,7 +477,7 @@ fn bench_recovery(c: &mut Criterion) {
 
         let path = dir.path().to_path_buf();
         let label = format!("tombstones={}", n_tombstones);
-        group.bench_function(BenchmarkId::new("open", &label), |b| {
+        group.bench_function(BenchmarkId::new("open_sst", &label), |b| {
             b.iter_batched(
                 || {
                     let temp_dir = tempfile::tempdir().unwrap();
@@ -449,6 +504,45 @@ fn bench_recovery(c: &mut Criterion) {
         drop(dir);
     }
 
+    // WAL recovery: tombstones in WAL (not flushed)
+    let dir_wal = tempfile::tempdir().unwrap();
+    {
+        let lsm = KvEngine::open(dir_wal.path(), make_options_wal()).unwrap();
+        load_entries(&lsm, 5000);
+        lsm.sync().unwrap();
+        insert_noncovering_tombstones(&lsm, 100);
+        lsm.sync().unwrap();
+        // Do NOT flush — tombstones live in WAL only
+        lsm.close().unwrap();
+    }
+
+    let path_wal = dir_wal.path().to_path_buf();
+    group.bench_function(BenchmarkId::new("open_wal", "tombstones=100"), |b| {
+        b.iter_batched(
+            || {
+                let temp_dir = tempfile::tempdir().unwrap();
+                for entry in std::fs::read_dir(&path_wal).unwrap() {
+                    let entry = entry.unwrap();
+                    std::fs::copy(
+                        entry.path(),
+                        temp_dir.path().join(entry.file_name()),
+                    )
+                    .unwrap();
+                }
+                temp_dir
+            },
+            |temp_dir| {
+                let lsm =
+                    KvEngine::open(temp_dir.path(), make_options_wal()).unwrap();
+                black_box(&lsm);
+                lsm.close().unwrap();
+                temp_dir
+            },
+            criterion::BatchSize::SmallInput,
+        )
+    });
+
+    drop(dir_wal);
     group.finish();
 }
 

--- a/kv-engine/benches/deleterange_benchmarks.rs
+++ b/kv-engine/benches/deleterange_benchmarks.rs
@@ -47,9 +47,7 @@ fn make_options_wal() -> LsmStorageOptions {
 
 fn flush_all(lsm: &KvEngine) {
     for _ in 0..5 {
-        if lsm.force_flush().is_err() {
-            break;
-        }
+        lsm.force_flush().unwrap();
     }
 }
 
@@ -69,7 +67,7 @@ fn insert_noncovering_tombstones(lsm: &KvEngine, n: usize) {
     for i in 0..n {
         let start = format!("del{:06}", i);
         let end = format!("del{:06}", i + 1);
-        let _ = lsm.delete_range(start.as_bytes(), end.as_bytes());
+        lsm.delete_range(start.as_bytes(), end.as_bytes()).unwrap();
     }
 }
 
@@ -483,11 +481,8 @@ fn bench_recovery(c: &mut Criterion) {
                     let temp_dir = tempfile::tempdir().unwrap();
                     for entry in std::fs::read_dir(&path).unwrap() {
                         let entry = entry.unwrap();
-                        std::fs::copy(
-                            entry.path(),
-                            temp_dir.path().join(entry.file_name()),
-                        )
-                        .unwrap();
+                        std::fs::copy(entry.path(), temp_dir.path().join(entry.file_name()))
+                            .unwrap();
                     }
                     temp_dir
                 },
@@ -523,17 +518,12 @@ fn bench_recovery(c: &mut Criterion) {
                 let temp_dir = tempfile::tempdir().unwrap();
                 for entry in std::fs::read_dir(&path_wal).unwrap() {
                     let entry = entry.unwrap();
-                    std::fs::copy(
-                        entry.path(),
-                        temp_dir.path().join(entry.file_name()),
-                    )
-                    .unwrap();
+                    std::fs::copy(entry.path(), temp_dir.path().join(entry.file_name())).unwrap();
                 }
                 temp_dir
             },
             |temp_dir| {
-                let lsm =
-                    KvEngine::open(temp_dir.path(), make_options_wal()).unwrap();
+                let lsm = KvEngine::open(temp_dir.path(), make_options_wal()).unwrap();
                 black_box(&lsm);
                 lsm.close().unwrap();
                 temp_dir

--- a/kv-engine/benches/deleterange_benchmarks.rs
+++ b/kv-engine/benches/deleterange_benchmarks.rs
@@ -269,6 +269,58 @@ fn bench_scan_dense_deleted(c: &mut Criterion) {
 }
 
 // ---------------------------------------------------------------------------
+// Group 3b: scan with non-covering tombstones (§12.5 acceptance gate)
+// ---------------------------------------------------------------------------
+
+fn bench_scan_noncovering(c: &mut Criterion) {
+    let mut group = c.benchmark_group("scan_noncovering_tombstones");
+    group.sample_size(50);
+
+    // 100 non-covering tombstones in active memtable, scan surviving keys
+    {
+        let dir = tempfile::tempdir().unwrap();
+        let lsm = KvEngine::open(dir.path(), make_options()).unwrap();
+        load_entries(&lsm, 5000);
+        flush_all(&lsm);
+        lsm.force_full_compaction().unwrap();
+        insert_noncovering_tombstones(&lsm, 100);
+
+        group.bench_function("noncovering_100", |b| {
+            b.iter(|| {
+                let iter = lsm
+                    .scan(Bound::Included(b"key000000"), Bound::Excluded(b"key004000"))
+                    .unwrap();
+                let count = count_scan(iter);
+                black_box(count);
+            })
+        });
+        lsm.close().unwrap();
+    }
+
+    // Baseline: same scan range without tombstones
+    {
+        let dir = tempfile::tempdir().unwrap();
+        let lsm = KvEngine::open(dir.path(), make_options()).unwrap();
+        load_entries(&lsm, 5000);
+        flush_all(&lsm);
+        lsm.force_full_compaction().unwrap();
+
+        group.bench_function("baseline", |b| {
+            b.iter(|| {
+                let iter = lsm
+                    .scan(Bound::Included(b"key000000"), Bound::Excluded(b"key004000"))
+                    .unwrap();
+                let count = count_scan(iter);
+                black_box(count);
+            })
+        });
+        lsm.close().unwrap();
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
 // Group 4: prefix_scan with tombstones
 // ---------------------------------------------------------------------------
 
@@ -338,6 +390,28 @@ fn bench_prefix_scan_tombstones(c: &mut Criterion) {
         insert_noncovering_tombstones(&lsm, 100);
 
         group.bench_function("non_overlapping_100", |b| {
+            b.iter(|| {
+                let iter = lsm.prefix_scan(b"pre0025").unwrap();
+                let count = count_scan(iter);
+                black_box(count);
+            })
+        });
+        lsm.close().unwrap();
+    }
+
+    // Baseline: same prefix scan without tombstones
+    {
+        let dir = tempfile::tempdir().unwrap();
+        let lsm = KvEngine::open(dir.path(), make_options()).unwrap();
+        let value = vec![0xABu8; 100];
+        for i in 0..5000 {
+            let key = format!("pre{:04}item{:04}", i / 50, i % 50);
+            lsm.put(key.as_bytes(), &value).unwrap();
+        }
+        flush_all(&lsm);
+        lsm.force_full_compaction().unwrap();
+
+        group.bench_function("baseline", |b| {
             b.iter(|| {
                 let iter = lsm.prefix_scan(b"pre0025").unwrap();
                 let count = count_scan(iter);
@@ -489,7 +563,8 @@ fn bench_recovery(c: &mut Criterion) {
                 |temp_dir| {
                     let lsm = KvEngine::open(temp_dir.path(), make_options()).unwrap();
                     black_box(&lsm);
-                    lsm.close().unwrap();
+                    // Drop without close() to exclude shutdown work from timing
+                    drop(lsm);
                     temp_dir
                 },
                 criterion::BatchSize::SmallInput,
@@ -525,7 +600,8 @@ fn bench_recovery(c: &mut Criterion) {
             |temp_dir| {
                 let lsm = KvEngine::open(temp_dir.path(), make_options_wal()).unwrap();
                 black_box(&lsm);
-                lsm.close().unwrap();
+                // Drop without close() to exclude shutdown work from timing
+                drop(lsm);
                 temp_dir
             },
             criterion::BatchSize::SmallInput,
@@ -545,6 +621,7 @@ criterion_group!(
     bench_get_noncovering,
     bench_get_covering,
     bench_scan_dense_deleted,
+    bench_scan_noncovering,
     bench_prefix_scan_tombstones,
     bench_flush_compaction,
     bench_recovery,

--- a/kv-engine/benches/deleterange_benchmarks.rs
+++ b/kv-engine/benches/deleterange_benchmarks.rs
@@ -1,0 +1,452 @@
+//! DeleteRange performance benchmarks (RFC 010 §12.5).
+//!
+//! Measures read-path overhead from range tombstones at various scales
+//! and data locations. Acceptance gate: ≤10% p95 regression for point-get,
+//! ≤15% p95 for scan/prefix-scan at 100 non-covering tombstones.
+
+use std::{hint::black_box, ops::Bound};
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use kv_engine::{
+    compact::{CompactionOptions, LeveledCompactionOptions},
+    iterators::StorageIterator,
+    lsm_storage::{KvEngine, LsmStorageOptions, PrefixBloomOptions},
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_options() -> LsmStorageOptions {
+    LsmStorageOptions {
+        block_size: 4096,
+        target_sst_size: 2 << 20,
+        num_memtable_limit: 2,
+        compaction_options: CompactionOptions::Leveled(LeveledCompactionOptions {
+            level0_file_num_compaction_trigger: 1000,
+            max_levels: 3,
+            base_level_size_mb: 1,
+            level_size_multiplier: 2,
+        }),
+        enable_wal: false,
+        serializable: false,
+        value_separation: None,
+        manifest_snapshot_threshold_bytes: 0,
+        block_cache_capacity: 1792,
+        enable_cache_backfill: true,
+        prefix_bloom: PrefixBloomOptions::default(),
+    }
+}
+
+fn flush_all(lsm: &KvEngine) {
+    for _ in 0..5 {
+        if lsm.force_flush().is_err() {
+            break;
+        }
+    }
+}
+
+/// Load `n` entries with key format `keyNNNNNN` and a 100-byte value.
+fn load_entries(lsm: &KvEngine, n: usize) {
+    let value = vec![0xABu8; 100];
+    for i in 0..n {
+        let key = format!("key{:06}", i);
+        lsm.put(key.as_bytes(), &value).unwrap();
+    }
+}
+
+/// Insert `n` non-covering range tombstones in disjoint small ranges.
+/// Each tombstone covers `delNNNN-delNNN1` (4-byte range), placed
+/// between data keys so they don't cover any `key*` entries.
+fn insert_noncovering_tombstones(lsm: &KvEngine, n: usize) {
+    for i in 0..n {
+        let start = format!("del{:06}", i);
+        let end = format!("del{:06}", i + 1);
+        let _ = lsm.delete_range(start.as_bytes(), end.as_bytes());
+    }
+}
+
+/// Count entries from a scan iterator.
+fn count_scan(iter: impl StorageIterator) -> usize {
+    let mut iter = iter;
+    let mut count = 0;
+    while iter.is_valid() {
+        count += 1;
+        iter.next().unwrap();
+    }
+    count
+}
+
+// ---------------------------------------------------------------------------
+// Group 1: get baseline with non-covering tombstones
+// ---------------------------------------------------------------------------
+
+fn bench_get_noncovering(c: &mut Criterion) {
+    let mut group = c.benchmark_group("get_noncovering_tombstones");
+    group.sample_size(100);
+
+    for n_tombstones in [0, 1, 100, 10_000] {
+        let dir = tempfile::tempdir().unwrap();
+        let lsm = KvEngine::open(dir.path(), make_options()).unwrap();
+
+        load_entries(&lsm, 5000);
+        flush_all(&lsm);
+        lsm.force_full_compaction().unwrap();
+
+        // Add tombstones after compaction so they live in memtable/imm
+        insert_noncovering_tombstones(&lsm, n_tombstones);
+        flush_all(&lsm);
+
+        let label = format!("tombstones={}", n_tombstones);
+        group.bench_function(BenchmarkId::new("get", &label), |b| {
+            b.iter(|| {
+                let result = lsm.get(b"key002500").unwrap();
+                black_box(result);
+            })
+        });
+
+        lsm.close().unwrap();
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Group 2: get with covering tombstones at different levels
+// ---------------------------------------------------------------------------
+
+fn bench_get_covering(c: &mut Criterion) {
+    let mut group = c.benchmark_group("get_covering_tombstones");
+    group.sample_size(100);
+
+    // Active memtable: tombstone in current memtable, no flush
+    {
+        let dir = tempfile::tempdir().unwrap();
+        let lsm = KvEngine::open(dir.path(), make_options()).unwrap();
+        load_entries(&lsm, 5000);
+        flush_all(&lsm);
+        lsm.force_full_compaction().unwrap();
+        // Cover key002500 in active memtable
+        lsm.delete_range(b"key002500", b"key002501").unwrap();
+
+        group.bench_function("active_memtable", |b| {
+            b.iter(|| {
+                let result = lsm.get(b"key002500").unwrap();
+                black_box(result);
+            })
+        });
+        lsm.close().unwrap();
+    }
+
+    // Immutable memtable: tombstone frozen to immutable but not flushed to SST.
+    // Fill active memtable with data to trigger a freeze (num_memtable_limit=2).
+    {
+        let dir = tempfile::tempdir().unwrap();
+        let opts = LsmStorageOptions {
+            target_sst_size: 2 << 20,
+            ..make_options()
+        };
+        let lsm = KvEngine::open(dir.path(), opts).unwrap();
+        load_entries(&lsm, 5000);
+        flush_all(&lsm);
+        lsm.force_full_compaction().unwrap();
+        // Write tombstone into active memtable
+        lsm.delete_range(b"key002500", b"key002501").unwrap();
+        // Write enough data to fill the memtable and trigger freeze.
+        // target_sst_size is 2MB, values are 100 bytes -> ~20k entries.
+        // Write in the filler range so they don't overlap with our target key.
+        let filler = vec![0xCDu8; 100];
+        for i in 0..25_000 {
+            let key = format!("fill{:06}", i);
+            lsm.put(key.as_bytes(), &filler).unwrap();
+        }
+        // Tombstone is now in an immutable memtable (frozen when filler
+        // exceeded the memtable capacity). Do NOT flush — keep it in memory.
+
+        group.bench_function("immutable_memtable", |b| {
+            b.iter(|| {
+                let result = lsm.get(b"key002500").unwrap();
+                black_box(result);
+            })
+        });
+        lsm.close().unwrap();
+    }
+
+    // L0: tombstone flushed to L0 SST
+    {
+        let dir = tempfile::tempdir().unwrap();
+        let lsm = KvEngine::open(dir.path(), make_options()).unwrap();
+        load_entries(&lsm, 5000);
+        flush_all(&lsm);
+        lsm.force_full_compaction().unwrap();
+        lsm.delete_range(b"key002500", b"key002501").unwrap();
+        flush_all(&lsm);
+
+        group.bench_function("l0", |b| {
+            b.iter(|| {
+                let result = lsm.get(b"key002500").unwrap();
+                black_box(result);
+            })
+        });
+        lsm.close().unwrap();
+    }
+
+    // Lower level: tombstone compacted to lower level
+    {
+        let dir = tempfile::tempdir().unwrap();
+        let lsm = KvEngine::open(dir.path(), make_options()).unwrap();
+        load_entries(&lsm, 5000);
+        flush_all(&lsm);
+        lsm.force_full_compaction().unwrap();
+        lsm.delete_range(b"key002500", b"key002501").unwrap();
+        flush_all(&lsm);
+        lsm.force_full_compaction().unwrap();
+
+        group.bench_function("lower_level", |b| {
+            b.iter(|| {
+                let result = lsm.get(b"key002500").unwrap();
+                black_box(result);
+            })
+        });
+        lsm.close().unwrap();
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Group 3: scan over fully deleted dense range
+// ---------------------------------------------------------------------------
+
+fn bench_scan_dense_deleted(c: &mut Criterion) {
+    let mut group = c.benchmark_group("scan_dense_deleted_range");
+    group.sample_size(50);
+
+    let dir = tempfile::tempdir().unwrap();
+    let lsm = KvEngine::open(dir.path(), make_options()).unwrap();
+
+    load_entries(&lsm, 5000);
+    flush_all(&lsm);
+    lsm.force_full_compaction().unwrap();
+
+    // Delete key1000..key2000 (1000 entries)
+    lsm.delete_range(b"key001000", b"key002000").unwrap();
+    flush_all(&lsm);
+    lsm.force_full_compaction().unwrap();
+
+    group.bench_function("scan_deleted_1000", |b| {
+        b.iter(|| {
+            let iter = lsm
+                .scan(Bound::Included(b"key001000"), Bound::Excluded(b"key002000"))
+                .unwrap();
+            let count = count_scan(iter);
+            black_box(count);
+        })
+    });
+
+    // Baseline: scan same range without tombstone
+    let dir2 = tempfile::tempdir().unwrap();
+    let lsm2 = KvEngine::open(dir2.path(), make_options()).unwrap();
+    load_entries(&lsm2, 5000);
+    flush_all(&lsm2);
+    lsm2.force_full_compaction().unwrap();
+
+    group.bench_function("scan_baseline_1000", |b| {
+        b.iter(|| {
+            let iter = lsm2
+                .scan(Bound::Included(b"key001000"), Bound::Excluded(b"key002000"))
+                .unwrap();
+            let count = count_scan(iter);
+            black_box(count);
+        })
+    });
+
+    lsm.close().unwrap();
+    lsm2.close().unwrap();
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Group 4: prefix_scan with tombstones
+// ---------------------------------------------------------------------------
+
+fn bench_prefix_scan_tombstones(c: &mut Criterion) {
+    let mut group = c.benchmark_group("prefix_scan_tombstones");
+    group.sample_size(50);
+
+    // Non-overlapping: tombstone in active memtable, data in SSTs
+    {
+        let dir = tempfile::tempdir().unwrap();
+        let lsm = KvEngine::open(dir.path(), make_options()).unwrap();
+        let value = vec![0xABu8; 100];
+        for i in 0..5000 {
+            let key = format!("pre{:04}item{:04}", i / 50, i % 50);
+            lsm.put(key.as_bytes(), &value).unwrap();
+        }
+        flush_all(&lsm);
+        lsm.force_full_compaction().unwrap();
+        // Tombstone in active memtable (not flushed to SST)
+        lsm.delete_range(b"pre9999", b"pre999a").unwrap();
+
+        group.bench_function("non_overlapping", |b| {
+            b.iter(|| {
+                let iter = lsm.prefix_scan(b"pre0025").unwrap();
+                let count = count_scan(iter);
+                black_box(count);
+            })
+        });
+        lsm.close().unwrap();
+    }
+
+    // Overlapping: tombstone in active memtable, data in SSTs
+    {
+        let dir = tempfile::tempdir().unwrap();
+        let lsm = KvEngine::open(dir.path(), make_options()).unwrap();
+        let value = vec![0xABu8; 100];
+        for i in 0..5000 {
+            let key = format!("pre{:04}item{:04}", i / 50, i % 50);
+            lsm.put(key.as_bytes(), &value).unwrap();
+        }
+        flush_all(&lsm);
+        lsm.force_full_compaction().unwrap();
+        // Tombstone in active memtable (not flushed to SST)
+        lsm.delete_range(b"pre0025", b"pre0026").unwrap();
+
+        group.bench_function("overlapping", |b| {
+            b.iter(|| {
+                let iter = lsm.prefix_scan(b"pre0025").unwrap();
+                let count = count_scan(iter);
+                black_box(count);
+            })
+        });
+        lsm.close().unwrap();
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Group 5: flush and compaction with tombstones
+// ---------------------------------------------------------------------------
+
+fn bench_flush_compaction(c: &mut Criterion) {
+    let mut group = c.benchmark_group("flush_compaction_tombstones");
+    group.sample_size(20);
+
+    // Mixed: point entries + range tombstone
+    group.bench_function("flush_mixed", |b| {
+        b.iter_batched(
+            || {
+                let dir = tempfile::tempdir().unwrap();
+                let lsm = KvEngine::open(dir.path(), make_options()).unwrap();
+                (dir, lsm)
+            },
+            |(dir, lsm)| {
+                let value = vec![0xABu8; 100];
+                for i in 0..1000 {
+                    let key = format!("key{:06}", i);
+                    lsm.put(key.as_bytes(), &value).unwrap();
+                }
+                lsm.delete_range(b"key000500", b"key000600").unwrap();
+                flush_all(&lsm);
+                lsm.close().unwrap();
+                drop(dir);
+            },
+            criterion::BatchSize::SmallInput,
+        )
+    });
+
+    // Range-only: just a tombstone, no point entries
+    group.bench_function("flush_range_only", |b| {
+        b.iter_batched(
+            || {
+                let dir = tempfile::tempdir().unwrap();
+                let lsm = KvEngine::open(dir.path(), make_options()).unwrap();
+                (dir, lsm)
+            },
+            |(dir, lsm)| {
+                lsm.delete_range(b"key000000", b"key001000").unwrap();
+                flush_all(&lsm);
+                lsm.close().unwrap();
+                drop(dir);
+            },
+            criterion::BatchSize::SmallInput,
+        )
+    });
+
+    // Compaction with mixed data
+    group.bench_function("compaction_mixed", |b| {
+        b.iter_batched(
+            || {
+                let dir = tempfile::tempdir().unwrap();
+                let lsm = KvEngine::open(dir.path(), make_options()).unwrap();
+                let value = vec![0xABu8; 100];
+                for i in 0..5000 {
+                    let key = format!("key{:06}", i);
+                    lsm.put(key.as_bytes(), &value).unwrap();
+                }
+                lsm.delete_range(b"key001000", b"key002000").unwrap();
+                flush_all(&lsm);
+                (dir, lsm)
+            },
+            |(dir, lsm)| {
+                lsm.force_full_compaction().unwrap();
+                lsm.close().unwrap();
+                drop(dir);
+            },
+            criterion::BatchSize::SmallInput,
+        )
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Group 6: recovery/open time with tombstones
+// ---------------------------------------------------------------------------
+
+fn bench_recovery(c: &mut Criterion) {
+    let mut group = c.benchmark_group("recovery_tombstones");
+    group.sample_size(20);
+
+    for n_tombstones in [0, 1, 100, 10_000] {
+        // Prepare data directory with tombstones
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let lsm = KvEngine::open(dir.path(), make_options()).unwrap();
+            load_entries(&lsm, 5000);
+            insert_noncovering_tombstones(&lsm, n_tombstones);
+            flush_all(&lsm);
+            lsm.close().unwrap();
+        }
+
+        let path = dir.path().to_path_buf();
+        let label = format!("tombstones={}", n_tombstones);
+        group.bench_function(BenchmarkId::new("open", &label), |b| {
+            b.iter(|| {
+                let lsm = KvEngine::open(&path, make_options()).unwrap();
+                black_box(&lsm);
+                lsm.close().unwrap();
+            })
+        });
+
+        drop(dir);
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Criterion harness
+// ---------------------------------------------------------------------------
+
+criterion_group!(
+    benches,
+    bench_get_noncovering,
+    bench_get_covering,
+    bench_scan_dense_deleted,
+    bench_prefix_scan_tombstones,
+    bench_flush_compaction,
+    bench_recovery,
+);
+criterion_main!(benches);

--- a/kv-engine/benches/deleterange_benchmarks.rs
+++ b/kv-engine/benches/deleterange_benchmarks.rs
@@ -339,14 +339,14 @@ fn bench_flush_compaction(c: &mut Criterion) {
             || {
                 let dir = tempfile::tempdir().unwrap();
                 let lsm = KvEngine::open(dir.path(), make_options()).unwrap();
-                (dir, lsm)
-            },
-            |(dir, lsm)| {
                 let value = vec![0xABu8; 100];
                 for i in 0..1000 {
                     let key = format!("key{:06}", i);
                     lsm.put(key.as_bytes(), &value).unwrap();
                 }
+                (dir, lsm)
+            },
+            |(dir, lsm)| {
                 lsm.delete_range(b"key000500", b"key000600").unwrap();
                 flush_all(&lsm);
                 lsm.close().unwrap();
@@ -423,11 +423,27 @@ fn bench_recovery(c: &mut Criterion) {
         let path = dir.path().to_path_buf();
         let label = format!("tombstones={}", n_tombstones);
         group.bench_function(BenchmarkId::new("open", &label), |b| {
-            b.iter(|| {
-                let lsm = KvEngine::open(&path, make_options()).unwrap();
-                black_box(&lsm);
-                lsm.close().unwrap();
-            })
+            b.iter_batched(
+                || {
+                    let temp_dir = tempfile::tempdir().unwrap();
+                    for entry in std::fs::read_dir(&path).unwrap() {
+                        let entry = entry.unwrap();
+                        std::fs::copy(
+                            entry.path(),
+                            temp_dir.path().join(entry.file_name()),
+                        )
+                        .unwrap();
+                    }
+                    temp_dir
+                },
+                |temp_dir| {
+                    let lsm = KvEngine::open(temp_dir.path(), make_options()).unwrap();
+                    black_box(&lsm);
+                    lsm.close().unwrap();
+                    temp_dir
+                },
+                criterion::BatchSize::SmallInput,
+            )
         });
 
         drop(dir);


### PR DESCRIPTION
## Summary

Implements the 6 benchmark gates required by RFC 010 §12.5 before DeleteRange is considered complete. All benchmarks use Criterion 0.5 and follow the existing `vlog_benchmarks.rs` patterns.

## Benchmarks

| Group | What it measures | §12.5 |
|---|---|---|
| `get_noncovering_tombstones` | `get` with 0/1/100/10k non-covering tombstones | 12.5.1 |
| `get_covering_tombstones` | `get` covered at active/immutable memtable, L0, lower level | 12.5.2 |
| `scan_dense_deleted_range` | `scan` over fully deleted 1000-entry range vs baseline | 12.5.3 |
| `scan_noncovering_tombstones` | `scan` with 100 non-covering tombstones vs baseline (§12.5 gate) | 12.5.3 |
| `prefix_scan_tombstones` | prefix scan with non-overlapping, overlapping, 100 non-covering, and baseline | 12.5.4 |
| `flush_compaction_tombstones` | flush (mixed/range-only) + compaction (mixed/range-only) | 12.5.5 |
| `recovery_tombstones` | `KvEngine::open` recovery with 0/1/100/10k tombstones (SST + WAL) | 12.5.6 |

## Results

```
get_noncovering (0 tombstones)    321 ns   (baseline)
get_noncovering (1)               386 ns   +20%
get_noncovering (100)             3.29 µs  +925%  ← O(R) active memtable scan
get_noncovering (10k)             293 µs   +91200%

get_covering (active memtable)    374 ns
get_covering (immutable memtable) 466 ns
get_covering (L0)                 366 ns
get_covering (lower level)        171 ns   ← fastest: binary search on L1+ SSTs

scan deleted 1000                 47.8 µs  (0 results, tombstone filtering)
scan baseline 1000                52.7 µs  (1000 results, full iteration)
scan noncovering 100              484 µs   (4000 results, 100 tombstone checks/entry)
scan baseline (no tombstones)     206 µs

prefix_scan non-overlapping       4.01 µs
prefix_scan overlapping           3.12 µs
prefix_scan 100 tombstones        42.4 µs  ← 13.7x baseline
prefix_scan baseline              3.09 µs

flush mixed                       505 µs
flush range-only                  449 µs
compaction mixed                  1.36 ms
compaction range-only             606 µs
```

## Acceptance Gates (RFC 010 §12.5)

| Gate | Target | Actual | Status |
|---|---|---|---|
| get ≤10% regression at 100 non-covering | ≤353 ns | 3.29 µs | ❌ |
| scan ≤15% regression at 100 non-covering | ≤237 µs | 484 µs | ❌ |
| prefix_scan ≤15% regression at 100 non-covering | ≤3.55 µs | 42.4 µs | ❌ |

## Root Cause Analysis

The acceptance gates fail due to **O(R) linear scan in the active memtable** for range tombstones:

- **`get` path**: `find_sst_with_range_ts()` scans all R tombstones in the active memtable linearly. At 100 tombstones = 200 key comparisons per get.
- **`scan` path**: merge iterator checks every candidate entry against all R tombstones. At 4000 entries × 100 tombstones = 400k comparisons.
- **`prefix_scan` path**: same as scan but per-prefix. 50 entries × 100 tombstones = 5k comparisons per prefix lookup.

**Fix direction** (RFC §12.2 deferred): replace the `Vec<RangeTombstone>` scan with an interval tree or sorted structure, reducing per-entry check from O(R) to O(log R + K). These benchmarks establish the baseline for that optimization.

## Verification

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --bench deleterange_benchmarks -- -D warnings` — clean
- [x] `cargo bench --bench deleterange_benchmarks` — all benchmarks pass