### PR TITLE
refactor: extract encode_kind_value helper for CAS methods

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -26,5 +26,5 @@
 - [x] **Replace `eprintln!` in background threads** — compaction, flush, GC threads use `eprintln!` for errors. Add proper logging or error channel.
 - [x] **Decompose `lsm_storage.rs`** — extract `open()` manifest replay (~190-line match block) into a `replay_manifest_record` method.
 - [x] **Consolidate test option constructors** — three `default_for_*` differ only in two fields. Use a builder or single constructor with overrides.
-- [ ] **Simplify `range_overlap` match arms** in `mem_table.rs`. A bound-normalizing helper would cut the 100-line match.
+- [x] **Simplify `range_overlap` match arms** in `mem_table.rs`. A bound-normalizing helper would cut the 100-line match.
 - [ ] **Extract `compare_and_set` shared logic** — three CAS methods duplicate the read-then-verify-then-write pattern.

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -2485,6 +2485,14 @@ impl LsmStorageInner {
         }
     }
 
+    /// Encode a value with its kind byte prefix: `[kind_byte, value...]`.
+    fn encode_kind_value(kind: KvKind, value: &[u8]) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(1 + value.len());
+        buf.push(kind as u8);
+        buf.extend_from_slice(value);
+        buf
+    }
+
     /// Acquires state_lock, does a full LSM lookup, and conditionally writes
     /// the new value to the memtable if the current value matches (old, old_kind).
     /// Returns true if the swap succeeded.
@@ -2507,10 +2515,7 @@ impl LsmStorageInner {
             return Ok(false);
         }
 
-        let mut prefixed = Vec::with_capacity(1 + new.len());
-        prefixed.push(new_kind as u8);
-        prefixed.extend_from_slice(new);
-
+        let prefixed = Self::encode_kind_value(new_kind, new);
         state.memtable.put_raw(key, &prefixed)?;
 
         Ok(true)
@@ -2586,9 +2591,7 @@ impl LsmStorageInner {
             }
 
             if still_matches {
-                let mut prefixed = Vec::with_capacity(1 + new.len());
-                prefixed.push(*new_kind as u8);
-                prefixed.extend_from_slice(new);
+                let prefixed = Self::encode_kind_value(*new_kind, new);
                 writes.push((KeySlice::from_slice(key), prefixed));
                 results[i] = true;
             }
@@ -2659,9 +2662,7 @@ impl LsmStorageInner {
             }
 
             if still_matches {
-                let mut prefixed = Vec::with_capacity(1 + new.len());
-                prefixed.push(*new_kind as u8);
-                prefixed.extend_from_slice(new);
+                let prefixed = Self::encode_kind_value(*new_kind, new);
                 writes.push((encoded, prefixed));
                 results[i] = true;
             }


### PR DESCRIPTION
## Summary

Extract encode_kind_value() helper that creates a kind-byte-prefixed value buffer. Replaces inline Vec construction in all three CAS methods.

## Changes

- Add encode_kind_value(kind, value) -> Vec<u8> helper
- compare_and_set_with_kind: use helper instead of inline Vec
- compare_and_set_batch_with_kind: use helper instead of inline Vec
- compare_and_set_batch_at_ts: use helper instead of inline Vec

## Verification

- [x] All checks pass (fmt, clippy, test)
- [x] No functional changes