### PR TITLE
refactor: replace eprintln! with logforth structured logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,7 +493,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -512,6 +521,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jiff"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +586,8 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-skiplist",
  "libc",
+ "log",
+ "logforth",
  "nom",
  "ouroboros",
  "parking_lot",
@@ -573,6 +625,94 @@ name = "log"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
+
+[[package]]
+name = "logforth"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "522000d3921e4b089de59204d2d3ca8792cd53f8ce5a54b5ac8b9a6e867259f0"
+dependencies = [
+ "log",
+ "logforth-append-async",
+ "logforth-append-file",
+ "logforth-bridge-log",
+ "logforth-core",
+ "logforth-filter-rustlog",
+ "logforth-layout-json",
+ "logforth-layout-text",
+]
+
+[[package]]
+name = "logforth-append-async"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c2f35f57d9a476b768927b079e364674db9a19d6389f623b69f202376bfb1f"
+dependencies = [
+ "logforth-core",
+ "oneshot",
+]
+
+[[package]]
+name = "logforth-append-file"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80f4ed78a03a30c12285135d98330f0f5d53cb0019bd1ac6d66863dae72d8d52"
+dependencies = [
+ "jiff",
+ "logforth-core",
+]
+
+[[package]]
+name = "logforth-bridge-log"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7224c78547e542572ae4d1f787f96c4395a4c3f24513bf221bd8e49888f610"
+dependencies = [
+ "log",
+ "logforth-core",
+]
+
+[[package]]
+name = "logforth-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "400ba5305e0cb6819efa6c2c503020562eb5b47fd53c91c935be55af1ffd374e"
+dependencies = [
+ "anyhow",
+ "serde",
+]
+
+[[package]]
+name = "logforth-filter-rustlog"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e8431cfa1d3eeca479c363651320a66c7003350528f678b30e8c1474fb0d802"
+dependencies = [
+ "logforth-core",
+]
+
+[[package]]
+name = "logforth-layout-json"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d86a105f8f32151ca1e0a6d4097d478badb02d5715239ba0fa431a188a5d966"
+dependencies = [
+ "jiff",
+ "logforth-core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "logforth-layout-text"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eafe007ac55293d807e8c7f5a23002e2518d32e476e195443cde23e7845416a"
+dependencies = [
+ "colored",
+ "jiff",
+ "logforth-core",
+]
 
 [[package]]
 name = "memchr"
@@ -641,6 +781,12 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "oneshot"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe21416a02c693fb9f980befcb230ecc70b0b3d1cc4abf88b9675c4c1457f0c"
 
 [[package]]
 name = "oorandom"
@@ -722,6 +868,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -1194,15 +1355,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -1234,28 +1386,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.5",
  "windows_aarch64_msvc 0.52.5",
  "windows_i686_gnu 0.52.5",
- "windows_i686_gnullvm 0.52.5",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.5",
  "windows_x86_64_gnu 0.52.5",
  "windows_x86_64_gnullvm 0.52.5",
  "windows_x86_64_msvc 0.52.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1271,12 +1406,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,12 +1416,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1307,22 +1430,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1337,12 +1448,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1353,12 +1458,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1373,12 +1472,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,12 +1482,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/kv-engine/Cargo.toml
+++ b/kv-engine/Cargo.toml
@@ -11,6 +11,8 @@ ignored = ["arc-swap", "crossbeam-epoch"]
 TinyUFO = "0.8"
 ahash = "0.8"
 anyhow = "1"
+log = "0.4"
+logforth = { version = "0.30", features = ["starter-log", "layout-json", "append-async"] }
 arc-swap = "1"
 bytes = "1"
 clap = { version = "4.4.17", features = ["derive"] }

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -1062,12 +1062,12 @@ impl LsmStorageInner {
                         }
                         std::result::Result::Ok(None) => {}
                         std::result::Result::Err(e) => {
-                            eprintln!("GC error for vlog file {}: {}", file_id, e);
+                            log::error!("GC error for vlog file {}: {}", file_id, e);
                         }
                     }
                 }
                 if let Err(e) = vlog.reclaim_pending_deletions() {
-                    eprintln!("vLog reclaim error: {}", e);
+                    log::error!("vLog reclaim error: {}", e);
                 }
             });
             {
@@ -1095,12 +1095,12 @@ impl LsmStorageInner {
                     }
                     std::result::Result::Ok(None) => {}
                     std::result::Result::Err(e) => {
-                        eprintln!("GC error for vlog file {}: {}", file_id, e);
+                        log::error!("GC error for vlog file {}: {}", file_id, e);
                     }
                 }
             }
             if let Err(e) = vlog2.reclaim_pending_deletions() {
-                eprintln!("vLog reclaim error: {}", e);
+                log::error!("vLog reclaim error: {}", e);
             }
         }
     }
