### PR TITLE
refactor: deduplicate WAL recovery, consolidate tombstone checks, clean up dead code

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,24 @@
+# Refactoring TODO
+
+## Completed
+
+- [x] **WAL recovery deduplication** (`wal.rs`) — `RecoveryHandler` trait + shared `recover_mvcc`/`recover_legacy_with` helpers. 830 → 669 lines.
+- [x] **Tombstone detection consolidation** — `KvKind::is_tombstone_value(&[u8])` in `vlog/mod.rs`, used across 14 call sites.
+- [x] **Eliminate `vlog_enabled` branching** — `MemTable::create(id, vlog_enabled)` replaces paired constructors.
+- [x] **Dedup `LsmStorageState::create` level init** — `init_levels` closure replaces copy-pasted blocks.
+- [x] **Dedup `map_bound`** — removed from `mvcc/txn.rs`, imports from `mem_table`.
+- [x] **Fix range tombstone + vlog recovery bug** — `recover_from_wal_with_range_tombstones` now accepts `vlog_enabled`.
+- [x] **Remove blanket `#![allow(dead_code)]`** — replaced with targeted `#[allow(dead_code)]` on intentional dead code.
+- [x] **Fix `unwrap()` in production** — `scan_with_vlog` now uses `expect()` with invariant message.
+- [x] **Remove unused `_vlog_enabled` param** — `resolve_item_value` signature cleaned up.
+- [x] **Add `debug_assert!` for corrupt timestamps** — `extract_ts` failures caught in debug builds.
+- [x] **Add unit test for `KvKind::is_tombstone_value`** — 6 edge cases covered.
+
+## Remaining (future PRs)
+
+- [ ] **Replace `expect()` with `Result`** on data-dependent paths in `lsm_storage.rs` (lines ~1504, ~1636, ~2357). These can panic on corrupted data.
+- [ ] **Replace `eprintln!` in background threads** — compaction, flush, GC threads use `eprintln!` for errors. Add proper logging or error channel.
+- [ ] **Decompose `lsm_storage.rs`** — extract `open()` manifest replay (~190-line match block) into a `replay_manifest_record` method.
+- [ ] **Consolidate test option constructors** — three `default_for_*` differ only in two fields. Use a builder or single constructor with overrides.
+- [ ] **Simplify `range_overlap` match arms** in `mem_table.rs`. A bound-normalizing helper would cut the 100-line match.
+- [ ] **Extract `compare_and_set` shared logic** — three CAS methods duplicate the read-then-verify-then-write pattern.

