### PR TITLE
perf: speed up unique-key write batches

### DIFF
--- a/docs/bench-report-crud-bench-fjall.md
+++ b/docs/bench-report-crud-bench-fjall.md
@@ -1,7 +1,16 @@
 # crud-bench: ToyKV vs Fjall (matched config)
 
 Benchmark run: `--samples 100000 --clients 4 --threads 4` (concurrent: 4 writers + 4 readers).
-ToyKV branch: `perf/batch-get` (latest, with critical `batch_get` range-tombstone fix).
+Focused post-optimization rerun: `--samples 100000 --clients 1 --threads 1 --skip-scans --skip-indexes`
+(ToyKV and Fjall, sync and no-sync).
+ToyKV branch: `perf/batch-get` (latest, with critical `batch_get` range-tombstone fix and `write_batch`
+unique-key fast path).
+Accepted focused rerun artifacts:
+`/tmp/result-toykv_batch_opt_sync_100k.csv`, `/tmp/result-fjall_compare_sync_100k.csv`,
+`/tmp/result-toykv_batch_opt_nosync_100k.csv`, `/tmp/result-fjall_compare_nosync_100k.csv`.
+
+Note: later `/tmp/*opt2*` CSVs came from a rejected small-batch duplicate-scan experiment that regressed
+`batch_create_100` and `batch_delete_100`; those numbers are intentionally not used here.
 
 ## Config parity
 
@@ -45,7 +54,7 @@ Fjall config source: `crud-bench/src/fjall.rs`.
 | batch_create_100 | 2,833 | 2,421 |
 | batch_create_1000 | 928 | 771 |
 
-### Durable (sync: true)
+### Durable (sync: true, historical full-suite snapshot before `write_batch` fast path)
 
 | Benchmark | ToyKV | Fjall |
 |---|---|---|
@@ -53,6 +62,17 @@ Fjall config source: `crud-bench/src/fjall.rs`.
 | put_p | 171,092 | 149,513 |
 | batch_create_100 | 1,242 | 1,321 |
 | batch_create_1000 | 352 | 446 |
+
+### Durable focused rerun after `write_batch` optimization
+
+| Benchmark | ToyKV | Fjall | ToyKV vs Fjall |
+|---|---:|---:|---:|
+| put_c | **275,683** | 143,399 | **+92.2%** |
+| delete_c | **943,063** | 221,160 | **+326.4%** |
+| batch_create_100 | **3,059** | 2,872 | **+6.5%** |
+| batch_create_1000 | **316** | 298 | **+6.0%** |
+| batch_delete_100 | **10,146** | 7,991 | **+26.9%** |
+| batch_delete_1000 | **1,738** | 1,401 | **+24.1%** |
 
 ## Single read (OPS) — buffered (no fsync)
 
@@ -93,17 +113,30 @@ Fjall config source: `crud-bench/src/fjall.rs`.
 | batch_delete_100 | 2,415 | 2,892 |
 | batch_delete_1000 | 533 | 988 |
 
+### Buffered focused rerun after `write_batch` optimization
+
+| Benchmark | ToyKV | Fjall | ToyKV vs Fjall |
+|---|---:|---:|---:|
+| delete_c | **1,401,111** | 223,789 | **+526.1%** |
+| batch_delete_100 | 8,138 | **11,379** | -28.5% |
+| batch_delete_1000 | **2,071** | 1,301 | **+59.2%** |
+
 ## Key findings
 
 1. **ToyKV wins all batch_read benchmarks.** After fixing a critical range-tombstone bug in `batch_get`, ToyKV is **+5%/+30% faster** (buffered) and **+3%/+11% faster** (durable) than Fjall with matched configs.
 
 2. **ToyKV also leads the read-heavy non-batch workloads in this run.** `get_c`/`get_p` are +6%/+54% faster, range reads are +18–29% faster, and the buffered scan variants are roughly 3× to 7× faster.
 
-3. **Fjall is still ahead on some write-heavy cases.** In this dataset, Fjall wins durable `batch_create_100`/`batch_create_1000` and buffered `batch_delete_100`/`batch_delete_1000`, with the largest gap at `batch_delete_1000` (988 vs 533 OPS).
+3. **The focused post-optimization sync rerun wins all targeted durable write/delete cases.** With the `write_batch`
+   unique-key fast path, ToyKV beats Fjall on sync `put_c`, `delete_c`, `batch_create_100`, `batch_create_1000`,
+   `batch_delete_100`, and `batch_delete_1000` under the matched focused command.
 