@@ -1333,7 +1333,7 @@ impl LsmStorageInner {
                 loop {
                     crossbeam_channel::select! {
                         recv(ticker) -> _ => if let Err(e) = this.trigger_compaction() {
-                            eprintln!("compaction failed: {e}");
+                            log::error!("compaction failed: {}", e);
                         },
                         recv(rx) -> _ => return
                     }
@@ -1364,7 +1364,7 @@ impl LsmStorageInner {
             loop {
                 crossbeam_channel::select! {
                     recv(ticker) -> _ => if let Err(e) = this.trigger_flush() {
-                        eprintln!("flush failed: {e}");
+                        log::error!("flush failed: {}", e);
                     },
                     recv(rx) -> _ => return
                 }

--- a/kv-engine/src/lib.rs
+++ b/kv-engine/src/lib.rs
@@ -14,23 +14,6 @@ pub mod table;
 pub mod vlog;
 pub mod wal;
 
-#[cfg(test)]
-mod tests;
-
-#[cfg(test)]
-mod logforth_tests {
-    #[test]
-    fn init_logging_is_safe_to_call_twice() {
-        crate::init_logging();
-        crate::init_logging(); // second call should be a no-op via try_apply
-        log::error!("test error from logforth");
-        log::warn!("test warning from logforth");
-        log::info!("test info from logforth");
-        // If we get here without panicking, try_apply works correctly
-        assert!(log::max_level() >= log::LevelFilter::Error);
-    }
-}
-
 /// Initialize structured logging via logforth.
 ///
 /// Reads `RUST_LOG` for level filtering (defaults to `info`).
@@ -47,4 +30,21 @@ pub fn init_logging() {
                 .append(append::Stderr::default().with_layout(layout::JsonLayout::default()))
         })
         .try_apply();
+}
+
+#[cfg(test)]
+mod tests;
+
+#[cfg(test)]
+mod logforth_tests {
+    #[test]
+    fn init_logging_is_safe_to_call_twice() {
+        crate::init_logging();
+        crate::init_logging(); // second call should be a no-op via try_apply
+        log::error!("test error from logforth");
+        log::warn!("test warning from logforth");
+        log::info!("test info from logforth");
+        // If we get here without panicking, try_apply works correctly
+        assert!(log::max_level() >= log::LevelFilter::Error);
+    }
 }

--- a/kv-engine/src/lib.rs
+++ b/kv-engine/src/lib.rs
@@ -26,7 +26,7 @@ pub fn init_logging() {
 
     let _ = logforth::starter_log::builder()
         .dispatch(|d| {
-            d.filter(filter::rustlog::RustLogFilterBuilder::from_default_env().build())
+            d.filter(filter::rustlog::RustLogFilterBuilder::from_default_env_or("info").build())
                 .append(append::Stderr::default().with_layout(layout::JsonLayout::default()))
         })
         .try_apply();

--- a/kv-engine/src/lib.rs
+++ b/kv-engine/src/lib.rs
@@ -27,10 +27,10 @@ pub fn init_logging() {
     use logforth::filter;
     use logforth::layout;
 
-    logforth::starter_log::builder()
+    let _ = logforth::starter_log::builder()
         .dispatch(|d| {
             d.filter(filter::rustlog::RustLogFilterBuilder::from_default_env().build())
                 .append(append::Stderr::default().with_layout(layout::JsonLayout::default()))
         })
-        .apply();
+        .try_apply();
 }

--- a/kv-engine/src/lib.rs
+++ b/kv-engine/src/lib.rs
@@ -16,3 +16,21 @@ pub mod wal;
 
 #[cfg(test)]
 mod tests;
+
+/// Initialize structured logging via logforth.
+///
+/// Reads `RUST_LOG` for level filtering (defaults to `info`).
+/// Outputs structured JSON to stderr. Safe to call multiple times;
+/// only the first call takes effect.
+pub fn init_logging() {
+    use logforth::append;
+    use logforth::filter;
+    use logforth::layout;
+
+    logforth::starter_log::builder()
+        .dispatch(|d| {
+            d.filter(filter::rustlog::RustLogFilterBuilder::from_default_env().build())
+                .append(append::Stderr::default().with_layout(layout::JsonLayout::default()))
+        })
+        .apply();
+}

--- a/kv-engine/src/lib.rs
+++ b/kv-engine/src/lib.rs
@@ -17,6 +17,20 @@ pub mod wal;
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
+mod logforth_tests {
+    #[test]
+    fn init_logging_is_safe_to_call_twice() {
+        crate::init_logging();
+        crate::init_logging(); // second call should be a no-op via try_apply
+        log::error!("test error from logforth");
+        log::warn!("test warning from logforth");
+        log::info!("test info from logforth");
+        // If we get here without panicking, try_apply works correctly
+        assert!(log::max_level() >= log::LevelFilter::Error);
+    }
+}
+
 /// Initialize structured logging via logforth.
 ///
 /// Reads `RUST_LOG` for level filtering (defaults to `info`).

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1264,7 +1264,7 @@ impl LsmStorageInner {
                 active_vlog_ids.extend(imm.collect_vlog_file_ids());
             }
             if let Err(e) = vlog.cleanup_orphan_vlog_files(&active_vlog_ids) {
-                eprintln!("vLog orphan cleanup error: {}", e);
+                log::error!("vLog orphan cleanup error: {}", e);
             }
         }
 
@@ -3084,10 +3084,7 @@ impl LsmStorageInner {
             if !vlog_index_entries.is_empty()
                 && let Err(e) = vlog.save_index(vlog_file_id, vlog_index_entries)
             {
-                eprintln!(
-                    "warning: failed to save vLog index for {}: {}",
-                    vlog_file_id, e
-                );
+                log::warn!("failed to save vLog index for {}: {}", vlog_file_id, e);
             }
             // Sync the vLog directory to ensure the .vlog and .vidx directory
             // entries are durable. The main data directory is synced separately
@@ -3156,11 +3153,7 @@ impl LsmStorageInner {
                 // recovery that re-flushed and then cleaned up). Log and
                 // continue — this is not a fatal error.
                 if e.kind() != std::io::ErrorKind::NotFound {
-                    eprintln!(
-                        "warning: failed to remove WAL {}: {}",
-                        wal_path.display(),
-                        e
-                    );
+                    log::warn!("failed to remove WAL {}: {}", wal_path.display(), e);
                 }
             }
         }

--- a/kv-engine/src/vlog/gc.rs
+++ b/kv-engine/src/vlog/gc.rs
@@ -259,10 +259,7 @@ impl<'a> GarbageCollector<'a> {
 
             // Persist the vLog index for the new file
             if let Err(e) = self.vlog.save_index(new_file_id, index_entries) {
-                eprintln!(
-                    "warning: failed to save vLog index for {}: {}",
-                    new_file_id, e
-                );
+                log::warn!("failed to save vLog index for {}: {}", new_file_id, e);
             }
             // Sync the directory to ensure the new file's directory entry is durable
             if let std::result::Result::Ok(dir) = std::fs::File::open(&self.vlog.path) {

--- a/kv-engine/src/vlog/mod.rs
+++ b/kv-engine/src/vlog/mod.rs
@@ -672,10 +672,7 @@ impl ValueLog {
                 let rebuilt = Arc::new(VlogIndex::rebuild_from_reader(&reader, file_id)?);
                 // Persist rebuilt index so next startup doesn't need to scan headers
                 if let Err(e) = rebuilt.save(&idx_path) {
-                    eprintln!(
-                        "warning: failed to persist rebuilt vLog index {}: {}",
-                        file_id, e
-                    );
+                    log::warn!("failed to persist rebuilt vLog index {}: {}", file_id, e);
                 }
                 rebuilt
             }


### PR DESCRIPTION
## Summary

Replace 11 `eprintln!` calls in background threads with structured logging via `logforth` — a versatile, extensible logging framework with JSON layout support.

## Changes

### Dependencies
- Added `log` (v0.4) and `logforth` (v0.30) with `starter-log`, `layout-json`, and `append-async` features

### Logger initialization
- Added `init_logging()` in `lib.rs` — one-call setup with `RUST_LOG` env filter and JSON output to stderr

### Replaced eprintln! calls (11 total)
| File | Calls | Level |
|---|---|---|
| `compact.rs` | 6 (GC errors, compaction/flush failures) | error |
| `lsm_storage.rs` | 3 (vLog cleanup, index save, WAL removal) | warn/error |
| `vlog/mod.rs` | 1 (rebuilt index persist) | warn |
| `vlog/gc.rs` | 1 (index save) | warn |

## Verification
- [x] 529 tests pass
- [x] 0 clippy warnings
- [x] cargo fmt clean