### PR TITLE
perf: optimize get_raw_exact with pre-computed bloom hash

### DIFF
--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -2617,8 +2617,10 @@ impl LsmStorageInner {
     ) -> Result<Vec<bool>> {
         let _lock = self.state_lock.lock();
 
-        // Phase 1: Lookups under read lock — check exact version
-        let mut candidates = Vec::with_capacity(entries.len());
+        // Phase 1: Lookups under read lock — check exact version.
+        // Carry pre-computed (encoded, bloom_hash) forward so Phase 2 can
+        // reuse them without re-encoding or re-hashing.
+        let mut candidates: Vec<Option<(Vec<u8>, u32)>> = Vec::with_capacity(entries.len());
         {
             let state = self.state.load_full();
             for (user_key, ts, old, old_kind, _, _) in entries {
@@ -2631,16 +2633,18 @@ impl LsmStorageInner {
                         m.get_raw_exact_with_hash(&encoded, bloom_hash)
                             .map(Self::parse_value_kind)
                     });
-                match current {
-                    Some((val, kind)) => {
-                        candidates.push(Self::values_match(&val, kind, old, *old_kind));
-                    }
+                let matches = match current {
+                    Some((val, kind)) => Self::values_match(&val, kind, old, *old_kind),
                     None => {
-                        // Key not in memtables — check SSTs
                         let (val, kind) = self.get_with_kind_at_ts(user_key, *ts)?;
-                        candidates.push(Self::values_match(&val, kind, old, *old_kind));
+                        Self::values_match(&val, kind, old, *old_kind)
                     }
-                }
+                };
+                candidates.push(if matches {
+                    Some((encoded, bloom_hash))
+                } else {
+                    None
+                });
             }
         }
 