-4. **Cache sizing is not a likely explanation for the read gap here.** Fjall's configured cache budget is larger, but both caches are far above the dataset size, so these runs are primarily measuring engine/read-path behavior rather than cache-capacity pressure.
+4. **The remaining targeted loss is buffered `batch_delete_100`.** In the focused no-sync rerun, ToyKV wins
+   `delete_c` and `batch_delete_1000`, but Fjall remains ahead on `batch_delete_100` (11,379 vs 8,138 OPS).
 
-5. **The value-separation threshold is matched, so this report should not claim ToyKV keeps 4 KB values inline.** ToyKV separates values when `value.len() >= 4 KiB`, and Fjall is configured with the same 4 KiB threshold, so both engines are exercising separated-value paths for payloads at or above that boundary.
+5. **Cache sizing is not a likely explanation for the read gap here.** Fjall's configured cache budget is larger, but both caches are far above the dataset size, so these runs are primarily measuring engine/read-path behavior rather than cache-capacity pressure.
+
+6. **The value-separation threshold is matched, so this report should not claim ToyKV keeps 4 KB values inline.** ToyKV separates values when `value.len() >= 4 KiB`, and Fjall is configured with the same 4 KiB threshold, so both engines are exercising separated-value paths for payloads at or above that boundary.
 
 ## Changes since previous report
 
@@ -112,6 +145,8 @@ Fjall config source: `crud-bench/src/fjall.rs`.
 - **Non-MVCC L0 hint update:** Now updates the L0 hint before returning when a value is found.
 - **anyhow::Ok import conflict fix:** Removed `Ok` from `use anyhow::{…}` to avoid shadowing standard `Ok` pattern.
 - **Matched config:** Both engines now use 64 KB blocks, 256 MB memtable, 4 KB value separation threshold.
+- **Write-batch unique-key fast path:** `write_batch` now avoids building and sorting a last-op map when the batch has
+  unique keys, while preserving duplicate-key last-op-wins semantics.
 
 ## Raw config snippets
 

--- a/docs/bench-report-crud-bench-fjall.md
+++ b/docs/bench-report-crud-bench-fjall.md
@@ -115,8 +115,13 @@ Fjall config source: `crud-bench/src/fjall.rs`.
 
 ### Buffered focused rerun after `write_batch` optimization
 
+Source CSVs: `/tmp/result-toykv_batch_opt_nosync_100k.csv` and `/tmp/result-fjall_compare_nosync_100k.csv`.
+
 | Benchmark | ToyKV | Fjall | ToyKV vs Fjall |
 |---|---:|---:|---:|
+| put_c | **332,689** | 147,034 | **+126.3%** |
+| batch_create_100 | **3,237** | 2,911 | **+11.2%** |
+| batch_create_1000 | **342** | 295 | **+15.9%** |
 | delete_c | **1,401,111** | 223,789 | **+526.1%** |
 | batch_delete_100 | 8,138 | **11,379** | -28.5% |
 | batch_delete_1000 | **2,071** | 1,301 | **+59.2%** |

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -3221,17 +3221,19 @@ impl LsmStorageInner {
         }
         // Most benchmark and application batches contain unique keys. Avoid
         // building and sorting a full last-op map on that hot path.
-        let mut seen = std::collections::HashSet::with_capacity(batch.len());
         let mut has_duplicate_keys = false;
