### PR TITLE
perf: rewrite write-perf as db_bench-style benchmark harness

### DIFF
--- a/kv-engine/Cargo.toml
+++ b/kv-engine/Cargo.toml
@@ -11,8 +11,6 @@ ignored = ["arc-swap", "crossbeam-epoch"]
 TinyUFO = "0.8"
 ahash = "0.8"
 anyhow = "1"
-log = "0.4"
-logforth = { version = "0.30", features = ["starter-log", "layout-json", "append-async"] }
 arc-swap = "1"
 bytes = "1"
 clap = { version = "4.4.17", features = ["derive"] }
@@ -20,6 +18,8 @@ crc32fast = "1.3.2"
 crossbeam-channel = "0.5.11"
 crossbeam-epoch = "0.9"
 crossbeam-skiplist = "0.1"
+log = "0.4"
+logforth = { version = "0.30", features = ["starter-log", "layout-json", "append-async"] }
 nom = "7.1.3"
 ouroboros = "0.18"
 parking_lot = "0.12"

--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -5,8 +5,8 @@ use std::io::Write as _;
 use std::ops::Bound;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use parking_lot::Mutex;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use wrapper::kv_engine_wrapper;
 
@@ -580,12 +580,13 @@ fn run_concurrent_rw(
 
     let value_size = cfg.value_size;
     let num = cfg.num;
+    let seed = cfg.seed;
     for t in 0..cfg.threads {
         let eng = engine.clone();
         let stop = stop.clone();
         let wc = write_count.clone();
         handles.push(std::thread::spawn(move || {
-            let mut rng = StdRng::seed_from_u64(t as u64);
+            let mut rng = StdRng::seed_from_u64(seed.wrapping_add(t as u64));
             let value = vec![b'x'; value_size];
             let mut local = 0u64;
             while !stop.load(Ordering::Relaxed) {
@@ -603,7 +604,7 @@ fn run_concurrent_rw(
         let stop = stop.clone();
         let rc = read_count.clone();
         handles.push(std::thread::spawn(move || {
-            let mut rng = StdRng::seed_from_u64(1_000 + t as u64);
+            let mut rng = StdRng::seed_from_u64(seed.wrapping_add(1_000 + t as u64));
             let mut local = 0u64;
             while !stop.load(Ordering::Relaxed) {
                 let key = format!("key{:08}", rng.gen_range(0..num as u64));
@@ -808,7 +809,7 @@ fn run_vlog_gc(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
         engine.drain_flush()?;
 
         let gc_start = Instant::now();
-        let gc_count = engine.trigger_gc()?;
+        let _gc_count = engine.trigger_gc()?;
         let gc_elapsed = gc_start.elapsed();
 
         let after_round = collect_counters(&engine)?;
@@ -830,7 +831,7 @@ fn run_vlog_gc(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
                 gc_elapsed_ms: Some(ms(gc_elapsed)),
                 writes: Some(entries_per_round as u64),
                 writes_per_sec: Some(rate(entries_per_round as u64, write_elapsed)),
-                gc_rounds: Some(gc_count as u64),
+                gc_rounds: Some(1),
                 ..MeasurementResult::default()
             },
             collect_counter_delta(&baseline, &after_round),
@@ -856,6 +857,7 @@ fn run_vlog_concurrent_gc(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> 
     let wc = Arc::new(AtomicU64::new(0));
     let rc = Arc::new(AtomicU64::new(0));
     let gcc = Arc::new(AtomicU64::new(0));
+    let seed = cfg.seed;
     let mut handles = vec![];
 
     {
@@ -863,7 +865,7 @@ fn run_vlog_concurrent_gc(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> 
         let stop = stop.clone();
         let wc = wc.clone();
         handles.push(std::thread::spawn(move || {
-            let mut rng = StdRng::seed_from_u64(42);
+            let mut rng = StdRng::seed_from_u64(seed);
             let val = vec![b'y'; 4096];
             let mut c = 0u64;
             while !stop.load(Ordering::Relaxed) {
@@ -881,7 +883,7 @@ fn run_vlog_concurrent_gc(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> 
         let stop = stop.clone();
         let rc = rc.clone();
         handles.push(std::thread::spawn(move || {
-            let mut rng = StdRng::seed_from_u64(100);
+            let mut rng = StdRng::seed_from_u64(seed.wrapping_add(100));
             let mut c = 0u64;
             while !stop.load(Ordering::Relaxed) {
                 let key = format!("key{:08}", rng.gen_range(0..5_000));
@@ -1038,10 +1040,12 @@ fn run_readrandom(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     let baseline = collect_counters(&engine)?;
 
     let mut rng = StdRng::seed_from_u64(cfg.seed + 123);
+    let mut key = String::with_capacity(11);
     let start = Instant::now();
     let mut found = 0u64;
     for _ in 0..cfg.reads {
-        let key = format!("key{:08}", rng.gen_range(0..cfg.num as u64));
+        key.clear();
+        let _ = write!(&mut key, "key{:08}", rng.gen_range(0..cfg.num as u64));
         if engine.get(key.as_bytes())?.is_some() {
             found += 1;
         }
@@ -1086,6 +1090,7 @@ fn run_readwhilewriting(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     let stop = Arc::new(AtomicBool::new(false));
     let wc = Arc::new(AtomicU64::new(0));
     let rc = Arc::new(AtomicU64::new(0));
+    let seed = cfg.seed;
     let mut handles = vec![];
 
     {
@@ -1095,7 +1100,7 @@ fn run_readwhilewriting(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
         let value = vec![b'x'; cfg.value_size];
         let num = cfg.num;
         handles.push(std::thread::spawn(move || {
-            let mut rng = StdRng::seed_from_u64(42);
+            let mut rng = StdRng::seed_from_u64(seed);
             let mut c = 0u64;
             while !stop.load(Ordering::Relaxed) {
                 let key = format!("key{:08}", rng.gen_range(0..num as u64));
@@ -1113,7 +1118,7 @@ fn run_readwhilewriting(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
         let rc = rc.clone();
         let num = cfg.num;
         handles.push(std::thread::spawn(move || {
-            let mut rng = StdRng::seed_from_u64(1000 + t as u64);
+            let mut rng = StdRng::seed_from_u64(seed.wrapping_add(1000 + t as u64));
             let mut c = 0u64;
             while !stop.load(Ordering::Relaxed) {
                 let key = format!("key{:08}", rng.gen_range(0..num as u64));
@@ -1173,6 +1178,7 @@ fn run_readrandomwriterandom(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement
     let options = cfg.build_options(false, false);
     let engine = KvEngine::open(&path, options.clone())?;
     let load_elapsed = populate_range(&engine, cfg.num, cfg.value_size)?;
+    let baseline = collect_counters(&engine)?;
 
     let stop = Arc::new(AtomicBool::new(false));
     let wc = Arc::new(AtomicU64::new(0));
@@ -1186,8 +1192,9 @@ fn run_readrandomwriterandom(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement
         let rc = rc.clone();
         let value = vec![b'x'; cfg.value_size];
         let num = cfg.num;
+        let seed = cfg.seed;
         handles.push(std::thread::spawn(move || {
-            let mut rng = StdRng::seed_from_u64(t as u64);
+            let mut rng = StdRng::seed_from_u64(seed.wrapping_add(t as u64));
             let mut writes = 0u64;
             let mut reads = 0u64;
             while !stop.load(Ordering::Relaxed) {
@@ -1217,7 +1224,7 @@ fn run_readrandomwriterandom(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement
 
     let writes = wc.load(Ordering::Relaxed);
     let reads = rc.load(Ordering::Relaxed);
-    let counters = collect_counters(&engine)?;
+    let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
     engine.close()?;
     finalize_path(cfg, &path)?;
 
@@ -1406,19 +1413,22 @@ fn run_readseq_validate_order(cfg: &HarnessConfig) -> Result<Vec<BenchMeasuremen
 
     let start = Instant::now();
     let mut count = 0u64;
-    let mut prev_key: Option<Vec<u8>> = None;
+    let mut prev_key = Vec::new();
+    let mut has_prev = false;
     let mut iter = engine.scan(Bound::Unbounded, Bound::Unbounded)?;
     while iter.is_valid() {
-        let current = iter.key().to_vec();
-        if let Some(prev) = &prev_key {
+        let current = iter.key();
+        if has_prev {
             anyhow::ensure!(
-                prev.as_slice() <= current.as_slice(),
+                prev_key.as_slice() < current,
                 "readseq_validate_order detected out-of-order scan: prev={:?} current={:?}",
-                prev,
+                prev_key,
                 current
             );
         }
-        prev_key = Some(current);
+        prev_key.clear();
+        prev_key.extend_from_slice(current);
+        has_prev = true;
         count += 1;
         iter.next()?;
     }
@@ -1536,8 +1546,9 @@ fn run_seekrandomwhilewriting(cfg: &HarnessConfig) -> Result<Vec<BenchMeasuremen
         let write_err = write_err.clone();
         let num = cfg.num;
         let value_size = cfg.value_size;
+        let seed = cfg.seed;
         handles.push(std::thread::spawn(move || {
-            let mut rng = StdRng::seed_from_u64(42);
+            let mut rng = StdRng::seed_from_u64(seed);
             let mut key_buf = [0u8; 11];
             key_buf[..3].copy_from_slice(b"key");
             let value = vec![b'x'; value_size];
@@ -1548,7 +1559,7 @@ fn run_seekrandomwhilewriting(cfg: &HarnessConfig) -> Result<Vec<BenchMeasuremen
                 match eng.put(&key_buf, &value) {
                     Ok(()) => c += 1,
                     Err(e) => {
-                        *write_err.lock().expect("lock poisoned") = Some(format!("{e}"));
+                        *write_err.lock() = Some(format!("{e}"));
                         break;
                     }
                 }
@@ -1585,7 +1596,7 @@ fn run_seekrandomwhilewriting(cfg: &HarnessConfig) -> Result<Vec<BenchMeasuremen
             .join()
             .map_err(|_| anyhow!("writer thread panicked"))?;
     }
-    if let Some(err) = write_err.lock().expect("lock poisoned").take() {
+    if let Some(err) = write_err.lock().take() {
         bail!("writer thread error: {err}");
     }
 
@@ -1723,7 +1734,10 @@ fn make_measurement(
         engine: ENGINE_NAME,
         engine_options: EngineOptionsRecord {
             wal: options.enable_wal,
-            value_separation: effective_value_separation(options, &params),
+            value_separation: options
+                .value_separation
+                .as_ref()
+                .is_some_and(|vlog| vlog.enabled),
             compaction: compaction_name(&options.compaction_options),
             target_sst_size: options.target_sst_size,
             memtable_limit: options.num_memtable_limit,
@@ -1934,15 +1948,6 @@ fn compaction_name(options: &CompactionOptions) -> &'static str {
         CompactionOptions::Leveled(_) => "leveled",
         CompactionOptions::Tiered(_) => "tiered",
     }
-}
-
-fn effective_value_separation(options: &LsmStorageOptions, params: &MeasurementParams) -> bool {
-    let Some(vlog) = options.value_separation.as_ref() else {
-        return false;
-    };
-    params
-        .value_size
-        .is_some_and(|value_size| value_size >= vlog.min_value_size)
 }
 
 fn diff_option_u64(before: Option<u64>, after: Option<u64>) -> Option<u64> {

--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -1,12 +1,12 @@
 mod wrapper;
 
+use parking_lot::Mutex;
 use std::fmt::Write as _;
 use std::io::Write as _;
 use std::ops::Bound;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use parking_lot::Mutex;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use wrapper::kv_engine_wrapper;
 

--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -1,121 +1,576 @@
 mod wrapper;
 
+use std::fmt::Write as _;
 use std::io::Write as _;
 use std::ops::Bound;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use wrapper::kv_engine_wrapper;
 
-use anyhow::Result;
+use anyhow::{Context, Result, anyhow, bail};
+use clap::{Parser, ValueEnum};
 use kv_engine_wrapper::{
-    compact::{CompactionOptions, LeveledCompactionOptions},
+    compact::{
+        CompactionOptions, LeveledCompactionOptions, SimpleLeveledCompactionOptions,
+        TieredCompactionOptions,
+    },
     iterators::StorageIterator,
     lsm_storage::{KvEngine, LsmStorageOptions, PrefixBloomOptions},
     vlog::ValueSeparationOptions,
 };
 use rand::prelude::*;
 use rand::rngs::StdRng;
+use serde::Serialize;
 
-fn make_options(vlog: bool, wal: bool) -> LsmStorageOptions {
-    LsmStorageOptions {
-        block_size: 4096,
-        target_sst_size: 1 << 20,
-        num_memtable_limit: 2,
-        compaction_options: CompactionOptions::Leveled(LeveledCompactionOptions {
-            level_size_multiplier: 2,
-            level0_file_num_compaction_trigger: 4,
-            max_levels: 6,
-            base_level_size_mb: 128,
-        }),
-        enable_wal: wal,
-        serializable: false,
-        value_separation: if vlog {
-            Some(ValueSeparationOptions {
-                enabled: true,
-                min_value_size: 1024,
-                max_value_size: 64 * 1024,
-                max_vlog_file_size: 64 * 1024 * 1024,
-                gc_threshold_ratio: 0.4,
-                max_open_vlog_files: 4,
-                value_cache_capacity_bytes: 16 * 1024 * 1024,
-            })
+const JSON_SCHEMA: &str = "kv-engine.write-perf.v1";
+const ENGINE_NAME: &str = "kv-engine";
+
+#[derive(Clone, Copy, Debug, ValueEnum, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum OutputFormat {
+    Text,
+    Json,
+    Both,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum Preset {
+    Default,
+    Large,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum CompactionMode {
+    None,
+    Simple,
+    Leveled,
+    Tiered,
+}
+
+#[derive(Parser, Debug)]
+#[command(name = "write-perf")]
+struct Args {
+    #[arg(long)]
+    bench: Option<String>,
+    #[arg(long, value_enum, default_value_t = Preset::Default)]
+    preset: Preset,
+    #[arg(long)]
+    large: bool,
+    #[arg(long, default_value = "/tmp/write-perf")]
+    path: PathBuf,
+    #[arg(long)]
+    no_cleanup: bool,
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    output: OutputFormat,
+    #[arg(long)]
+    num: Option<usize>,
+    #[arg(long)]
+    reads: Option<usize>,
+    #[arg(long)]
+    duration: Option<u64>,
+    #[arg(long)]
+    scan_num: Option<usize>,
+    #[arg(long)]
+    value_size: Option<usize>,
+    #[arg(long)]
+    threads: Option<usize>,
+    #[arg(long)]
+    readers: Option<usize>,
+    #[arg(long)]
+    seeks: Option<usize>,
+    #[arg(long)]
+    seek_nexts: Option<usize>,
+    #[arg(long, default_value_t = 42)]
+    seed: u64,
+    #[arg(long)]
+    cache_capacity: Option<u64>,
+    #[arg(long)]
+    target_sst_size: Option<usize>,
+    #[arg(long)]
+    memtable_limit: Option<usize>,
+    #[arg(long, value_enum, default_value_t = CompactionMode::Leveled)]
+    compaction: CompactionMode,
+    #[arg(long)]
+    wal: bool,
+    #[arg(long)]
+    vlog: bool,
+}
+
+#[derive(Clone, Debug)]
+struct HarnessConfig {
+    preset_name: &'static str,
+    run_id: String,
+    base_path: PathBuf,
+    cleanup: bool,
+    output: OutputFormat,
+    num: usize,
+    reads: usize,
+    duration_secs: u64,
+    scan_num: usize,
+    value_size: usize,
+    threads: usize,
+    readers: usize,
+    seeks: usize,
+    seek_nexts: usize,
+    seed: u64,
+    cache_capacity: u64,
+    target_sst_size: usize,
+    memtable_limit: usize,
+    compaction: CompactionMode,
+    wal_override: bool,
+    vlog_override: bool,
+    num_overridden: bool,
+    value_size_overridden: bool,
+}
+
+impl HarnessConfig {
+    fn from_args(args: Args) -> Self {
+        let preset = if args.large {
+            Preset::Large
         } else {
-            None
-        },
-        manifest_snapshot_threshold_bytes: 4 << 20,
-        block_cache_capacity: 8192,
-        enable_cache_backfill: true,
-        prefix_bloom: PrefixBloomOptions::default(),
+            args.preset
+        };
+        let (preset_name, num, reads, duration_secs, scan_num) = match preset {
+            Preset::Default => ("default", 200_000, 100_000, 5, 100_000),
+            Preset::Large => ("large", 2_000_000, 500_000, 10, 1_000_000),
+        };
+        let run_ms = unix_epoch_ms();
+
+        Self {
+            preset_name,
+            run_id: format!("{run_ms}"),
+            base_path: args.path,
+            cleanup: !args.no_cleanup,
+            output: args.output,
+            num: args.num.unwrap_or(num),
+            reads: args.reads.unwrap_or(reads),
+            duration_secs: args.duration.unwrap_or(duration_secs),
+            scan_num: args.scan_num.unwrap_or(scan_num),
+            value_size: args.value_size.unwrap_or(1024),
+            threads: args.threads.unwrap_or(4),
+            readers: args.readers.unwrap_or(4),
+            seeks: args.seeks.unwrap_or(10_000),
+            seek_nexts: args.seek_nexts.unwrap_or(10),
+            seed: args.seed,
+            cache_capacity: args.cache_capacity.unwrap_or(8192),
+            target_sst_size: args.target_sst_size.unwrap_or(1 << 20),
+            memtable_limit: args.memtable_limit.unwrap_or(2),
+            compaction: args.compaction,
+            wal_override: args.wal,
+            vlog_override: args.vlog,
+            num_overridden: args.num.is_some(),
+            value_size_overridden: args.value_size.is_some(),
+        }
+    }
+
+    fn path_for(&self, workload: &str) -> PathBuf {
+        self.base_path.join(workload)
+    }
+
+    fn build_options(&self, wal: bool, vlog: bool) -> LsmStorageOptions {
+        let enable_wal = wal || self.wal_override;
+        let enable_vlog = vlog || self.vlog_override;
+        LsmStorageOptions {
+            block_size: 4096,
+            target_sst_size: self.target_sst_size,
+            num_memtable_limit: self.memtable_limit,
+            compaction_options: match self.compaction {
+                CompactionMode::None => CompactionOptions::NoCompaction,
+                CompactionMode::Simple => {
+                    CompactionOptions::Simple(SimpleLeveledCompactionOptions {
+                        size_ratio_percent: 200,
+                        level0_file_num_compaction_trigger: 4,
+                        max_levels: 6,
+                    })
+                }
+                CompactionMode::Leveled => CompactionOptions::Leveled(LeveledCompactionOptions {
+                    level_size_multiplier: 2,
+                    level0_file_num_compaction_trigger: 4,
+                    max_levels: 6,
+                    base_level_size_mb: 128,
+                }),
+                CompactionMode::Tiered => CompactionOptions::Tiered(TieredCompactionOptions {
+                    num_tiers: 3,
+                    max_size_amplification_percent: 200,
+                    size_ratio: 2,
+                    min_merge_width: 2,
+                    max_merge_width: None,
+                }),
+            },
+            enable_wal,
+            serializable: false,
+            value_separation: if enable_vlog {
+                Some(ValueSeparationOptions {
+                    enabled: true,
+                    min_value_size: 1024,
+                    max_value_size: 64 * 1024,
+                    max_vlog_file_size: 64 * 1024 * 1024,
+                    gc_threshold_ratio: 0.4,
+                    max_open_vlog_files: 4,
+                    value_cache_capacity_bytes: 16 * 1024 * 1024,
+                })
+            } else {
+                None
+            },
+            manifest_snapshot_threshold_bytes: 4 << 20,
+            block_cache_capacity: self.cache_capacity,
+            enable_cache_backfill: true,
+            prefix_bloom: PrefixBloomOptions::default(),
+        }
     }
 }
 
-fn bench_scan(path: &str, num_entries: usize) -> Result<()> {
-    let _ = std::fs::remove_dir_all(path);
-    let engine = KvEngine::open(path, make_options(false, false))?;
-    let value = vec![b'x'; 256];
-    for i in 0..num_entries {
-        engine.put(format!("key{:08}", i).as_bytes(), &value)?;
-    }
-    engine.force_flush()?;
+type WorkloadFn = fn(&HarnessConfig) -> Result<Vec<BenchMeasurement>>;
 
-    // Full scan
+#[derive(Debug)]
+struct WorkloadSpec {
+    name: &'static str,
+    aliases: &'static [&'static str],
+    run: WorkloadFn,
+}
+
+const WORKLOADS: &[WorkloadSpec] = &[
+    WorkloadSpec {
+        name: "scan",
+        aliases: &[],
+        run: run_scan,
+    },
+    WorkloadSpec {
+        name: "concurrent_rw_no_wal",
+        aliases: &["rw_no_wal"],
+        run: run_concurrent_rw_no_wal,
+    },
+    WorkloadSpec {
+        name: "concurrent_rw_wal",
+        aliases: &["rw_wal"],
+        run: run_concurrent_rw_wal,
+    },
+    WorkloadSpec {
+        name: "wal_throughput",
+        aliases: &["wal"],
+        run: run_wal_throughput,
+    },
+    WorkloadSpec {
+        name: "wal_concurrent",
+        aliases: &[],
+        run: run_wal_concurrent,
+    },
+    WorkloadSpec {
+        name: "vlog_gc",
+        aliases: &[],
+        run: run_vlog_gc,
+    },
+    WorkloadSpec {
+        name: "vlog_concurrent_gc",
+        aliases: &[],
+        run: run_vlog_concurrent_gc,
+    },
+    WorkloadSpec {
+        name: "fillseq",
+        aliases: &[],
+        run: run_fillseq,
+    },
+    WorkloadSpec {
+        name: "fillrandom",
+        aliases: &[],
+        run: run_fillrandom,
+    },
+    WorkloadSpec {
+        name: "readrandom",
+        aliases: &[],
+        run: run_readrandom,
+    },
+    WorkloadSpec {
+        name: "readwhilewriting",
+        aliases: &["rww"],
+        run: run_readwhilewriting,
+    },
+    WorkloadSpec {
+        name: "readrandomwriterandom",
+        aliases: &["rwrw"],
+        run: run_readrandomwriterandom,
+    },
+    WorkloadSpec {
+        name: "seekrandom",
+        aliases: &[],
+        run: run_seekrandom,
+    },
+    WorkloadSpec {
+        name: "overwrite",
+        aliases: &[],
+        run: run_overwrite,
+    },
+    WorkloadSpec {
+        name: "readseq",
+        aliases: &[],
+        run: run_readseq,
+    },
+    WorkloadSpec {
+        name: "readseq_validate_order",
+        aliases: &["readreverse"],
+        run: run_readseq_validate_order,
+    },
+    WorkloadSpec {
+        name: "readmissing",
+        aliases: &[],
+        run: run_readmissing,
+    },
+    WorkloadSpec {
+        name: "seekrandomwhilewriting",
+        aliases: &["seekww"],
+        run: run_seekrandomwhilewriting,
+    },
+    WorkloadSpec {
+        name: "deleterandom",
+        aliases: &[],
+        run: run_deleterandom,
+    },
+    WorkloadSpec {
+        name: "compact",
+        aliases: &[],
+        run: run_compact,
+    },
+];
+
+#[derive(Clone)]
+struct BenchMeasurement {
+    record: MeasurementRecord,
+    summary: String,
+}
+
+#[derive(Clone, Serialize)]
+struct MeasurementRecord {
+    schema: &'static str,
+    unix_epoch_ms: u64,
+    run_id: String,
+    workload: String,
+    measurement: String,
+    preset: &'static str,
+    engine: &'static str,
+    engine_options: EngineOptionsRecord,
+    params: MeasurementParams,
+    result: MeasurementResult,
+    counters: MeasurementCounters,
+}
+
+#[derive(Clone, Serialize)]
+struct EngineOptionsRecord {
+    wal: bool,
+    value_separation: bool,
+    compaction: &'static str,
+    target_sst_size: usize,
+    memtable_limit: usize,
+    cache_capacity: u64,
+}
+
+#[derive(Clone, Default, Serialize)]
+struct MeasurementParams {
+    num: Option<usize>,
+    reads: Option<usize>,
+    value_size: Option<usize>,
+    duration_secs: Option<u64>,
+    threads: Option<usize>,
+    readers: Option<usize>,
+    seeks: Option<usize>,
+    seek_nexts: Option<usize>,
+    seed: Option<u64>,
+}
+
+#[derive(Clone, Default, Serialize)]
+struct MeasurementResult {
+    load_elapsed_ms: Option<f64>,
+    measure_elapsed_ms: f64,
+    write_elapsed_ms: Option<f64>,
+    gc_elapsed_ms: Option<f64>,
+    ops: Option<u64>,
+    ops_per_sec: Option<f64>,
+    entries: Option<u64>,
+    entries_per_sec: Option<f64>,
+    reads: Option<u64>,
+    reads_per_sec: Option<f64>,
+    writes: Option<u64>,
+    writes_per_sec: Option<f64>,
+    found: Option<u64>,
+    total_nexts: Option<u64>,
+    gc_rounds: Option<u64>,
+}
+
+#[derive(Clone, Default, Serialize)]
+struct MeasurementCounters {
+    block_cache_entry_count: u64,
+    value_cache_hit_count: u64,
+    value_cache_miss_count: u64,
+    vlog_total_bytes: Option<u64>,
+    vlog_file_count: Option<u32>,
+    vlog_gc_entries_rewritten: Option<u64>,
+    vlog_gc_bytes_rewritten: Option<u64>,
+    vlog_gc_files_processed: Option<u64>,
+    compaction_filter_entries_eligible: u64,
+    compaction_filter_entries_dropped: u64,
+    compaction_filter_bytes_dropped: u64,
+    compaction_filter_filters_active: usize,
+    range_tombstone_active_count: u64,
+    range_tombstone_immutable_count: u64,
+    range_tombstone_sst_count: u64,
+    range_tombstone_total_sst_fragment_count: u64,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let bench_arg = args.bench.clone();
+    let cfg = HarnessConfig::from_args(args);
+    validate_config(&cfg)?;
+    let workloads = select_workloads(bench_arg.as_deref())?;
+
+    let mut all_measurements = Vec::new();
+    for workload in workloads {
+        all_measurements.extend((workload.run)(&cfg)?);
+    }
+
+    emit_measurements(&cfg, &all_measurements)
+}
+
+fn select_workloads(filter: Option<&str>) -> Result<Vec<&'static WorkloadSpec>> {
+    match filter {
+        None => Ok(WORKLOADS.iter().collect()),
+        Some(filter) => {
+            let mut selected = Vec::new();
+            for name in filter.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+                if name == "readreverse" {
+                    bail!(
+                        "workload `readreverse` is unsupported until reverse iteration exists; use `readseq_validate_order` for the current forward-scan placeholder"
+                    );
+                }
+                let workload = WORKLOADS
+                    .iter()
+                    .find(|w| w.name == name || w.aliases.contains(&name))
+                    .with_context(|| format!("unknown workload: {name}"))?;
+                selected.push(workload);
+            }
+            Ok(selected)
+        }
+    }
+}
+
+fn emit_measurements(cfg: &HarnessConfig, measurements: &[BenchMeasurement]) -> Result<()> {
+    for measurement in measurements {
+        match cfg.output {
+            OutputFormat::Text => {
+                println!("{}", measurement.summary);
+            }
+            OutputFormat::Json => {
+                println!("{}", serde_json::to_string(&measurement.record)?);
+            }
+            OutputFormat::Both => {
+                eprintln!("{}", measurement.summary);
+                println!("{}", serde_json::to_string(&measurement.record)?);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn run_scan(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    let workload = "scan";
+    let path = prepare_path(cfg, workload)?;
+    let options = cfg.build_options(false, false);
+    let engine = KvEngine::open(&path, options.clone())?;
+    let load_elapsed = populate_range(&engine, cfg.scan_num, cfg.value_size)?;
+    let baseline = collect_counters(&engine)?;
+
+    let mut measurements = Vec::new();
+
     let start = Instant::now();
     let mut count = 0u64;
-    let mut iter = engine.scan(std::ops::Bound::Unbounded, std::ops::Bound::Unbounded)?;
+    let mut iter = engine.scan(Bound::Unbounded, Bound::Unbounded)?;
     while iter.is_valid() {
         count += 1;
         iter.next()?;
     }
     let elapsed = start.elapsed();
-    println!(
-        "  full scan: {} entries in {:?} ({:.0} entries/sec)",
-        count,
-        elapsed,
-        count as f64 / elapsed.as_secs_f64()
-    );
+    let after_full_scan = collect_counters(&engine)?;
+    measurements.push(make_measurement(
+        cfg,
+        workload,
+        "full_scan",
+        &options,
+        MeasurementParams {
+            num: Some(cfg.scan_num),
+            value_size: Some(cfg.value_size),
+            seed: Some(cfg.seed),
+            ..MeasurementParams::default()
+        },
+        MeasurementResult {
+            load_elapsed_ms: Some(ms(load_elapsed)),
+            measure_elapsed_ms: ms(elapsed),
+            entries: Some(count),
+            entries_per_sec: Some(rate(count, elapsed)),
+            ..MeasurementResult::default()
+        },
+        collect_counter_delta(&baseline, &after_full_scan),
+    ));
 
-    // Partial scan (10%)
-    let hi = num_entries / 10;
+    let hi = cfg.scan_num / 10;
     let start = Instant::now();
     let mut count = 0u64;
     let mut iter = engine.scan(
-        std::ops::Bound::Included(format!("key{:08}", 0).as_bytes()),
-        std::ops::Bound::Excluded(format!("key{:08}", hi).as_bytes()),
+        Bound::Included(format!("key{:08}", 0).as_bytes()),
+        Bound::Excluded(format!("key{:08}", hi).as_bytes()),
     )?;
     while iter.is_valid() {
         count += 1;
         iter.next()?;
     }
     let elapsed = start.elapsed();
-    println!(
-        "  10% scan: {} entries in {:?} ({:.0} entries/sec)",
-        count,
-        elapsed,
-        count as f64 / elapsed.as_secs_f64()
-    );
+    let after_partial_scan = collect_counters(&engine)?;
+    measurements.push(make_measurement(
+        cfg,
+        workload,
+        "scan_10pct",
+        &options,
+        MeasurementParams {
+            num: Some(cfg.scan_num),
+            value_size: Some(cfg.value_size),
+            seed: Some(cfg.seed),
+            ..MeasurementParams::default()
+        },
+        MeasurementResult {
+            load_elapsed_ms: Some(ms(load_elapsed)),
+            measure_elapsed_ms: ms(elapsed),
+            entries: Some(count),
+            entries_per_sec: Some(rate(count, elapsed)),
+            ..MeasurementResult::default()
+        },
+        collect_counter_delta(&after_full_scan, &after_partial_scan),
+    ));
 
     engine.close()?;
-    let _ = std::fs::remove_dir_all(path);
-    Ok(())
+    finalize_path(cfg, &path)?;
+    Ok(measurements)
 }
 
-fn bench_concurrent_rw(
-    path: &str,
-    num_writers: usize,
-    num_readers: usize,
-    duration_secs: u64,
-    val_size: usize,
+fn run_concurrent_rw_no_wal(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    run_concurrent_rw(cfg, "concurrent_rw_no_wal", false)
+}
+
+fn run_concurrent_rw_wal(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    run_concurrent_rw(cfg, "concurrent_rw_wal", true)
+}
+
+fn run_concurrent_rw(
+    cfg: &HarnessConfig,
+    workload: &str,
     wal: bool,
-) -> Result<()> {
-    let _ = std::fs::remove_dir_all(path);
-    let engine = KvEngine::open(path, make_options(false, wal))?;
-    let value = vec![b'x'; val_size];
-    for i in 0..10_000 {
-        engine.put(format!("key{:08}", i).as_bytes(), &value)?;
-    }
-    engine.force_flush()?;
+) -> Result<Vec<BenchMeasurement>> {
+    let path = prepare_path(cfg, workload)?;
+    let options = cfg.build_options(wal, false);
+    let engine = KvEngine::open(&path, options.clone())?;
+    let load_elapsed = populate_range(&engine, cfg.num, cfg.value_size)?;
+    let baseline = collect_counters(&engine)?;
 
     let stop = Arc::new(AtomicBool::new(false));
     let write_count = Arc::new(AtomicU64::new(0));
@@ -123,17 +578,19 @@ fn bench_concurrent_rw(
     let scan_count = Arc::new(AtomicU64::new(0));
     let mut handles = vec![];
 
-    for t in 0..num_writers {
+    let value_size = cfg.value_size;
+    let num = cfg.num;
+    for t in 0..cfg.threads {
         let eng = engine.clone();
-        let val = value.clone();
         let stop = stop.clone();
         let wc = write_count.clone();
         handles.push(std::thread::spawn(move || {
             let mut rng = StdRng::seed_from_u64(t as u64);
+            let value = vec![b'x'; value_size];
             let mut local = 0u64;
             while !stop.load(Ordering::Relaxed) {
-                let key = format!("key{:08}", rng.gen_range(0..50_000));
-                if eng.put(key.as_bytes(), &val).is_ok() {
+                let key = format!("key{:08}", rng.gen_range(0..num as u64));
+                if eng.put(key.as_bytes(), &value).is_ok() {
                     local += 1;
                 }
             }
@@ -141,15 +598,15 @@ fn bench_concurrent_rw(
         }));
     }
 
-    for t in 0..num_readers {
+    for t in 0..cfg.readers {
         let eng = engine.clone();
         let stop = stop.clone();
         let rc = read_count.clone();
         handles.push(std::thread::spawn(move || {
-            let mut rng = StdRng::seed_from_u64(1000 + t as u64);
+            let mut rng = StdRng::seed_from_u64(1_000 + t as u64);
             let mut local = 0u64;
             while !stop.load(Ordering::Relaxed) {
-                let key = format!("key{:08}", rng.gen_range(0..10_000));
+                let key = format!("key{:08}", rng.gen_range(0..num as u64));
                 let _ = eng.get(key.as_bytes());
                 local += 1;
             }
@@ -157,7 +614,6 @@ fn bench_concurrent_rw(
         }));
     }
 
-    // Scanner thread
     {
         let eng = engine.clone();
         let stop = stop.clone();
@@ -165,9 +621,7 @@ fn bench_concurrent_rw(
         handles.push(std::thread::spawn(move || {
             let mut local = 0u64;
             while !stop.load(Ordering::Relaxed) {
-                if let Ok(mut iter) =
-                    eng.scan(std::ops::Bound::Unbounded, std::ops::Bound::Unbounded)
-                {
+                if let Ok(mut iter) = eng.scan(Bound::Unbounded, Bound::Unbounded) {
                     while iter.is_valid() {
                         if iter.next().is_err() {
                             break;
@@ -180,144 +634,223 @@ fn bench_concurrent_rw(
         }));
     }
 
-    std::thread::sleep(Duration::from_secs(duration_secs));
-    stop.store(true, Ordering::Relaxed);
-    for h in handles {
-        h.join().expect("thread panicked");
-    }
-
-    let wc = write_count.load(Ordering::Relaxed);
-    let rc = read_count.load(Ordering::Relaxed);
-    let sc = scan_count.load(Ordering::Relaxed);
-    println!(
-        "  {}W/{}R+scanner, {}s: {} writes ({:.0}/s), {} reads ({:.0}/s), {} scan_entries",
-        num_writers,
-        num_readers,
-        duration_secs,
-        wc,
-        wc as f64 / duration_secs as f64,
-        rc,
-        rc as f64 / duration_secs as f64,
-        sc,
-    );
-
-    engine.close()?;
-    let _ = std::fs::remove_dir_all(path);
-    Ok(())
-}
-
-fn bench_wal_throughput(path: &str, num_keys: usize, val_size: usize) -> Result<()> {
-    let _ = std::fs::remove_dir_all(path);
-    let engine = KvEngine::open(path, make_options(false, true))?;
-    let value = vec![b'x'; val_size];
     let start = Instant::now();
-    for i in 0..num_keys {
-        engine.put(format!("key{:08}", i).as_bytes(), &value)?;
+    std::thread::sleep(Duration::from_secs(cfg.duration_secs));
+    stop.store(true, Ordering::Relaxed);
+    for handle in handles {
+        handle
+            .join()
+            .map_err(|_| anyhow!("worker thread panicked"))?;
     }
     let elapsed = start.elapsed();
-    println!(
-        "  WAL seq: {} puts ({}B) in {:?} ({:.0} ops/sec)",
-        num_keys,
-        val_size,
-        elapsed,
-        num_keys as f64 / elapsed.as_secs_f64()
-    );
-    engine.force_flush()?;
+
+    let writes = write_count.load(Ordering::Relaxed);
+    let reads = read_count.load(Ordering::Relaxed);
+    let scan_entries = scan_count.load(Ordering::Relaxed);
+    let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
     engine.close()?;
-    let _ = std::fs::remove_dir_all(path);
-    Ok(())
+    finalize_path(cfg, &path)?;
+
+    Ok(vec![make_measurement(
+        cfg,
+        workload,
+        "mixed",
+        &options,
+        MeasurementParams {
+            num: Some(cfg.num),
+            duration_secs: Some(cfg.duration_secs),
+            threads: Some(cfg.threads),
+            readers: Some(cfg.readers),
+            value_size: Some(cfg.value_size),
+            seed: Some(cfg.seed),
+            ..MeasurementParams::default()
+        },
+        MeasurementResult {
+            load_elapsed_ms: Some(ms(load_elapsed)),
+            measure_elapsed_ms: ms(elapsed),
+            writes: Some(writes),
+            writes_per_sec: Some(rate(writes, elapsed)),
+            reads: Some(reads),
+            reads_per_sec: Some(rate(reads, elapsed)),
+            entries: Some(scan_entries),
+            ..MeasurementResult::default()
+        },
+        counters,
+    )])
 }
 
-fn bench_wal_concurrent(
-    path: &str,
-    num_keys: usize,
-    val_size: usize,
-    nthreads: usize,
-) -> Result<()> {
-    let _ = std::fs::remove_dir_all(path);
-    let engine = KvEngine::open(path, make_options(false, true))?;
-    let value = vec![b'x'; val_size];
-    let per_thread = num_keys / nthreads;
+fn run_wal_throughput(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    let workload = "wal_throughput";
+    let options = cfg.build_options(true, false);
+    let mut results = Vec::new();
+    let cases = if cfg.num_overridden || cfg.value_size_overridden {
+        vec![("seq".to_string(), cfg.num, cfg.value_size)]
+    } else {
+        vec![
+            ("seq_256b".to_string(), 50_000usize, 256usize),
+            ("seq_4096b".to_string(), 20_000usize, 4096usize),
+        ]
+    };
+    for (measurement, num_keys, value_size) in cases {
+        let path = prepare_path(cfg, &format!("{workload}_{measurement}"))?;
+        let engine = KvEngine::open(&path, options.clone())?;
+        let value = vec![b'x'; value_size];
+        let start = Instant::now();
+        for i in 0..num_keys {
+            engine.put(format!("key{:08}", i).as_bytes(), &value)?;
+        }
+        let elapsed = start.elapsed();
+        engine.drain_flush()?;
+        let counters = collect_counters(&engine)?;
+        engine.close()?;
+        finalize_path(cfg, &path)?;
+        results.push(make_measurement(
+            cfg,
+            workload,
+            measurement,
+            &options,
+            MeasurementParams {
+                num: Some(num_keys),
+                value_size: Some(value_size),
+                seed: Some(cfg.seed),
+                ..MeasurementParams::default()
+            },
+            MeasurementResult {
+                measure_elapsed_ms: ms(elapsed),
+                ops: Some(num_keys as u64),
+                ops_per_sec: Some(rate(num_keys as u64, elapsed)),
+                ..MeasurementResult::default()
+            },
+            counters,
+        ));
+    }
+    Ok(results)
+}
+
+fn run_wal_concurrent(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    let workload = "wal_concurrent";
+    let path = prepare_path(cfg, workload)?;
+    let options = cfg.build_options(true, false);
+    let engine = KvEngine::open(&path, options.clone())?;
+    let value = vec![b'x'; cfg.value_size];
+    let num_keys = cfg.num;
+    let writer_threads = cfg.threads;
+    let baseline = collect_counters(&engine)?;
+    let per_thread = num_keys / writer_threads;
+    let remainder = num_keys % writer_threads;
     let start = Instant::now();
     let mut handles = vec![];
-    for t in 0..nthreads {
+    for t in 0..writer_threads {
         let eng = engine.clone();
         let val = value.clone();
         handles.push(std::thread::spawn(move || {
-            for i in 0..per_thread {
-                eng.put(format!("key{:08}", t * per_thread + i).as_bytes(), &val)
+            let thread_ops = per_thread + usize::from(t < remainder);
+            let start_idx = t * per_thread + remainder.min(t);
+            for i in 0..thread_ops {
+                eng.put(format!("key{:08}", start_idx + i).as_bytes(), &val)
                     .expect("put failed");
             }
         }));
     }
-    for h in handles {
-        h.join().expect("thread panicked");
+    for handle in handles {
+        handle
+            .join()
+            .map_err(|_| anyhow!("writer thread panicked"))?;
     }
     let elapsed = start.elapsed();
-    println!(
-        "  WAL conc({}T): {} puts ({}B) in {:?} ({:.0} ops/sec)",
-        nthreads,
-        num_keys,
-        val_size,
-        elapsed,
-        num_keys as f64 / elapsed.as_secs_f64()
-    );
-    engine.force_flush()?;
+    engine.drain_flush()?;
+    let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
     engine.close()?;
-    let _ = std::fs::remove_dir_all(path);
-    Ok(())
+    finalize_path(cfg, &path)?;
+
+    Ok(vec![make_measurement(
+        cfg,
+        workload,
+        "concurrent",
+        &options,
+        MeasurementParams {
+            num: Some(num_keys),
+            value_size: Some(cfg.value_size),
+            threads: Some(writer_threads),
+            seed: Some(cfg.seed),
+            ..MeasurementParams::default()
+        },
+        MeasurementResult {
+            measure_elapsed_ms: ms(elapsed),
+            ops: Some(num_keys as u64),
+            ops_per_sec: Some(rate(num_keys as u64, elapsed)),
+            ..MeasurementResult::default()
+        },
+        counters,
+    )])
 }
 
-fn bench_vlog_gc(path: &str, num_rounds: usize, entries_per_round: usize) -> Result<()> {
-    let _ = std::fs::remove_dir_all(path);
-    let engine = KvEngine::open(path, make_options(true, false))?;
-    let value = vec![b'x'; 4096];
+fn run_vlog_gc(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    let workload = "vlog_gc";
+    let path = prepare_path(cfg, workload)?;
+    let options = cfg.build_options(false, true);
+    let engine = KvEngine::open(&path, options.clone())?;
+    let entries_per_round = 5_000usize;
+    let num_rounds = 3usize;
+    let initial_value = vec![b'x'; 4096];
+    let load_elapsed = populate_fixed_value(&engine, entries_per_round, &initial_value)?;
+    let mut baseline = collect_counters(&engine)?;
+    let mut measurements = Vec::new();
 
-    println!(
-        "  vLog GC: {} rounds x {} entries (4KB)",
-        num_rounds, entries_per_round
-    );
-    for i in 0..entries_per_round {
-        engine.put(format!("key{:08}", i).as_bytes(), &value)?;
-    }
-    engine.force_flush()?;
-    if let Ok(stats) = engine.vlog_stats() {
-        println!("    round 0: {:?}", stats);
-    }
-
-    let padding = "x".repeat(4000);
     for round in 1..=num_rounds {
-        let start = Instant::now();
-        let value = format!("v{}_{}", round, padding);
+        let padding = "x".repeat(4000);
+        let value = format!("v{round}_{padding}");
+        let write_start = Instant::now();
         for i in 0..entries_per_round {
             engine.put(format!("key{:08}", i).as_bytes(), value.as_bytes())?;
         }
-        let we = start.elapsed();
-        engine.force_flush()?;
-        let gs = Instant::now();
+        let write_elapsed = write_start.elapsed();
+        engine.drain_flush()?;
+
+        let gc_start = Instant::now();
         let gc_count = engine.trigger_gc()?;
-        let ge = gs.elapsed();
-        if let Ok(stats) = engine.vlog_stats() {
-            println!(
-                "    round {}: writes {:?}, GC {} files in {:?}, {:?}",
-                round, we, gc_count, ge, stats
-            );
-        }
+        let gc_elapsed = gc_start.elapsed();
+
+        let after_round = collect_counters(&engine)?;
+        measurements.push(make_measurement(
+            cfg,
+            workload,
+            format!("round_{round}"),
+            &options,
+            MeasurementParams {
+                num: Some(entries_per_round),
+                value_size: Some(4096),
+                seed: Some(cfg.seed),
+                ..MeasurementParams::default()
+            },
+            MeasurementResult {
+                load_elapsed_ms: Some(ms(load_elapsed)),
+                measure_elapsed_ms: ms(write_elapsed + gc_elapsed),
+                write_elapsed_ms: Some(ms(write_elapsed)),
+                gc_elapsed_ms: Some(ms(gc_elapsed)),
+                writes: Some(entries_per_round as u64),
+                writes_per_sec: Some(rate(entries_per_round as u64, write_elapsed)),
+                gc_rounds: Some(gc_count as u64),
+                ..MeasurementResult::default()
+            },
+            collect_counter_delta(&baseline, &after_round),
+        ));
+        baseline = after_round;
     }
 
     engine.close()?;
-    let _ = std::fs::remove_dir_all(path);
-    Ok(())
+    finalize_path(cfg, &path)?;
+    Ok(measurements)
 }
 
-fn bench_vlog_concurrent_gc(path: &str, duration_secs: u64) -> Result<()> {
-    let _ = std::fs::remove_dir_all(path);
-    let engine = KvEngine::open(path, make_options(true, false))?;
-    let value = vec![b'x'; 4096];
-    for i in 0..5_000 {
-        engine.put(format!("key{:08}", i).as_bytes(), &value)?;
-    }
-    engine.force_flush()?;
+fn run_vlog_concurrent_gc(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    let workload = "vlog_concurrent_gc";
+    let path = prepare_path(cfg, workload)?;
+    let options = cfg.build_options(false, true);
+    let engine = KvEngine::open(&path, options.clone())?;
+    let initial_value = vec![b'x'; 4096];
+    let load_elapsed = populate_fixed_value(&engine, 5_000, &initial_value)?;
+    let baseline = collect_counters(&engine)?;
 
     let stop = Arc::new(AtomicBool::new(false));
     let wc = Arc::new(AtomicU64::new(0));
@@ -325,7 +858,6 @@ fn bench_vlog_concurrent_gc(path: &str, duration_secs: u64) -> Result<()> {
     let gcc = Arc::new(AtomicU64::new(0));
     let mut handles = vec![];
 
-    // Writer
     {
         let eng = engine.clone();
         let stop = stop.clone();
@@ -343,7 +875,7 @@ fn bench_vlog_concurrent_gc(path: &str, duration_secs: u64) -> Result<()> {
             wc.fetch_add(c, Ordering::Relaxed);
         }));
     }
-    // Reader
+
     {
         let eng = engine.clone();
         let stop = stop.clone();
@@ -360,7 +892,7 @@ fn bench_vlog_concurrent_gc(path: &str, duration_secs: u64) -> Result<()> {
             rc.fetch_add(c, Ordering::Relaxed);
         }));
     }
-    // GC
+
     {
         let eng = engine.clone();
         let stop = stop.clone();
@@ -368,163 +900,206 @@ fn bench_vlog_concurrent_gc(path: &str, duration_secs: u64) -> Result<()> {
         handles.push(std::thread::spawn(move || {
             let mut c = 0u64;
             while !stop.load(Ordering::Relaxed) {
-                let _ = eng.trigger_gc();
-                c += 1;
+                if eng.trigger_gc().is_ok() {
+                    c += 1;
+                }
                 std::thread::sleep(Duration::from_millis(500));
             }
             gcc.fetch_add(c, Ordering::Relaxed);
         }));
     }
 
-    std::thread::sleep(Duration::from_secs(duration_secs));
+    let start = Instant::now();
+    std::thread::sleep(Duration::from_secs(cfg.duration_secs));
     stop.store(true, Ordering::Relaxed);
-    for h in handles {
-        h.join().expect("thread panicked");
+    for handle in handles {
+        handle
+            .join()
+            .map_err(|_| anyhow!("worker thread panicked"))?;
     }
+    let elapsed = start.elapsed();
 
-    let w = wc.load(Ordering::Relaxed);
-    let r = rc.load(Ordering::Relaxed);
-    let g = gcc.load(Ordering::Relaxed);
-    println!(
-        "  vLog concurrent {}s: {} writes ({:.0}/s), {} reads ({:.0}/s), {} GC rounds",
-        duration_secs,
-        w,
-        w as f64 / duration_secs as f64,
-        r,
-        r as f64 / duration_secs as f64,
-        g,
-    );
-    if let Ok(stats) = engine.vlog_stats() {
-        println!("    final: {:?}", stats);
-    }
+    let writes = wc.load(Ordering::Relaxed);
+    let reads = rc.load(Ordering::Relaxed);
+    let gc_rounds = gcc.load(Ordering::Relaxed);
+    let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
     engine.close()?;
-    let _ = std::fs::remove_dir_all(path);
-    Ok(())
+    finalize_path(cfg, &path)?;
+
+    Ok(vec![make_measurement(
+        cfg,
+        workload,
+        "mixed",
+        &options,
+        MeasurementParams {
+            duration_secs: Some(cfg.duration_secs),
+            seed: Some(cfg.seed),
+            ..MeasurementParams::default()
+        },
+        MeasurementResult {
+            load_elapsed_ms: Some(ms(load_elapsed)),
+            measure_elapsed_ms: ms(elapsed),
+            writes: Some(writes),
+            writes_per_sec: Some(rate(writes, elapsed)),
+            reads: Some(reads),
+            reads_per_sec: Some(rate(reads, elapsed)),
+            gc_rounds: Some(gc_rounds),
+            ..MeasurementResult::default()
+        },
+        counters,
+    )])
 }
 
-// --- RocksDB-style workloads (fillseq, fillrandom, readrandom, readwhilewriting,
-//     readrandomwriterandom, seekrandom) ---
-
-fn bench_fillseq(path: &str, num_entries: usize, val_size: usize) -> Result<()> {
-    let _ = std::fs::remove_dir_all(path);
-    let engine = KvEngine::open(path, make_options(false, false))?;
-    let value = vec![b'x'; val_size];
+fn run_fillseq(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    let workload = "fillseq";
+    let path = prepare_path(cfg, workload)?;
+    let options = cfg.build_options(false, false);
+    let engine = KvEngine::open(&path, options.clone())?;
+    let value = vec![b'x'; cfg.value_size];
     let start = Instant::now();
-    for i in 0..num_entries {
+    for i in 0..cfg.num {
         engine.put(format!("key{:08}", i).as_bytes(), &value)?;
     }
     let elapsed = start.elapsed();
-    println!(
-        "  fillseq: {} entries ({}B) in {:?} ({:.0} ops/sec)",
-        num_entries,
-        val_size,
-        elapsed,
-        num_entries as f64 / elapsed.as_secs_f64()
-    );
-    engine.force_flush()?;
+    engine.drain_flush()?;
+    let counters = collect_counters(&engine)?;
     engine.close()?;
-    let _ = std::fs::remove_dir_all(path);
-    Ok(())
+    finalize_path(cfg, &path)?;
+
+    Ok(vec![make_measurement(
+        cfg,
+        workload,
+        "write",
+        &options,
+        MeasurementParams {
+            num: Some(cfg.num),
+            value_size: Some(cfg.value_size),
+            seed: Some(cfg.seed),
+            ..MeasurementParams::default()
+        },
+        MeasurementResult {
+            measure_elapsed_ms: ms(elapsed),
+            ops: Some(cfg.num as u64),
+            ops_per_sec: Some(rate(cfg.num as u64, elapsed)),
+            ..MeasurementResult::default()
+        },
+        counters,
+    )])
 }
 
-fn bench_fillrandom(path: &str, num_entries: usize, val_size: usize) -> Result<()> {
-    let _ = std::fs::remove_dir_all(path);
-    let engine = KvEngine::open(path, make_options(false, false))?;
-    let value = vec![b'x'; val_size];
-    let mut rng = StdRng::seed_from_u64(42);
-    let mut key_buf = [0u8; 12]; // "key" + 8 digits
+fn run_fillrandom(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    let workload = "fillrandom";
+    let path = prepare_path(cfg, workload)?;
+    let options = cfg.build_options(false, false);
+    let engine = KvEngine::open(&path, options.clone())?;
+    let value = vec![b'x'; cfg.value_size];
+    let mut rng = StdRng::seed_from_u64(cfg.seed);
+    let mut key_buf = [0u8; 11];
+    key_buf[..3].copy_from_slice(b"key");
     let start = Instant::now();
-    for _ in 0..num_entries {
-        let n = rng.gen_range(0..num_entries as u64);
-        // Format key directly into buffer to avoid allocation
-        key_buf[..3].copy_from_slice(b"key");
-        write!(&mut key_buf[3..], "{:08}", n)
-            .expect("key_buf is 11 bytes; 8-digit format always fits");
+    for _ in 0..cfg.num {
+        let n = rng.gen_range(0..cfg.num as u64);
+        write!(&mut key_buf[3..], "{:08}", n).expect("key format");
         engine.put(&key_buf, &value)?;
     }
     let elapsed = start.elapsed();
-    println!(
-        "  fillrandom: {} entries ({}B) in {:?} ({:.0} ops/sec)",
-        num_entries,
-        val_size,
-        elapsed,
-        num_entries as f64 / elapsed.as_secs_f64()
-    );
-    engine.force_flush()?;
+    engine.drain_flush()?;
+    let counters = collect_counters(&engine)?;
     engine.close()?;
-    let _ = std::fs::remove_dir_all(path);
-    Ok(())
+    finalize_path(cfg, &path)?;
+
+    Ok(vec![make_measurement(
+        cfg,
+        workload,
+        "write",
+        &options,
+        MeasurementParams {
+            num: Some(cfg.num),
+            value_size: Some(cfg.value_size),
+            seed: Some(cfg.seed),
+            ..MeasurementParams::default()
+        },
+        MeasurementResult {
+            measure_elapsed_ms: ms(elapsed),
+            ops: Some(cfg.num as u64),
+            ops_per_sec: Some(rate(cfg.num as u64, elapsed)),
+            ..MeasurementResult::default()
+        },
+        counters,
+    )])
 }
 
-fn bench_readrandom(
-    path: &str,
-    num_entries: usize,
-    num_reads: usize,
-    val_size: usize,
-) -> Result<()> {
-    let _ = std::fs::remove_dir_all(path);
-    let engine = KvEngine::open(path, make_options(false, false))?;
-    let value = vec![b'x'; val_size];
-    for i in 0..num_entries {
-        engine.put(format!("key{:08}", i).as_bytes(), &value)?;
-    }
-    engine.force_flush()?;
+fn run_readrandom(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    let workload = "readrandom";
+    let path = prepare_path(cfg, workload)?;
+    let options = cfg.build_options(false, false);
+    let engine = KvEngine::open(&path, options.clone())?;
+    let load_elapsed = populate_range(&engine, cfg.num, cfg.value_size)?;
+    let baseline = collect_counters(&engine)?;
 
-    let mut rng = StdRng::seed_from_u64(123);
+    let mut rng = StdRng::seed_from_u64(cfg.seed + 123);
     let start = Instant::now();
     let mut found = 0u64;
-    for _ in 0..num_reads {
-        let key = format!("key{:08}", rng.gen_range(0..num_entries as u64));
+    for _ in 0..cfg.reads {
+        let key = format!("key{:08}", rng.gen_range(0..cfg.num as u64));
         if engine.get(key.as_bytes())?.is_some() {
             found += 1;
         }
     }
     let elapsed = start.elapsed();
-    println!(
-        "  readrandom: {} reads over {} entries in {:?} ({:.0} ops/sec, {} found)",
-        num_reads,
-        num_entries,
-        elapsed,
-        num_reads as f64 / elapsed.as_secs_f64(),
-        found
-    );
+    let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
     engine.close()?;
-    let _ = std::fs::remove_dir_all(path);
-    Ok(())
+    finalize_path(cfg, &path)?;
+
+    Ok(vec![make_measurement(
+        cfg,
+        workload,
+        "point_get",
+        &options,
+        MeasurementParams {
+            num: Some(cfg.num),
+            reads: Some(cfg.reads),
+            value_size: Some(cfg.value_size),
+            seed: Some(cfg.seed + 123),
+            ..MeasurementParams::default()
+        },
+        MeasurementResult {
+            load_elapsed_ms: Some(ms(load_elapsed)),
+            measure_elapsed_ms: ms(elapsed),
+            ops: Some(cfg.reads as u64),
+            ops_per_sec: Some(rate(cfg.reads as u64, elapsed)),
+            found: Some(found),
+            ..MeasurementResult::default()
+        },
+        counters,
+    )])
 }
 
-fn bench_readwhilewriting(
-    path: &str,
-    num_entries: usize,
-    num_readers: usize,
-    duration_secs: u64,
-    val_size: usize,
-) -> Result<()> {
-    let _ = std::fs::remove_dir_all(path);
-    let engine = KvEngine::open(path, make_options(false, false))?;
-    let value = vec![b'x'; val_size];
-    for i in 0..num_entries {
-        engine.put(format!("key{:08}", i).as_bytes(), &value)?;
-    }
-    engine.force_flush()?;
+fn run_readwhilewriting(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    let workload = "readwhilewriting";
+    let path = prepare_path(cfg, workload)?;
+    let options = cfg.build_options(false, false);
+    let engine = KvEngine::open(&path, options.clone())?;
+    let load_elapsed = populate_range(&engine, cfg.num, cfg.value_size)?;
+    let baseline = collect_counters(&engine)?;
 
     let stop = Arc::new(AtomicBool::new(false));
     let wc = Arc::new(AtomicU64::new(0));
     let rc = Arc::new(AtomicU64::new(0));
     let mut handles = vec![];
 
-    // 1 writer thread
     {
         let eng = engine.clone();
         let stop = stop.clone();
         let wc = wc.clone();
-        let val = value.clone();
+        let value = vec![b'x'; cfg.value_size];
+        let num = cfg.num;
         handles.push(std::thread::spawn(move || {
             let mut rng = StdRng::seed_from_u64(42);
             let mut c = 0u64;
             while !stop.load(Ordering::Relaxed) {
-                let key = format!("key{:08}", rng.gen_range(0..num_entries as u64));
-                if eng.put(key.as_bytes(), &val).is_ok() {
+                let key = format!("key{:08}", rng.gen_range(0..num as u64));
+                if eng.put(key.as_bytes(), &value).is_ok() {
                     c += 1;
                 }
             }
@@ -532,16 +1107,16 @@ fn bench_readwhilewriting(
         }));
     }
 
-    // N reader threads
-    for t in 0..num_readers {
+    for t in 0..cfg.readers {
         let eng = engine.clone();
         let stop = stop.clone();
         let rc = rc.clone();
+        let num = cfg.num;
         handles.push(std::thread::spawn(move || {
             let mut rng = StdRng::seed_from_u64(1000 + t as u64);
             let mut c = 0u64;
             while !stop.load(Ordering::Relaxed) {
-                let key = format!("key{:08}", rng.gen_range(0..num_entries as u64));
+                let key = format!("key{:08}", rng.gen_range(0..num as u64));
                 if eng.get(key.as_bytes()).is_ok() {
                     c += 1;
                 }
@@ -550,62 +1125,75 @@ fn bench_readwhilewriting(
         }));
     }
 
-    std::thread::sleep(Duration::from_secs(duration_secs));
+    let start = Instant::now();
+    std::thread::sleep(Duration::from_secs(cfg.duration_secs));
     stop.store(true, Ordering::Relaxed);
-    for h in handles {
-        h.join().expect("thread panicked");
+    for handle in handles {
+        handle
+            .join()
+            .map_err(|_| anyhow!("worker thread panicked"))?;
     }
+    let elapsed = start.elapsed();
 
-    let w = wc.load(Ordering::Relaxed);
-    let r = rc.load(Ordering::Relaxed);
-    println!(
-        "  readwhilewriting: {}s, 1W/{}R: {} writes ({:.0}/s), {} reads ({:.0}/s)",
-        duration_secs,
-        num_readers,
-        w,
-        w as f64 / duration_secs as f64,
-        r,
-        r as f64 / duration_secs as f64,
-    );
+    let writes = wc.load(Ordering::Relaxed);
+    let reads = rc.load(Ordering::Relaxed);
+    let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
     engine.close()?;
-    let _ = std::fs::remove_dir_all(path);
-    Ok(())
+    finalize_path(cfg, &path)?;
+
+    Ok(vec![make_measurement(
+        cfg,
+        workload,
+        "mixed",
+        &options,
+        MeasurementParams {
+            num: Some(cfg.num),
+            duration_secs: Some(cfg.duration_secs),
+            readers: Some(cfg.readers),
+            value_size: Some(cfg.value_size),
+            seed: Some(cfg.seed),
+            ..MeasurementParams::default()
+        },
+        MeasurementResult {
+            load_elapsed_ms: Some(ms(load_elapsed)),
+            measure_elapsed_ms: ms(elapsed),
+            writes: Some(writes),
+            writes_per_sec: Some(rate(writes, elapsed)),
+            reads: Some(reads),
+            reads_per_sec: Some(rate(reads, elapsed)),
+            ..MeasurementResult::default()
+        },
+        counters,
+    )])
 }
 
-fn bench_readrandomwriterandom(
-    path: &str,
-    num_entries: usize,
-    num_threads: usize,
-    duration_secs: u64,
-    val_size: usize,
-) -> Result<()> {
-    let _ = std::fs::remove_dir_all(path);
-    let engine = KvEngine::open(path, make_options(false, false))?;
-    let value = vec![b'x'; val_size];
-    for i in 0..num_entries {
-        engine.put(format!("key{:08}", i).as_bytes(), &value)?;
-    }
-    engine.force_flush()?;
+fn run_readrandomwriterandom(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    let workload = "readrandomwriterandom";
+    let path = prepare_path(cfg, workload)?;
+    let options = cfg.build_options(false, false);
+    let engine = KvEngine::open(&path, options.clone())?;
+    let load_elapsed = populate_range(&engine, cfg.num, cfg.value_size)?;
 
     let stop = Arc::new(AtomicBool::new(false));
     let wc = Arc::new(AtomicU64::new(0));
     let rc = Arc::new(AtomicU64::new(0));
     let mut handles = vec![];
 
-    for t in 0..num_threads {
+    for t in 0..cfg.threads {
         let eng = engine.clone();
         let stop = stop.clone();
         let wc = wc.clone();
         let rc = rc.clone();
-        let val = value.clone();
+        let value = vec![b'x'; cfg.value_size];
+        let num = cfg.num;
         handles.push(std::thread::spawn(move || {
             let mut rng = StdRng::seed_from_u64(t as u64);
             let mut writes = 0u64;
             let mut reads = 0u64;
             while !stop.load(Ordering::Relaxed) {
-                let key = format!("key{:08}", rng.gen_range(0..num_entries as u64));
+                let key = format!("key{:08}", rng.gen_range(0..num as u64));
                 if rng.gen_bool(0.5) {
-                    if eng.put(key.as_bytes(), &val).is_ok() {
+                    if eng.put(key.as_bytes(), &value).is_ok() {
                         writes += 1;
                     }
                 } else if eng.get(key.as_bytes()).is_ok() {
@@ -617,52 +1205,63 @@ fn bench_readrandomwriterandom(
         }));
     }
 
-    std::thread::sleep(Duration::from_secs(duration_secs));
+    let start = Instant::now();
+    std::thread::sleep(Duration::from_secs(cfg.duration_secs));
     stop.store(true, Ordering::Relaxed);
-    for h in handles {
-        h.join().expect("thread panicked");
+    for handle in handles {
+        handle
+            .join()
+            .map_err(|_| anyhow!("worker thread panicked"))?;
     }
+    let elapsed = start.elapsed();
 
-    let w = wc.load(Ordering::Relaxed);
-    let r = rc.load(Ordering::Relaxed);
-    println!(
-        "  readrandomwriterandom: {}s, {} threads: {} writes ({:.0}/s), {} reads ({:.0}/s)",
-        duration_secs,
-        num_threads,
-        w,
-        w as f64 / duration_secs as f64,
-        r,
-        r as f64 / duration_secs as f64,
-    );
+    let writes = wc.load(Ordering::Relaxed);
+    let reads = rc.load(Ordering::Relaxed);
+    let counters = collect_counters(&engine)?;
     engine.close()?;
-    let _ = std::fs::remove_dir_all(path);
-    Ok(())
+    finalize_path(cfg, &path)?;
+
+    Ok(vec![make_measurement(
+        cfg,
+        workload,
+        "mixed",
+        &options,
+        MeasurementParams {
+            num: Some(cfg.num),
+            duration_secs: Some(cfg.duration_secs),
+            threads: Some(cfg.threads),
+            value_size: Some(cfg.value_size),
+            seed: Some(cfg.seed),
+            ..MeasurementParams::default()
+        },
+        MeasurementResult {
+            load_elapsed_ms: Some(ms(load_elapsed)),
+            measure_elapsed_ms: ms(elapsed),
+            writes: Some(writes),
+            writes_per_sec: Some(rate(writes, elapsed)),
+            reads: Some(reads),
+            reads_per_sec: Some(rate(reads, elapsed)),
+            ..MeasurementResult::default()
+        },
+        counters,
+    )])
 }
 
-fn bench_seekrandom(
-    path: &str,
-    num_entries: usize,
-    num_seeks: usize,
-    seek_nexts: usize,
-) -> Result<()> {
-    let _ = std::fs::remove_dir_all(path);
-    let engine = KvEngine::open(path, make_options(false, false))?;
-    let value = vec![b'x'; 256];
-    for i in 0..num_entries {
-        engine.put(format!("key{:08}", i).as_bytes(), &value)?;
-    }
-    engine.force_flush()?;
+fn run_seekrandom(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    let workload = "seekrandom";
+    let path = prepare_path(cfg, workload)?;
+    let options = cfg.build_options(false, false);
+    let engine = KvEngine::open(&path, options.clone())?;
+    let load_elapsed = populate_fixed_value(&engine, cfg.num, &vec![b'x'; cfg.value_size])?;
+    let baseline = collect_counters(&engine)?;
 
-    let mut rng = StdRng::seed_from_u64(999);
+    let mut rng = StdRng::seed_from_u64(cfg.seed + 999);
     let start = Instant::now();
     let mut total_nexts = 0u64;
-    for _ in 0..num_seeks {
-        let key = format!("key{:08}", rng.gen_range(0..num_entries as u64));
-        if let Ok(mut iter) = engine.scan(
-            std::ops::Bound::Included(key.as_bytes()),
-            std::ops::Bound::Unbounded,
-        ) {
-            for _ in 0..seek_nexts {
+    for _ in 0..cfg.seeks {
+        let key = format!("key{:08}", rng.gen_range(0..cfg.num as u64));
+        if let Ok(mut iter) = engine.scan(Bound::Included(key.as_bytes()), Bound::Unbounded) {
+            for _ in 0..cfg.seek_nexts {
                 if !iter.is_valid() {
                     break;
                 }
@@ -674,66 +1273,88 @@ fn bench_seekrandom(
         }
     }
     let elapsed = start.elapsed();
-    println!(
-        "  seekrandom: {} seeks ({} nexts each) in {:?} ({:.0} seeks/sec, {} total nexts)",
-        num_seeks,
-        seek_nexts,
-        elapsed,
-        num_seeks as f64 / elapsed.as_secs_f64(),
-        total_nexts
-    );
+    let counters = collect_counters(&engine)?;
     engine.close()?;
-    let _ = std::fs::remove_dir_all(path);
-    Ok(())
+    finalize_path(cfg, &path)?;
+
+    Ok(vec![make_measurement(
+        cfg,
+        workload,
+        "seek",
+        &options,
+        MeasurementParams {
+            num: Some(cfg.num),
+            seeks: Some(cfg.seeks),
+            seek_nexts: Some(cfg.seek_nexts),
+            value_size: Some(cfg.value_size),
+            seed: Some(cfg.seed + 999),
+            ..MeasurementParams::default()
+        },
+        MeasurementResult {
+            load_elapsed_ms: Some(ms(load_elapsed)),
+            measure_elapsed_ms: ms(elapsed),
+            ops: Some(cfg.seeks as u64),
+            ops_per_sec: Some(rate(cfg.seeks as u64, elapsed)),
+            total_nexts: Some(total_nexts),
+            ..MeasurementResult::default()
+        },
+        collect_counter_delta(&baseline, &counters),
+    )])
 }
 
-// --- Additional RocksDB-style workloads ---
+fn run_overwrite(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    let workload = "overwrite";
+    let path = prepare_path(cfg, workload)?;
+    let options = cfg.build_options(false, false);
+    let engine = KvEngine::open(&path, options.clone())?;
+    let load_elapsed = populate_range(&engine, cfg.num, cfg.value_size)?;
+    let baseline = collect_counters(&engine)?;
 
-fn bench_overwrite(path: &str, num_entries: usize, num_ops: usize, val_size: usize) -> Result<()> {
-    let _ = std::fs::remove_dir_all(path);
-    let engine = KvEngine::open(path, make_options(false, false))?;
-    let value = vec![b'x'; val_size];
-    // Populate
-    for i in 0..num_entries {
-        engine.put(format!("key{:08}", i).as_bytes(), &value)?;
-    }
-    engine.force_flush()?;
-
-    // Overwrite existing keys randomly
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = StdRng::seed_from_u64(cfg.seed);
     let mut key_buf = [0u8; 11];
     key_buf[..3].copy_from_slice(b"key");
-    let new_val = vec![b'y'; val_size];
+    let value = vec![b'y'; cfg.value_size];
     let start = Instant::now();
-    for _ in 0..num_ops {
-        let n = rng.gen_range(0..num_entries as u64);
-        write!(&mut key_buf[3..], "{:08}", n)
-            .expect("key_buf is 11 bytes; 8-digit format always fits");
-        engine.put(&key_buf, &new_val)?;
+    for _ in 0..cfg.num {
+        let n = rng.gen_range(0..cfg.num as u64);
+        write!(&mut key_buf[3..], "{:08}", n).expect("key format");
+        engine.put(&key_buf, &value)?;
     }
     let elapsed = start.elapsed();
-    println!(
-        "  overwrite: {} ops over {} entries ({}B) in {:?} ({:.0} ops/sec)",
-        num_ops,
-        num_entries,
-        val_size,
-        elapsed,
-        num_ops as f64 / elapsed.as_secs_f64()
-    );
-    engine.force_flush()?;
-    drop(engine);
-    let _ = std::fs::remove_dir_all(path);
-    Ok(())
+    engine.drain_flush()?;
+    let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
+    engine.close()?;
+    finalize_path(cfg, &path)?;
+
+    Ok(vec![make_measurement(
+        cfg,
+        workload,
+        "update",
+        &options,
+        MeasurementParams {
+            num: Some(cfg.num),
+            value_size: Some(cfg.value_size),
+            seed: Some(cfg.seed),
+            ..MeasurementParams::default()
+        },
+        MeasurementResult {
+            load_elapsed_ms: Some(ms(load_elapsed)),
+            measure_elapsed_ms: ms(elapsed),
+            ops: Some(cfg.num as u64),
+            ops_per_sec: Some(rate(cfg.num as u64, elapsed)),
+            ..MeasurementResult::default()
+        },
+        counters,
+    )])
 }
 
-fn bench_readseq(path: &str, num_entries: usize, val_size: usize) -> Result<()> {
-    let _ = std::fs::remove_dir_all(path);
-    let engine = KvEngine::open(path, make_options(false, false))?;
-    let value = vec![b'x'; val_size];
-    for i in 0..num_entries {
-        engine.put(format!("key{:08}", i).as_bytes(), &value)?;
-    }
-    engine.force_flush()?;
+fn run_readseq(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    let workload = "readseq";
+    let path = prepare_path(cfg, workload)?;
+    let options = cfg.build_options(false, false);
+    let engine = KvEngine::open(&path, options.clone())?;
+    let load_elapsed = populate_range(&engine, cfg.num, cfg.value_size)?;
+    let baseline = collect_counters(&engine)?;
 
     let start = Instant::now();
     let mut count = 0u64;
@@ -743,152 +1364,191 @@ fn bench_readseq(path: &str, num_entries: usize, val_size: usize) -> Result<()> 
         iter.next()?;
     }
     let elapsed = start.elapsed();
-    println!(
-        "  readseq: {} entries ({}) in {:?} ({:.0} entries/sec)",
-        count,
-        val_size,
-        elapsed,
-        count as f64 / elapsed.as_secs_f64()
-    );
     anyhow::ensure!(
-        count == num_entries as u64,
-        "bench_readseq expected {} entries, got {}",
-        num_entries,
+        count == cfg.num as u64,
+        "readseq expected {} entries, got {}",
+        cfg.num,
         count
     );
+    let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
     engine.close()?;
-    let _ = std::fs::remove_dir_all(path);
-    Ok(())
+    finalize_path(cfg, &path)?;
+
+    Ok(vec![make_measurement(
+        cfg,
+        workload,
+        "forward_scan",
+        &options,
+        MeasurementParams {
+            num: Some(cfg.num),
+            value_size: Some(cfg.value_size),
+            seed: Some(cfg.seed),
+            ..MeasurementParams::default()
+        },
+        MeasurementResult {
+            load_elapsed_ms: Some(ms(load_elapsed)),
+            measure_elapsed_ms: ms(elapsed),
+            entries: Some(count),
+            entries_per_sec: Some(rate(count, elapsed)),
+            ..MeasurementResult::default()
+        },
+        counters,
+    )])
 }
 
-fn bench_readreverse(path: &str, num_entries: usize, val_size: usize) -> Result<()> {
-    let _ = std::fs::remove_dir_all(path);
-    let engine = KvEngine::open(path, make_options(false, false))?;
-    let value = vec![b'x'; val_size];
-    for i in 0..num_entries {
-        engine.put(format!("key{:08}", i).as_bytes(), &value)?;
-    }
-    engine.force_flush()?;
+fn run_readseq_validate_order(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    let workload = "readseq_validate_order";
+    let path = prepare_path(cfg, workload)?;
+    let options = cfg.build_options(false, false);
+    let engine = KvEngine::open(&path, options.clone())?;
+    let load_elapsed = populate_range(&engine, cfg.num, cfg.value_size)?;
+    let baseline = collect_counters(&engine)?;
 
-    // NOTE: reverse iteration is not supported by the engine yet.
-    // This measures forward scan as a baseline placeholder.
     let start = Instant::now();
     let mut count = 0u64;
+    let mut prev_key: Option<Vec<u8>> = None;
     let mut iter = engine.scan(Bound::Unbounded, Bound::Unbounded)?;
     while iter.is_valid() {
+        let current = iter.key().to_vec();
+        if let Some(prev) = &prev_key {
+            anyhow::ensure!(
+                prev.as_slice() <= current.as_slice(),
+                "readseq_validate_order detected out-of-order scan: prev={:?} current={:?}",
+                prev,
+                current
+            );
+        }
+        prev_key = Some(current);
         count += 1;
         iter.next()?;
     }
     let elapsed = start.elapsed();
-    println!(
-        "  readreverse (placeholder, forward scan): {} entries ({}) in {:?} ({:.0} entries/sec)",
-        count,
-        val_size,
-        elapsed,
-        count as f64 / elapsed.as_secs_f64()
-    );
     anyhow::ensure!(
-        count == num_entries as u64,
-        "bench_readreverse expected {} entries, got {}",
-        num_entries,
+        count == cfg.num as u64,
+        "readseq_validate_order expected {} entries, got {}",
+        cfg.num,
         count
     );
+    let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
     engine.close()?;
-    let _ = std::fs::remove_dir_all(path);
-    Ok(())
+    finalize_path(cfg, &path)?;
+
+    Ok(vec![make_measurement(
+        cfg,
+        workload,
+        "forward_placeholder",
+        &options,
+        MeasurementParams {
+            num: Some(cfg.num),
+            value_size: Some(cfg.value_size),
+            seed: Some(cfg.seed),
+            ..MeasurementParams::default()
+        },
+        MeasurementResult {
+            load_elapsed_ms: Some(ms(load_elapsed)),
+            measure_elapsed_ms: ms(elapsed),
+            entries: Some(count),
+            entries_per_sec: Some(rate(count, elapsed)),
+            ..MeasurementResult::default()
+        },
+        counters,
+    )])
 }
 
-fn bench_readmissing(
-    path: &str,
-    num_entries: usize,
-    num_reads: usize,
-    val_size: usize,
-) -> Result<()> {
-    let _ = std::fs::remove_dir_all(path);
-    let engine = KvEngine::open(path, make_options(false, false))?;
-    let value = vec![b'x'; val_size];
-    // Populate even-numbered keys only. After compaction, the SST covers
-    // key range "key00000000".."key00199998" (even max). Odd keys like
-    // "key00000001" fall within this range but were never inserted,
-    // so SsTable::point_get passes the range check and hits the bloom filter.
-    for i in (0..num_entries).step_by(2) {
+fn run_readmissing(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    let workload = "readmissing";
+    anyhow::ensure!(cfg.num >= 2, "readmissing requires --num >= 2");
+    let path = prepare_path(cfg, workload)?;
+    let options = cfg.build_options(false, false);
+    let engine = KvEngine::open(&path, options.clone())?;
+    let value = vec![b'x'; cfg.value_size];
+    let load_start = Instant::now();
+    for i in (0..cfg.num).step_by(2) {
         engine.put(format!("key{:08}", i).as_bytes(), &value)?;
     }
-    engine.force_flush()?;
+    engine.drain_flush()?;
+    let load_elapsed = load_start.elapsed();
+    let baseline = collect_counters(&engine)?;
 
-    // Probe odd keys within the SST range — bloom filter should reject them.
-    let mut rng = StdRng::seed_from_u64(777);
+    let mut rng = StdRng::seed_from_u64(cfg.seed + 777);
     let mut key_buf = [0u8; 11];
     key_buf[..3].copy_from_slice(b"key");
     let start = Instant::now();
     let mut found = 0u64;
-    for _ in 0..num_reads {
-        let n = rng.gen_range(0..num_entries as u64 / 2) * 2 + 1; // always odd, in range
-        write!(&mut key_buf[3..], "{:08}", n)
-            .expect("key_buf is 11 bytes; 8-digit format always fits");
+    for _ in 0..cfg.reads {
+        let n = rng.gen_range(0..cfg.num as u64 / 2) * 2 + 1;
+        write!(&mut key_buf[3..], "{:08}", n).expect("key format");
         if engine.get(&key_buf)?.is_some() {
             found += 1;
         }
     }
     let elapsed = start.elapsed();
-    println!(
-        "  readmissing: {} reads over {} entries in {:?} ({:.0} ops/sec, {} found)",
-        num_reads,
-        num_entries,
-        elapsed,
-        num_reads as f64 / elapsed.as_secs_f64(),
-        found
-    );
     anyhow::ensure!(
         found == 0,
-        "bench_readmissing expected 0 found entries, got {}",
+        "readmissing expected 0 found entries, got {}",
         found
     );
+    let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
     engine.close()?;
-    let _ = std::fs::remove_dir_all(path);
-    Ok(())
+    finalize_path(cfg, &path)?;
+
+    Ok(vec![make_measurement(
+        cfg,
+        workload,
+        "negative_point_get",
+        &options,
+        MeasurementParams {
+            num: Some(cfg.num),
+            reads: Some(cfg.reads),
+            value_size: Some(cfg.value_size),
+            seed: Some(cfg.seed + 777),
+            ..MeasurementParams::default()
+        },
+        MeasurementResult {
+            load_elapsed_ms: Some(ms(load_elapsed)),
+            measure_elapsed_ms: ms(elapsed),
+            ops: Some(cfg.reads as u64),
+            ops_per_sec: Some(rate(cfg.reads as u64, elapsed)),
+            found: Some(found),
+            ..MeasurementResult::default()
+        },
+        counters,
+    )])
 }
 
-fn bench_seekrandomwhilewriting(
-    path: &str,
-    num_entries: usize,
-    num_seeks: usize,
-    seek_nexts: usize,
-    val_size: usize,
-) -> Result<()> {
-    let _ = std::fs::remove_dir_all(path);
-    let engine = KvEngine::open(path, make_options(false, false))?;
-    let value = vec![b'x'; val_size];
-    for i in 0..num_entries {
-        engine.put(format!("key{:08}", i).as_bytes(), &value)?;
-    }
-    engine.force_flush()?;
+fn run_seekrandomwhilewriting(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    let workload = "seekrandomwhilewriting";
+    let path = prepare_path(cfg, workload)?;
+    let options = cfg.build_options(false, false);
+    let engine = KvEngine::open(&path, options.clone())?;
+    let load_elapsed = populate_fixed_value(&engine, cfg.num, &vec![b'x'; cfg.value_size])?;
+    let baseline = collect_counters(&engine)?;
 
     let stop = Arc::new(AtomicBool::new(false));
     let wc = Arc::new(AtomicU64::new(0));
     let write_err: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
     let mut handles = vec![];
 
-    // Writer thread
     {
         let eng = engine.clone();
         let stop = stop.clone();
         let wc = wc.clone();
         let write_err = write_err.clone();
-        let val = value.clone();
+        let num = cfg.num;
+        let value_size = cfg.value_size;
         handles.push(std::thread::spawn(move || {
             let mut rng = StdRng::seed_from_u64(42);
             let mut key_buf = [0u8; 11];
             key_buf[..3].copy_from_slice(b"key");
+            let value = vec![b'x'; value_size];
             let mut c = 0u64;
             while !stop.load(Ordering::Relaxed) {
-                let n = rng.gen_range(0..num_entries as u64);
-                write!(&mut key_buf[3..], "{:08}", n)
-                    .expect("key_buf is 11 bytes; 8-digit format always fits");
-                match eng.put(&key_buf, &val) {
+                let n = rng.gen_range(0..num as u64);
+                write!(&mut key_buf[3..], "{:08}", n).expect("key format");
+                match eng.put(&key_buf, &value) {
                     Ok(()) => c += 1,
                     Err(e) => {
-                        *write_err.lock().unwrap() = Some(format!("{}", e));
+                        *write_err.lock().expect("lock poisoned") = Some(format!("{e}"));
                         break;
                     }
                 }
@@ -897,19 +1557,17 @@ fn bench_seekrandomwhilewriting(
         }));
     }
 
-    // Seek thread — propagate iterator errors instead of silently ignoring them.
-    let mut rng = StdRng::seed_from_u64(999);
+    let mut rng = StdRng::seed_from_u64(cfg.seed + 999);
     let mut key_buf = [0u8; 11];
     key_buf[..3].copy_from_slice(b"key");
     let start = Instant::now();
     let seek_result: Result<u64> = (|| {
         let mut total_nexts = 0u64;
-        for _ in 0..num_seeks {
-            let n = rng.gen_range(0..num_entries as u64);
-            write!(&mut key_buf[3..], "{:08}", n)
-                .expect("key_buf is 11 bytes; 8-digit format always fits");
+        for _ in 0..cfg.seeks {
+            let n = rng.gen_range(0..cfg.num as u64);
+            write!(&mut key_buf[3..], "{:08}", n).expect("key format");
             let mut iter = engine.scan(Bound::Included(&key_buf), Bound::Unbounded)?;
-            for _ in 0..seek_nexts {
+            for _ in 0..cfg.seek_nexts {
                 if !iter.is_valid() {
                     break;
                 }
@@ -922,178 +1580,501 @@ fn bench_seekrandomwhilewriting(
     let elapsed = start.elapsed();
 
     stop.store(true, Ordering::Relaxed);
-    for h in handles {
-        h.join().expect("thread panicked");
+    for handle in handles {
+        handle
+            .join()
+            .map_err(|_| anyhow!("writer thread panicked"))?;
     }
-    if let Some(err) = write_err.lock().unwrap().take() {
-        anyhow::bail!("writer thread error: {}", err);
+    if let Some(err) = write_err.lock().expect("lock poisoned").take() {
+        bail!("writer thread error: {err}");
     }
-    let w = wc.load(Ordering::Relaxed);
-    let total_nexts = seek_result?;
 
-    println!(
-        "  seekrandomwhilewriting: {} seeks ({} nexts each) in {:?} ({:.0} seeks/sec, {} total nexts, {} writes)",
-        num_seeks,
-        seek_nexts,
-        elapsed,
-        num_seeks as f64 / elapsed.as_secs_f64(),
-        total_nexts,
-        w
-    );
+    let writes = wc.load(Ordering::Relaxed);
+    let total_nexts = seek_result?;
+    let counters = collect_counters(&engine)?;
     engine.close()?;
-    let _ = std::fs::remove_dir_all(path);
-    Ok(())
+    finalize_path(cfg, &path)?;
+
+    Ok(vec![make_measurement(
+        cfg,
+        workload,
+        "seek_mixed",
+        &options,
+        MeasurementParams {
+            num: Some(cfg.num),
+            seeks: Some(cfg.seeks),
+            seek_nexts: Some(cfg.seek_nexts),
+            value_size: Some(cfg.value_size),
+            seed: Some(cfg.seed + 999),
+            ..MeasurementParams::default()
+        },
+        MeasurementResult {
+            load_elapsed_ms: Some(ms(load_elapsed)),
+            measure_elapsed_ms: ms(elapsed),
+            ops: Some(cfg.seeks as u64),
+            ops_per_sec: Some(rate(cfg.seeks as u64, elapsed)),
+            writes: Some(writes),
+            total_nexts: Some(total_nexts),
+            ..MeasurementResult::default()
+        },
+        collect_counter_delta(&baseline, &counters),
+    )])
 }
 
-fn bench_deleterandom(path: &str, num_entries: usize, num_deletes: usize) -> Result<()> {
-    let _ = std::fs::remove_dir_all(path);
-    let engine = KvEngine::open(path, make_options(false, false))?;
-    let value = vec![b'x'; 1024];
-    for i in 0..num_entries {
-        engine.put(format!("key{:08}", i).as_bytes(), &value)?;
-    }
-    engine.force_flush()?;
+fn run_deleterandom(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    let workload = "deleterandom";
+    let path = prepare_path(cfg, workload)?;
+    let options = cfg.build_options(false, false);
+    let engine = KvEngine::open(&path, options.clone())?;
+    let load_elapsed = populate_fixed_value(&engine, cfg.num, &vec![b'x'; cfg.value_size])?;
+    let baseline = collect_counters(&engine)?;
 
-    let mut rng = StdRng::seed_from_u64(42);
-    let mut key_buf = [0u8; 11]; // "key" + 8 digits
+    let mut rng = StdRng::seed_from_u64(cfg.seed);
+    let mut key_buf = [0u8; 11];
     key_buf[..3].copy_from_slice(b"key");
     let start = Instant::now();
-    for _ in 0..num_deletes {
-        let n = rng.gen_range(0..num_entries as u64);
-        write!(&mut key_buf[3..], "{:08}", n)
-            .expect("key_buf is 11 bytes; 8-digit format always fits");
+    for _ in 0..cfg.num {
+        let n = rng.gen_range(0..cfg.num as u64);
+        write!(&mut key_buf[3..], "{:08}", n).expect("key format");
         engine.delete(&key_buf)?;
     }
     let elapsed = start.elapsed();
-    println!(
-        "  deleterandom: {} deletes over {} entries in {:?} ({:.0} ops/sec)",
-        num_deletes,
-        num_entries,
-        elapsed,
-        num_deletes as f64 / elapsed.as_secs_f64()
-    );
-    engine.force_flush()?;
+    engine.drain_flush()?;
+    let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
     engine.close()?;
-    let _ = std::fs::remove_dir_all(path);
-    Ok(())
+    finalize_path(cfg, &path)?;
+
+    Ok(vec![make_measurement(
+        cfg,
+        workload,
+        "delete",
+        &options,
+        MeasurementParams {
+            num: Some(cfg.num),
+            value_size: Some(cfg.value_size),
+            seed: Some(cfg.seed),
+            ..MeasurementParams::default()
+        },
+        MeasurementResult {
+            load_elapsed_ms: Some(ms(load_elapsed)),
+            measure_elapsed_ms: ms(elapsed),
+            ops: Some(cfg.num as u64),
+            ops_per_sec: Some(rate(cfg.num as u64, elapsed)),
+            ..MeasurementResult::default()
+        },
+        counters,
+    )])
 }
 
-fn bench_compact(path: &str, num_entries: usize, val_size: usize) -> Result<()> {
-    let _ = std::fs::remove_dir_all(path);
-    // Use NoCompaction to prevent background compaction from merging SSTs
-    // before we start timing.
-    let mut opts = make_options(false, false);
-    opts.compaction_options = CompactionOptions::NoCompaction;
-    let engine = KvEngine::open(path, opts)?;
-    let value = vec![b'x'; val_size];
-    let mut key_buf = [0u8; 11];
-    key_buf[..3].copy_from_slice(b"key");
-    for i in 0..num_entries {
-        write!(&mut key_buf[3..], "{:08}", i)
-            .expect("key_buf is 11 bytes; 8-digit format always fits");
-        engine.put(&key_buf, &value)?;
-    }
-    engine.force_flush()?;
+fn run_compact(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    let workload = "compact";
+    let path = prepare_path(cfg, workload)?;
+    let mut options = cfg.build_options(false, false);
+    options.compaction_options = CompactionOptions::NoCompaction;
+    let engine = KvEngine::open(&path, options.clone())?;
+    let load_elapsed = populate_range(&engine, cfg.num, cfg.value_size)?;
+    let baseline = collect_counters(&engine)?;
 
     let start = Instant::now();
     engine.force_full_compaction()?;
     let elapsed = start.elapsed();
-    println!(
-        "  compact: {} entries ({}B) in {:?}",
-        num_entries, val_size, elapsed
-    );
+    let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
     engine.close()?;
-    let _ = std::fs::remove_dir_all(path);
+    finalize_path(cfg, &path)?;
+
+    Ok(vec![make_measurement(
+        cfg,
+        workload,
+        "full_compaction",
+        &options,
+        MeasurementParams {
+            num: Some(cfg.num),
+            value_size: Some(cfg.value_size),
+            seed: Some(cfg.seed),
+            ..MeasurementParams::default()
+        },
+        MeasurementResult {
+            load_elapsed_ms: Some(ms(load_elapsed)),
+            measure_elapsed_ms: ms(elapsed),
+            entries: Some(cfg.num as u64),
+            ..MeasurementResult::default()
+        },
+        counters,
+    )])
+}
+
+fn make_measurement(
+    cfg: &HarnessConfig,
+    workload: &str,
+    measurement: impl Into<String>,
+    options: &LsmStorageOptions,
+    params: MeasurementParams,
+    result: MeasurementResult,
+    counters: MeasurementCounters,
+) -> BenchMeasurement {
+    let measurement = measurement.into();
+    let record = MeasurementRecord {
+        schema: JSON_SCHEMA,
+        unix_epoch_ms: unix_epoch_ms(),
+        run_id: cfg.run_id.clone(),
+        workload: workload.to_string(),
+        measurement: measurement.clone(),
+        preset: cfg.preset_name,
+        engine: ENGINE_NAME,
+        engine_options: EngineOptionsRecord {
+            wal: options.enable_wal,
+            value_separation: effective_value_separation(options, &params),
+            compaction: compaction_name(&options.compaction_options),
+            target_sst_size: options.target_sst_size,
+            memtable_limit: options.num_memtable_limit,
+            cache_capacity: options.block_cache_capacity,
+        },
+        params,
+        result,
+        counters,
+    };
+    let summary = summary_for(&record);
+    BenchMeasurement { record, summary }
+}
+
+fn summary_for(record: &MeasurementRecord) -> String {
+    let mut summary = format!("{}/{}", record.workload, record.measurement);
+    if let Some(num) = record.params.num {
+        let _ = write!(summary, " num={num}");
+    }
+    if let Some(reads) = record.params.reads {
+        let _ = write!(summary, " reads={reads}");
+    }
+    if let Some(duration) = record.params.duration_secs {
+        let _ = write!(summary, " duration={}s", duration);
+    }
+    if let Some(value_size) = record.params.value_size {
+        let _ = write!(summary, " value={}B", value_size);
+    }
+    let _ = write!(
+        summary,
+        " measure={:.2}ms",
+        record.result.measure_elapsed_ms
+    );
+    if let Some(ops) = record.result.ops {
+        let _ = write!(summary, " ops={ops}");
+    }
+    if let Some(rate) = record.result.ops_per_sec {
+        let _ = write!(summary, " ops/s={:.0}", rate);
+    }
+    if let Some(entries) = record.result.entries {
+        let _ = write!(summary, " entries={entries}");
+    }
+    if let Some(rate) = record.result.entries_per_sec {
+        let _ = write!(summary, " entries/s={:.0}", rate);
+    }
+    if let Some(writes) = record.result.writes {
+        let _ = write!(summary, " writes={writes}");
+    }
+    if let Some(rate) = record.result.writes_per_sec {
+        let _ = write!(summary, " writes/s={:.0}", rate);
+    }
+    if let Some(reads) = record.result.reads {
+        let _ = write!(summary, " reads={reads}");
+    }
+    if let Some(rate) = record.result.reads_per_sec {
+        let _ = write!(summary, " reads/s={:.0}", rate);
+    }
+    if let Some(found) = record.result.found {
+        let _ = write!(summary, " found={found}");
+    }
+    if let Some(nexts) = record.result.total_nexts {
+        let _ = write!(summary, " nexts={nexts}");
+    }
+    if let Some(rounds) = record.result.gc_rounds {
+        let _ = write!(summary, " gc_rounds={rounds}");
+    }
+    summary
+}
+
+fn collect_counters(engine: &KvEngine) -> Result<MeasurementCounters> {
+    let cache = engine.cache_stats();
+    let range = engine.range_tombstone_stats();
+    let filters = engine.compaction_filter_stats();
+    let vlog = engine.vlog_stats().ok();
+    Ok(MeasurementCounters {
+        block_cache_entry_count: cache.block_cache_entry_count,
+        value_cache_hit_count: cache.value_cache_hit_count,
+        value_cache_miss_count: cache.value_cache_miss_count,
+        vlog_total_bytes: vlog.as_ref().map(|s| s.vlog_total_bytes),
+        vlog_file_count: vlog.as_ref().map(|s| s.vlog_file_count),
+        vlog_gc_entries_rewritten: vlog.as_ref().map(|s| s.gc_entries_rewritten),
+        vlog_gc_bytes_rewritten: vlog.as_ref().map(|s| s.gc_bytes_rewritten),
+        vlog_gc_files_processed: vlog.as_ref().map(|s| s.gc_files_processed),
+        compaction_filter_entries_eligible: filters.entries_eligible,
+        compaction_filter_entries_dropped: filters.entries_dropped,
+        compaction_filter_bytes_dropped: filters.bytes_dropped,
+        compaction_filter_filters_active: filters.filters_active,
+        range_tombstone_active_count: range.active_count,
+        range_tombstone_immutable_count: range.immutable_count,
+        range_tombstone_sst_count: range.sst_count,
+        range_tombstone_total_sst_fragment_count: range.total_sst_fragment_count,
+    })
+}
+
+fn collect_counter_delta(
+    before: &MeasurementCounters,
+    after: &MeasurementCounters,
+) -> MeasurementCounters {
+    MeasurementCounters {
+        block_cache_entry_count: after
+            .block_cache_entry_count
+            .saturating_sub(before.block_cache_entry_count),
+        value_cache_hit_count: after
+            .value_cache_hit_count
+            .saturating_sub(before.value_cache_hit_count),
+        value_cache_miss_count: after
+            .value_cache_miss_count
+            .saturating_sub(before.value_cache_miss_count),
+        vlog_total_bytes: diff_option_u64(before.vlog_total_bytes, after.vlog_total_bytes),
+        vlog_file_count: diff_option_u32(before.vlog_file_count, after.vlog_file_count),
+        vlog_gc_entries_rewritten: diff_option_u64(
+            before.vlog_gc_entries_rewritten,
+            after.vlog_gc_entries_rewritten,
+        ),
+        vlog_gc_bytes_rewritten: diff_option_u64(
+            before.vlog_gc_bytes_rewritten,
+            after.vlog_gc_bytes_rewritten,
+        ),
+        vlog_gc_files_processed: diff_option_u64(
+            before.vlog_gc_files_processed,
+            after.vlog_gc_files_processed,
+        ),
+        compaction_filter_entries_eligible: after
+            .compaction_filter_entries_eligible
+            .saturating_sub(before.compaction_filter_entries_eligible),
+        compaction_filter_entries_dropped: after
+            .compaction_filter_entries_dropped
+            .saturating_sub(before.compaction_filter_entries_dropped),
+        compaction_filter_bytes_dropped: after
+            .compaction_filter_bytes_dropped
+            .saturating_sub(before.compaction_filter_bytes_dropped),
+        compaction_filter_filters_active: after
+            .compaction_filter_filters_active
+            .saturating_sub(before.compaction_filter_filters_active),
+        range_tombstone_active_count: after
+            .range_tombstone_active_count
+            .saturating_sub(before.range_tombstone_active_count),
+        range_tombstone_immutable_count: after
+            .range_tombstone_immutable_count
+            .saturating_sub(before.range_tombstone_immutable_count),
+        range_tombstone_sst_count: after
+            .range_tombstone_sst_count
+            .saturating_sub(before.range_tombstone_sst_count),
+        range_tombstone_total_sst_fragment_count: after
+            .range_tombstone_total_sst_fragment_count
+            .saturating_sub(before.range_tombstone_total_sst_fragment_count),
+    }
+}
+
+fn populate_range(engine: &KvEngine, num_entries: usize, value_size: usize) -> Result<Duration> {
+    let value = vec![b'x'; value_size];
+    let start = Instant::now();
+    for i in 0..num_entries {
+        engine.put(format!("key{:08}", i).as_bytes(), &value)?;
+    }
+    engine.drain_flush()?;
+    Ok(start.elapsed())
+}
+
+fn populate_fixed_value(engine: &KvEngine, num_entries: usize, value: &[u8]) -> Result<Duration> {
+    let start = Instant::now();
+    for i in 0..num_entries {
+        engine.put(format!("key{:08}", i).as_bytes(), value)?;
+    }
+    engine.drain_flush()?;
+    Ok(start.elapsed())
+}
+
+fn prepare_path(cfg: &HarnessConfig, workload: &str) -> Result<PathBuf> {
+    let path = cfg.path_for(workload);
+    remove_path(&path)?;
+    Ok(path)
+}
+
+fn finalize_path(cfg: &HarnessConfig, path: &Path) -> Result<()> {
+    if cfg.cleanup {
+        remove_path(path)?;
+    }
     Ok(())
 }
 
-fn main() -> Result<()> {
-    let large = std::env::args().any(|a| a == "--large");
-    let (n, reads, dur, scan_n) = if large {
-        (2_000_000, 500_000, 10, 1_000_000)
-    } else {
-        (200_000, 100_000, 5, 100_000)
+fn remove_path(path: &Path) -> Result<()> {
+    match std::fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err).with_context(|| format!("failed to remove {}", path.display())),
+    }
+}
+
+fn ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1000.0
+}
+
+fn rate(count: u64, duration: Duration) -> f64 {
+    count as f64 / duration.as_secs_f64()
+}
+
+fn unix_epoch_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before epoch")
+        .as_millis() as u64
+}
+
+fn compaction_name(options: &CompactionOptions) -> &'static str {
+    match options {
+        CompactionOptions::NoCompaction => "none",
+        CompactionOptions::Simple(_) => "simple",
+        CompactionOptions::Leveled(_) => "leveled",
+        CompactionOptions::Tiered(_) => "tiered",
+    }
+}
+
+fn effective_value_separation(options: &LsmStorageOptions, params: &MeasurementParams) -> bool {
+    let Some(vlog) = options.value_separation.as_ref() else {
+        return false;
     };
+    params
+        .value_size
+        .is_some_and(|value_size| value_size >= vlog.min_value_size)
+}
 
-    // --- Original workloads ---
-    println!("=== 1. Scan ({}) ===", scan_n);
-    bench_scan("/tmp/perf-scan", scan_n)?;
+fn diff_option_u64(before: Option<u64>, after: Option<u64>) -> Option<u64> {
+    match (before, after) {
+        (Some(before), Some(after)) => Some(after.saturating_sub(before)),
+        (None, Some(after)) => Some(after),
+        _ => None,
+    }
+}
 
-    println!("\n=== 2. Concurrent R/W (no WAL) ===");
-    bench_concurrent_rw("/tmp/perf-rw-nowal", 2, 4, dur, 256, false)?;
+fn diff_option_u32(before: Option<u32>, after: Option<u32>) -> Option<u32> {
+    match (before, after) {
+        (Some(before), Some(after)) => Some(after.saturating_sub(before)),
+        (None, Some(after)) => Some(after),
+        _ => None,
+    }
+}
 
-    println!("\n=== 3. Concurrent R/W (WAL) ===");
-    bench_concurrent_rw("/tmp/perf-rw-wal", 2, 4, dur, 256, true)?;
-
-    println!("\n=== 4. WAL throughput ===");
-    bench_wal_throughput("/tmp/perf-wal1", 50_000, 256)?;
-    bench_wal_throughput("/tmp/perf-wal2", 20_000, 4096)?;
-    bench_wal_concurrent("/tmp/perf-wal3", 50_000, 256, 4)?;
-
-    println!("\n=== 5. vLog GC pressure ===");
-    bench_vlog_gc("/tmp/perf-vgc", 3, 5_000)?;
-
-    println!("\n=== 6. vLog concurrent R/W+GC ===");
-    bench_vlog_concurrent_gc("/tmp/perf-vgc2", dur)?;
-
-    // --- RocksDB-style workloads ---
-    println!("\n=== 7. fillseq ({} entries, 1KB) ===", n);
-    bench_fillseq("/tmp/perf-fillseq", n, 1024)?;
-
-    println!("\n=== 8. fillrandom ({} entries, 1KB) ===", n);
-    bench_fillrandom("/tmp/perf-fillrandom", n, 1024)?;
-
-    println!(
-        "\n=== 9. readrandom ({} entries, {} reads, 1KB) ===",
-        n, reads
-    );
-    bench_readrandom("/tmp/perf-readrandom", n, reads, 1024)?;
-
-    println!(
-        "\n=== 10. readwhilewriting ({} entries, 4 readers, {}s) ===",
-        n, dur
-    );
-    bench_readwhilewriting("/tmp/perf-rww", n, 4, dur, 1024)?;
-
-    println!(
-        "\n=== 11. readrandomwriterandom ({} entries, 4 threads, {}s) ===",
-        n, dur
-    );
-    bench_readrandomwriterandom("/tmp/perf-rwrw", n, 4, dur, 1024)?;
-
-    println!(
-        "\n=== 12. seekrandom ({} entries, 10k seeks, 10 nexts) ===",
-        n
-    );
-    bench_seekrandom("/tmp/perf-seek", n, 10_000, 10)?;
-
-    // --- Additional RocksDB-style workloads ---
-    println!("\n=== 13. overwrite ({} entries, {} ops, 1KB) ===", n, n);
-    bench_overwrite("/tmp/perf-overwrite", n, n, 1024)?;
-
-    println!("\n=== 14. readseq ({} entries, 1KB) ===", n);
-    bench_readseq("/tmp/perf-readseq", n, 1024)?;
-
-    println!("\n=== 15. readreverse ({} entries, 1KB) ===", n);
-    bench_readreverse("/tmp/perf-readrev", n, 1024)?;
-
-    println!(
-        "\n=== 16. readmissing ({} populated, {} reads, 1KB) ===",
-        n, reads
-    );
-    bench_readmissing("/tmp/perf-readmiss", n, reads, 1024)?;
-
-    println!(
-        "\n=== 17. seekrandomwhilewriting ({} entries, 1k seeks, 10 nexts, 256B) ===",
-        n
-    );
-    bench_seekrandomwhilewriting("/tmp/perf-seekww", n, 1_000, 10, 256)?;
-
-    println!("\n=== 18. deleterandom ({} entries, {} deletes) ===", n, n);
-    bench_deleterandom("/tmp/perf-delrand", n, n)?;
-
-    println!("\n=== 19. compact ({} entries, 1KB) ===", n);
-    bench_compact("/tmp/perf-compact", n, 1024)?;
-
+fn validate_config(cfg: &HarnessConfig) -> Result<()> {
+    anyhow::ensure!(cfg.num > 0, "--num must be > 0");
+    anyhow::ensure!(cfg.reads > 0, "--reads must be > 0");
+    anyhow::ensure!(cfg.duration_secs > 0, "--duration must be > 0");
+    anyhow::ensure!(cfg.scan_num > 0, "--scan-num must be > 0");
+    anyhow::ensure!(cfg.value_size > 0, "--value-size must be > 0");
+    anyhow::ensure!(cfg.threads > 0, "--threads must be > 0");
+    anyhow::ensure!(cfg.readers > 0, "--readers must be > 0");
+    anyhow::ensure!(cfg.seeks > 0, "--seeks must be > 0");
+    anyhow::ensure!(cfg.seek_nexts > 0, "--seek-nexts must be > 0");
+    anyhow::ensure!(cfg.cache_capacity > 0, "--cache-capacity must be > 0");
+    anyhow::ensure!(cfg.target_sst_size > 0, "--target-sst-size must be > 0");
+    anyhow::ensure!(cfg.memtable_limit > 0, "--memtable-limit must be > 0");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_large_alias() {
+        let args = Args::try_parse_from(["write-perf", "--large"]).expect("parse args");
+        let cfg = HarnessConfig::from_args(args);
+        assert_eq!(cfg.preset_name, "large");
+        assert_eq!(cfg.num, 2_000_000);
+    }
+
+    #[test]
+    fn parse_subset_aliases() {
+        let selected =
+            select_workloads(Some("fillseq,readseq_validate_order")).expect("select workloads");
+        let names: Vec<_> = selected.iter().map(|w| w.name).collect();
+        assert_eq!(names, vec!["fillseq", "readseq_validate_order"]);
+    }
+
+    #[test]
+    fn reject_unsupported_readreverse_selector() {
+        let err = select_workloads(Some("readreverse")).expect_err("readreverse should fail");
+        assert!(err.to_string().contains("unsupported"));
+    }
+
+    #[test]
+    fn json_record_contains_measurement_name() {
+        let cfg = HarnessConfig {
+            preset_name: "default",
+            run_id: "1".to_string(),
+            base_path: PathBuf::from("/tmp/write-perf"),
+            cleanup: true,
+            output: OutputFormat::Json,
+            num: 1,
+            reads: 1,
+            duration_secs: 1,
+            scan_num: 1,
+            value_size: 1,
+            threads: 1,
+            readers: 1,
+            seeks: 1,
+            seek_nexts: 1,
+            seed: 1,
+            cache_capacity: 1,
+            target_sst_size: 1,
+            memtable_limit: 1,
+            compaction: CompactionMode::None,
+            wal_override: false,
+            vlog_override: false,
+            num_overridden: false,
+            value_size_overridden: false,
+        };
+        let options = cfg.build_options(false, false);
+        let measurement = make_measurement(
+            &cfg,
+            "fillseq",
+            "write",
+            &options,
+            MeasurementParams::default(),
+            MeasurementResult {
+                measure_elapsed_ms: 1.0,
+                ..MeasurementResult::default()
+            },
+            MeasurementCounters::default(),
+        );
+        let json = serde_json::to_value(&measurement.record).expect("serialize record");
+        assert_eq!(json["measurement"], "write");
+        assert_eq!(json["schema"], JSON_SCHEMA);
+    }
+
+    #[test]
+    fn reject_zero_num() {
+        let cfg = HarnessConfig {
+            preset_name: "default",
+            run_id: "1".to_string(),
+            base_path: PathBuf::from("/tmp/write-perf"),
+            cleanup: true,
+            output: OutputFormat::Json,
+            num: 0,
+            reads: 1,
+            duration_secs: 1,
+            scan_num: 1,
+            value_size: 1,
+            threads: 1,
+            readers: 1,
+            seeks: 1,
+            seek_nexts: 1,
+            seed: 1,
+            cache_capacity: 1,
+            target_sst_size: 1,
+            memtable_limit: 1,
+            compaction: CompactionMode::None,
+            wal_override: false,
+            vlog_override: false,
+            num_overridden: false,
+            value_size_overridden: false,
+        };
+        assert!(validate_config(&cfg).is_err());
+    }
 }

--- a/rfcs/011-db-bench-harness.md
+++ b/rfcs/011-db-bench-harness.md
@@ -1,0 +1,917 @@
+# RFC 011: db_bench-Style Benchmark Harness
+
+**Status:** Draft  
+**Date:** 2026-06-21  
+**Author:** kv-engine Contributors  
+**Tracking Issue:** N/A (design RFC)
+
+---
+
+## 1. Summary
+
+This RFC proposes turning `kv-engine/src/bin/write-perf.rs` into a
+db_bench-style benchmark harness for kv-engine. The current binary already
+contains many RocksDB-inspired workloads:
+
+```text
+fillseq
+fillrandom
+readrandom
+readwhilewriting
+readrandomwriterandom
+seekrandom
+overwrite
+readseq
+readseq_validate_order
+readmissing
+seekrandomwhilewriting
+deleterandom
+compact
+```
+
+The missing piece is not workload coverage alone. The current runner is a fixed
+script with hard-coded paths, sizes, engine options, and text output. That makes
+it useful for manual profiling, but weaker as a repeatable benchmark contract
+for RFCs, pull requests, and external comparisons.
+
+The proposed harness keeps the existing default suite, but adds:
+
+1. Configurable workload selection.
+2. Configurable data sizes, value sizes, durations, thread counts, cache size,
+   WAL, vLog, and compaction options.
+3. Machine-readable output.
+4. Optional latency sampling.
+5. Explicit load, reopen, measure, and cleanup phases so read workloads cannot
+   accidentally benchmark an empty or incompatible database.
+6. A stable report schema for comparing kv-engine changes over time and, later,
+   comparing against RocksDB or Fjall adapters.
+
+The goal is a practical local tool:
+
+```bash
+cargo run --release --bin write-perf -- \
+  --bench fillrandom,readrandom,readwhilewriting \
+  --num 1000000 \
+  --reads 250000 \
+  --value-size 1024 \
+  --duration 10 \
+  --threads 4 \
+  --compaction leveled \
+  --output json
+```
+
+---
+
+## 2. Motivation
+
+kv-engine increasingly uses benchmark evidence to justify storage-engine
+changes. Recent RFCs and PRs rely on workloads such as cache-backfill
+read-after-write, prefix scan pruning, vLog read/write amplification, range
+tombstone overhead, and RocksDB-style point-read/write patterns.
+
+Today, there are two benchmark styles in the repo:
+
+1. Criterion micro/macro benchmarks under `kv-engine/benches/`.
+2. The `write-perf` binary, which runs a fixed sequence of operational
+   workloads and prints human-readable throughput numbers.
+
+Both are useful, but the current `write-perf` runner has practical limits:
+
+1. Workload parameters are compiled into the binary.
+2. Every run executes the whole suite unless the source is edited.
+3. Output is hard to parse in CI, scripts, or comparison dashboards.
+4. Path lifecycle is implicit: many workloads delete their directory before and
+   after the run.
+5. Warm-cache, reopen, and cache-pressure measurements are easy to
+   accidentally conflate.
+6. Engine options such as WAL, vLog, compaction strategy, cache capacity, and
+   prefix bloom settings are not consistently exposed.
+7. Comparisons to RocksDB's `db_bench` are currently documented manually rather
+   than produced by a repeatable harness.
+
+That is enough friction that benchmark numbers can become stale or difficult to
+reproduce. A db_bench-style CLI gives each performance claim a concrete command
+line and structured output.
+
+---
+
+## 3. Goals
+
+1. Preserve the existing `write-perf` default suite for continuity.
+2. Add workload selection via `--bench`.
+3. Add configurable benchmark dimensions: key count, read count, value size,
+   duration, reader/writer threads, seek-next count, random seed, and database
+   path.
+4. Add configurable engine options: WAL, vLog, compaction strategy, cache
+   capacity, cache backfill, prefix bloom, target SST size, memtable limit, and
+   manifest snapshot threshold.
+5. Emit both human-readable text and JSON Lines, with diagnostics on stderr so
+   stdout remains parseable.
+6. Include enough per-workload metadata to reproduce a run.
+7. Track both throughput and optional sampled latency.
+8. Track engine counters that explain results, separating currently available
+   counters from follow-up engine instrumentation.
+9. Make database lifecycle explicit: fresh, reuse, reopen, and cleanup modes.
+10. Add tests for CLI parsing, workload selection, output schema stability, and
+    lifecycle behavior.
+
+## 4. Non-Goals
+
+1. Replacing Criterion benchmarks. Criterion remains better for statistically
+   controlled microbenchmarks and focused regression tracking.
+2. Guaranteeing stable performance numbers across machines.
+3. Building a dashboard or long-term metrics service in the MVP.
+4. Adding RocksDB or Fjall dependencies to the kv-engine crate in the MVP.
+5. Dropping OS page cache from the benchmark runner by default. That requires
+   elevated privileges and is environment-specific.
+6. Enforcing performance gates in normal CI in the MVP.
+7. Rewriting engine internals to fit the benchmark harness.
+
+---
+
+## 5. Existing Baseline
+
+The current `write-perf` binary already has the right workload seed. It runs:
+
+```text
+1.  scan
+2.  concurrent R/W without WAL
+3.  concurrent R/W with WAL
+4.  WAL throughput
+5.  vLog GC pressure
+6.  vLog concurrent R/W + GC
+7.  fillseq
+8.  fillrandom
+9.  readrandom
+10. readwhilewriting
+11. readrandomwriterandom
+12. seekrandom
+13. overwrite
+14. readseq
+15. readseq_validate_order (current `readreverse` placeholder)
+16. readmissing
+17. seekrandomwhilewriting
+18. deleterandom
+19. compact
+```
+
+This is 19 printed sections today, but more than 19 reported measurements
+because some sections emit multiple rows. For example, WAL throughput reports
+separate 256B, 4KB, and concurrent cases, while `scan` reports full-scan and
+10% scan measurements.
+
+The binary has a small `--large` mode:
+
+```text
+default: num=200_000, reads=100_000, duration=5s, scan=100_000,
+         seekrandom=10_000 seeks x 10 nexts,
+         seekrandomwhilewriting=1_000 seeks x 10 nexts,
+         wal_seq=(50_000 x 256B, 20_000 x 4KB),
+         wal_concurrent=(50_000 x 256B x 4 threads),
+         vlog_gc=(3 rounds x 5_000 entries)
+large:   num=2_000_000, reads=500_000, duration=10s, scan=1_000_000,
+         with the same per-workload constants unless explicitly overridden
+```
+
+The proposed harness should keep those presets:
+
+```bash
+cargo run --release --bin write-perf
+cargo run --release --bin write-perf -- --preset large
+```
+
+The first implementation can treat `--large` as an alias for `--preset large`
+to avoid breaking existing local usage.
+
+---
+
+## 6. Design Overview
+
+### 6.1 CLI Shape
+
+Use `clap`, which is already a normal crate dependency, for typed argument
+parsing. Use `serde` and `serde_json`, which are also already dependencies, for
+machine-readable output.
+
+Recommended top-level options:
+
+```text
+--bench <list>              Comma-separated workloads, default: all
+--preset <default|large>    Default workload sizes
+--path <path>               Database path or base path
+--fresh                     Delete path before each workload
+--reuse                     Reuse existing path
+--cleanup                   Delete path after workload
+--no-cleanup                Preserve path after workload
+--reopen                    Close and reopen before measured read phase
+--cache-pressure <bytes>    Best-effort cache pressure before measurement
+--output <text|json|both>   Output format
+--seed <u64>                Base RNG seed
+--num <usize>               Number of inserted keys
+--reads <usize>             Number of read operations
+--value-size <usize>        Value size in bytes
+--duration <secs>           Duration for concurrent workloads
+--threads <usize>           Worker thread count for mixed workloads
+--readers <usize>           Reader thread count for readwhilewriting
+--writers <usize>           Writer thread count where supported
+--seek-nexts <usize>        Number of next() calls after each seek
+--sample-latency <n>        Target latency sample interval; 0 disables
+```
+
+Engine options:
+
+```text
+--wal <on|off>
+--serializable <on|off>
+--compaction <none|simple|leveled|tiered>
+--target-sst-size <bytes>
+--memtable-limit <usize>
+--cache-capacity <entries>
+--cache-backfill <on|off>
+--vlog <on|off>
+--vlog-threshold <bytes>
+--vlog-cache <bytes>
+--prefix-bloom <off|len-list>
+--manifest-snapshot-threshold <bytes>
+```
+
+The CLI should reject incompatible options early. For example:
+
+```text
+--bench readwhilewriting --duration 0
+--vlog on --vlog-threshold 0
+--prefix-bloom ""
+--compaction unknown
+```
+
+### 6.2 Workload Registry
+
+Replace the fixed `main()` sequence with a registry:
+
+```rust
+struct BenchSpec {
+    name: &'static str,
+    aliases: &'static [&'static str],
+    run: fn(&BenchContext) -> anyhow::Result<Vec<BenchMeasurement>>,
+}
+```
+
+The registry provides:
+
+1. Stable names for reports.
+2. Alias compatibility with RocksDB names where useful.
+3. A single place to list supported workloads.
+4. A single place to validate workload-specific options.
+
+Example aliases:
+
+```text
+fillseq                 -> fillseq
+fillrandom              -> fillrandom
+readrandom              -> readrandom
+readwhilewriting        -> readwhilewriting,rww
+readrandomwriterandom   -> readrandomwriterandom,rwrw
+seekrandom              -> seekrandom
+prefixscanrandom        -> prefixscanrandom,prefixscan
+```
+
+### 6.3 Load and Measure Phases
+
+Every workload must declare how its data is prepared before measurement:
+
+```rust
+enum LoadMode {
+    SelfContained,
+    ReuseExisting,
+}
+
+struct WorkloadPlan {
+    load_mode: LoadMode,
+    measured_phase: &'static str,
+}
+```
+
+The default mode is `SelfContained`: the workload creates or refreshes the
+dataset required for its measurement, then measures only the intended
+operation. This preserves the current behavior of read workloads such as
+`readrandom`, which populate data before timing reads.
+
+`--reuse` switches compatible read workloads to `ReuseExisting`. In that mode
+the harness must validate a small metadata file in the database path before
+measuring:
+
+```json
+{
+  "schema": "kv-engine.write-perf.dataset.v1",
+  "workload_family": "ordered_keyspace",
+  "num": 200000,
+  "value_size": 1024,
+  "seed": 42,
+  "engine_options_hash": "..."
+}
+```
+
+If the metadata is missing or incompatible with the requested benchmark
+parameters, the harness must fail instead of silently reporting throughput over
+an empty, stale, or differently configured database.
+
+Workloads with separate reopen behavior must report timings separately:
+
+```text
+load_elapsed_ms
+close_elapsed_ms
+reopen_elapsed_ms
+warmup_elapsed_ms
+measure_elapsed_ms
+```
+
+`ops_per_sec` is always computed from `measure_elapsed_ms`. End-to-end
+workloads may additionally report `end_to_end_elapsed_ms`, but they must not be
+compared directly with steady-state read throughput.
+
+### 6.4 Benchmark Context
+
+All workloads should receive the same normalized context:
+
+```rust
+struct BenchContext {
+    config: BenchConfig,
+    engine_options: LsmStorageOptions,
+    path: PathBuf,
+    rng_seed: u64,
+}
+```
+
+Workloads should not call `remove_dir_all` directly. They should request a
+database from a lifecycle helper:
+
+```rust
+let engine = ctx.open_engine("fillrandom")?;
+```
+
+The helper owns:
+
+1. Per-workload path construction.
+2. Fresh/reuse/reopen cleanup behavior.
+3. Engine option construction.
+4. Consistent close/drop ordering.
+
+### 6.5 Output Schema
+
+JSON Lines output should emit one object per measurement. A workload that
+produces multiple measurements, such as full scan plus 10% scan or multiple WAL
+cases, emits multiple JSON lines with the same `run_id` and `workload` but
+different `measurement` names:
+
+```json
+{
+  "schema": "kv-engine.write-perf.v1",
+  "unix_epoch_ms": 1782045296000,
+  "run_id": "20260621T123456Z-0001",
+  "workload": "readrandom",
+  "measurement": "point_get",
+  "preset": "default",
+  "engine": "kv-engine",
+  "engine_options": {
+    "wal": false,
+    "compaction": "leveled",
+    "value_separation": false,
+    "cache_capacity": 8192
+  },
+  "params": {
+    "num": 200000,
+    "reads": 100000,
+    "value_size": 1024,
+    "threads": 1,
+    "seed": 123
+  },
+  "result": {
+    "load_elapsed_ms": 900.12,
+    "reopen_elapsed_ms": null,
+    "measure_elapsed_ms": 147.06,
+    "ops": 100000,
+    "ops_per_sec": 680000.0,
+    "found": 100000
+  },
+  "latency": {
+    "sampled": false
+  },
+  "counters": {
+    "block_cache_entry_count": 8192,
+    "vlog_cache_hits": 0,
+    "vlog_cache_misses": 0,
+    "range_tombstones": 0
+  }
+}
+```
+
+`schema` must be stable. Additive fields are allowed. Renaming or changing the
+meaning of existing fields requires a new schema name.
+
+All diagnostics, lifecycle warnings, cleanup errors, and progress logs must go
+to stderr. JSON Lines output must keep stdout machine-readable.
+
+### 6.6 Text Output
+
+Text output should remain compact and readable:
+
+```text
+readrandom/point_get num=200000 reads=100000 value=1024B measure=147.06ms ops=100000 ops/s=680000 found=100000
+```
+
+This format is intentionally less decorative than the current sectioned output
+so it is easy to scan and grep.
+
+### 6.7 Latency Sampling
+
+Throughput is the default metric. Latency sampling is optional because timing
+every operation can distort high-throughput workloads.
+
+When `--sample-latency N` is set:
+
+1. Use per-thread randomized sampling with an expected interval of N
+   operations. Do not deterministically time every Nth operation, because that
+   can alias with key generation, flush cadence, or mixed workload patterns.
+2. Store sampled latencies in memory or a bounded reservoir for that workload.
+3. Report p50, p95, p99, and max.
+4. Include the sample interval and sample count in output.
+5. Report samples separately for operation types such as read and write in
+   mixed workloads.
+
+Example:
+
+```json
+"latency": {
+  "sampled": true,
+  "target_interval": 1000,
+  "samples": 100,
+  "operation": "read",
+  "p50_us": 12.4,
+  "p95_us": 37.8,
+  "p99_us": 61.2,
+  "max_us": 81.0
+}
+```
+
+Latency sampling should start disabled.
+
+---
+
+## 7. Workloads
+
+### 7.1 Existing Workloads to Preserve
+
+The MVP should preserve these workloads:
+
+| Workload | Purpose |
+|----------|---------|
+| `scan` | Full forward scan throughput |
+| `fillseq` | Sequential write throughput |
+| `fillrandom` | Random write throughput |
+| `readrandom` | Random point-read throughput |
+| `readwhilewriting` | One writer plus N readers |
+| `readrandomwriterandom` | Balanced random reads and writes |
+| `seekrandom` | Random seek plus bounded `next()` calls |
+| `overwrite` | Random updates to existing keys |
+| `readseq` | Sequential scan after load |
+| `readseq_validate_order` | Current forward-scan order validation formerly printed as `readreverse` |
+| `readmissing` | Negative point-read throughput |
+| `seekrandomwhilewriting` | Seek workload under write pressure |
+| `deleterandom` | Random point-delete throughput |
+| `compact` | Manual full-compaction cost |
+| `wal_throughput` | WAL write throughput |
+| `wal_concurrent` | WAL under concurrent writers |
+| `vlog_gc` | vLog GC pressure |
+| `vlog_concurrent_gc` | vLog GC under concurrent activity |
+
+The current binary prints a `readreverse` section, but the engine does not yet
+support reverse iteration and the workload measures a forward scan placeholder.
+The refactor should rename that measurement to `readseq_validate_order` and
+mark `readreverse` as unsupported until the iterator stack has real reverse
+support. The harness must not emit db_bench-compatible `readreverse` results
+from a forward scan.
+
+### 7.2 New Workloads
+
+Add the following workloads after the CLI refactor, not necessarily in the same
+patch:
+
+#### prefixscanrandom
+
+Populate structured keys:
+
+```text
+tenant:{tenant_id}:user:{user_id}
+```
+
+Then issue random prefix scans:
+
+```text
+tenant:{tenant_id}:
+```
+
+This workload measures prefix-scan iterator setup, prefix bloom pruning, and
+scan throughput over tenant-shaped keyspaces.
+
+Config:
+
+```text
+--tenants <usize>
+--prefix-scan-limit <usize>
+--prefix-hit-rate <0.0..1.0>
+```
+
+#### rangeseekrandom
+
+Issue random bounded range scans:
+
+```text
+[keyNNNNNNNN, keyNNNNNNNN + range_width)
+```
+
+This isolates range-bound handling, seek cost, and iterator merge overhead.
+
+Config:
+
+```text
+--range-width <usize>
+--ranges <usize>
+```
+
+#### readhot
+
+Use a skewed distribution where most reads hit a small hot set. This exercises
+block cache policy, value cache policy, and memtable negative lookup behavior.
+
+Config:
+
+```text
+--hot-keys <usize>
+--hot-ratio <0.0..1.0>
+```
+
+#### readwhilecompacting
+
+Populate enough data to trigger compaction, then measure reads while compaction
+is known to be active. The current public API has `force_full_compaction()`,
+which is blocking, and no public "compaction in progress" signal. This workload
+therefore requires either a test-only/benchmark-only observation hook or a
+narrower name such as `read_after_compaction_trigger` that reports it is
+best-effort and does not prove overlap.
+
+Config:
+
+```text
+--compaction-inputs <usize>
+--duration <secs>
+--readers <usize>
+```
+
+#### reopen_readrandom
+
+Populate, close, reopen, then measure random reads. This separates recovery,
+manifest load, vLog index load, engine-cache reset, and metadata loading costs
+from steady-state point-read throughput.
+
+Config:
+
+```text
+--reopen
+--reads <usize>
+```
+
+#### blob_fillrandom and blob_readrandom
+
+Large-value workloads that force value separation:
+
+```text
+--vlog on --value-size 4096 --vlog-threshold 1024
+```
+
+These should report LSM bytes, vLog bytes, vLog GC stats, and value cache
+hit/miss counts.
+
+---
+
+## 8. Database Lifecycle
+
+Benchmark lifecycle must be explicit because it changes results.
+
+### 8.1 Fresh
+
+`--fresh` deletes the workload path before opening the engine. This should be
+the default for write workloads.
+
+### 8.2 Cleanup
+
+`--cleanup` deletes the workload path after the run. This should remain default
+for the current full-suite behavior, but reusable benchmark paths should be
+possible.
+
+### 8.3 Reuse
+
+`--reuse` opens an existing path and does not delete it first. This is useful
+for read-only measurement after a separate load step.
+
+### 8.4 Reopen
+
+`--reopen` closes and reopens the engine between load and measured phase. It
+should be supported by read workloads and rejected for workloads that have no
+separate load phase.
+
+### 8.5 Cache Pressure
+
+The harness should support a `--cache-pressure <bytes>` option only as best
+effort:
+
+1. Close and reopen the engine.
+2. Optionally read an unrelated file to create cache pressure if configured.
+3. Do not require privileged OS page-cache dropping.
+
+The output must report:
+
+```text
+engine_reopened=true|false
+engine_cache_cleared=true|false
+os_page_cache_dropped=true|false
+pressure_file_bytes=<bytes|null>
+```
+
+The MVP should not attempt privileged cache dropping. Results must not be
+described as "cold cache" unless true OS page-cache dropping happened.
+
+---
+
+## 9. Engine Counters
+
+Each workload should capture counters before and after the measured phase.
+
+MVP counters using currently exposed APIs:
+
+1. Block cache entry count. This is an approximate upper bound because the
+   current TinyUFO wrapper cannot observe every eviction.
+2. vLog value-cache hits and misses.
+3. vLog file count and bytes from `vlog_stats()`.
+4. Range tombstone stats.
+5. Compaction filter stats.
+
+Follow-up counters:
+
+1. Block cache hits and misses.
+2. Flush count.
+3. Compaction count.
+4. Compaction elapsed time.
+5. Bytes written to SSTs.
+6. Bytes written to WAL.
+7. Bytes written to vLog.
+8. SST count by level.
+9. L0 file count.
+10. Manifest size.
+11. Whether flush or compaction was active during the measured phase.
+
+If a counter is unavailable, the JSON field should be omitted or set to `null`
+rather than guessed.
+
+Counters should be captured in phases:
+
+```text
+setup_counters
+measured_delta_counters
+post_quiesce_counters
+```
+
+The measured delta is the primary value. Setup counters and post-quiesce
+counters help detect background flush/compaction or cache warmup effects that
+would otherwise pollute interpretation.
+
+---
+
+## 10. External Comparisons
+
+The MVP should benchmark only kv-engine. However, the output schema should leave
+room for external adapters:
+
+```text
+--engine kv-engine
+--engine rocksdb
+--engine fjall
+```
+
+Adapters should be separate optional binaries or feature-gated crates. The
+main kv-engine crate should not depend on RocksDB or Fjall just to run local
+benchmarks.
+
+Adapter requirements:
+
+1. Use the same key generator.
+2. Use the same value generator.
+3. Use the same workload definitions where semantics match.
+4. Record adapter-specific options in `engine_options`.
+5. Declare a comparison profile covering durability, fsync policy, WAL/journal
+   mode, compression, block/cache sizing units, bloom/filter settings,
+   background compaction threads, value-separation/blob settings, write-buffer
+   limits, and data lifecycle.
+6. Mark profiles as `equivalent`, `best_effort`, or `non_equivalent`.
+7. Clearly mark unsupported workloads.
+
+RocksDB is the reference for db_bench naming and broad workload shape. Fjall is
+useful for comparing embedded Rust API ergonomics and keyspace-oriented
+workloads, but it does not need to define the harness shape.
+
+---
+
+## 11. Implementation Plan
+
+### Phase 1: CLI and Registry
+
+1. Introduce `BenchConfig`, `BenchContext`, `BenchSpec`, and
+   `BenchMeasurement`.
+2. Move the existing fixed `main()` list into a workload registry.
+3. Add `--bench`, `--preset`, and `--large` compatibility.
+4. Add parser tests for valid and invalid option combinations.
+5. Keep text output only in this phase.
+6. Split multi-row sections into named measurements or return
+   `Vec<BenchMeasurement>`.
+
+Validation:
+
+```bash
+cargo run --release --bin write-perf -- --bench fillseq --num 10000
+cargo run --release --bin write-perf -- --bench fillseq,readrandom --preset default
+```
+
+### Phase 2: Lifecycle and Engine Options
+
+1. Add path lifecycle helpers.
+2. Add `--path`, `--fresh`, `--reuse`, `--cleanup`, and `--reopen`.
+3. Add `--no-cleanup` rather than accepting ad hoc `--cleanup=false` syntax.
+4. Refactor workloads into explicit load, optional reopen, measure, and cleanup
+   phases.
+5. Add dataset metadata validation for `--reuse`.
+6. Add engine option flags for WAL, compaction, cache, vLog, and prefix bloom.
+7. Normalize all existing workloads to use the lifecycle helper.
+
+Validation:
+
+```bash
+cargo run --release --bin write-perf -- --bench fillrandom --path /tmp/kvbench --fresh --no-cleanup
+cargo run --release --bin write-perf -- --bench readrandom --path /tmp/kvbench --reuse --reopen
+```
+
+### Phase 3: JSON Lines Output
+
+1. Add `--output text|json|both`.
+2. Define `kv-engine.write-perf.v1`.
+3. Emit one JSON object per measurement.
+4. Add snapshot tests for JSON field names and required metadata.
+5. Keep JSON Lines on stdout and all diagnostics on stderr.
+
+Validation:
+
+```bash
+cargo run --release --bin write-perf -- --bench readrandom --output json
+```
+
+### Phase 4: Counters and Latency Sampling
+
+1. Capture available engine counters before and after each workload.
+2. Add optional `--sample-latency`.
+3. Report p50, p95, p99, max, and sample count when enabled.
+4. Use randomized per-thread sampling or a bounded reservoir instead of
+   deterministic every-Nth-operation sampling.
+5. Ensure latency sampling can be disabled with zero overhead in the hot loop
+   except a branch outside the measured operation path where practical.
+
+Validation:
+
+```bash
+cargo run --release --bin write-perf -- --bench readrandom --sample-latency 1000 --output both
+```
+
+### Phase 5: New Workloads
+
+Add focused workloads:
+
+1. `prefixscanrandom`
+2. `rangeseekrandom`
+3. `readhot`
+4. `readwhilecompacting`
+5. `reopen_readrandom`
+6. `blob_fillrandom`
+7. `blob_readrandom`
+
+Each workload should include at least one small smoke test for setup and output
+shape. Performance assertions should not be part of normal unit tests.
+
+### Phase 6: Optional External Adapters
+
+After the kv-engine harness is stable, add optional comparison adapters outside
+the core crate:
+
+1. `bench-adapter-rocksdb`
+2. `bench-adapter-fjall`
+
+Adapters should consume the same workload config and emit the same JSON schema
+with `engine` set appropriately.
+
+---
+
+## 12. Testing Strategy
+
+### 12.1 Unit Tests
+
+Add tests for:
+
+1. `--bench` parsing.
+2. Preset normalization.
+3. Engine option normalization.
+4. Invalid option combinations.
+5. JSON schema required fields.
+6. Workload registry lookup.
+7. Path lifecycle behavior using temporary directories.
+8. Dataset metadata compatibility checks for `--reuse`.
+9. Multi-measurement output for workloads such as `scan` and WAL throughput.
+10. stdout/stderr separation for JSON output.
+
+### 12.2 Smoke Tests
+
+Add tiny benchmark smoke tests that run with small inputs:
+
+```text
+--bench fillseq --num 100 --value-size 16
+--bench readrandom --num 100 --reads 50 --value-size 16
+--bench readwhilewriting --num 100 --duration 1 --readers 1
+```
+
+These tests should verify completion and output shape, not throughput.
+
+### 12.3 Manual Performance Runs
+
+Manual comparison commands should be documented:
+
+```bash
+cargo run --release --bin write-perf -- --preset default --output json > default.jsonl
+cargo run --release --bin write-perf -- --preset large --output json > large.jsonl
+```
+
+For optimization PRs, authors should include the exact command and the relevant
+JSON rows in the PR body or linked benchmark report.
+
+---
+
+## 13. Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Benchmark harness complexity grows too much | Keep Criterion for focused benchmarks; keep `write-perf` as operational workloads only |
+| Latency sampling changes throughput | Disable by default; use randomized sampling; report sampling configuration |
+| JSON schema churn breaks scripts | Version schema as `kv-engine.write-perf.v1`; only add fields compatibly |
+| Cache-pressure numbers are mislabeled as cold-cache results | Use `--cache-pressure`; report whether OS cache was actually dropped; do not claim cold-cache unless true |
+| Benchmarks become CI-flaky | Use smoke tests in CI; keep real performance runs manual or scheduled |
+| External adapters add dependency burden | Keep adapters optional and outside the core crate |
+| Workload names drift from RocksDB terminology | Keep RocksDB-compatible aliases in the registry |
+| Read workloads measure empty or incompatible reused data | Require self-contained loading by default and dataset metadata validation for `--reuse` |
+| Background work pollutes counter deltas | Report setup, measured, and post-quiesce counter phases |
+
+---
+
+## 14. Open Questions
+
+1. Should benchmark reports include hardware metadata such as CPU model, memory,
+   filesystem, kernel, and rustc version?
+2. Should the harness support loading once and running multiple read workloads
+   against the same database path?
+3. Should optional RocksDB/Fjall adapters live in this repository or in a
+   separate benchmarking repository?
+4. Should long-running performance gates be added as manual GitHub Actions
+   workflows after the harness stabilizes?
+5. Should follow-up engine instrumentation add exact block-cache hit/miss
+   counters and compaction activity counters?
+6. Should timestamp output remain Unix epoch milliseconds only, or should the
+   repo add a time-formatting dependency for RFC3339 strings?
+
+---
+
+## 15. Acceptance Criteria
+
+The RFC is implemented when:
+
+1. Existing default `write-perf` behavior still runs the current suite.
+2. `--bench` can run one workload or a comma-separated subset.
+3. `--preset default` and `--preset large` work, and `--large` remains
+   compatible.
+4. Benchmark sizes and durations are configurable without editing source.
+5. Engine options for WAL, compaction, cache, and vLog are configurable.
+6. Path lifecycle is explicit and tested, including `--no-cleanup`.
+7. Read workloads are self-contained by default, and `--reuse` validates dataset
+   metadata before measuring.
+8. JSON Lines output emits stable `kv-engine.write-perf.v1` records to stdout,
+   one object per measurement.
+9. Currently exposed cache, vLog, compaction filter, and range tombstone
+   counters are included when available; missing counters are omitted or null.
+10. `readreverse` is not emitted as a db_bench-compatible result until real
+    reverse iteration exists.
+11. Smoke tests cover parser, registry, lifecycle, reuse validation,
+    multi-measurement output, and JSON output shape.
+12. `docs/perf-profile.md` documents the new benchmark commands and replaces
+    stale fixed-run instructions.


### PR DESCRIPTION
## Summary

Rewrite `write-perf.rs` from a fixed-script benchmark runner into a configurable db_bench-style harness with CLI flags, machine-readable output, and explicit benchmark phases.

## Changes

### Code — `write-perf.rs`
- Add clap CLI with `--bench`, `--preset`, `--output`, `--num`, `--path` flags
- Support Text, Json, and Both output formats via `--output`
- Add Default and Large presets for quick benchmark configs
- Add configurable compaction modes (None, Simple, Leveled, Tiered)
- Explicit load, reopen, measure, and cleanup phases

### Docs
- Add RFC 011 (`rfcs/011-db-bench-harness.md`) documenting the harness design and motivation

### Misc
- Sort `kv-engine/Cargo.toml` dependencies (dep-sort fix)

## Verification
- [x] `./dev check` passes (fmt, clippy, dep-sort, machete)
- [x] 608/608 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmark tool now supports configurable CLI arguments for workload selection, performance parameters, and database lifecycle controls.
  * Added multiple output format options (Text/JSON/Both) for benchmark results.
  * Introduced preset configurations and optional latency sampling capabilities.
  * Implemented structured result recording with stable JSON schema for consistent measurement tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->