@@ -2652,14 +2656,12 @@ impl LsmStorageInner {
         // Store owned encoded keys to avoid lifetime issues.
         let mut writes: Vec<(Vec<u8>, Vec<u8>)> = Vec::with_capacity(entries.len());
 
-        for (i, (user_key, ts, old, old_kind, new, new_kind)) in entries.iter().enumerate() {
-            if !candidates[i] {
+        for (i, (_, _, old, old_kind, new, new_kind)) in entries.iter().enumerate() {
+            let Some((encoded, bloom_hash)) = candidates[i].take() else {
                 continue;
-            }
+            };
 
-            // Re-verify against the memtable using exact key
-            let encoded = crate::key::encode_internal_key(user_key, *ts);
-            let bloom_hash = crate::table::bloom::hash_key(user_key);
+            // Re-verify against the memtable using the pre-computed key
             let mut still_matches = true;
             if let Some(raw) = state.memtable.get_raw_exact_with_hash(&encoded, bloom_hash) {
                 let (current_val, current_kind) = Self::parse_value_kind(raw);

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -2623,14 +2623,16 @@ impl LsmStorageInner {
         let mut candidates: Vec<Option<(Vec<u8>, u32)>> = Vec::with_capacity(entries.len());
         {
             let state = self.state.load_full();
+            let mut encode_buf = Vec::with_capacity(64);
             for (user_key, ts, old, old_kind, _, _) in entries {
-                let encoded = crate::key::encode_internal_key(user_key, *ts);
+                encode_buf.clear();
+                crate::key::encode_internal_key_to_buf(&mut encode_buf, user_key, *ts);
                 let bloom_hash = crate::table::bloom::hash_key(user_key);
                 // Check memtable + imm_memtables for the exact version
                 let current = std::iter::once(&state.memtable)
                     .chain(state.imm_memtables.iter())
                     .find_map(|m| {
-                        m.get_raw_exact_with_hash(&encoded, bloom_hash)
+                        m.get_raw_exact_with_hash(&encode_buf, bloom_hash)
                             .map(Self::parse_value_kind)
                     });
                 let matches = match current {
@@ -2641,7 +2643,7 @@ impl LsmStorageInner {
                     }
                 };
                 candidates.push(if matches {
-                    Some((encoded, bloom_hash))
+                    Some((encode_buf.clone(), bloom_hash))
                 } else {
                     None
                 });

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1638,11 +1638,11 @@ impl LsmStorageInner {
         let bloom_hash = crate::table::bloom::hash_key(user_key);
 
         // Check active + immutable memtables (exact key match, no version scan)
-        if let Some(raw) = state.memtable.get_raw_exact(&encoded) {
+        if let Some(raw) = state.memtable.get_raw_exact_with_hash(&encoded, bloom_hash) {
             return Ok(Self::parse_value_kind(raw));
         }
         for m in state.imm_memtables.iter() {
-            if let Some(raw) = m.get_raw_exact(&encoded) {
+            if let Some(raw) = m.get_raw_exact_with_hash(&encoded, bloom_hash) {
                 return Ok(Self::parse_value_kind(raw));
             }
         }
@@ -2623,10 +2623,14 @@ impl LsmStorageInner {
             let state = self.state.load_full();
             for (user_key, ts, old, old_kind, _, _) in entries {
                 let encoded = crate::key::encode_internal_key(user_key, *ts);
+                let bloom_hash = crate::table::bloom::hash_key(user_key);
                 // Check memtable + imm_memtables for the exact version
                 let current = std::iter::once(&state.memtable)
                     .chain(state.imm_memtables.iter())
-                    .find_map(|m| m.get_raw_exact(&encoded).map(Self::parse_value_kind));
+                    .find_map(|m| {
+                        m.get_raw_exact_with_hash(&encoded, bloom_hash)
+                            .map(Self::parse_value_kind)
+                    });
                 match current {
                     Some((val, kind)) => {
                         candidates.push(Self::values_match(&val, kind, old, *old_kind));
@@ -2655,8 +2659,9 @@ impl LsmStorageInner {
 
             // Re-verify against the memtable using exact key
             let encoded = crate::key::encode_internal_key(user_key, *ts);
+            let bloom_hash = crate::table::bloom::hash_key(user_key);
             let mut still_matches = true;
-            if let Some(raw) = state.memtable.get_raw_exact(&encoded) {
+            if let Some(raw) = state.memtable.get_raw_exact_with_hash(&encoded, bloom_hash) {
                 let (current_val, current_kind) = Self::parse_value_kind(raw);
                 still_matches = Self::values_match(&current_val, current_kind, old, *old_kind);
             }

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -282,11 +282,31 @@ impl MemTable {
             if !may_contain {
                 return None;
             }
-        } else {
-            let h = super::table::bloom::hash_key(encoded_internal_key);
-            if !self.bloom.may_contain_hash(h) {
-                return None;
-            }
+        } else if !self
+            .bloom
+            .may_contain_hash(super::table::bloom::hash_key(encoded_internal_key))
+        {
+            return None;
+        }
+
+        self.map
+            .get(encoded_internal_key)
+            .map(|x| x.value().clone())
+    }
+
+    /// Exact lookup by encoded internal key with a pre-computed bloom hash.
+    ///
+    /// Avoids the thread-local buffer overhead of [`get_raw_exact`] by
+    /// accepting a pre-computed `hash_key(user_key)` from the caller. This
+    /// eliminates the per-call `thread_local!` + `RefCell` + `decode_user_key`
+    /// overhead that dominates the `get_raw_exact` profile.
+    pub fn get_raw_exact_with_hash(
+        &self,
+        encoded_internal_key: &[u8],
+        bloom_hash: u32,
+    ) -> Option<Bytes> {
+        if !self.bloom.may_contain_hash(bloom_hash) {
+            return None;
         }
         self.map
             .get(encoded_internal_key)


### PR DESCRIPTION
## Summary

Optimize `get_raw_exact` — the hot path for GC and CAS operations — by eliminating thread-local buffer overhead.

## Problem

`perf record` showed 44% of cycles in `MemTable::get_raw_exact` from:
- `thread_local!` + `RefCell::borrow_mut()` per call
- `decode_user_key_into` allocating into the TLS buffer
- `hash_key` recomputing bloom hash that callers already have

## Solution

Add `get_raw_exact_with_hash(key, bloom_hash)` that:
- Accepts a pre-computed bloom hash from the caller
- Skips the thread-local buffer entirely
- Does a single `bloom.may_contain_hash` check then skiplist lookup

Update all 3 call sites (`get_with_kind_at_ts`, `compare_and_set_batch_at_ts` x2) to pass bloom hash through.

Also flatten the `else { if }` in `get_raw_exact` to `else if` for early return style.

## Microbenchmark (100K entries, 100K iterations)

| Path | Original | Optimized | Speedup |
|------|----------|-----------|---------|
| Hit (skiplist lookup) | 6.8M ops/sec | 7.7M ops/sec | **1.13x** |
| Miss (bloom rejection) | 15.5M ops/sec | 19.9M ops/sec | **1.28x** |

## Verification

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -D warnings` passes
- [x] 530 tests pass
- [x] No write-perf regression


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal key lookup operations to utilize bloom hash values more efficiently, improving performance for exact-key searches in the storage engine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->