### PR TITLE
fix: replace data-dependent expect() with Result in lsm_storage

### DIFF
--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1499,8 +1499,12 @@ impl LsmStorageInner {
         kind: KvKind,
     ) -> Result<Option<Bytes>> {
         match kind {
-            KvKind::ValuePointer => self
-                .resolve_vlog_value_bytes(key, value.expect("ValuePointer kind must have a value")),
+            KvKind::ValuePointer => self.resolve_vlog_value_bytes(
+                key,
+                value.ok_or_else(|| {
+                    anyhow::anyhow!("ValuePointer entry missing value for key {:?}", key)
+                })?,
+            ),
             KvKind::Inline | KvKind::Tombstone => Ok(value),
         }
     }
@@ -2349,10 +2353,13 @@ impl LsmStorageInner {
         }
         // Leveled SSTs — with MVCC, accumulate the newest version across
         // all levels without returning early.
-        let search_prefix = mvcc_read_ts.map(|_| {
-            crate::key::encoded_user_key_prefix(key)
-                .expect("key must be a valid encoded internal key when mvcc_read_ts is set")
-        });
+        let search_prefix = mvcc_read_ts
+            .map(|_| {
+                crate::key::encoded_user_key_prefix(key).ok_or_else(|| {
+                    anyhow::anyhow!("invalid encoded internal key ({} bytes)", key.len())
+                })
+            })
+            .transpose()?;
         for (_, sst_ids) in state.levels.iter() {
             if let Some(read_ts) = mvcc_read_ts {
                 // Leveled SSTs (L1+) have non-overlapping user key ranges.


### PR DESCRIPTION
## Summary

Replace two `expect()` calls in `lsm_storage.rs` that can panic on corrupted data with proper `Result` error propagation.

## Changes

### `resolve_value` (line 1503)
- **Before**: `value.expect("ValuePointer kind must have a value")`
- **After**: `value.ok_or_else(|| anyhow!("ValuePointer entry missing value for key {:?}", key))?`
- **Rationale**: `value` comes from SST/memtable data. Corrupted storage could produce a `ValuePointer` kind with `None` value.

### `lookup_sst_raw` (line 2354)
- **Before**: `.expect("key must be a valid encoded internal key when mvcc_read_ts is set")`
- **After**: `.ok_or_else(|| anyhow!("invalid encoded internal key ({} bytes)", key.len()))?`
- **Rationale**: `key` comes from caller input. No type-level guarantee it's a valid encoded internal key.

### Not changed (invariant-level)
- SST existence checks (1636, 1643, 2369, 2379) — copy-on-write state guarantees IDs in `levels` exist in `sstables`
- Encoded key prefix check (1634) — `encode_internal_key` always produces output >= 17 bytes
- Manifest/MVCC initialization invariants (1354, 1377, 2053, 2077, 3023, 3130, 3169)

## Verification
- [x] 529 tests pass
- [x] 0 clippy warnings
- [x] cargo fmt clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during data retrieval and key-value pointer operations
  * Enhanced system resilience when processing internal key encoding
  * Application now gracefully manages unexpected conditions instead of crashing
  * Overall stability and reliability improvements across storage operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->