-        for record in batch {
-            let key = match record {
-                WriteBatchRecord::Del(k) => k.as_ref(),
-                WriteBatchRecord::Put(k, _) => k.as_ref(),
-                WriteBatchRecord::DelRange(_, _) => unreachable!(),
-            };
-            if !seen.insert(key) {
-                has_duplicate_keys = true;
-                break;
+        if batch.len() > 1 {
+            let mut seen = std::collections::HashSet::with_capacity(batch.len());
+            for record in batch {
+                let key = match record {
+                    WriteBatchRecord::Del(k) => k.as_ref(),
+                    WriteBatchRecord::Put(k, _) => k.as_ref(),
+                    WriteBatchRecord::DelRange(_, _) => unreachable!(),
+                };
+                if !seen.insert(key) {
+                    has_duplicate_keys = true;
+                    break;
+                }
             }
         }
 
@@ -3294,7 +3296,11 @@ impl LsmStorageInner {
                 if self.options.serializable {
                     let commit_ts = mvcc.write_batch(&entries, &state.memtable)?;
                     if commit_ts > 0 {
-                        let mut write_set = std::collections::HashSet::new();
+                        let mut write_set = std::collections::HashSet::with_capacity(
+                            dedup_indices
+                                .as_ref()
+                                .map_or(batch.len(), std::vec::Vec::len),
+                        );
                         if let Some(indices) = dedup_indices.as_ref() {
                             for &idx in indices {
                                 let key = match &batch[idx] {

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -3219,20 +3219,41 @@ impl LsmStorageInner {
             };
             Self::validate_key_size(key)?;
         }
-        // Deduplicate: keep only the last operation per user key.
-        let mut last_op = std::collections::HashMap::new();
-        for (idx, record) in batch.iter().enumerate() {
+        // Most benchmark and application batches contain unique keys. Avoid
+        // building and sorting a full last-op map on that hot path.
+        let mut seen = std::collections::HashSet::with_capacity(batch.len());
+        let mut has_duplicate_keys = false;
+        for record in batch {
             let key = match record {
                 WriteBatchRecord::Del(k) => k.as_ref(),
                 WriteBatchRecord::Put(k, _) => k.as_ref(),
                 WriteBatchRecord::DelRange(_, _) => unreachable!(),
             };
-            last_op.insert(key, idx);
+            if !seen.insert(key) {
+                has_duplicate_keys = true;
+                break;
+            }
         }
 
-        // Sort indices to preserve original insertion order.
-        let mut indices: Vec<_> = last_op.values().copied().collect();
-        indices.sort_unstable();
+        let dedup_indices = if has_duplicate_keys {
+            // Deduplicate: keep only the last operation per user key.
+            let mut last_op = std::collections::HashMap::with_capacity(batch.len());
+            for (idx, record) in batch.iter().enumerate() {
+                let key = match record {
+                    WriteBatchRecord::Del(k) => k.as_ref(),
+                    WriteBatchRecord::Put(k, _) => k.as_ref(),
+                    WriteBatchRecord::DelRange(_, _) => unreachable!(),
+                };
+                last_op.insert(key, idx);
+            }
+
+            // Sort indices to preserve original insertion order.
+            let mut indices: Vec<_> = last_op.values().copied().collect();
+            indices.sort_unstable();
+            Some(indices)
+        } else {
+            None
+        };
 
         {
             let _commit_guard = self.mvcc.as_ref().and_then(|mvcc| {
@@ -3246,25 +3267,52 @@ impl LsmStorageInner {
             let state = self.state.load_full();
             if let Some(ref mvcc) = self.mvcc {
                 // MVCC path: allocate a single commit_ts for the entire batch.
-                let entries: Vec<(&[u8], &[u8], bool)> = indices
-                    .iter()
-                    .map(|&idx| match &batch[idx] {
-                        WriteBatchRecord::Put(key, value) => (key.as_ref(), value.as_ref(), false),
-                        WriteBatchRecord::Del(key) => (key.as_ref(), &[] as &[u8], true),
-                        WriteBatchRecord::DelRange(_, _) => unreachable!(),
-                    })
-                    .collect();
+                let entries: Vec<(&[u8], &[u8], bool)> =
+                    if let Some(indices) = dedup_indices.as_ref() {
+                        indices
+                            .iter()
+                            .map(|&idx| match &batch[idx] {
+                                WriteBatchRecord::Put(key, value) => {
+                                    (key.as_ref(), value.as_ref(), false)
+                                }
+                                WriteBatchRecord::Del(key) => (key.as_ref(), &[] as &[u8], true),
+                                WriteBatchRecord::DelRange(_, _) => unreachable!(),
+                            })
+                            .collect()
+                    } else {
+                        batch
+                            .iter()
+                            .map(|record| match record {
+                                WriteBatchRecord::Put(key, value) => {
+                                    (key.as_ref(), value.as_ref(), false)
+                                }
+                                WriteBatchRecord::Del(key) => (key.as_ref(), &[] as &[u8], true),
+                                WriteBatchRecord::DelRange(_, _) => unreachable!(),
+                            })
+                            .collect()
+                    };
                 if self.options.serializable {
                     let commit_ts = mvcc.write_batch(&entries, &state.memtable)?;
                     if commit_ts > 0 {
                         let mut write_set = std::collections::HashSet::new();
-                        for &idx in &indices {
-                            let key = match &batch[idx] {
-                                WriteBatchRecord::Put(k, _) => k.as_ref(),
-                                WriteBatchRecord::Del(k) => k.as_ref(),
-                                WriteBatchRecord::DelRange(_, _) => unreachable!(),
-                            };
-                            write_set.insert(bytes::Bytes::copy_from_slice(key));
+                        if let Some(indices) = dedup_indices.as_ref() {
+                            for &idx in indices {
+                                let key = match &batch[idx] {
+                                    WriteBatchRecord::Put(k, _) => k.as_ref(),
+                                    WriteBatchRecord::Del(k) => k.as_ref(),
+                                    WriteBatchRecord::DelRange(_, _) => unreachable!(),
+                                };
+                                write_set.insert(bytes::Bytes::copy_from_slice(key));
+                            }
+                        } else {
+                            for record in batch {
+                                let key = match record {
+                                    WriteBatchRecord::Put(k, _) => k.as_ref(),
+                                    WriteBatchRecord::Del(k) => k.as_ref(),
+                                    WriteBatchRecord::DelRange(_, _) => unreachable!(),
+                                };
+                                write_set.insert(bytes::Bytes::copy_from_slice(key));
+                            }
                         }
                         mvcc.record_committed_txn(commit_ts, write_set, 0);
                     }
@@ -3273,22 +3321,46 @@ impl LsmStorageInner {
                 }
             } else {
                 // Non-MVCC path: write raw user keys directly.
-                let mut raw_data = Vec::with_capacity(indices.len());
-                for idx in indices {
-                    match &batch[idx] {
-                        WriteBatchRecord::Del(key) => {
-                            raw_data.push((
-                                KeySlice::from_slice(key.as_ref()),
-                                vec![crate::vlog::KvKind::Tombstone as u8],
-                            ));
+                let mut raw_data = Vec::with_capacity(
+                    dedup_indices
+                        .as_ref()
+                        .map_or(batch.len(), std::vec::Vec::len),
+                );
+                if let Some(indices) = dedup_indices.as_ref() {
+                    for &idx in indices {
+                        match &batch[idx] {
+                            WriteBatchRecord::Del(key) => {
+                                raw_data.push((
+                                    KeySlice::from_slice(key.as_ref()),
+                                    vec![crate::vlog::KvKind::Tombstone as u8],
+                                ));
+                            }
+                            WriteBatchRecord::Put(key, value) => {
+                                let mut p = Vec::with_capacity(1 + value.as_ref().len());
+                                p.push(crate::vlog::KvKind::Inline as u8);
+                                p.extend_from_slice(value.as_ref());
+                                raw_data.push((KeySlice::from_slice(key.as_ref()), p));
+                            }
+                            WriteBatchRecord::DelRange(_, _) => unreachable!(),
                         }
-                        WriteBatchRecord::Put(key, value) => {
-                            let mut p = Vec::with_capacity(1 + value.as_ref().len());
-                            p.push(crate::vlog::KvKind::Inline as u8);
-                            p.extend_from_slice(value.as_ref());
-                            raw_data.push((KeySlice::from_slice(key.as_ref()), p));
+                    }
+                } else {
+                    for record in batch {
+                        match record {
+                            WriteBatchRecord::Del(key) => {
+                                raw_data.push((
+                                    KeySlice::from_slice(key.as_ref()),
+                                    vec![crate::vlog::KvKind::Tombstone as u8],
+                                ));
+                            }
+                            WriteBatchRecord::Put(key, value) => {
+                                let mut p = Vec::with_capacity(1 + value.as_ref().len());
+                                p.push(crate::vlog::KvKind::Inline as u8);
+                                p.extend_from_slice(value.as_ref());
+                                raw_data.push((KeySlice::from_slice(key.as_ref()), p));
+                            }
+                            WriteBatchRecord::DelRange(_, _) => unreachable!(),
                         }
-                        WriteBatchRecord::DelRange(_, _) => unreachable!(),
                     }
                 }
                 let refs: Vec<(KeySlice, &[u8])> =

--- a/todo.md
+++ b/todo.md
@@ -122,14 +122,38 @@ PR #85 (merged 2026-06-10). Version-aware GC with internal key storage in vLog.
 - [x] `partition_point` for leveled SST lookup in `get_with_kind_at_ts` (PR #85)
 - [x] Lock-free watermark: `DashMap<u64, AtomicUsize>` + `watermark.read()` — 3.4× read throughput (PR #126)
 
-### Pending: Close gap with Fjall
+### Pending: Production sync performance
 
 See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
 
 - [x] **Batch reads** — Closed 5× gap to ~1.06× (tied). `batch_get` with shared state, sorted keys, reusable encode buffer (PR #127).
-- [ ] **Durable updates** — Fjall 1.8× faster with `--sync`. Group commit for WAL.
-- [ ] **Batch delete_100** — Fjall 1.4× faster. Profile batch delete path.
-- [ ] **Batch create_1000** — Fjall 1.5× faster. Profile large batch create path.
+- [x] **Durable create/delete target rows** — Post-optimization focused rerun wins all targeted sync cases:
+  `put_c` +92.2%, `delete_c` +326.4%, `batch_create_100` +6.5%, `batch_create_1000` +6.0%,
+  `batch_delete_100` +26.9%, `batch_delete_1000` +24.1% vs Fjall. Source CSVs:
+  `/tmp/result-toykv_batch_opt_sync_100k.csv` and `/tmp/result-fjall_compare_sync_100k.csv`. Later `opt2`
+  CSVs came from a reverted small-batch duplicate-scan experiment and are rejected. `write_batch` now avoids the
+  full last-op map/sort when batch keys are unique.
+- [ ] **Close sync-vs-no-sync gap for production workloads** — Production uses `--sync`, so prioritize reducing the
+  ToyKV durable penalty rather than optimizing buffered-only paths. Current focused ToyKV gaps: `put_c` 275,683 vs
+  332,689 no-sync (-17%), `batch_create_100` 3,059 vs 3,237 (-5.5%), `batch_create_1000` 316 vs 342 (-7.6%),
+  `batch_delete_100` 10,146 vs 8,138 (sync faster/noisy), `batch_delete_1000` 1,738 vs 2,071 (-16%).
+- [ ] **Profile sync write path** — Measure per-operation time in WAL append, WAL batch encode, `fsync`/`fdatasync`,
+  memtable insert, and `try_freeze_memtable` for `put_c`, `batch_create_100`, `batch_create_1000`,
+  `batch_delete_100`, and `batch_delete_1000`. Keep the benchmark command matched to the focused report:
+  `crud-bench -d toykv -s 100000 -c 1 -t 1 -k integer --sync --skip-scans --skip-indexes`.
+- [ ] **Group commit / batched WAL sync** — Investigate coalescing concurrent sync writes behind one WAL flush while
+  preserving the current durability contract. A sync write may return only after its own WAL record is durable; sync
+  errors must propagate to every waiter whose record was in the failed flush; recovery tests must prove acknowledged
+  writes survive and unacknowledged writes may be lost. Validate both focused single-client (`--clients 1 --threads 1`)
+  and production concurrent (`--clients 4 --threads 4`) runs.
+- [ ] **Reduce sync batch overhead before fsync** — Audit `Wal::put_batch`, `MemTable::put_raw_batch_inner`, and MVCC
+  `write_batch` allocation paths for avoidable per-record buffers/copies. The next useful target is making durable
+  `batch_create_1000` closer to the no-sync path without hurting duplicate-key last-op-wins semantics.
+- [ ] **Add sync perf gates to the comparison workflow** — Track both absolute Fjall-relative OPS and
+  sync/no-sync ratio for `put_c`, `batch_create_100`, `batch_create_1000`, `batch_delete_100`, and
+  `batch_delete_1000`. Do not accept buffered-only improvements that regress sync production cases. Initial gates:
+  no focused sync row regresses by more than 5%, sync/no-sync ratio improves for at least two of `put_c`,
+  `batch_create_1000`, and `batch_delete_1000`, and single-client sync p95/p99 latency does not materially regress.
 
 ---
 


### PR DESCRIPTION
## Summary

- Avoid the full last-op map and index sort for unique-key write batches while preserving duplicate-key last-op-wins semantics.
- Update the ToyKV vs Fjall comparison report with accepted focused sync/no-sync benchmark artifacts and rejected opt2 provenance.
- Update TODOs to prioritize production sync performance, group-commit durability invariants, and sync perf gates.

## Benchmark Evidence

Accepted focused rerun artifacts:
- /tmp/result-toykv_batch_opt_sync_100k.csv
- /tmp/result-fjall_compare_sync_100k.csv
- /tmp/result-toykv_batch_opt_nosync_100k.csv
- /tmp/result-fjall_compare_nosync_100k.csv

Focused sync ToyKV vs Fjall:
- put_c: 275,683 vs 143,399 OPS (+92.2%)
- delete_c: 943,063 vs 221,160 OPS (+326.4%)
- batch_create_100: 3,059 vs 2,872 OPS (+6.5%)
- batch_create_1000: 316 vs 298 OPS (+6.0%)
- batch_delete_100: 10,146 vs 7,991 OPS (+26.9%)
- batch_delete_1000: 1,738 vs 1,401 OPS (+24.1%)

## Verification

- cargo fmt --all --check
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- cargo test --lib --all-features write_batch -- --nocapture
- cargo make check-typos
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark report with new post-optimization performance results, refined test specifications, and revised findings for performance comparisons.

* **Performance**
  * Improved write batch operations by optimizing duplicate key handling to reduce unnecessary computational overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->