--- a/kv-engine/src/bin/compaction-simulator.rs
+++ b/kv-engine/src/bin/compaction-simulator.rs
@@ -109,7 +109,7 @@ impl Default for MockStorage {
 impl MockStorage {
     pub fn new() -> Self {
         let snapshot = LsmStorageState {
-            memtable: Arc::new(MemTable::create(0)),
+            memtable: Arc::new(MemTable::create(0, false)),
             imm_memtables: Vec::new(),
             l0_sstables: Vec::new(),
             levels: Vec::new(),

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -420,7 +420,7 @@ impl LsmStorageInner {
 
             // Detect tombstones: single KvKind::Tombstone byte.
             let raw = iter.raw_value();
-            let is_tombstone = raw.len() == 1 && raw[0] == crate::vlog::KvKind::Tombstone as u8;
+            let is_tombstone = crate::vlog::KvKind::is_tombstone_value(raw);
 
             // Decode user key once into the reused buffer to avoid heap
             // allocations. Reused for watermark logic, drop-check, and
@@ -690,7 +690,7 @@ impl LsmStorageInner {
         // Collect merged range-tombstone fragments from all input SSTs.
         let (merged_fragments, lower_level) = match task {
             CompactionTask::Leveled(LeveledCompactionTask {
-                upper_level,
+                upper_level: _,
                 upper_level_sst_ids,
                 lower_level,
                 lower_level_sst_ids,
@@ -710,7 +710,7 @@ impl LsmStorageInner {
                 (frags, Some(*lower_level))
             }
             CompactionTask::Simple(SimpleLeveledCompactionTask {
-                upper_level,
+                upper_level: _,
                 upper_level_sst_ids,
                 lower_level,
                 lower_level_sst_ids,

--- a/kv-engine/src/lib.rs
+++ b/kv-engine/src/lib.rs
@@ -1,6 +1,3 @@
-#![allow(dead_code)]
-#![allow(unused_variables)]
-
 pub mod block;
 pub(crate) mod cache;
 pub mod compact;

--- a/kv-engine/src/lsm_iterator.rs
+++ b/kv-engine/src/lsm_iterator.rs
@@ -81,11 +81,6 @@ impl LsmIterator {
         })
     }
 
-    /// Check if a value represents a tombstone (single KvKind::Tombstone byte).
-    fn is_tombstone_value(v: &[u8]) -> bool {
-        v.len() == 1 && v[0] == crate::vlog::KvKind::Tombstone as u8
-    }
-
     /// Skip entries with empty values (tombstones) and versions beyond `read_ts`.
     /// When MVCC is enabled, skip all versions of a dead user key, and for
     /// each user key skip versions with `ts > read_ts` (invisible to this
@@ -129,7 +124,7 @@ impl LsmIterator {
                     continue;
                 }
             }
-            if Self::is_tombstone_value(iter.value()) {
+            if crate::vlog::KvKind::is_tombstone_value(iter.value()) {
                 // Point tombstone — skip all versions of this dead user key
                 if TS_ENABLED {
                     while iter.is_valid()
@@ -226,7 +221,9 @@ impl StorageIterator for LsmIterator {
         } else {
             self.inner.next()?;
             // Legacy: skip tombstone values
-            while self.inner.is_valid() && Self::is_tombstone_value(self.inner.value()) {
+            while self.inner.is_valid()
+                && crate::vlog::KvKind::is_tombstone_value(self.inner.value())
+            {
                 self.inner.next()?;
             }
         }
@@ -321,6 +318,7 @@ impl ScanIterator {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn into_inner(self) -> FusedIterator<LsmIterator> {
         self.iter
     }

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -80,30 +80,22 @@ pub enum WriteBatchRecord<T: AsRef<[u8]>> {
 
 impl LsmStorageState {
     fn create(options: &LsmStorageOptions, vlog_enabled: bool) -> Self {
-        let levels = match &options.compaction_options {
-            CompactionOptions::Leveled(LeveledCompactionOptions { max_levels, .. })
-            | CompactionOptions::Simple(SimpleLeveledCompactionOptions { max_levels, .. }) => (1
-                ..=*max_levels)
-                .map(|level| (level, Vec::new()))
-                .collect::<Vec<_>>(),
-            CompactionOptions::Tiered(_) => Vec::new(),
-            CompactionOptions::NoCompaction => vec![(1, Vec::new())],
+        // Both leveled and simple-leveled compaction need per-level vectors;
+        // tiered needs none; no-compaction needs a single level.
+        let init_levels = |opts: &CompactionOptions| -> Vec<(usize, Vec<usize>)> {
+            match opts {
+                CompactionOptions::Leveled(LeveledCompactionOptions { max_levels, .. })
+                | CompactionOptions::Simple(SimpleLeveledCompactionOptions {
+                    max_levels, ..
+                }) => (1..=*max_levels).map(|level| (level, Vec::new())).collect(),
+                CompactionOptions::Tiered(_) => Vec::new(),
+                CompactionOptions::NoCompaction => vec![(1, Vec::new())],
+            }
         };
-        let range_only_ssts = match &options.compaction_options {
-            CompactionOptions::Leveled(LeveledCompactionOptions { max_levels, .. })
-            | CompactionOptions::Simple(SimpleLeveledCompactionOptions { max_levels, .. }) => (1
-                ..=*max_levels)
-                .map(|level| (level, Vec::new()))
-                .collect::<Vec<_>>(),
-            CompactionOptions::Tiered(_) => Vec::new(),
-            CompactionOptions::NoCompaction => vec![(1, Vec::new())],
-        };
+        let levels = init_levels(&options.compaction_options);
+        let range_only_ssts = init_levels(&options.compaction_options);
         Self {
-            memtable: Arc::new(if vlog_enabled {
-                MemTable::create_vlog(0)
-            } else {
-                MemTable::create(0)
-            }),
+            memtable: Arc::new(MemTable::create(0, vlog_enabled)),
             imm_memtables: Vec::new(),
             l0_sstables: Vec::new(),
             levels,
@@ -572,11 +564,7 @@ impl KvEngine {
 
         // flush memtable to imm_memtable
         let new_id = self.inner.next_sst_id();
-        let new_mt = if self.inner.vlog.is_some() {
-            MemTable::create_vlog(new_id)
-        } else {
-            MemTable::create(new_id)
-        };
+        let new_mt = MemTable::create(new_id, self.inner.vlog.is_some());
         self.inner.force_freeze_with_new_memtable(new_mt)?;
 
         // flush all imm_memtable to disk
@@ -895,13 +883,9 @@ impl LsmStorageInner {
             if options.enable_wal {
                 let id = state.memtable.id();
                 let wal_path = Self::path_of_wal_static(path, id);
-                state.memtable = Arc::new(if vlog_enabled {
-                    MemTable::create_with_wal_vlog(id, wal_path)?
-                } else {
-                    MemTable::create_with_wal(id, wal_path)?
-                })
-            } else if vlog_enabled {
-                state.memtable = Arc::new(MemTable::create_vlog(state.memtable.id()));
+                state.memtable = Arc::new(MemTable::create_with_wal(id, vlog_enabled, wal_path)?)
+            } else {
+                state.memtable = Arc::new(MemTable::create(state.memtable.id(), vlog_enabled));
             }
             let m = Manifest::create(manifest_path).context("failed to create manifest")?;
             m.add_records_when_init(&[
@@ -1143,11 +1127,11 @@ impl LsmStorageInner {
                 // just recover all to imm_memtables, then create a new memtable
                 for id in im_memtables {
                     let wal_path = Self::path_of_wal_static(path, id);
-                    let (m, wal_max_ts) = if vlog_enabled {
-                        MemTable::recover_from_wal_vlog(id, wal_path)?
-                    } else {
-                        MemTable::recover_from_wal_with_range_tombstones(id, wal_path)?
-                    };
+                    let (m, wal_max_ts) = MemTable::recover_from_wal_with_range_tombstones(
+                        id,
+                        vlog_enabled,
+                        wal_path,
+                    )?;
                     if wal_max_ts > max_commit_ts {
                         max_commit_ts = wal_max_ts;
                     }
@@ -1252,17 +1236,10 @@ impl LsmStorageInner {
             // Create the new active memtable (with WAL v3 if enabled).
             if options.enable_wal {
                 let wal_path = Self::path_of_wal_static(path, max_id);
-                state.memtable = Arc::new(if vlog_enabled {
-                    MemTable::create_with_wal_vlog(max_id, wal_path)?
-                } else {
-                    MemTable::create_with_wal(max_id, wal_path)?
-                });
+                state.memtable =
+                    Arc::new(MemTable::create_with_wal(max_id, vlog_enabled, wal_path)?);
             } else {
-                state.memtable = Arc::new(if vlog_enabled {
-                    MemTable::create_vlog(max_id)
-                } else {
-                    MemTable::create(max_id)
-                });
+                state.memtable = Arc::new(MemTable::create(max_id, vlog_enabled));
             }
             ret.0
                 .add_record_when_init(ManifestRecord::NewMemtable(max_id))?;
@@ -1584,10 +1561,6 @@ impl LsmStorageInner {
             key.len()
         );
         Ok(())
-    }
-
-    fn is_tombstone_value(v: &Bytes) -> bool {
-        v.len() == 1 && v[0] == crate::vlog::KvKind::Tombstone as u8
     }
 
     fn parse_value_kind(raw: Bytes) -> (Option<Bytes>, KvKind) {
@@ -1962,7 +1935,6 @@ impl LsmStorageInner {
                     .get(id)
                     .is_some_and(|s| s.has_range_tombstones())
             });
-        let read_ts_for_range = mvcc_read_ts.unwrap_or(u64::MAX);
         let range_ts_iter = if has_active || has_imm || has_sst_rt {
             let active_frags = if has_active {
                 state.memtable.range_tombstones().cached_fragments()
@@ -2307,14 +2279,14 @@ impl LsmStorageInner {
                 }
             } else {
                 if let Some(v) = state.memtable.get_with_hash(key, bloom_hash) {
-                    if Self::is_tombstone_value(&v) {
+                    if crate::vlog::KvKind::is_tombstone_value(&v) {
                         return Ok(Some((None, KvKind::Inline, Vec::new(), 0)));
                     }
                     return Ok(Some((Some(v), KvKind::Inline, Vec::new(), 0)));
                 }
                 for m in state.imm_memtables.iter() {
                     if let Some(v) = m.get_with_hash(key, bloom_hash) {
-                        if Self::is_tombstone_value(&v) {
+                        if crate::vlog::KvKind::is_tombstone_value(&v) {
                             return Ok(Some((None, KvKind::Inline, Vec::new(), 0)));
                         }
                         return Ok(Some((Some(v), KvKind::Inline, Vec::new(), 0)));
@@ -2479,6 +2451,7 @@ impl LsmStorageInner {
     /// Acquires state_lock, does a full LSM lookup, and conditionally writes
     /// the new value to the memtable if the current value matches (old, old_kind).
     /// Returns true if the swap succeeded.
+    #[allow(dead_code)]
     pub(crate) fn compare_and_set_with_kind(
         &self,
         key: &[u8],
@@ -2567,7 +2540,7 @@ impl LsmStorageInner {
                     still_matches = Self::values_match(&current_val, current_kind, old, *old_kind);
                 }
             } else if let Some(v) = state.memtable.get(key) {
-                let current_val = if Self::is_tombstone_value(&v) {
+                let current_val = if crate::vlog::KvKind::is_tombstone_value(&v) {
                     None
                 } else {
                     Some(v)
@@ -3037,15 +3010,9 @@ impl LsmStorageInner {
         let sst_id = self.next_sst_id();
         let vlog_enabled = self.vlog.is_some();
         let mem_table = if self.options.enable_wal {
-            if vlog_enabled {
-                mem_table::MemTable::create_with_wal_vlog(sst_id, self.path_of_wal(sst_id))?
-            } else {
-                mem_table::MemTable::create_with_wal(sst_id, self.path_of_wal(sst_id))?
-            }
-        } else if vlog_enabled {
-            mem_table::MemTable::create_vlog(sst_id)
+            mem_table::MemTable::create_with_wal(sst_id, vlog_enabled, self.path_of_wal(sst_id))?
         } else {
-            mem_table::MemTable::create(sst_id)
+            mem_table::MemTable::create(sst_id, vlog_enabled)
         };
         self.force_freeze_with_new_memtable(mem_table)?;
 

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -327,7 +327,7 @@ impl MemTable {
             // debug_assert catches corruption in test builds; release falls back to ts=0.
             let ts_opt = crate::key::extract_ts(found_key);
             debug_assert!(
-                ts_opt.is_some(),
+                !crate::key::TS_ENABLED || ts_opt.is_some(),
                 "corrupt MVCC key missing timestamp: {} bytes",
                 found_key.len()
             );
@@ -380,7 +380,7 @@ impl MemTable {
             }
             let ts_opt = crate::key::extract_ts(found_key);
             debug_assert!(
-                ts_opt.is_some(),
+                !crate::key::TS_ENABLED || ts_opt.is_some(),
                 "corrupt MVCC key missing timestamp: {} bytes",
                 found_key.len()
             );

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -103,14 +103,15 @@ pub(crate) fn map_bound(bound: Bound<&[u8]>) -> Bound<Bytes> {
 }
 
 impl MemTable {
-    /// Create a new mem-table. id is the sst_id when flush this memtable to sst
-    pub fn create(id: usize) -> Self {
+    /// Create a new mem-table. `id` is the sst_id when flushing this memtable to SST.
+    /// When `vlog_enabled` is true, values are stored with a [`KvKind`] prefix byte.
+    pub fn create(id: usize, vlog_enabled: bool) -> Self {
         Self {
             map: Arc::new(SkipMap::new()),
             wal: None,
             id,
             approximate_size: Arc::new(AtomicUsize::new(0)),
-            vlog_enabled: false,
+            vlog_enabled,
             bloom: IncrementalBloom::new(BLOOM_EXPECTED_ENTRIES, BLOOM_FALSE_POSITIVE_RATE),
             range_tombstones: RangeTombstoneSet::new(),
             immutable_range_tombstones: OnceLock::new(),
@@ -119,34 +120,20 @@ impl MemTable {
 
     /// Create a new mem-table with vLog (kind-prefixed values).
     pub fn create_vlog(id: usize) -> Self {
-        Self {
-            map: Arc::new(SkipMap::new()),
-            wal: None,
-            id,
-            approximate_size: Arc::new(AtomicUsize::new(0)),
-            vlog_enabled: true,
-            bloom: IncrementalBloom::new(BLOOM_EXPECTED_ENTRIES, BLOOM_FALSE_POSITIVE_RATE),
-            range_tombstones: RangeTombstoneSet::new(),
-            immutable_range_tombstones: OnceLock::new(),
-        }
+        Self::create(id, true)
     }
 
-    /// Create a new mem-table with WAL
-    pub fn create_with_wal(id: usize, path: impl AsRef<Path>) -> Result<Self> {
-        let mut ret = Self::create(id);
-        let wal = Wal::create(path)?;
-        ret.wal = Some(wal);
+    /// Create a new mem-table with WAL.
+    pub fn create_with_wal(id: usize, vlog_enabled: bool, path: impl AsRef<Path>) -> Result<Self> {
+        let mut ret = Self::create(id, vlog_enabled);
+        ret.wal = Some(Wal::create(path)?);
 
         Ok(ret)
     }
 
     /// Create a new mem-table with WAL and vLog (kind-prefixed values).
     pub fn create_with_wal_vlog(id: usize, path: impl AsRef<Path>) -> Result<Self> {
-        let mut ret = Self::create_vlog(id);
-        let wal = Wal::create(path)?;
-        ret.wal = Some(wal);
-
-        Ok(ret)
+        Self::create_with_wal(id, true, path)
     }
 
     /// Create a memtable from WAL. Returns the memtable and the max commit_ts found.
@@ -154,11 +141,14 @@ impl MemTable {
     /// Uses [`Wal::recover`] which replays point entries into the skiplist but
     /// silently discards range tombstones. For full recovery including range
     /// tombstones, use [`recover_from_wal_with_range_tombstones`].
-    pub fn recover_from_wal(id: usize, path: impl AsRef<Path>) -> Result<(Self, u64)> {
-        let mut ret = Self::create(id);
+    pub fn recover_from_wal(
+        id: usize,
+        vlog_enabled: bool,
+        path: impl AsRef<Path>,
+    ) -> Result<(Self, u64)> {
+        let mut ret = Self::create(id, vlog_enabled);
         let (wal, max_ts) = Wal::recover(path, &ret.map)?;
         ret.wal = Some(wal);
-        // Populate bloom filter from recovered entries
         ret.rebuild_bloom();
 
         Ok((ret, max_ts))
@@ -167,13 +157,7 @@ impl MemTable {
     /// Create a memtable from WAL with vLog (kind-prefixed values). Returns the memtable and max
     /// commit_ts.
     pub fn recover_from_wal_vlog(id: usize, path: impl AsRef<Path>) -> Result<(Self, u64)> {
-        let mut ret = Self::create_vlog(id);
-        let (wal, max_ts) = Wal::recover(path, &ret.map)?;
-        ret.wal = Some(wal);
-        // Populate bloom filter from recovered entries
-        ret.rebuild_bloom();
-
-        Ok((ret, max_ts))
+        Self::recover_from_wal(id, true, path)
     }
 
     /// Create a memtable from WAL with full range-tombstone recovery.
@@ -183,9 +167,10 @@ impl MemTable {
     /// [`RangeTombstoneSet`] from WAL v3 range-tombstone entries.
     pub fn recover_from_wal_with_range_tombstones(
         id: usize,
+        vlog_enabled: bool,
         path: impl AsRef<Path>,
     ) -> Result<(Self, u64)> {
-        let mut ret = Self::create(id);
+        let mut ret = Self::create(id, vlog_enabled);
         let (wal, batch) =
             Wal::recover_with_range_tombstones(path, &ret.map, &ret.range_tombstones)?;
         ret.wal = Some(wal);
@@ -338,7 +323,15 @@ impl MemTable {
                 break;
             }
             // Check timestamp visibility: skip versions newer than read_ts.
-            let ts = crate::key::extract_ts(found_key).unwrap_or(0);
+            // extract_ts returns None for keys < 17 bytes (non-MVCC or corrupt).
+            // debug_assert catches corruption in test builds; release falls back to ts=0.
+            let ts_opt = crate::key::extract_ts(found_key);
+            debug_assert!(
+                ts_opt.is_some(),
+                "corrupt MVCC key missing timestamp: {} bytes",
+                found_key.len()
+            );
+            let ts = ts_opt.unwrap_or(0);
             if ts > read_ts {
                 continue;
             }
@@ -385,7 +378,13 @@ impl MemTable {
             } else {
                 break;
             }
-            let ts = crate::key::extract_ts(found_key).unwrap_or(0);
+            let ts_opt = crate::key::extract_ts(found_key);
+            debug_assert!(
+                ts_opt.is_some(),
+                "corrupt MVCC key missing timestamp: {} bytes",
+                found_key.len()
+            );
+            let ts = ts_opt.unwrap_or(0);
             if ts > read_ts {
                 continue;
             }
@@ -541,7 +540,9 @@ impl MemTable {
             resolved: Bytes::new(),
         }
         .build();
-        iter.next().unwrap();
+        // next() always returns Ok(()) — positions iterator at first element or marks invalid.
+        iter.next()
+            .expect("next() is infallible for MemTableIterator");
 
         iter
     }
@@ -848,7 +849,7 @@ impl StorageIterator for MemTableIterator {
 
         self.with_mut(|m| {
             *m.item = n;
-            *m.resolved = Self::resolve_item_value(m.vlog, m.vlog_enabled, m.item);
+            *m.resolved = Self::resolve_item_value(m.vlog, m.item);
         });
 
         Ok(())
@@ -858,11 +859,7 @@ impl StorageIterator for MemTableIterator {
 impl MemTableIterator {
     /// Resolve the value for the current item: dereference ValuePointers via vLog,
     /// strip kind prefix for Inline entries.
-    fn resolve_item_value(
-        vlog: &Option<Arc<ValueLog>>,
-        _vlog_enabled: &bool,
-        item: &(Bytes, Bytes),
-    ) -> Bytes {
+    fn resolve_item_value(vlog: &Option<Arc<ValueLog>>, item: &(Bytes, Bytes)) -> Bytes {
         let val = &item.1;
         if val.is_empty() {
             return val.clone();

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -21,7 +21,11 @@ use crate::{
 
 pub(crate) struct CommittedTxnData {
     pub(crate) write_set: HashSet<Bytes>,
+    // Stored for watermark/GC purposes; currently only write_set is read during
+    // conflict detection. Suppress dead_code until GC consumes these fields.
+    #[allow(dead_code)]
     pub(crate) read_ts: u64,
+    #[allow(dead_code)]
     pub(crate) commit_ts: u64,
 }
 
@@ -42,10 +46,12 @@ impl LsmMvccInner {
         }
     }
 
+    #[allow(dead_code)]
     pub fn latest_commit_ts(&self) -> u64 {
         self.ts.lock().0
     }
 
+    #[allow(dead_code)]
     pub fn update_commit_ts(&self, ts: u64) {
         self.ts.lock().0 = ts;
     }
@@ -198,6 +204,7 @@ impl LsmMvccInner {
 
     /// Get a read timestamp (the latest committed ts).
     /// This does NOT add a reader to the watermark — use `new_read_guard()` instead.
+    #[allow(dead_code)]
     pub(crate) fn read_ts(&self) -> u64 {
         self.ts.lock().0
     }
@@ -316,7 +323,7 @@ mod tests {
     #[test]
     fn test_mvcc_inner_write() {
         let mvcc = LsmMvccInner::new(0);
-        let memtable = crate::mem_table::MemTable::create(0);
+        let memtable = crate::mem_table::MemTable::create(0, false);
         mvcc.write(b"key1", b"val1", &memtable).unwrap();
         assert_eq!(mvcc.latest_commit_ts(), 1);
         mvcc.write(b"key1", b"val2", &memtable).unwrap();
@@ -350,7 +357,7 @@ mod tests {
     #[test]
     fn test_read_guard_registers_in_watermark() {
         let mvcc = Arc::new(LsmMvccInner::new(50));
-        let memtable = crate::mem_table::MemTable::create(0);
+        let memtable = crate::mem_table::MemTable::create(0, false);
         mvcc.write(b"k", b"v", &memtable).unwrap(); // ts=51
 
         // Create guard at ts=51 while latest is still 51
@@ -365,7 +372,7 @@ mod tests {
     #[test]
     fn test_read_guard_drop_unregisters() {
         let mvcc = Arc::new(LsmMvccInner::new(50));
-        let memtable = crate::mem_table::MemTable::create(0);
+        let memtable = crate::mem_table::MemTable::create(0, false);
 
         {
             let _guard = mvcc.new_read_guard(); // read_ts=50
@@ -382,7 +389,7 @@ mod tests {
     fn test_read_guard_multiple_readers() {
         let mvcc = Arc::new(LsmMvccInner::new(50));
         // Write to advance the timestamp
-        let memtable = crate::mem_table::MemTable::create(0);
+        let memtable = crate::mem_table::MemTable::create(0, false);
         mvcc.write(b"k", b"v1", &memtable).unwrap(); // ts=51
         mvcc.write(b"k", b"v2", &memtable).unwrap(); // ts=52
 
@@ -429,7 +436,7 @@ mod tests {
         assert_eq!(guard.read_ts(), 100);
 
         // Advance the timestamp — watermark should stay pinned at 100
-        let memtable = crate::mem_table::MemTable::create(0);
+        let memtable = crate::mem_table::MemTable::create(0, false);
         mvcc.write(b"k", b"v1", &memtable).unwrap(); // ts=101
         mvcc.write(b"k", b"v2", &memtable).unwrap(); // ts=102
         assert_eq!(mvcc.watermark(), 100);

--- a/kv-engine/src/mvcc/txn.rs
+++ b/kv-engine/src/mvcc/txn.rs
@@ -10,6 +10,7 @@ use crate::{
     iterators::{StorageIterator, two_merge_iterator::TwoMergeIterator},
     lsm_iterator::{FusedIterator, LsmIterator},
     lsm_storage::{LsmStorageInner, prefix_upper_bound},
+    mem_table::map_bound,
     mvcc::ReadGuard,
 };
 
@@ -39,10 +40,6 @@ pub struct Transaction {
     pub(crate) _not_sync: std::marker::PhantomData<std::cell::Cell<()>>,
 }
 
-fn is_tombstone(val: &[u8]) -> bool {
-    val.len() == 1 && val[0] == crate::vlog::KvKind::Tombstone as u8
-}
-
 impl Transaction {
     fn ensure_not_committed(&self) -> Result<()> {
         anyhow::ensure!(
@@ -70,7 +67,7 @@ impl Transaction {
         if let Some(entry) = self.local_storage.get(key) {
             let val = entry.value();
             // Tombstone in local storage means deleted within this txn.
-            if is_tombstone(val) {
+            if crate::vlog::KvKind::is_tombstone_value(val) {
                 return Ok(None);
             }
             return Ok(Some(val.clone()));
@@ -145,7 +142,7 @@ impl Transaction {
     pub fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
         self.ensure_not_committed()?;
         anyhow::ensure!(
-            !is_tombstone(value),
+            !crate::vlog::KvKind::is_tombstone_value(value),
             "value must not be the tombstone marker byte (0x02)"
         );
         // Record in write_set for OCC conflict detection.
@@ -198,7 +195,7 @@ impl Transaction {
             .iter()
             .map(|e| {
                 let val = e.value();
-                let is_tomb = is_tombstone(val);
+                let is_tomb = crate::vlog::KvKind::is_tombstone_value(val);
                 (e.key().clone(), val.clone(), is_tomb)
             })
             .collect();
@@ -292,14 +289,6 @@ impl Transaction {
     }
 }
 
-fn map_bound(b: Bound<&[u8]>) -> Bound<Bytes> {
-    match b {
-        Bound::Included(v) => Bound::Included(Bytes::copy_from_slice(v)),
-        Bound::Excluded(v) => Bound::Excluded(Bytes::copy_from_slice(v)),
-        Bound::Unbounded => Bound::Unbounded,
-    }
-}
-
 type SkipMapRangeIter<'a> =
     crossbeam_skiplist::map::Range<'a, Bytes, (Bound<Bytes>, Bound<Bytes>), Bytes, Bytes>;
 
@@ -360,7 +349,7 @@ impl TxnIterator {
     ) -> Result<Self> {
         let mut s = Self { _txn: txn, iter };
         // Position at first valid entry, skipping tombstones.
-        while s.iter.is_valid() && is_tombstone(s.iter.value()) {
+        while s.iter.is_valid() && crate::vlog::KvKind::is_tombstone_value(s.iter.value()) {
             s.iter.next()?;
         }
         // Record the first key in read_set for OCC.
@@ -394,7 +383,7 @@ impl StorageIterator for TxnIterator {
     fn next(&mut self) -> Result<()> {
         // Advance past current entry, then skip tombstones.
         self.iter.next()?;
-        while self.iter.is_valid() && is_tombstone(self.iter.value()) {
+        while self.iter.is_valid() && crate::vlog::KvKind::is_tombstone_value(self.iter.value()) {
             self.iter.next()?;
         }
         // Record the current key in read_set for OCC.

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -714,6 +714,7 @@ impl SsTable {
     /// Returns `Bytes` directly from the block cache via zero-copy slice.
     /// The returned `Bytes` shares the cached block's underlying buffer —
     /// no heap allocation on the read path.
+    #[allow(dead_code)]
     pub(crate) fn point_get(&self, key: &[u8]) -> Result<Option<Bytes>> {
         self.point_get_with_hash(key, bloom::hash_key(key))
     }

--- a/kv-engine/src/tests/iterators.rs
+++ b/kv-engine/src/tests/iterators.rs
@@ -15,7 +15,7 @@ use crate::{
 #[test]
 fn test_task1_memtable_iter() {
     use std::ops::Bound;
-    let memtable = MemTable::create(0);
+    let memtable = MemTable::create(0, false);
     memtable.for_testing_put_slice(b"key1", b"value1").unwrap();
     memtable.for_testing_put_slice(b"key2", b"value2").unwrap();
     memtable.for_testing_put_slice(b"key3", b"value3").unwrap();
@@ -65,7 +65,7 @@ fn test_task1_memtable_iter() {
 #[test]
 fn test_task1_empty_memtable_iter() {
     use std::ops::Bound;
-    let memtable = MemTable::create(0);
+    let memtable = MemTable::create(0, false);
     {
         let iter =
             memtable.for_testing_scan_slice(Bound::Excluded(b"key1"), Bound::Excluded(b"key3"));

--- a/kv-engine/src/tests/memtable.rs
+++ b/kv-engine/src/tests/memtable.rs
@@ -11,7 +11,7 @@ use crate::{
 
 #[test]
 fn test_task1_memtable_get() {
-    let memtable = MemTable::create(0);
+    let memtable = MemTable::create(0, false);
     memtable.for_testing_put_slice(b"key1", b"value1").unwrap();
     memtable.for_testing_put_slice(b"key2", b"value2").unwrap();
     memtable.for_testing_put_slice(b"key3", b"value3").unwrap();
@@ -31,7 +31,7 @@ fn test_task1_memtable_get() {
 
 #[test]
 fn test_task1_memtable_overwrite() {
-    let memtable = MemTable::create(0);
+    let memtable = MemTable::create(0, false);
     memtable.for_testing_put_slice(b"key1", b"value1").unwrap();
     memtable.for_testing_put_slice(b"key2", b"value2").unwrap();
     memtable.for_testing_put_slice(b"key3", b"value3").unwrap();
@@ -148,7 +148,7 @@ fn test_task4_storage_integration() {
 
 #[test]
 fn test_memtable_range_tombstone_is_not_empty() {
-    let mt = crate::mem_table::MemTable::create(0);
+    let mt = crate::mem_table::MemTable::create(0, false);
     assert!(mt.is_empty());
     mt.put_range_tombstone(b"a", b"z", 10, 0).unwrap();
     assert!(!mt.is_empty());
@@ -156,7 +156,7 @@ fn test_memtable_range_tombstone_is_not_empty() {
 
 #[test]
 fn test_memtable_range_tombstone_approximate_size() {
-    let mt = crate::mem_table::MemTable::create(0);
+    let mt = crate::mem_table::MemTable::create(0, false);
     let before = mt.approximate_size();
     mt.put_range_tombstone(b"a", b"z", 10, 0).unwrap();
     let after = mt.approximate_size();
@@ -168,7 +168,7 @@ fn test_memtable_range_tombstone_approximate_size() {
 
 #[test]
 fn test_memtable_range_tombstone_lookup() {
-    let mt = crate::mem_table::MemTable::create(0);
+    let mt = crate::mem_table::MemTable::create(0, false);
     mt.put_range_tombstone(b"tenant:42:", b"tenant:43:", 20, 0)
         .unwrap();
 
@@ -198,7 +198,7 @@ fn test_memtable_range_tombstone_lookup() {
 
 #[test]
 fn test_memtable_put_range_tombstone_batch() {
-    let mt = crate::mem_table::MemTable::create(0);
+    let mt = crate::mem_table::MemTable::create(0, false);
     mt.put_range_tombstone_batch(&[(b"a", b"m"), (b"x", b"z")], 42, 0)
         .unwrap();
 
@@ -217,7 +217,7 @@ fn test_memtable_put_range_tombstone_batch() {
 
 #[test]
 fn test_memtable_put_range_tombstone_batch_empty() {
-    let mt = crate::mem_table::MemTable::create(0);
+    let mt = crate::mem_table::MemTable::create(0, false);
     mt.put_range_tombstone_batch(&[], 10, 0).unwrap();
     assert!(mt.range_tombstones().is_empty());
 }
@@ -246,7 +246,7 @@ fn test_memtable_range_overlap_containment() {
 
 #[test]
 fn test_memtable_range_overlap_with_range_tombstones() {
-    let mt = crate::mem_table::MemTable::create(0);
+    let mt = crate::mem_table::MemTable::create(0, false);
     mt.put_range_tombstone(b"f", b"p", 10, 0).unwrap();
 
     // Overlapping query.
@@ -265,7 +265,7 @@ fn test_memtable_range_overlap_with_range_tombstones() {
     // No key can be both > p and < p\0, so no overlap.
     let mut p_succ = b"p".to_vec();
     p_succ.push(0);
-    let mt2 = crate::mem_table::MemTable::create(0);
+    let mt2 = crate::mem_table::MemTable::create(0, false);
     mt2.put_range_tombstone(b"f", &p_succ, 10, 0).unwrap();
     assert!(!mt2.range_overlap(
         std::ops::Bound::Excluded(b"p" as &[u8]),
@@ -316,7 +316,7 @@ fn test_write_batch_range_only_vlog_guard() {
 
 #[test]
 fn test_memtable_range_overlap_unbounded_lower() {
-    let mt = crate::mem_table::MemTable::create(0);
+    let mt = crate::mem_table::MemTable::create(0, false);
     mt.put_range_tombstone(b"f", b"p", 10, 0).unwrap();
 
     // Unbounded lower + Included upper that covers the tombstone.
@@ -345,7 +345,7 @@ fn test_memtable_range_overlap_unbounded_lower() {
 
 #[test]
 fn test_memtable_range_overlap_excluded_lower() {
-    let mt = crate::mem_table::MemTable::create(0);
+    let mt = crate::mem_table::MemTable::create(0, false);
     mt.put_range_tombstone(b"f", b"p", 10, 0).unwrap();
 
     // Excluded lower inside the tombstone range.
@@ -367,7 +367,7 @@ fn test_memtable_range_overlap_excluded_lower() {
 
 #[test]
 fn test_memtable_range_overlap_unbounded_upper() {
-    let mt = crate::mem_table::MemTable::create(0);
+    let mt = crate::mem_table::MemTable::create(0, false);
     mt.put_range_tombstone(b"f", b"p", 10, 0).unwrap();
 
     // Included lower before tombstone + Unbounded upper.
@@ -394,7 +394,7 @@ fn test_memtable_range_overlap_unbounded_upper() {
 
 #[test]
 fn test_memtable_range_overlap_empty() {
-    let mt = crate::mem_table::MemTable::create(0);
+    let mt = crate::mem_table::MemTable::create(0, false);
     // Empty memtable: no point entries, no range tombstones.
     assert!(!mt.range_overlap(
         std::ops::Bound::Included(b"a" as &[u8]),
@@ -987,7 +987,7 @@ fn test_get_with_ts_range_tombstone() {
 #[test]
 fn test_flush_writes_range_tombstones_to_sst() {
     let dir = tempdir().unwrap();
-    let memtable = MemTable::create(0);
+    let memtable = MemTable::create(0, false);
     memtable.for_testing_put_slice(b"key1", b"val1").unwrap();
     memtable.put_range_tombstone(b"a", b"z", 10, 0).unwrap();
 

--- a/kv-engine/src/tests/tiered_unit.rs
+++ b/kv-engine/src/tests/tiered_unit.rs
@@ -8,7 +8,7 @@ use crate::{
 
 fn make_state(levels: Vec<(usize, Vec<usize>)>) -> LsmStorageState {
     LsmStorageState {
-        memtable: Arc::new(MemTable::create(0)),
+        memtable: Arc::new(MemTable::create(0, false)),
         imm_memtables: Vec::new(),
         l0_sstables: Vec::new(),
         levels,

--- a/kv-engine/src/tests/wal.rs
+++ b/kv-engine/src/tests/wal.rs
@@ -972,7 +972,8 @@ fn test_manifest_v3_to_v4_upgrade() {
     }
 
     // Reopen: should recover from v4 manifest successfully.
-    let _storage = LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap();
+    let _storage =
+        LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap();
     // Just verify it opens without error — manifest recovery worked.
 }
 

--- a/kv-engine/src/tests/wal.rs
+++ b/kv-engine/src/tests/wal.rs
@@ -849,7 +849,7 @@ fn test_wal_v3_truncated_batch_recovery() {
     // A truncated batch should be detected and recovery should stop.
     let dir = tempdir().unwrap();
     let path = dir.path().join("test_v3_trunc.wal");
-    let skiplist = new_skiplist();
+    let _skiplist = new_skiplist();
 
     let wal = Wal::create(&path).unwrap();
     wal.put_batch(&[(b"key1", b"val1")], 10).unwrap();
@@ -878,7 +878,7 @@ fn test_memtable_recover_from_wal_with_range_tombstones() {
 
     // Create a memtable with WAL and write range tombstones.
     {
-        let mt = crate::mem_table::MemTable::create_with_wal(0, &path).unwrap();
+        let mt = crate::mem_table::MemTable::create_with_wal(0, false, &path).unwrap();
         mt.put_range_tombstone(b"a", b"z", 42, 0).unwrap();
         // Force WAL write via a point entry.
         mt.for_testing_put_slice(b"key1", b"val1").unwrap();
@@ -886,7 +886,8 @@ fn test_memtable_recover_from_wal_with_range_tombstones() {
 
     // Recover from WAL.
     let (mt, max_ts) =
-        crate::mem_table::MemTable::recover_from_wal_with_range_tombstones(0, &path).unwrap();
+        crate::mem_table::MemTable::recover_from_wal_with_range_tombstones(0, false, &path)
+            .unwrap();
     assert_eq!(max_ts, 42);
     // Range tombstone should be recovered.
     assert_eq!(
@@ -953,7 +954,7 @@ fn test_memtable_recover_from_wal_plain() {
         wal.sync().unwrap();
     }
 
-    let (mt, max_ts) = crate::mem_table::MemTable::recover_from_wal(0, &path).unwrap();
+    let (mt, max_ts) = crate::mem_table::MemTable::recover_from_wal(0, false, &path).unwrap();
     assert_eq!(max_ts, 20);
     assert!(!mt.is_empty());
 }
@@ -971,7 +972,7 @@ fn test_manifest_v3_to_v4_upgrade() {
     }
 
     // Reopen: should recover from v4 manifest successfully.
-    let storage = LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap();
+    let _storage = LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap();
     // Just verify it opens without error — manifest recovery worked.
 }
 
@@ -1129,7 +1130,7 @@ fn test_wal_recover_corrupted_crc() {
 fn test_memtable_create_with_wal() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("test_create_wal.wal");
-    let mt = crate::mem_table::MemTable::create_with_wal(0, &path).unwrap();
+    let mt = crate::mem_table::MemTable::create_with_wal(0, false, &path).unwrap();
     assert!(!mt.vlog_enabled());
 }
 
@@ -1149,7 +1150,7 @@ fn test_memtable_create_vlog() {
 
 #[test]
 fn test_memtable_is_empty() {
-    let mt = crate::mem_table::MemTable::create(0);
+    let mt = crate::mem_table::MemTable::create(0, false);
     assert!(mt.is_empty());
     mt.for_testing_put_slice(b"key", b"val").unwrap();
     assert!(!mt.is_empty());
@@ -1157,7 +1158,7 @@ fn test_memtable_is_empty() {
 
 #[test]
 fn test_memtable_range_tombstones_accessor() {
-    let mt = crate::mem_table::MemTable::create(0);
+    let mt = crate::mem_table::MemTable::create(0, false);
     assert!(mt.range_tombstones().is_empty());
     mt.put_range_tombstone(b"a", b"z", 10, 0).unwrap();
     assert!(!mt.range_tombstones().is_empty());
@@ -1169,7 +1170,7 @@ fn test_memtable_put_range_tombstone_with_wal() {
     // Test put_range_tombstone with WAL enabled (exercises WAL write path).
     let dir = tempdir().unwrap();
     let path = dir.path().join("test_rt_wal.wal");
-    let mt = crate::mem_table::MemTable::create_with_wal(0, &path).unwrap();
+    let mt = crate::mem_table::MemTable::create_with_wal(0, false, &path).unwrap();
     mt.put_range_tombstone(b"a", b"z", 42, 0).unwrap();
     assert_eq!(mt.range_tombstones().len(), 1);
     assert_eq!(
@@ -1183,7 +1184,7 @@ fn test_memtable_put_range_tombstone_batch_with_wal() {
     // Test put_range_tombstone_batch with WAL enabled.
     let dir = tempdir().unwrap();
     let path = dir.path().join("test_rt_batch_wal.wal");
-    let mt = crate::mem_table::MemTable::create_with_wal(0, &path).unwrap();
+    let mt = crate::mem_table::MemTable::create_with_wal(0, false, &path).unwrap();
     mt.put_range_tombstone_batch(&[(b"a", b"m"), (b"x", b"z")], 42, 0)
         .unwrap();
     assert_eq!(mt.range_tombstones().len(), 2);
@@ -1193,13 +1194,13 @@ fn test_memtable_put_range_tombstone_batch_with_wal() {
 fn test_memtable_vlog_enabled() {
     let mt = crate::mem_table::MemTable::create_vlog(0);
     assert!(mt.vlog_enabled());
-    let mt2 = crate::mem_table::MemTable::create(0);
+    let mt2 = crate::mem_table::MemTable::create(0, false);
     assert!(!mt2.vlog_enabled());
 }
 
 #[test]
 fn test_memtable_approximate_size_with_range_tombstones() {
-    let mt = crate::mem_table::MemTable::create(0);
+    let mt = crate::mem_table::MemTable::create(0, false);
     let before = mt.approximate_size();
     mt.put_range_tombstone(b"a", b"z", 10, 0).unwrap();
     mt.put_range_tombstone(b"b", b"y", 20, 1).unwrap();

--- a/kv-engine/src/vlog/mod.rs
+++ b/kv-engine/src/vlog/mod.rs
@@ -63,6 +63,13 @@ impl KvKind {
     pub fn is_tombstone(self) -> bool {
         matches!(self, Self::Tombstone)
     }
+
+    /// Returns `true` if the raw value bytes represent a tombstone marker.
+    ///
+    /// A tombstone is encoded as a single byte with the value [`KvKind::Tombstone`].
+    pub fn is_tombstone_value(val: &[u8]) -> bool {
+        val.len() == 1 && val[0] == Self::Tombstone as u8
+    }
 }
 
 /// A pointer to a value stored in the Value Log.
@@ -954,6 +961,24 @@ mod tests {
         assert!(!KvKind::Inline.is_tombstone());
         assert!(!KvKind::ValuePointer.is_tombstone());
         assert!(KvKind::Tombstone.is_tombstone());
+    }
+
+    #[test]
+    fn test_kv_kind_is_tombstone_value() {
+        // Single tombstone byte — the canonical tombstone encoding.
+        assert!(KvKind::is_tombstone_value(&[KvKind::Tombstone as u8]));
+        // Empty value — not a tombstone.
+        assert!(!KvKind::is_tombstone_value(&[]));
+        // Tombstone byte with trailing data — not a tombstone.
+        assert!(!KvKind::is_tombstone_value(&[
+            KvKind::Tombstone as u8,
+            0xFF
+        ]));
+        // Other KvKind variants — not tombstones.
+        assert!(!KvKind::is_tombstone_value(&[KvKind::Inline as u8]));
+        assert!(!KvKind::is_tombstone_value(&[KvKind::ValuePointer as u8]));
+        // Arbitrary byte — not a tombstone.
+        assert!(!KvKind::is_tombstone_value(&[0xFF]));
     }
 
     // ---------------------------------------------------------------

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -57,6 +57,11 @@ pub struct Wal {
     pub(crate) file: Arc<Mutex<BufWriter<File>>>,
     /// Whether this WAL uses the MVCC batch format (has file header).
     mvcc_format: bool,
+    /// Whether this WAL uses v3 typed entries (kind prefix).
+    /// Only meaningful when `mvcc_format` is true. When false, the WAL uses v2
+    /// untyped entries. Preserved from recovery so appended records match the
+    /// file header.
+    is_v3: bool,
 }
 
 /// Abstraction over WAL entry recovery actions.
@@ -113,6 +118,12 @@ struct SkiplistRangeRecovery<'a> {
 
 impl RecoveryHandler for SkiplistRangeRecovery<'_> {
     fn handle_put(&mut self, key: Bytes, value: Bytes) -> Result<()> {
+        if crate::vlog::KvKind::is_tombstone_value(&value) {
+            self.point_tombstones.push(key.clone());
+            self.skiplist.insert(key, value);
+            return Ok(());
+        }
+
         self.points.push((key.clone(), value.clone()));
         self.skiplist.insert(key, value);
 
@@ -159,6 +170,7 @@ impl Wal {
         Ok(Self {
             file: Arc::new(Mutex::new(w)),
             mvcc_format: true,
+            is_v3: true,
         })
     }
 
@@ -469,6 +481,7 @@ impl Wal {
             Self {
                 file: Arc::new(Mutex::new(BufWriter::new(f))),
                 mvcc_format,
+                is_v3,
             },
             max_ts,
         ))
@@ -515,6 +528,7 @@ impl Wal {
             Self {
                 file: Arc::new(Mutex::new(BufWriter::new(f))),
                 mvcc_format,
+                is_v3,
             },
             RecoveredWalBatch {
                 points: handler.points,
@@ -595,14 +609,21 @@ impl Wal {
             return file.write_all(&buf).context("failed to write to WAL");
         }
 
-        // v3: typed entries with Put kind prefix.
-        // Each entry: [kind:1=0][key_len:2][key][value_len:2][value]
-        let entries_size: usize = data.iter().map(|(k, v)| 5 + k.len() + v.len()).sum();
+        // Compute entry size based on WAL version.
+        // v3: typed entries with Put kind prefix — [kind:1=0][key_len:2][key][value_len:2][value]
+        // v2: untyped entries — [key_len:2][key][value_len:2][value] (no kind byte)
+        let per_entry_overhead = if self.is_v3 { 5 } else { 4 };
+        let entries_size: usize = data
+            .iter()
+            .map(|(k, v)| per_entry_overhead + k.len() + v.len())
+            .sum();
         let mut buf = Vec::with_capacity(BATCH_HEADER_SIZE + entries_size);
         buf.resize(BATCH_HEADER_SIZE, 0); // reserve header space
 
         for (key, value) in data {
-            buf.put_u8(WalEntryKind::Put as u8);
+            if self.is_v3 {
+                buf.put_u8(WalEntryKind::Put as u8);
+            }
             buf.put_u16(u16::try_from(key.len()).context("key length exceeds u16::MAX")?);
             buf.put(*key);
             buf.put_u16(u16::try_from(value.len()).context("value length exceeds u16::MAX")?);

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -73,6 +73,10 @@ trait RecoveryHandler {
     fn handle_range_tombstone(&mut self, _start: Bytes, _end: Bytes, _ts: u64) -> Result<()> {
         Ok(())
     }
+
+    /// Called at the start of each WAL batch so range-tombstone ordinals
+    /// restart from 0 (matching live-write behaviour).
+    fn reset_range_ordinals(&mut self) {}
 }
 
 /// Recovery handler that replays entries into a skiplist.
@@ -135,6 +139,10 @@ impl RecoveryHandler for SkiplistRangeRecovery<'_> {
 
         Ok(())
     }
+
+    fn reset_range_ordinals(&mut self) {
+        self.range_tombstone_idx = 0;
+    }
 }
 
 // WAL files are garbage-collected by LsmStorageInner::force_flush_next_imm_memtable
@@ -171,6 +179,7 @@ impl Wal {
             let commit_ts = data.get_u64();
             let entry_count = data.get_u32() as usize;
             let data_crc32 = data.get_u32();
+            handler.reset_range_ordinals();
 
             let entries_start = data.remaining();
             let min_entry_size = if is_v3 { 3 } else { 4 };
@@ -205,6 +214,10 @@ impl Wal {
                             }
                             let val_size =
                                 (&data[pos + 2 + key_size..pos + 4 + key_size]).get_u16() as usize;
+                            if entries_start - expected_size < 4 + key_size + val_size {
+                                ok = false;
+                                break;
+                            }
                             expected_size += 4 + key_size + val_size;
                         }
                         1 => {
@@ -215,6 +228,10 @@ impl Wal {
                             }
                             let pos = expected_size;
                             let key_size = (&data[pos..pos + 2]).get_u16() as usize;
+                            if entries_start - expected_size < 2 + key_size {
+                                ok = false;
+                                break;
+                            }
                             expected_size += 2 + key_size;
                         }
                         2 => {
@@ -231,6 +248,10 @@ impl Wal {
                             }
                             let end_size = (&data[pos + 2 + start_size..pos + 4 + start_size])
                                 .get_u16() as usize;
+                            if entries_start - expected_size < 4 + start_size + end_size {
+                                ok = false;
+                                break;
+                            }
                             expected_size += 4 + start_size + end_size;
                         }
                         _ => {
@@ -252,6 +273,10 @@ impl Wal {
                     }
                     let val_size =
                         (&data[pos + 2 + key_size..pos + 4 + key_size]).get_u16() as usize;
+                    if entries_start - expected_size < 4 + key_size + val_size {
+                        ok = false;
+                        break;
+                    }
                     expected_size += 4 + key_size + val_size;
                 }
                 if expected_size > entries_start {

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -45,6 +45,9 @@ enum WalEntryKind {
     /// A point key-value put.
     Put = 0,
     /// A point tombstone (deletion marker).
+    /// Read during WAL recovery but never written — point tombstones are stored
+    /// as `Put` entries with a tombstone value byte.
+    #[allow(dead_code)]
     PointTombstone = 1,
     /// A range tombstone covering `[start, end)`.
     RangeTombstone = 2,
@@ -54,6 +57,84 @@ pub struct Wal {
     pub(crate) file: Arc<Mutex<BufWriter<File>>>,
     /// Whether this WAL uses the MVCC batch format (has file header).
     mvcc_format: bool,
+}
+
+/// Abstraction over WAL entry recovery actions.
+///
+/// Implementors decide what to do with each recovered entry (e.g., replay into
+/// a skiplist, collect into vectors, or both). This eliminates the massive code
+/// duplication between [`Wal::recover`] and [`Wal::recover_with_range_tombstones`].
+trait RecoveryHandler {
+    /// Handle a recovered point key-value put.
+    fn handle_put(&mut self, key: Bytes, value: Bytes) -> Result<()>;
+    /// Handle a recovered point tombstone.
+    fn handle_point_tombstone(&mut self, key: Bytes) -> Result<()>;
+    /// Handle a recovered range tombstone (default: no-op).
+    fn handle_range_tombstone(&mut self, _start: Bytes, _end: Bytes, _ts: u64) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Recovery handler that replays entries into a skiplist.
+struct SkiplistRecovery<'a> {
+    skiplist: &'a SkipMap<Bytes, Bytes>,
+}
+
+impl RecoveryHandler for SkiplistRecovery<'_> {
+    fn handle_put(&mut self, key: Bytes, value: Bytes) -> Result<()> {
+        self.skiplist.insert(key, value);
+
+        Ok(())
+    }
+
+    fn handle_point_tombstone(&mut self, key: Bytes) -> Result<()> {
+        self.skiplist.insert(
+            key,
+            Bytes::from_static(&[crate::vlog::KvKind::Tombstone as u8]),
+        );
+
+        Ok(())
+    }
+}
+
+/// Recovery handler that replays into a skiplist AND collects entries for range
+/// tombstone support.
+struct SkiplistRangeRecovery<'a> {
+    skiplist: &'a SkipMap<Bytes, Bytes>,
+    points: Vec<(Bytes, Bytes)>,
+    point_tombstones: Vec<Bytes>,
+    range_ts: Vec<(Bytes, Bytes, u64, u32)>,
+    range_tombstone_idx: u32,
+}
+
+impl RecoveryHandler for SkiplistRangeRecovery<'_> {
+    fn handle_put(&mut self, key: Bytes, value: Bytes) -> Result<()> {
+        self.points.push((key.clone(), value.clone()));
+        self.skiplist.insert(key, value);
+
+        Ok(())
+    }
+
+    fn handle_point_tombstone(&mut self, key: Bytes) -> Result<()> {
+        self.point_tombstones.push(key.clone());
+        self.skiplist.insert(
+            key,
+            Bytes::from_static(&[crate::vlog::KvKind::Tombstone as u8]),
+        );
+
+        Ok(())
+    }
+
+    fn handle_range_tombstone(&mut self, start: Bytes, end: Bytes, ts: u64) -> Result<()> {
+        self.range_ts
+            .push((start, end, ts, self.range_tombstone_idx));
+        self.range_tombstone_idx = self
+            .range_tombstone_idx
+            .checked_add(1)
+            .context("ordinal overflow")?;
+
+        Ok(())
+    }
 }
 
 // WAL files are garbage-collected by LsmStorageInner::force_flush_next_imm_memtable
@@ -73,12 +154,236 @@ impl Wal {
         })
     }
 
-    /// Recover a WAL file, replaying entries into the skiplist.
-    /// Returns the WAL handle and the maximum `commit_ts` found in any complete batch.
-    pub fn recover(
-        path: impl AsRef<Path>,
-        skiplist: &SkipMap<Bytes, Bytes>,
-    ) -> Result<(Self, u64)> {
+    /// Parse an MVCC-format WAL file, delegating each recovered entry to the
+    /// given handler. Returns the file (positioned for append) and `mvcc_format`.
+    fn recover_mvcc<H: RecoveryHandler>(
+        f: File,
+        mut data: Bytes,
+        is_v3: bool,
+        file_len: u64,
+        handler: &mut H,
+    ) -> Result<(File, u64)> {
+        let data_len = data.len();
+        let mut max_ts: u64 = 0;
+
+        while data.remaining() >= BATCH_HEADER_SIZE {
+            let before_batch = data.clone();
+            let commit_ts = data.get_u64();
+            let entry_count = data.get_u32() as usize;
+            let data_crc32 = data.get_u32();
+
+            let entries_start = data.remaining();
+            let min_entry_size = if is_v3 { 3 } else { 4 };
+            if entry_count > entries_start / min_entry_size {
+                data = before_batch;
+                break;
+            }
+
+            // Validate all entries fit and compute expected_size.
+            let mut expected_size: usize = 0;
+            let mut ok = true;
+            for _ in 0..entry_count {
+                if is_v3 {
+                    if entries_start - expected_size < 1 {
+                        ok = false;
+                        break;
+                    }
+                    let kind = data[expected_size];
+                    expected_size += 1;
+                    match kind {
+                        0 => {
+                            // Put: [key_len:2][key][value_len:2][value]
+                            if entries_start - expected_size < 4 {
+                                ok = false;
+                                break;
+                            }
+                            let pos = expected_size;
+                            let key_size = (&data[pos..pos + 2]).get_u16() as usize;
+                            if entries_start - expected_size < 4 + key_size {
+                                ok = false;
+                                break;
+                            }
+                            let val_size =
+                                (&data[pos + 2 + key_size..pos + 4 + key_size]).get_u16() as usize;
+                            expected_size += 4 + key_size + val_size;
+                        }
+                        1 => {
+                            // PointTombstone: [key_len:2][key]
+                            if entries_start - expected_size < 2 {
+                                ok = false;
+                                break;
+                            }
+                            let pos = expected_size;
+                            let key_size = (&data[pos..pos + 2]).get_u16() as usize;
+                            expected_size += 2 + key_size;
+                        }
+                        2 => {
+                            // RangeTombstone: [start_len:2][start][end_len:2][end]
+                            if entries_start - expected_size < 4 {
+                                ok = false;
+                                break;
+                            }
+                            let pos = expected_size;
+                            let start_size = (&data[pos..pos + 2]).get_u16() as usize;
+                            if entries_start - expected_size < 4 + start_size {
+                                ok = false;
+                                break;
+                            }
+                            let end_size = (&data[pos + 2 + start_size..pos + 4 + start_size])
+                                .get_u16() as usize;
+                            expected_size += 4 + start_size + end_size;
+                        }
+                        _ => {
+                            ok = false;
+                            break;
+                        }
+                    }
+                } else {
+                    // v2: [key_len:2][key][value_len:2][value]
+                    if entries_start - expected_size < 4 {
+                        ok = false;
+                        break;
+                    }
+                    let pos = expected_size;
+                    let key_size = (&data[pos..pos + 2]).get_u16() as usize;
+                    if entries_start - expected_size < 4 + key_size {
+                        ok = false;
+                        break;
+                    }
+                    let val_size =
+                        (&data[pos + 2 + key_size..pos + 4 + key_size]).get_u16() as usize;
+                    expected_size += 4 + key_size + val_size;
+                }
+                if expected_size > entries_start {
+                    ok = false;
+                    break;
+                }
+            }
+
+            if !ok || expected_size > entries_start {
+                data = before_batch;
+                break;
+            }
+
+            // Validate CRC32 over the entry data.
+            let entry_data = &data[..expected_size];
+            let computed_crc = crc32fast::hash(entry_data);
+            if computed_crc != data_crc32 {
+                data = before_batch;
+                break;
+            }
+
+            // Replay entries into handler using zero-copy Bytes slices.
+            let mut entry_buf = data.split_to(expected_size);
+            for _ in 0..entry_count {
+                if is_v3 {
+                    let kind = entry_buf.get_u8();
+                    match kind {
+                        0 => {
+                            // Put
+                            let key_size = entry_buf.get_u16() as usize;
+                            let key = entry_buf.split_to(key_size);
+                            let value_size = entry_buf.get_u16() as usize;
+                            let value = entry_buf.split_to(value_size);
+                            handler.handle_put(key, value)?;
+                        }
+                        1 => {
+                            // PointTombstone
+                            let key_size = entry_buf.get_u16() as usize;
+                            let key = entry_buf.split_to(key_size);
+                            handler.handle_point_tombstone(key)?;
+                        }
+                        2 => {
+                            // RangeTombstone
+                            let start_size = entry_buf.get_u16() as usize;
+                            let start = entry_buf.split_to(start_size);
+                            let end_size = entry_buf.get_u16() as usize;
+                            let end = entry_buf.split_to(end_size);
+                            handler.handle_range_tombstone(start, end, commit_ts)?;
+                        }
+                        _ => {
+                            anyhow::bail!("unknown WAL v3 entry kind: {}", kind);
+                        }
+                    }
+                } else {
+                    // v2: untyped entries
+                    let key_size = entry_buf.get_u16() as usize;
+                    let key = entry_buf.split_to(key_size);
+                    let value_size = entry_buf.get_u16() as usize;
+                    let value = entry_buf.split_to(value_size);
+                    handler.handle_put(key, value)?;
+                }
+            }
+            if commit_ts > max_ts {
+                max_ts = commit_ts;
+            }
+        }
+
+        // Truncate file to the last valid byte.
+        let valid_data = data_len - data.remaining();
+        let valid_file = WAL_HEADER_SIZE + valid_data;
+        if (valid_file as u64) < file_len {
+            f.set_len(valid_file as u64)?;
+        }
+
+        Ok((f, max_ts))
+    }
+
+    /// Parse a legacy-format WAL file, delegating each recovered entry to the
+    /// given handler. Returns the file (positioned for append) and max_ts.
+    fn recover_legacy_with<H: RecoveryHandler>(
+        f: File,
+        mut data: Bytes,
+        file_len: u64,
+        handler: &mut H,
+    ) -> Result<(File, u64)> {
+        let data_len = data.len();
+        let mut max_ts: u64 = 0;
+
+        while data.has_remaining() {
+            let before_entry = data.clone();
+            if data.remaining() < 4 {
+                data = before_entry;
+                break;
+            }
+            let key_size = data.get_u16() as usize;
+            if data.remaining() < key_size + 2 {
+                data = before_entry;
+                break;
+            }
+            let key = data.split_to(key_size);
+
+            if data.remaining() < 2 {
+                data = before_entry;
+                break;
+            }
+            let value_size = data.get_u16() as usize;
+            if data.remaining() < value_size {
+                data = before_entry;
+                break;
+            }
+            let value = data.split_to(value_size);
+
+            if let Some(ts) = crate::key::extract_ts(&key)
+                && ts > max_ts
+            {
+                max_ts = ts;
+            }
+            handler.handle_put(key, value)?;
+        }
+
+        // Truncate file to the last valid byte.
+        let valid_len = data_len - data.remaining();
+        if (valid_len as u64) < file_len {
+            f.set_len(valid_len as u64)?;
+        }
+
+        Ok((f, max_ts))
+    }
+
+    /// Open a WAL file, read its contents, and detect the format.
+    /// Returns `(file, data, mvcc_format, is_v3, file_len)`.
+    fn open_and_detect(path: impl AsRef<Path>) -> Result<(File, Bytes, bool, bool, u64)> {
         let mut f = File::options()
             .read(true)
             .append(true)
@@ -94,15 +399,10 @@ impl Wal {
         let mut buf = Vec::with_capacity(file_len as usize);
         f.read_to_end(&mut buf)?;
 
-        // Convert to Bytes once so that copy_to_bytes below yields zero-copy
-        // slices sharing the same allocation, avoiding per-key/value heap allocs.
-        let buf_bytes = Bytes::from(buf);
-        let mut max_ts: u64 = 0;
-        let mut data = buf_bytes.clone();
+        let data = Bytes::from(buf);
 
-        // Detect MVCC format by checking the magic number AND version field.
-        // Accept both v2 (untyped entries) and v3 (typed entries).
-        let mvcc_format = if data.len() >= WAL_HEADER_SIZE {
+        // Detect MVCC format by checking magic number AND version field.
+        let (mvcc_format, is_v3) = if data.len() >= WAL_HEADER_SIZE {
             let magic = (&data[..4]).get_u32();
             let version = (&data[4..6]).get_u16();
             if magic == WAL_MVCC_MAGIC {
@@ -113,252 +413,32 @@ impl Wal {
                     WAL_FORMAT_VERSION_V2,
                     WAL_FORMAT_VERSION_V3
                 );
-                true
+                (true, version == WAL_FORMAT_VERSION_V3)
             } else {
-                false
+                (false, false)
             }
         } else {
-            false
+            (false, false)
         };
 
-        // Determine if this is v3 (typed entries) or v2 (untyped entries).
-        let is_v3 = if data.len() >= WAL_HEADER_SIZE {
-            (&data[4..6]).get_u16() == WAL_FORMAT_VERSION_V3
-        } else {
-            false
-        };
+        Ok((f, data, mvcc_format, is_v3, file_len))
+    }
 
-        if mvcc_format {
-            // Skip file header.
+    /// Recover a WAL file, replaying entries into the skiplist.
+    /// Returns the WAL handle and the maximum `commit_ts` found in any complete batch.
+    pub fn recover(
+        path: impl AsRef<Path>,
+        skiplist: &SkipMap<Bytes, Bytes>,
+    ) -> Result<(Self, u64)> {
+        let (f, mut data, mvcc_format, is_v3, file_len) = Self::open_and_detect(path)?;
+        let mut handler = SkiplistRecovery { skiplist };
+
+        let (f, max_ts) = if mvcc_format {
             data.advance(WAL_HEADER_SIZE);
-
-            // Parse batch-framed records.
-            let data_len = data.len();
-            while data.remaining() >= BATCH_HEADER_SIZE {
-                // Snapshot position before consuming the batch header so we can
-                // back up if the batch turns out to be truncated / corrupt.
-                // Bytes::clone() is a cheap refcount bump (no data copy).
-                let before_batch = data.clone();
-
-                let commit_ts = data.get_u64();
-                let entry_count = data.get_u32() as usize;
-                let data_crc32 = data.get_u32();
-
-                // Compute the expected size of all entries.
-                let entries_start = data.remaining();
-                // v3 PointTombstone is only 3 bytes (kind:1 + key_len:2);
-                // v2 entries are at least 4 bytes (key_len:2 + value_len:2).
-                let min_entry_size = if is_v3 { 3 } else { 4 };
-                if entry_count > entries_start / min_entry_size {
-                    data = before_batch;
-                    break;
-                }
-                let mut expected_size: usize = 0;
-                let mut ok = true;
-                // Peek ahead to check if we have enough data for all entries.
-                for _ in 0..entry_count {
-                    if is_v3 {
-                        // v3: [kind:1][...]
-                        if entries_start - expected_size < 1 {
-                            ok = false;
-                            break;
-                        }
-                        let kind = data[expected_size];
-                        expected_size += 1;
-                        match kind {
-                            0 => {
-                                // Put: [key_len:2][key][value_len:2][value]
-                                if entries_start - expected_size < 4 {
-                                    ok = false;
-                                    break;
-                                }
-                                let pos = expected_size;
-                                let key_size = (&data[pos..pos + 2]).get_u16() as usize;
-                                if entries_start - expected_size < 4 + key_size {
-                                    ok = false;
-                                    break;
-                                }
-                                let val_size = (&data[pos + 2 + key_size..pos + 4 + key_size])
-                                    .get_u16()
-                                    as usize;
-                                expected_size += 4 + key_size + val_size;
-                            }
-                            1 => {
-                                // PointTombstone: [key_len:2][key]
-                                if entries_start - expected_size < 2 {
-                                    ok = false;
-                                    break;
-                                }
-                                let pos = expected_size;
-                                let key_size = (&data[pos..pos + 2]).get_u16() as usize;
-                                expected_size += 2 + key_size;
-                            }
-                            2 => {
-                                // RangeTombstone: [start_len:2][start][end_len:2][end]
-                                if entries_start - expected_size < 4 {
-                                    ok = false;
-                                    break;
-                                }
-                                let pos = expected_size;
-                                let start_size = (&data[pos..pos + 2]).get_u16() as usize;
-                                if entries_start - expected_size < 4 + start_size {
-                                    ok = false;
-                                    break;
-                                }
-                                let end_size = (&data[pos + 2 + start_size..pos + 4 + start_size])
-                                    .get_u16()
-                                    as usize;
-                                expected_size += 4 + start_size + end_size;
-                            }
-                            _ => {
-                                ok = false;
-                                break;
-                            }
-                        }
-                    } else {
-                        // v2: [key_len:2][key][value_len:2][value]
-                        if entries_start - expected_size < 4 {
-                            ok = false;
-                            break;
-                        }
-                        let pos = expected_size;
-                        let key_size = (&data[pos..pos + 2]).get_u16() as usize;
-                        if entries_start - expected_size < 4 + key_size {
-                            ok = false;
-                            break;
-                        }
-                        let val_size =
-                            (&data[pos + 2 + key_size..pos + 4 + key_size]).get_u16() as usize;
-                        expected_size += 4 + key_size + val_size;
-                    }
-                    if expected_size > entries_start {
-                        ok = false;
-                        break;
-                    }
-                }
-
-                if !ok || expected_size > entries_start {
-                    // Truncated batch — restore cursor to before the header so
-                    // the truncation below cuts at the right offset.
-                    data = before_batch;
-                    break;
-                }
-
-                // Validate CRC32 over the entry data.
-                let entry_data = &data[..expected_size];
-                let computed_crc = crc32fast::hash(entry_data);
-                if computed_crc != data_crc32 {
-                    // CRC mismatch — restore cursor to before the header.
-                    data = before_batch;
-                    break;
-                }
-
-                // Replay entries into skiplist using zero-copy Bytes slices.
-                let mut entry_buf = data.split_to(expected_size);
-                for _ in 0..entry_count {
-                    if is_v3 {
-                        // v3: typed entries with kind prefix.
-                        let kind = entry_buf.get_u8();
-                        match kind {
-                            0 => {
-                                // Put: [kind:1][key_len:2][key][value_len:2][value]
-                                let key_size = entry_buf.get_u16() as usize;
-                                let key = entry_buf.split_to(key_size);
-                                let value_size = entry_buf.get_u16() as usize;
-                                let value = entry_buf.split_to(value_size);
-                                skiplist.insert(key, value);
-                            }
-                            1 => {
-                                // PointTombstone: [kind:1][key_len:2][key]
-                                let key_size = entry_buf.get_u16() as usize;
-                                let key = entry_buf.split_to(key_size);
-                                // Store tombstone as key -> KvKind::Tombstone byte.
-                                skiplist.insert(
-                                    key,
-                                    Bytes::from_static(&[crate::vlog::KvKind::Tombstone as u8]),
-                                );
-                            }
-                            2 => {
-                                // RangeTombstone: [kind:1][start_len:2][start][end_len:2][end]
-                                let start_size = entry_buf.get_u16() as usize;
-                                let start = entry_buf.split_to(start_size);
-                                let end_size = entry_buf.get_u16() as usize;
-                                let _end = entry_buf.split_to(end_size);
-                                // Range tombstones are not replayed into the skiplist;
-                                // they are recovered via recover_with_range_tombstones().
-                                // Track max_ts from the batch header (already done above).
-                                let _ = start;
-                            }
-                            _ => {
-                                anyhow::bail!("unknown WAL v3 entry kind: {}", kind);
-                            }
-                        }
-                    } else {
-                        // v2: untyped entries [key_len:2][key][value_len:2][value].
-                        let key_size = entry_buf.get_u16() as usize;
-                        let key = entry_buf.split_to(key_size);
-                        let value_size = entry_buf.get_u16() as usize;
-                        let value = entry_buf.split_to(value_size);
-                        skiplist.insert(key, value);
-                    }
-                }
-                if commit_ts > max_ts {
-                    max_ts = commit_ts;
-                }
-            }
-            // Truncate file to the last valid byte — drop any trailing
-            // partial/corrupt batch so subsequent appends don't leave garbage.
-            // The valid data is already in the file (recovery doesn't rewrite
-            // it); we only need to shorten the file to remove trailing junk.
-            let valid_data = data_len - data.remaining();
-            let valid_file = WAL_HEADER_SIZE + valid_data;
-            if (valid_file as u64) < file_len {
-                f.set_len(valid_file as u64)?;
-            }
+            Self::recover_mvcc(f, data, is_v3, file_len, &mut handler)?
         } else {
-            // Legacy format: flat [key_len: u16][key][value_len: u16][value] entries.
-            let data_len = data.len();
-            while data.has_remaining() {
-                // Snapshot before reading entry fields so truncation cuts
-                // at the right offset on parse failure.
-                let before_entry = data.clone();
-                // Guard against truncated entries.
-                if data.remaining() < 4 {
-                    data = before_entry;
-                    break;
-                }
-                let key_size = data.get_u16() as usize;
-                if data.remaining() < key_size + 2 {
-                    data = before_entry;
-                    break;
-                }
-                let key = data.split_to(key_size);
-
-                if data.remaining() < 2 {
-                    data = before_entry;
-                    break;
-                }
-                let value_size = data.get_u16() as usize;
-                if data.remaining() < value_size {
-                    data = before_entry;
-                    break;
-                }
-                let value = data.split_to(value_size);
-
-                // Extract timestamp from encoded MVCC key (if present).
-                if let Some(ts) = crate::key::extract_ts(&key)
-                    && ts > max_ts
-                {
-                    max_ts = ts;
-                }
-                skiplist.insert(key, value);
-            }
-            // Truncate file to the last valid byte.
-            let valid_len = data_len - data.remaining();
-            if (valid_len as u64) < file_len {
-                f.set_len(valid_len as u64)?;
-            }
-        }
+            Self::recover_legacy_with(f, data, file_len, &mut handler)?
+        };
 
         Ok((
             Self {
@@ -379,272 +459,25 @@ impl Wal {
         skiplist: &SkipMap<Bytes, Bytes>,
         range_tombstones: &crate::range_tombstone::RangeTombstoneSet,
     ) -> Result<(Self, RecoveredWalBatch)> {
-        let mut f = File::options()
-            .read(true)
-            .append(true)
-            .open(path.as_ref())
-            .context("failed to recover from WAL")?;
-        let file_len = f.metadata()?.len();
-        anyhow::ensure!(
-            file_len <= MAX_WAL_FILE_SIZE,
-            "WAL file too large: {} bytes (max {})",
-            file_len,
-            MAX_WAL_FILE_SIZE
-        );
-        let mut buf = Vec::with_capacity(file_len as usize);
-        f.read_to_end(&mut buf)?;
-
-        let buf_bytes = Bytes::from(buf);
-        let mut max_ts: u64 = 0;
-        let mut data = buf_bytes.clone();
-        let mut points = Vec::new();
-        let mut point_tombstones = Vec::new();
-        let mut range_ts = Vec::new();
-
-        // Detect MVCC format.
-        let mvcc_format = if data.len() >= WAL_HEADER_SIZE {
-            let magic = (&data[..4]).get_u32();
-            let version = (&data[4..6]).get_u16();
-            if magic == WAL_MVCC_MAGIC {
-                anyhow::ensure!(
-                    version == WAL_FORMAT_VERSION_V2 || version == WAL_FORMAT_VERSION_V3,
-                    "unsupported WAL version: got {}, expected {} or {}",
-                    version,
-                    WAL_FORMAT_VERSION_V2,
-                    WAL_FORMAT_VERSION_V3
-                );
-                true
-            } else {
-                false
-            }
-        } else {
-            false
+        let (f, mut data, mvcc_format, is_v3, file_len) = Self::open_and_detect(path)?;
+        let mut handler = SkiplistRangeRecovery {
+            skiplist,
+            points: Vec::new(),
+            point_tombstones: Vec::new(),
+            range_ts: Vec::new(),
+            range_tombstone_idx: 0,
         };
 
-        let is_v3 = if data.len() >= WAL_HEADER_SIZE {
-            (&data[4..6]).get_u16() == WAL_FORMAT_VERSION_V3
-        } else {
-            false
-        };
-
-        if mvcc_format {
+        let (f, max_ts) = if mvcc_format {
             data.advance(WAL_HEADER_SIZE);
-            let data_len = data.len();
-
-            while data.remaining() >= BATCH_HEADER_SIZE {
-                let before_batch = data.clone();
-                let commit_ts = data.get_u64();
-                let entry_count = data.get_u32() as usize;
-                let data_crc32 = data.get_u32();
-
-                let entries_start = data.remaining();
-                // v3 PointTombstone is only 3 bytes (kind:1 + key_len:2);
-                // v2 entries are at least 4 bytes (key_len:2 + value_len:2).
-                let min_entry_size = if is_v3 { 3 } else { 4 };
-                if entry_count > entries_start / min_entry_size {
-                    data = before_batch;
-                    break;
-                }
-
-                // For v3, we need to scan entries to compute expected size
-                // because entry sizes vary by kind.
-                let mut expected_size: usize = 0;
-                let mut ok = true;
-                for _ in 0..entry_count {
-                    if is_v3 {
-                        // v3: [kind:1][...]
-                        if entries_start - expected_size < 1 {
-                            ok = false;
-                            break;
-                        }
-                        let kind = data[expected_size];
-                        expected_size += 1;
-                        match kind {
-                            0 => {
-                                // Put: [key_len:2][key][value_len:2][value]
-                                if entries_start - expected_size < 4 {
-                                    ok = false;
-                                    break;
-                                }
-                                let pos = expected_size;
-                                let key_size = (&data[pos..pos + 2]).get_u16() as usize;
-                                if entries_start - expected_size < 4 + key_size {
-                                    ok = false;
-                                    break;
-                                }
-                                let val_size = (&data[pos + 2 + key_size..pos + 4 + key_size])
-                                    .get_u16()
-                                    as usize;
-                                expected_size += 4 + key_size + val_size;
-                            }
-                            1 => {
-                                // PointTombstone: [key_len:2][key]
-                                if entries_start - expected_size < 2 {
-                                    ok = false;
-                                    break;
-                                }
-                                let pos = expected_size;
-                                let key_size = (&data[pos..pos + 2]).get_u16() as usize;
-                                expected_size += 2 + key_size;
-                            }
-                            2 => {
-                                // RangeTombstone: [start_len:2][start][end_len:2][end]
-                                if entries_start - expected_size < 4 {
-                                    ok = false;
-                                    break;
-                                }
-                                let pos = expected_size;
-                                let start_size = (&data[pos..pos + 2]).get_u16() as usize;
-                                if entries_start - expected_size < 4 + start_size {
-                                    ok = false;
-                                    break;
-                                }
-                                let end_size = (&data[pos + 2 + start_size..pos + 4 + start_size])
-                                    .get_u16()
-                                    as usize;
-                                expected_size += 4 + start_size + end_size;
-                            }
-                            _ => {
-                                ok = false;
-                                break;
-                            }
-                        }
-                    } else {
-                        // v2: [key_len:2][key][value_len:2][value]
-                        if entries_start - expected_size < 4 {
-                            ok = false;
-                            break;
-                        }
-                        let pos = expected_size;
-                        let key_size = (&data[pos..pos + 2]).get_u16() as usize;
-                        if entries_start - expected_size < 4 + key_size {
-                            ok = false;
-                            break;
-                        }
-                        let val_size =
-                            (&data[pos + 2 + key_size..pos + 4 + key_size]).get_u16() as usize;
-                        expected_size += 4 + key_size + val_size;
-                    }
-                    if expected_size > entries_start {
-                        ok = false;
-                        break;
-                    }
-                }
-
-                if !ok || expected_size > entries_start {
-                    data = before_batch;
-                    break;
-                }
-
-                let entry_data = &data[..expected_size];
-                let computed_crc = crc32fast::hash(entry_data);
-                if computed_crc != data_crc32 {
-                    data = before_batch;
-                    break;
-                }
-
-                let mut entry_buf = data.split_to(expected_size);
-                let mut range_tombstone_idx: u32 = 0;
-                for _ in 0..entry_count {
-                    if is_v3 {
-                        let kind = entry_buf.get_u8();
-                        match kind {
-                            0 => {
-                                // Put
-                                let key_size = entry_buf.get_u16() as usize;
-                                let key = entry_buf.split_to(key_size);
-                                let value_size = entry_buf.get_u16() as usize;
-                                let value = entry_buf.split_to(value_size);
-                                points.push((key.clone(), value.clone()));
-                                skiplist.insert(key, value);
-                            }
-                            1 => {
-                                // PointTombstone
-                                let key_size = entry_buf.get_u16() as usize;
-                                let key = entry_buf.split_to(key_size);
-                                point_tombstones.push(key.clone());
-                                skiplist.insert(
-                                    key,
-                                    Bytes::from_static(&[crate::vlog::KvKind::Tombstone as u8]),
-                                );
-                            }
-                            2 => {
-                                // RangeTombstone
-                                let start_size = entry_buf.get_u16() as usize;
-                                let start = entry_buf.split_to(start_size);
-                                let end_size = entry_buf.get_u16() as usize;
-                                let end = entry_buf.split_to(end_size);
-                                range_ts.push((start, end, commit_ts, range_tombstone_idx));
-                                range_tombstone_idx = range_tombstone_idx
-                                    .checked_add(1)
-                                    .context("ordinal overflow")?;
-                            }
-                            _ => unreachable!(),
-                        }
-                    } else {
-                        // v2: untyped entries
-                        let key_size = entry_buf.get_u16() as usize;
-                        let key = entry_buf.split_to(key_size);
-                        let value_size = entry_buf.get_u16() as usize;
-                        let value = entry_buf.split_to(value_size);
-                        points.push((key.clone(), value.clone()));
-                        skiplist.insert(key, value);
-                    }
-                }
-
-                if commit_ts > max_ts {
-                    max_ts = commit_ts;
-                }
-            }
-
-            let valid_data = data_len - data.remaining();
-            let valid_file = WAL_HEADER_SIZE + valid_data;
-            if (valid_file as u64) < file_len {
-                f.set_len(valid_file as u64)?;
-            }
+            Self::recover_mvcc(f, data, is_v3, file_len, &mut handler)?
         } else {
-            // Legacy format: flat entries.
-            let data_len = data.len();
-            while data.has_remaining() {
-                let before_entry = data.clone();
-                if data.remaining() < 4 {
-                    data = before_entry;
-                    break;
-                }
-                let key_size = data.get_u16() as usize;
-                if data.remaining() < key_size + 2 {
-                    data = before_entry;
-                    break;
-                }
-                let key = data.split_to(key_size);
-                if data.remaining() < 2 {
-                    data = before_entry;
-                    break;
-                }
-                let value_size = data.get_u16() as usize;
-                if data.remaining() < value_size {
-                    data = before_entry;
-                    break;
-                }
-                let value = data.split_to(value_size);
-                if let Some(ts) = crate::key::extract_ts(&key)
-                    && ts > max_ts
-                {
-                    max_ts = ts;
-                }
-                points.push((key.clone(), value.clone()));
-                skiplist.insert(key, value);
-            }
-            let valid_len = data_len - data.remaining();
-            if (valid_len as u64) < file_len {
-                f.set_len(valid_len as u64)?;
-            }
-        }
+            Self::recover_legacy_with(f, data, file_len, &mut handler)?
+        };
 
-        // Insert recovered range tombstones into the set and build the batch
-        // list in a single pass, avoiding a separate iteration.
-        let mut recovered_range_tombstones = Vec::with_capacity(range_ts.len());
-        for (start, end, ts, ordinal) in range_ts {
+        // Insert recovered range tombstones into the set and build the batch.
+        let mut recovered_range_tombstones = Vec::with_capacity(handler.range_ts.len());
+        for (start, end, ts, ordinal) in handler.range_ts {
             recovered_range_tombstones.push(RangeTombstone {
                 start: start.clone(),
                 end: end.clone(),
@@ -659,8 +492,8 @@ impl Wal {
                 mvcc_format,
             },
             RecoveredWalBatch {
-                points,
-                point_tombstones,
+                points: handler.points,
+                point_tombstones: handler.point_tombstones,
                 range_tombstones: recovered_range_tombstones,
                 max_ts,
             },

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -654,6 +654,10 @@ impl Wal {
             self.mvcc_format,
             "range tombstone batches require MVCC WAL format"
         );
+        anyhow::ensure!(
+            self.is_v3,
+            "range tombstone batches require v3 WAL format (found v2)"
+        );
         for (start, end) in tombstones {
             anyhow::ensure!(
                 start.len() <= u16::MAX as usize,


### PR DESCRIPTION
## Summary

Code quality refactoring pass addressing duplication, dead code, and a recovery bug across 16 files (-673/+512 lines).

## Changes

### WAL Recovery Deduplication
- Introduced `RecoveryHandler` trait to abstract over entry recovery actions
- Extracted shared helpers: `recover_mvcc`, `recover_legacy_with`, `open_and_detect`
- `recover()` and `recover_with_range_tombstones()` now delegate to shared parsing core
- ~300 lines of duplicated batch parsing eliminated

### Tombstone Detection Consolidation
- Added `KvKind::is_tombstone_value(&[u8])` in `vlog/mod.rs`
- Removed 5 local definitions across `lsm_iterator.rs`, `mvcc/txn.rs`, `lsm_storage.rs`, `compact.rs`
- Added unit test covering 6 edge cases

### vlog_enabled Branching Elimination
- Unified `MemTable::create(id, vlog_enabled)` replacing paired constructors
- `create_with_wal` and `recover_from_wal` now accept `vlog_enabled` param
- Eliminated 6+ `if vlog_enabled` branches in `lsm_storage.rs`

### Bug Fix
- `recover_from_wal_with_range_tombstones` now accepts `vlog_enabled` parameter
- Previously hardcoded `vlog_enabled: false`, causing silent range tombstone loss when vlog was enabled
- Caller in `lsm_storage.rs` now uses unified recovery path for all cases

### Dead Code Cleanup
- Removed blanket `#![allow(dead_code)]` and `#![allow(unused_variables)]` from `lib.rs`
- Added targeted `#[allow(dead_code)]` on 7 intentional items (test-used APIs, WAL format variants)
- Fixed clippy warnings (unused variables in tests)

### Other Deduplication
- `LsmStorageState::create`: extracted `init_levels` closure for level vector initialization
- `map_bound`: removed duplicate from `mvcc/txn.rs`, imports from `mem_table`

## Review Fixes

### WAL Safety Hardening
- **Bounds validation**: Added full entry size checks before updating `expected_size` in `recover_mvcc` validation loop, preventing underflow on corrupted WAL files
- **Range tombstone ordinal reset**: Added `reset_range_ordinals()` to `RecoveryHandler` trait, called per WAL batch so crash recovery matches live-write behaviour (base_ordinal = 0 per batch)
- **Tombstone classification**: `SkiplistRangeRecovery::handle_put` now checks `is_tombstone_value(&value)` and routes tombstone-valued Put entries to `point_tombstones` instead of `points`
- **WAL version preservation**: Added `is_v3` field to `Wal` struct, preserved through recovery so `put_batch()` writes records matching the file header format (v2 or v3)
- **v2 range tombstone rejection**: `put_range_tombstone_batch` now rejects writes on v2 WALs, preventing v3 kind-tagged records from corrupting a v2 header
- **Debug assert safety**: `debug_assert!` on `extract_ts` in `mem_table.rs` now guarded with `!crate::key::TS_ENABLED` to prevent panics in non-MVCC builds

## Verification
- [x] 529 tests pass
- [x] 0 clippy warnings
- [x] cargo fmt clean
- [x] All benchmarks pass (no regression)

| Benchmark | Time |
|---|---|
| flush_range_only | ~700 µs |
| compaction_mixed | ~1.6 ms |
| compaction_range_only | ~800 µs |
| recovery_tombstones/open_sst (100) | ~130 µs |
| recovery_tombstones/open_sst (10000) | ~9.5 ms |
| recovery_tombstones/open_wal (100) | ~2.6 ms |
| backfill_flush_cliff | ~1.6 ms |
| backfill_compaction | ~5.4 ms |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Unified storage initialization and recovery mechanisms for improved consistency
  * Consolidated error handling across internal components
  * Removed overly permissive compiler warnings

* **Bug Fixes**
  * Enhanced data integrity validation with stricter assertions and error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->