### PR TITLE
docs: add RFC 012 — parallel WAL with multiple loggers

### DIFF
--- a/rfcs/012-parallel-wal.md
+++ b/rfcs/012-parallel-wal.md
@@ -125,8 +125,10 @@ struct DirectBuf {
 
 // SAFETY: DirectBuf owns its allocation and is not shared across threads
 // without synchronization. The raw pointer is not aliased.
+// Send is required for transfer via ArrayQueue. Sync is NOT implemented
+// because DirectBuf provides &mut access (as_mut_slice) — sharing a
+// &DirectBuf across threads without synchronization would be unsound.
 unsafe impl Send for DirectBuf {}
-unsafe impl Sync for DirectBuf {}
 
 impl DirectBuf {
     fn new(size: usize) -> Self {
@@ -137,6 +139,10 @@ impl DirectBuf {
         let mut ptr: *mut libc::c_void = std::ptr::null_mut();
         let ret = unsafe { libc::posix_memalign(&mut ptr, 4096, cap) };
         assert_eq!(ret, 0, "posix_memalign failed");
+        // Zero-initialize immediately: creating a &mut [u8] over
+        // uninitialized memory is UB in Rust. This also prevents stale
+        // data leakage if the buffer is read before being fully written.
+        unsafe { libc::memset(ptr, 0, cap) };
         Self {
             ptr: ptr as *mut u8,
             len: 0,
@@ -263,9 +269,13 @@ impl Wal {
         //    logical commit group — the generation counter is only incremented
         //    once after ALL chunks complete. This prevents callers in later
         //    chunks from returning prematurely before their data is durable.
+        //
+        //    user_data uses global indices (not chunk-relative) so that stale
+        //    CQEs from a failed chunk can be detected and discarded.
         let max_writes_per_chunk = 63;  // leave 1 slot for fsync
         let chunks: Vec<&[DirectBuf]> = bufs.chunks(max_writes_per_chunk).collect();
         let mut offset = base_offset;
+        let mut global_idx: u64 = 0;
         for chunk in chunks {
             let total_sqes = chunk.len() + 1; // writes + fsync
 
@@ -273,7 +283,7 @@ impl Wal {
             //    Each SQE is tagged with its index via user_data so that CQEs
             //    can be matched back to the correct buffer regardless of
             //    completion order (io_uring does not guarantee submission order).
-            for (i, buf) in chunk.iter().enumerate() {
+            for buf in chunk.iter() {
                 let aligned_len = Self::align_up(buf.len());
                 let sqe = opcode::Write::new(
                     types::Fixed(WAL_FD_INDEX),
@@ -282,9 +292,10 @@ impl Wal {
                 )
                 .offset(offset)
                 .build()
-                .user_data(i as u64);  // tag with buffer index
+                .user_data(global_idx);  // global index for stale CQE detection
                 unsafe { self.ring.submission().push(&sqe)?; }
                 offset += aligned_len as u64;
+                global_idx += 1;
             }
 
             // 4. Submit fsync with IOSQE_IO_DRAIN.
@@ -309,6 +320,7 @@ impl Wal {
             //    distinguish write CQEs from the fsync CQE.
             let mut write_err: Option<i32> = None;
             let mut fsync_err: Option<i32> = None;
+            let chunk_start = global_idx - chunk.len() as u64;
             let mut cq = self.ring.completion();
             for _ in 0..total_sqes {
                 let cqe = cq.next()
@@ -319,18 +331,29 @@ impl Wal {
                         fsync_err = Some(cqe.result());
                     }
                 } else {
-                    let idx = user_data as usize;
-                    if cqe.result() < 0 {
-                        if write_err.is_none() {
-                            write_err = Some(cqe.result());
-                        }
-                    } else {
-                        let written = cqe.result() as usize;
-                        let expected = Self::align_up(chunk[idx].len());
-                        if written < expected {
-                            if write_err.is_none() {
-                                write_err = Some(-libc::EIO);
+                    // Validate that this CQE belongs to the current chunk.
+                    // Stale CQEs from a previous failed submission have
+                    // user_data outside the current chunk's range.
+                    let local_idx = user_data.checked_sub(chunk_start);
+                    match local_idx {
+                        Some(idx) if idx < chunk.len() as u64 => {
+                            if cqe.result() < 0 {
+                                if write_err.is_none() {
+                                    write_err = Some(cqe.result());
+                                }
+                            } else {
+                                let written = cqe.result() as usize;
+                                let expected = Self::align_up(chunk[idx as usize].len());
+                                if written < expected {
+                                    if write_err.is_none() {
+                                        write_err = Some(-libc::EIO);
+                                    }
+                                }
                             }
+                        }
+                        _ => {
+                            // Stale CQE from a previous submission — discard.
+                            log::warn!("io_uring: stale CQE with user_data={}", user_data);
                         }
                     }
                 }
@@ -340,6 +363,12 @@ impl Wal {
             // before bailing. Without the pool return, repeated errors
             // would exhaust the 16-buffer pool (buffers freed via Drop
             // are never returned to the ArrayQueue).
+            //
+            // CRITICAL: All CQEs for this chunk have already been polled
+            // above (the loop runs total_sqes times). This guarantees no
+            // in-flight SQEs remain before we return the buffers to the
+            // pool — returning buffers while SQEs are still in-flight
+            // would cause use-after-free when the kernel completes them.
             if write_err.is_some() || fsync_err.is_some() {
                 self.poisoned.store(true, Ordering::Release);
                 for buf in bufs {
@@ -601,7 +630,18 @@ fn maybe_preallocate(&self) -> Result<()> {
             )
         };
         if ret != 0 {
-            anyhow::bail!("fallocate failed: {}", std::io::Error::last_os_error());
+            let err = std::io::Error::last_os_error();
+            // EOPNOTSUPP/ENOSYS: filesystem doesn't support fallocate.
+            // Fall back to ftruncate — less optimal (may take exclusive
+            // inode lock on first write) but keeps the engine usable.
+            if err.raw_os_error() == Some(libc::EOPNOTSUPP)
+                || err.raw_os_error() == Some(libc::ENOSYS)
+            {
+                log::warn!("fallocate not supported, falling back to ftruncate: {}", err);
+                self.write_file.set_len(new_size)?;
+            } else {
+                anyhow::bail!("fallocate failed: {}", err);
+            }
         }
         self.preallocated_size.store(new_size, Ordering::Relaxed);
     }

--- a/rfcs/012-parallel-wal.md
+++ b/rfcs/012-parallel-wal.md
@@ -1,4 +1,4 @@
-# RFC 012: Parallel WAL — Ordered Commit with Piggyback Fsync
+# RFC 012: WAL Write Throughput — Parallel I/O via io_uring
 
 **Status:** Proposed
 **Date:** 2026-06-26
@@ -10,228 +10,242 @@
 ## 1. Summary
 
 This RFC proposes improving WAL write throughput by replacing the current
-group-commit leader-follower model with an **ordered commit sequencer** that
-piggybacks fsyncs. The key insight from the SpanDB paper is that `fsync` flushes
-all dirty pages for the entire file — so multiple batches written between two
-fsyncs get committed for free.
+synchronous leader-follower group commit with **io_uring-based parallel I/O**,
+inspired by the SpanDB paper's multi-logger design.
+
+The key insight: the current group commit already batches concurrent writers
+efficiently (1 fsync for N writers). The bottleneck is not fsync count, but
+**single-threaded I/O** — one leader writes all buffers sequentially. With
+io_uring, multiple writers submit I/O in parallel, and the kernel dispatches
+to NVMe channels concurrently.
 
 The design:
 
-1. **Atomic offset allocator** — each batch gets a sequential file offset via `fetch_add`.
-2. **Single writer** — batches are written sequentially to the WAL file (same as current).
-3. **Record checksum** — CRC32 per batch (already exists, unchanged).
-4. **Ordered commit sequencer** — batches are committed in order; fsync is skipped when a prior fsync already covered the data.
-5. **Recovery scan** — sequential scan, validate CRC, stop at first invalid entry (unchanged).
-
-This is Phase 1 of a two-phase plan. Phase 2 (future, RFC 002) adds io_uring
-for parallel I/O submission and kernel-level fsync batching.
+1. **Atomic offset allocator** — each batch gets a sequential file offset.
+2. **io_uring submission** — writers submit write SQEs at their allocated offsets.
+3. **Record checksum** — CRC32 per batch (unchanged).
+4. **Ordered commit** — writers poll for completion; fsync chained via `IOSQE_IO_LINK`.
+5. **Recovery scan** — sequential scan, validate CRC (unchanged).
 
 ---
 
 ## 2. Motivation
 
-### Current Bottleneck
+### Current Design Is Already Good
 
-The current WAL uses a single file with a leader-follower group commit:
-
-```
-Writer threads → ready_queue (SegQueue) → leader drains → BufWriter → fsync → wake followers
-```
-
-The bottleneck is **fsync** (50-100µs on NVMe, 1-10ms on SATA). Every batch
-triggers one fsync, even when multiple batches arrive between fsyncs:
+The current group commit (`wal.rs:878-977`) is well-designed:
 
 ```
-Time:   0µs        50µs       100µs      150µs
-        Batch 0    Batch 1    Batch 2    Batch 3
-        ───fsync─── ───fsync─── ───fsync─── ───fsync───
-        4 fsyncs for 4 batches = 200µs total
+8 concurrent writers → leader drains all 8 → 1 sequential write → 1 fsync → wake all
 ```
 
-### The Piggyback Insight
+This already achieves **1 fsync per N concurrent writers**. Under burst
+concurrency (the common case), the current design is efficient.
 
-`fsync` flushes **all** dirty pages for the file, not just the last write.
-If batches 0, 1, 2 are all written before the first fsync, one fsync covers all three:
+### Where It Falls Short
+
+The bottleneck is the **single leader thread** doing all the work:
 
 ```
-Time:   0µs        50µs       100µs
-        Batch 0    Batch 1    Batch 2
-        ───fsync───────────────────────
-        1 fsync for 3 batches = 50µs total (4× faster)
+Leader: drain queue → seek → write_all(buf[0]) → write_all(buf[1]) → ... → flush → fsync
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        All sequential, single thread, single file descriptor
 ```
 
-The sequencer ensures ordering: a batch is only committed after all prior
-batches are durably written. This prevents the race where a later batch's
-fsync completes before an earlier batch's write.
+With 8 writers each producing 4KB batches:
+- **Current:** 1 thread writes 32KB sequentially + 1 fsync ≈ 20µs + 50µs = 70µs
+- **io_uring:** 8 threads submit 8 SQEs + kernel writes in parallel to NVMe + 1 fsync ≈ 5µs + 50µs = 55µs
+
+The savings come from parallelizing the write I/O, not from reducing fsync count.
+
+### What About a Sequencer (Piggyback Fsync)?
+
+An earlier version of this RFC proposed replacing the leader-follower model with
+an "ordered commit sequencer" that piggybacks fsyncs. After review, this was
+found to be **not an improvement** over the current design:
+
+| Scenario | Current (group commit) | Sequencer |
+|----------|----------------------|-----------|
+| 8 writers arrive together | 1 leader drains all 8 → 1 fsync | 1 thread fsyncs, 7 piggyback → 1 fsync |
+| 1 writer arrives alone | 1 fsync | 1 fsync + sequencer overhead |
+| Writers arrive during fsync | New group forms → next leader does 1 fsync | Piggyback if offset already covered |
+
+**The fsync count is the same.** The sequencer adds complexity (atomic offset
+tracking, commit_mutex, condvar) without reducing fsyncs. The current leader
+election is simpler and equally efficient for batching.
+
+The sequencer also introduced critical correctness issues:
+- `written_offset` (allocated) ≠ "bytes in page cache" — data loss if fsync
+  claims bytes that were only reserved, not written.
+- BufWriter + seek defeats buffering (each seek flushes the internal buffer).
+- Missing `flush()` before `sync_all()` leaves data in userspace buffer.
+
+**Conclusion:** The sequencer is not the right optimization. The real win is
+io_uring, which parallelizes the I/O itself.
 
 ---
 
 ## 3. Goals
 
-1. Replace leader-follower group commit with an ordered commit sequencer.
-2. Piggyback fsyncs — skip fsync when a prior fsync already covered the data.
-3. No changes to the public `KvEngine` API.
-4. Backward compatible WAL file format (v3, unchanged).
-5. Recovery unchanged — sequential scan + CRC validation.
+1. Replace single-leader writes with parallel io_uring submissions.
+2. Maintain the existing WAL file format (v3, unchanged).
+3. Maintain the two-phase write protocol (`write_wal_batch_only` → `commit_wal` → `publish_raw_batch`).
+4. Recovery unchanged — sequential scan + CRC validation.
+5. Linux-only (gated by `cfg(target_os = "linux")`), with fallback to current design.
 
 ## 4. Non-Goals
 
-1. Parallel pwrite (deferred to Phase 2 with io_uring).
-2. Multiple WAL files / shards (unnecessary with piggyback fsync).
-3. SPDK integration.
-4. Changing the WAL file format.
+1. SPDK integration.
+2. Multiple WAL files / shards.
+3. Changing the WAL file format.
+4. io_uring for reads (separate concern).
 
 ---
 
 ## 5. Design
 
-### 5.1 Current vs Proposed
+### 5.1 Overview
 
-| Aspect | Current (Group Commit) | Proposed (Sequencer) |
-|--------|----------------------|---------------------|
-| Writer role | Push buffer, wait for leader | Push buffer, write, register with sequencer |
-| Leader | Drains queue, writes, fsyncs, wakes followers | No leader |
-| Fsync trigger | Every batch | Only when no prior fsync covers this batch |
-| Ordering | Implicit (leader writes in queue order) | Explicit (sequencer tracks committed offset) |
-| Followers | Block on condvar | Block on sequencer (check if prior batch committed) |
+```
+Current:
+  Writers → ready_queue → leader → BufWriter → write_all → flush → fsync → wake
 
-### 5.2 Sequencer State
+Proposed:
+  Writers → ready_queue → drain → allocate offsets → submit SQEs → io_uring_enter
+            → poll CQE completions → wake
+```
+
+The key change: instead of one leader writing all buffers sequentially, the
+drained buffers are submitted as parallel io_uring SQEs.
+
+### 5.2 io_uring Setup
 
 ```rust
-/// Tracks the commit state of the WAL.
-struct CommitSequencer {
-    /// Highest file offset that has been fsynced to disk.
-    synced_offset: AtomicU64,
-    /// Highest file offset that has been written (but not necessarily synced).
-    written_offset: AtomicU64,
-    /// Mutex + condvar for commit signaling.
-    commit_mutex: Mutex<()>,
-    commit_cond: Condvar,
+use io_uring::{opcode, types, IoUring};
+
+struct IoUringWal {
+    ring: IoUring,
+    file_fd: types::Fixed,
+    // ... other fields
 }
 ```
 
-### 5.3 Write + Commit Flow
+- Create an `IoUring` instance with a shared submission/completion queue.
+- Register the WAL file descriptor with `ring.submitter().register_files()`.
+- Use a fixed number of SQE slots (e.g., 64) to bound memory usage.
+
+### 5.3 Write Path
 
 ```rust
-fn write_and_commit(&self, buf: &[u8]) -> Result<()> {
-    // 1. Allocate file offset atomically.
-    let offset = self.sequencer.written_offset.fetch_add(
-        buf.len() as u64, Ordering::AcqRel
-    );
+fn write_and_commit(&self, bufs: &[Vec<u8>]) -> Result<()> {
+    let mut offset = self.alloc_offset(bufs);  // atomic fetch_add for total size
 
-    // 2. Write to file at allocated offset (single writer, sequential).
-    //    Currently: BufWriter under mutex (same as today).
-    //    Phase 2: io_uring SQE submission (parallel).
-    {
-        let mut file = self.file.lock();
-        file.seek(SeekFrom::Start(offset))?;
-        file.write_all(buf)?;
+    // Submit one SQE per buffer (parallel I/O).
+    for buf in bufs {
+        let write_e = opcode::Write::new(self.file_fd, buf.as_ptr(), buf.len() as u32)
+            .offset(offset)
+            .build()
+            .user_data(offset as u64);  // tag with offset for completion tracking
+
+        unsafe { self.ring.submission().push(&write_e)?; }
+        offset += buf.len() as u64;
     }
 
-    // 3. Register with sequencer and commit.
-    self.sequencer.commit(offset + buf.len() as u64)
-}
-```
+    // Chain fsync after the last write.
+    let fsync_e = opcode::Fsync::new(self.file_fd)
+        .build()
+        .user_data(FSYNC_TOKEN);
 
-### 5.4 Sequencer Commit Logic
+    unsafe { self.ring.submission().push(&fsync_e)?; }
 
-```rust
-impl CommitSequencer {
-    fn commit(&self, my_end_offset: u64) -> Result<()> {
-        // Wait for all prior batches to be committed.
-        let mut guard = self.commit_mutex.lock();
-        while self.synced_offset.load(Ordering::Acquire) < my_end_offset {
-            // Check if we need to fsync.
-            let synced = self.synced_offset.load(Ordering::Acquire);
-            let written = self.written_offset.load(Ordering::Acquire);
+    // Submit all SQEs in one syscall.
+    self.ring.submit_and_wait(bufs.len() + 1)?;
 
-            // If there are unwritten-or-unsynced bytes before us, we may need
-            // to fsync. But only the first thread in a contiguous group does it.
-            if synced < my_end_offset {
-                // Fsync — this covers ALL dirty pages, including prior batches.
-                self.file.lock().sync_all()?;
-
-                // Advance synced_offset to cover all written data.
-                // This wakes all waiters whose batches are now durable.
-                self.synced_offset.store(written, Ordering::Release);
-                self.commit_cond.notify_all();
-                return Ok(());
-            }
-
-            // Another thread is fsyncing for us — wait.
-            self.commit_cond.wait(&mut guard);
+    // Poll for completions.
+    for _ in 0..bufs.len() + 1 {
+        let cqe = self.ring.completion().next()
+            .ok_or_else(|| anyhow!("io_uring: missing CQE"))?;
+        if cqe.result() < 0 {
+            anyhow::bail!("io_uring I/O error: {}", cqe.result());
         }
+    }
 
-        // Our batch was already covered by a prior fsync.
-        Ok(())
+    Ok(())
+}
+```
+
+### 5.4 Atomic Offset Allocator
+
+```rust
+struct OffsetAllocator {
+    next_offset: AtomicU64,
+}
+
+impl OffsetAllocator {
+    fn alloc(&self, size: u64) -> u64 {
+        self.next_offset.fetch_add(size, Ordering::AcqRel)
     }
 }
 ```
 
-### 5.5 How Piggyback Works
+Each batch gets a unique, sequential file region. The allocator is updated
+**before** submission, but the I/O is submitted in parallel. The completion
+poll ensures all data is on disk before returning.
 
-Example with 3 concurrent writers:
+**Key difference from the sequencer design:** The offset allocator only tracks
+"where to write." The actual durability is confirmed by CQE completion, not by
+a `synced_offset` atomic. This avoids the data-loss bug in the sequencer design.
 
-```
-Writer A: offset=0,   len=100  → pwrite 0-100   → commit(100)
-Writer B: offset=100, len=50   → pwrite 100-150  → commit(150)
-Writer C: offset=150, len=80   → pwrite 150-230  → commit(230)
+### 5.5 Ordered Commit
 
-Sequencer state: synced_offset=0, written_offset=230
+Ordering is maintained by the file offset allocation:
+- Buffers are drained from `ready_queue` in FIFO order (same as current).
+- Each buffer gets a sequential offset (atomic fetch_add).
+- io_uring writes them in parallel, but the offsets guarantee non-overlapping regions.
+- Fsync is chained after the last write, so all data is durable when the CQE arrives.
 
-Writer A arrives at commit(100):
-  synced_offset (0) < my_end_offset (100) → fsync
-  fsync flushes pages 0-230 (all dirty data)
-  synced_offset = 230 (written_offset)
-  notify_all
-  → Writer A returns ✓
+### 5.6 Two-Phase Protocol (Unchanged)
 
-Writer B arrives at commit(150):
-  synced_offset (230) >= my_end_offset (150) → already committed
-  → Writer B returns immediately ✓ (no fsync)
-
-Writer C arrives at commit(230):
-  synced_offset (230) >= my_end_offset (230) → already committed
-  → Writer C returns immediately ✓ (no fsync)
-
-Result: 1 fsync for 3 batches (vs 3 fsyncs in current design)
-```
-
-### 5.6 The Ordering Race (Why Sequencer Is Needed)
-
-Without the sequencer, a dangerous race exists:
+The existing two-phase write protocol is preserved:
 
 ```
-Writer C: pwrite at 150 → fsync → returns to caller (thinks data is safe)
-Writer A: pwrite at 0   → NOT DONE YET
-  crash → Batch 0 lost, but Writer C's caller was told it's safe ✗
+Phase 1 (under locks):
+  write_wal_batch_only() → encode buffer, push to ready_queue
+
+Phase 2 (locks released):
+  commit_wal() → drain ready_queue → submit io_uring SQEs → poll completions → wake
 ```
 
-With the sequencer:
+The ready_queue survives as the buffer staging area between lock release and
+io_uring submission. This is the same role it plays today — the only change is
+how the leader writes the drained buffers.
 
+### 5.7 Buffer Pool (Unchanged)
+
+The buffer pool (`ArrayQueue<Vec<u8>>`) lifecycle is unchanged:
+1. `put_batch()` pops from pool, encodes, pushes to ready_queue.
+2. After io_uring completions are polled, buffers are returned to the pool.
+
+### 5.8 Recovery (Unchanged)
+
+Recovery scans the WAL file sequentially, validates CRC per batch, and stops
+at the first invalid entry. The WAL file format is unchanged — io_uring writes
+the same bytes to the same offsets as the current `BufWriter::write_all`.
+
+### 5.9 Fallback
+
+On non-Linux platforms (or kernels < 5.6), fall back to the current
+leader-follower group commit. Gated by:
+
+```rust
+#[cfg(target_os = "linux")]
+mod io_uring_wal { ... }
+
+#[cfg(not(target_os = "linux"))]
+mod io_uring_wal {
+    // Re-export current group commit as fallback.
+}
 ```
-Writer C: pwrite at 150 → commit(230) → waits for synced_offset >= 230
-Writer A: pwrite at 0   → commit(100) → fsync → synced_offset = 230
-  → Writer C's commit(230) satisfied → returns ✓
-  → All data 0-230 is on disk before either caller returns ✓
-```
-
-The rule: **a batch is committed only after all prior bytes are fsynced**.
-
-### 5.7 Recovery
-
-No changes. Recovery scans the file sequentially:
-
-1. Read batch header (commit_ts, entry_count, crc32).
-2. Validate CRC32 over entry data.
-3. If valid, replay entries into skiplist.
-4. If invalid (CRC mismatch, truncated), stop — this is the recovery point.
-5. Truncate file to last valid byte.
-
-This works because:
-- Batches are written in offset order (atomic allocator guarantees this).
-- The sequencer ensures all bytes up to `synced_offset` are on disk.
-- On crash, bytes beyond `synced_offset` may be partial — CRC catches this.
 
 ---
 
@@ -239,79 +253,59 @@ This works because:
 
 ### Advantages
 
-1. **Fewer fsyncs** — Under concurrency, multiple batches piggyback on one fsync. The higher the concurrency, the bigger the win.
-2. **Simpler code** — No leader election, no condvar wake-up storms, no batch results ring buffer. Just atomic offset + sequencer.
-3. **No new files** — Single WAL file, same format, same recovery.
-4. **Phase 2 ready** — The atomic offset allocator maps directly to io_uring SQE offsets.
+1. **Parallel I/O** — Multiple buffers written simultaneously to NVMe channels.
+2. **Reduced syscall overhead** — Single `io_uring_enter` for N submissions vs N `write_all` syscalls.
+3. **Near-SPDK latency** — io_uring poll mode eliminates kernel transition overhead.
+4. **No correctness risks** — CQE completion confirms durability. No `synced_offset` race.
+5. **Minimal code change** — Only the write+commit path changes. Recovery, buffer pool, two-phase protocol all unchanged.
 
 ### Disadvantages
 
-1. **Single writer still** — Batches are written sequentially under the file mutex. Same as current design. (Phase 2 with io_uring adds parallel writes.)
-2. **Fsync latency unchanged** — Each fsync still takes 50-100µs on NVMe. The win is fewer fsyncs, not faster fsyncs.
-3. **Low concurrency regression risk** — With 1 writer, every batch fsyncs (same as now). The sequencer overhead (atomic ops, mutex) is pure overhead. Mitigation: short-circuit when `num_writers == 1`.
+1. **Linux-only** — Requires kernel 5.6+. Fallback needed for other platforms.
+2. **Complexity** — io_uring's SQE/CQE model is more complex than `write_all` + `fsync`.
+3. **Debugging** — Async I/O errors are harder to diagnose than synchronous ones.
+4. **Marginal gain for small writes** — The overhead of io_uring setup may exceed savings for very small batches.
 
 ### When It Helps Most
 
-- **High concurrency** (4+ writer threads) — more batches arrive between fsyncs.
-- **Fast NVMe** — fsync is cheap but not free; fewer fsyncs = less total time.
-- **Small batches** — each batch's write time is negligible; fsync dominates.
+- Fast NVMe SSDs with internal parallelism.
+- High concurrency (many writer threads).
+- Moderate to large batch sizes (4KB+).
 
 ### When It Helps Least
 
-- **Single writer** — no batching opportunity; sequencer overhead is wasted.
-- **SATA/HDD** — fsync is so slow (1-10ms) that the software overhead is negligible.
+- SATA SSDs or HDDs (I/O latency dominates).
+- Single writer (no parallelism to exploit).
+- Very small batches (io_uring overhead > savings).
 
 ---
 
-## 7. Phase 2: io_uring (Future, RFC 002)
-
-Phase 2 replaces the sequential write under mutex with parallel io_uring submissions:
-
-```
-Phase 1 (this RFC):
-  Writer A: lock → seek → write_all → unlock → commit
-  Writer B: lock → seek → write_all → unlock → commit   (serialized)
-
-Phase 2 (RFC 002):
-  Writer A: submit SQE [write@0]   → commit (poll CQE)
-  Writer B: submit SQE [write@100] → commit (poll CQE)   (parallel)
-```
-
-Benefits of Phase 2:
-- **No file mutex** — io_uring ring is lock-free (MPSC queue).
-- **Parallel writes** — kernel dispatches to NVMe channels.
-- **Linked SQEs** — chain write→fsync, kernel handles sequencing.
-- **Poll mode** — near-SPDK latency without SPDK's access restrictions.
-
-The atomic offset allocator from Phase 1 is reused directly as the SQE offset.
-
----
-
-## 8. Implementation Plan
+## 7. Implementation Plan
 
 | Phase | Description | Files |
 |-------|-------------|-------|
-| 1 | Add `CommitSequencer` struct to `wal.rs` | `wal.rs` |
-| 2 | Replace `submit_and_commit()` with sequencer-based commit | `wal.rs` |
-| 3 | Remove leader-follower group commit code | `wal.rs` |
-| 4 | Add short-circuit for single-writer case | `wal.rs` |
-| 5 | Add tests | `tests/wal.rs` |
-| 6 | Benchmark: `write-perf --workload wal_concurrent` | — |
+| 1 | Add `io-uring` dependency (feature-gated) | `Cargo.toml` |
+| 2 | Implement `IoUringWal` write path | `wal.rs` |
+| 3 | Integrate with existing `submit_and_commit()` | `wal.rs` |
+| 4 | Add fallback to current group commit | `wal.rs` |
+| 5 | Benchmark: `write-perf --workload wal_concurrent` | — |
+| 6 | Add tests | `tests/wal.rs` |
 
 ---
 
-## 9. Testing Strategy
+## 8. Testing Strategy
 
 1. **Correctness:** All existing WAL tests pass (format unchanged).
-2. **Piggyback:** Verify that concurrent writers trigger fewer fsyncs (instrument with counter).
-3. **Ordering:** Crash-injection test — verify no batch is committed before prior batches are durable.
-4. **Single writer:** Verify no regression (short-circuit path).
-5. **Benchmark:** `write-perf --workload wal_concurrent --threads 1,2,4,8` — compare vs current group commit.
+2. **io_uring path:** Test with `cfg(target_os = "linux")` — write, read back, verify.
+3. **Fallback path:** Test with forced fallback — same correctness guarantees.
+4. **Benchmark:** `write-perf --workload wal_concurrent --threads 1,2,4,8` — compare io_uring vs fallback.
+5. **Stress test:** High concurrency (16+ threads) with crash injection.
 
 ---
 
-## 10. Open Questions
+## 9. Open Questions
 
-1. **Mutex vs RwLock for file access:** The file is currently under `Mutex`. With the sequencer, only one writer writes at a time (sequential), so `Mutex` is correct. Phase 2 (io_uring) removes the mutex entirely.
-2. **BufWriter retention:** Should we keep `BufWriter` or switch to raw `File`? `BufWriter` batches small writes into larger ones, reducing syscall count. Recommendation: keep `BufWriter` for Phase 1, switch to raw `File` with io_uring in Phase 2.
-3. **Fsync batching window:** Should we add a small delay (e.g., 10µs) to let more writers arrive before fsyncing? This trades latency for throughput. Recommendation: no delay for Phase 1 — the sequencer already batches naturally under concurrency.
+1. **io_uring ring size:** How many SQE slots? Recommendation: 64 (matches typical max concurrent batches).
+2. **Poll mode:** Should we use `IORING_SETUP_SQPOLL` for kernel-side polling? Trade-off: lower latency vs higher CPU usage. Recommendation: start without poll mode, add as optimization.
+3. **Fixed buffers:** Should we register fixed buffers (`IORING_REGISTER_BUFFERS`) to avoid per-SQE buffer setup? Recommendation: not in initial implementation — the variable-sized WAL batches make fixed buffers awkward.
+4. **Kernel version:** Minimum 5.6 for basic io_uring. 5.11+ for `IORING_OP_FSYNC`. 5.19+ for `IORING_SETUP_SINGLE_ISSUER` (optimization). Recommendation: target 5.11+.

--- a/rfcs/012-parallel-wal.md
+++ b/rfcs/012-parallel-wal.md
@@ -68,9 +68,10 @@ kernel dispatches SQEs to different NVMe submission queues concurrently.
 2. Parallel write I/O to the NVMe device.
 3. Single fsync per batch group via `IOSQE_IO_DRAIN`.
 4. Maintain the two-phase write protocol (`write_wal_batch_only` → `commit_wal`).
-5. Backward compatible WAL file format (v3, unchanged).
+5. Backward compatible WAL file format — v3 files still readable; new v4
+   format adds `data_len` field for O_DIRECT alignment-gap skipping.
 6. Recovery compatible — sequential scan + CRC validation, with alignment-gap
-   skipping for O_DIRECT padded batches.
+   skipping for v4 O_DIRECT padded batches.
 
 ## 4. Non-Goals
 
@@ -78,10 +79,10 @@ kernel dispatches SQEs to different NVMe submission queues concurrently.
 2. SPDK integration.
 3. io_uring for reads (separate concern).
 
-**Note:** The WAL file format gains a 4-byte `encoded_len` field in the batch
-header (§5.10). This is backward compatible — old batches without the field
-are handled by recovery. The format version (v3) is unchanged because the
-new field is within the existing header padding.
+**Note:** The WAL file format gains a 4-byte `data_len` field in the batch
+header (§5.10), introduced as `WAL_FORMAT_VERSION_V4`. Old v3 files (16-byte
+headers) are still readable. New batches are written with v4 headers. The
+version is stored in the WAL file header and detected by recovery.
 
 ---
 
@@ -300,37 +301,46 @@ impl Wal {
         //    Calling ring.completion() in a loop creates and drops a new
         //    CompletionQueue on each iteration, triggering a kernel sync
         //    per iteration (the Drop impl commits the shared head pointer).
-        //    Also, match CQEs by user_data tag, not by position — io_uring
-        //    does not guarantee completion order.
+        //    Process ALL CQEs in a single loop, checking user_data to
+        //    distinguish write CQEs (tagged with buffer index) from the
+        //    fsync CQE (tagged with u64::MAX). io_uring does not guarantee
+        //    completion order — the fsync CQE may arrive before writes.
         let mut write_err: Option<i32> = None;
+        let mut fsync_err: Option<i32> = None;
         let mut cq = self.ring.completion();
-        for _ in 0..bufs.len() {
+        for _ in 0..total_sqes {
             let cqe = cq.next()
-                .ok_or_else(|| anyhow!("io_uring: missing write CQE"))?;
-            let idx = cqe.user_data() as usize;
-            if cqe.result() < 0 {
-                if write_err.is_none() {
-                    write_err = Some(cqe.result());
+                .ok_or_else(|| anyhow!("io_uring: missing CQE"))?;
+            let user_data = cqe.user_data();
+            if user_data == u64::MAX {
+                // This is the fsync CQE.
+                if cqe.result() < 0 {
+                    fsync_err = Some(cqe.result());
                 }
             } else {
-                let written = cqe.result() as usize;
-                let expected = Self::align_up(bufs[idx].len());
-                if written < expected {
+                // This is a write CQE — user_data is the buffer index.
+                let idx = user_data as usize;
+                if cqe.result() < 0 {
                     if write_err.is_none() {
-                        write_err = Some(-libc::EIO);
+                        write_err = Some(cqe.result());
+                    }
+                } else {
+                    let written = cqe.result() as usize;
+                    let expected = Self::align_up(bufs[idx].len());
+                    if written < expected {
+                        if write_err.is_none() {
+                            write_err = Some(-libc::EIO);
+                        }
                     }
                 }
             }
         }
-        // Fsync CQE — always poll it, even if writes failed.
-        let fsync_cqe = cq.next()
-            .ok_or_else(|| anyhow!("io_uring: missing fsync CQE"))?;
         drop(cq);  // explicit drop for clarity
         if let Some(err) = write_err {
             anyhow::bail!("io_uring write error: {}", err);
         }
-        if fsync_cqe.result() < 0 {
-            anyhow::bail!("io_uring fsync error: {}", fsync_cqe.result());
+        if let Some(err) = fsync_err {
+            anyhow::bail!("io_uring fsync error: {}", err);
         }
 
         // 7. Return buffers to pool.
@@ -388,9 +398,12 @@ struct CompletionInner {
 
 impl Wal {
     pub fn submit_and_commit(&self) -> Result<()> {
-        // Record the generation BEFORE draining pending.
-        // If our data is taken by another thread, we wait for a result
-        // at this generation or later.
+        // Serialize the drain-or-wait decision to prevent TOCTOU races.
+        // Without this lock, two threads could both drain pending (one gets
+        // bufs, the other gets empty) and both proceed — one submits I/O
+        // while the other returns Ok() before the data is durable.
+        let _submit_guard = self.submission_lock.lock();
+
         let my_generation = {
             let state = self.completion_state.mutex.lock();
             state.generation
@@ -412,10 +425,14 @@ impl Wal {
                 }
             }
             // Wait for the completion signal at our generation.
+            // Drop the submit guard to allow the active submitter to proceed.
+            drop(_submit_guard);
             return self.wait_for_completion(my_generation);
         }
 
         // I am the submitter — mark in-flight and do the I/O.
+        // submission_lock prevents any other thread from entering this path
+        // until we finish and signal.
         {
             let mut state = self.completion_state.mutex.lock();
             state.in_flight = true;
@@ -586,24 +603,45 @@ Each batch has a CRC32 checksum over the entry data (existing `BATCH_HEADER_SIZE
 = 16 bytes: commit_ts + entry_count + data_crc32). O_DIRECT does not affect
 the checksum — it covers only the valid bytes (before zero-padding).
 
-**New field: `encoded_len`** (4 bytes, added after `data_crc32`). Stores the
-unpadded encoded size of the batch (header + entries, excluding alignment
-padding). Recovery uses this to skip to the next 4KB boundary after reading
-a batch, preventing padding bytes from being misinterpreted as batch headers.
+**New field: `data_len`** (4 bytes, added after `data_crc32`). Stores the
+**data-only** size of the batch (entries only, excluding the header and
+alignment padding). Recovery uses this to skip to the next 4KB boundary
+after reading a batch, preventing padding bytes from being misinterpreted
+as batch headers.
+
+**Backward compatibility:** The new header is 20 bytes, introduced as
+`WAL_FORMAT_VERSION_V4`. Old v3 files (16-byte headers) are still supported —
+recovery detects the version from the WAL file header and uses the
+corresponding header size. New batches are always written with v4 headers.
 
 ```
-BATCH_HEADER_SIZE = 20 bytes (was 16):
+WAL_FORMAT_VERSION_V4: BATCH_HEADER_SIZE = 20 bytes (was 16 in v3):
   commit_ts:     u64   (8 bytes)
   entry_count:   u16   (2 bytes)
   data_crc32:    u32   (4 bytes)
-  encoded_len:   u32   (4 bytes)  ← NEW
+  data_len:      u32   (4 bytes)  ← NEW (data-only, excludes header)
   reserved:      u16   (2 bytes)  ← padding to 20 bytes
+
+WAL_FORMAT_VERSION_V3: BATCH_HEADER_SIZE = 16 bytes (unchanged):
+  commit_ts:     u64   (8 bytes)
+  entry_count:   u16   (2 bytes)
+  data_crc32:    u32   (4 bytes)
+  reserved:      u16   (2 bytes)
 ```
 
-The CRC covers `commit_ts + entry_count + data_crc32` (unchanged). `encoded_len`
+The CRC covers `commit_ts + entry_count + data_crc32` (unchanged). `data_len`
 is outside the CRC — it is an optimization hint for recovery, not a data
-integrity field. An incorrect `encoded_len` causes recovery to skip incorrectly and
-fail CRC on the next batch, which is safe (truncation, not corruption).
+integrity field. An incorrect `data_len` causes recovery to skip incorrectly
+and fail CRC on the next batch, which is safe (truncation, not corruption).
+
+**Recovery offset calculation (v4):**
+```rust
+let total_batch_size = BATCH_HEADER_SIZE + batch.data_len as usize;
+let aligned_size = align_up(total_batch_size);
+next_offset = current_offset + aligned_size;
+```
+
+This does NOT double-count the header because `data_len` is data-only.
 
 ### 5.11 Recovery Scan (Modified)
 
@@ -612,13 +650,18 @@ validates CRC per batch, and stops at the first invalid entry. The WAL file
 format is backward compatible — old batches without `encoded_len` are handled
 as before (sequential scan).
 
-**Alignment-gap skipping:** After reading a valid batch, recovery advances
-the read offset to the next 4KB boundary using `encoded_len`:
+**Alignment-gap skipping (v4):** After reading a valid batch, recovery advances
+the read offset to the next 4KB boundary using `data_len`:
 
 ```rust
-let aligned_len = align_up(BATCH_HEADER_SIZE + batch.encoded_len as usize);
-offset += aligned_len;
+let total_batch_size = BATCH_HEADER_SIZE + batch.data_len as usize;
+let aligned_size = align_up(total_batch_size);
+offset += aligned_size;
 ```
+
+**v3 fallback:** Old v3 batches don't have `data_len`. Recovery uses the
+existing sequential scan (header + entry_count-based parsing) for v3 files.
+The alignment-gap skipping only applies to v4+ batches written with O_DIRECT.
 
 This prevents trailing zero-padding bytes from being combined with the next
 batch's header, which would fail CRC and cause truncation.

--- a/rfcs/012-parallel-wal.md
+++ b/rfcs/012-parallel-wal.md
@@ -1,0 +1,330 @@
+# RFC 012: Parallel WAL with Multiple Loggers
+
+**Status:** Proposed
+**Date:** 2026-06-26
+**Author:** kv-engine Contributors
+**Reference:** SpanDB (FAST 2021) — "SpanDB: A Fast, Cost-Effective LSM-tree Based KV Store on Hybrid Storage"
+
+---
+
+## 1. Summary
+
+This RFC proposes adding parallel WAL (Write-Ahead Log) logging to kv-engine,
+inspired by the SpanDB paper's multi-logger design. Instead of a single WAL file
+per memtable with one leader thread performing all writes and fsyncs, the engine
+would maintain N independent WAL shards per memtable, each with its own file,
+buffer pool, and group commit mechanism. Writers are distributed across shards
+using round-robin assignment, allowing multiple fsyncs to proceed in parallel.
+
+The design provides:
+
+1. N parallel WAL loggers per memtable (configurable, default 1 for backward compatibility).
+2. Independent group commit per shard — concurrent writers on different shards do not block each other.
+3. Parallel fsync across all shards during `submit_and_commit()`.
+4. Full backward compatibility — single-shard mode uses the existing WAL file format and naming.
+5. Compatible with MVCC, vLog, compaction, and all existing WAL features.
+
+---
+
+## 2. Motivation
+
+### Current Bottleneck
+
+The current WAL implementation (`wal.rs`) uses a single file per memtable with a
+group-commit mechanism:
+
+```
+Writer threads → ready_queue (SegQueue) → leader drains → BufWriter → fsync
+                                                    ↑
+                                          single file Mutex
+```
+
+Under high concurrency, this creates a bottleneck:
+
+- **Single writer:** One leader thread serially writes all batched buffers and fsyncs.
+- **Mutex contention:** The file Mutex is held during the entire drain + write + fsync cycle.
+- **Followers wait:** All non-leader threads block on the condvar until the leader finishes.
+
+The SpanDB paper measured that RocksDB spends **81% of write request time** waiting
+on the synchronous group logging path when using Optane via SPDK. While this engine
+uses standard filesystem I/O (not SPDK), the same principle applies: the single-writer
+bottleneck limits throughput under high concurrency.
+
+### What Parallel WAL Achieves
+
+With N shards, N groups of writers can commit simultaneously:
+
+```
+Shard 0: writers → ready_queue_0 → leader_0 → write → fsync  ─┐
+Shard 1: writers → ready_queue_1 → leader_1 → write → fsync  ─┤ parallel
+Shard 2: writers → ready_queue_2 → leader_2 → write → fsync  ─┘
+```
+
+Benefits:
+- **Pipelining:** While shard A fsyncs, shard B collects new writes.
+- **Reduced contention:** Writers on different shards never contend on the same mutex.
+- **SSD parallelism:** NVMe SSDs have internal parallelism (multiple channels); parallel fsyncs on different files can utilize this.
+
+The paper's "3L3R" configuration (3 loggers × 3 concurrent requests) achieved
+peak WAL throughput on Intel Optane.
+
+---
+
+## 3. Goals
+
+1. Implement N parallel WAL shards per memtable, each with independent group commit.
+2. Keep backward compatibility — `num_wal_shards=1` uses the existing `{id:05}.wal` format.
+3. No changes to the public `KvEngine` API.
+4. Recovery must correctly merge entries from all shards.
+5. WAL cleanup (during flush) must delete all shard files.
+6. Configuration via `LsmStorageOptions::num_wal_shards`.
+
+## 4. Non-Goals
+
+1. SPDK integration (separate concern, see RFC 002 for io_uring).
+2. Changing the WAL file format — each shard uses the existing v3 format.
+3. Cross-shard ordering — MVCC timestamps handle correctness.
+4. Dynamic shard count — fixed at engine creation time.
+
+---
+
+## 5. Design
+
+### 5.1 New `ParallelWal` Struct
+
+```rust
+pub struct ParallelWal {
+    /// N independent WAL shards.
+    shards: Vec<Wal>,
+    /// Atomic counter for round-robin shard assignment.
+    next_shard: AtomicUsize,
+}
+```
+
+Each shard is a full `Wal` instance with its own:
+- File (`Arc<Mutex<BufWriter<File>>>`)
+- Buffer pool (`ArrayQueue<Vec<u8>>`, 16 × 64KB)
+- Ready queue (`SegQueue<Vec<u8>>`)
+- Group commit state (`commit_waiters`, `committed_gen`, `leader_active`, etc.)
+
+### 5.2 WAL File Naming
+
+| Shard Count | File Names |
+|-------------|-----------|
+| 1 (default) | `{id:05}.wal` (unchanged) |
+| N > 1 | `{id:05}.wal.0`, `{id:05}.wal.1`, ..., `{id:05}.wal.{N-1}` |
+
+### 5.3 Write Path
+
+```rust
+impl ParallelWal {
+    pub fn put_batch(&self, data: &[(&[u8], &[u8])], commit_ts: u64) -> Result<()> {
+        let shard_idx = self.next_shard.fetch_add(1, Ordering::Relaxed) % self.shards.len();
+        self.shards[shard_idx].put_batch(data, commit_ts)
+    }
+
+    pub fn put_range_tombstone_batch(
+        &self,
+        tombstones: &[(&[u8], &[u8])],
+        commit_ts: u64,
+    ) -> Result<()> {
+        let shard_idx = self.next_shard.fetch_add(1, Ordering::Relaxed) % self.shards.len();
+        self.shards[shard_idx].put_range_tombstone_batch(tombstones, commit_ts)
+    }
+}
+```
+
+Each batch is written to exactly one shard. The round-robin distribution ensures
+even load across shards.
+
+### 5.4 Group Commit (Parallel Fsync)
+
+```rust
+impl ParallelWal {
+    pub fn submit_and_commit(&self) -> Result<()> {
+        if self.shards.len() == 1 {
+            return self.shards[0].submit_and_commit();
+        }
+
+        // Trigger all shards' group commits in parallel.
+        let results: Vec<Result<()>> = std::thread::scope(|s| {
+            let handles: Vec<_> = self.shards.iter()
+                .map(|shard| s.spawn(|| shard.submit_and_commit()))
+                .collect();
+            handles.into_iter()
+                .map(|h| h.join().unwrap_or_else(|_| anyhow::bail!("shard panic")))
+                .collect()
+        });
+
+        // Return Ok only if all shards succeeded.
+        for r in results {
+            r?;
+        }
+        Ok(())
+    }
+}
+```
+
+Key points:
+- Each shard's `submit_and_commit()` runs independently — writers on shard 0 do not wait for shard 1.
+- The `submit_and_commit()` call returns only when ALL shards have fsynced.
+- If any shard fails, the error is propagated.
+
+### 5.5 Recovery
+
+```rust
+impl ParallelWal {
+    pub fn recover(
+        base_path: impl AsRef<Path>,
+        num_shards: usize,
+        skiplist: &SkipMap<Bytes, Bytes>,
+    ) -> Result<(Self, u64)> {
+        let mut shards = Vec::with_capacity(num_shards);
+        let mut max_ts: u64 = 0;
+
+        for i in 0..num_shards {
+            let shard_path = if num_shards == 1 {
+                base_path.as_ref().to_path_buf()
+            } else {
+                PathBuf::from(format!("{}.{}", base_path.as_ref().display(), i))
+            };
+
+            if shard_path.exists() {
+                let (wal, ts) = Wal::recover(&shard_path, skiplist)?;
+                shards.push(wal);
+                max_ts = max_ts.max(ts);
+            } else {
+                // Shard file doesn't exist — create a new one.
+                shards.push(Wal::create(&shard_path)?);
+            }
+        }
+
+        Ok((Self {
+            shards,
+            next_shard: AtomicUsize::new(0),
+        }, max_ts))
+    }
+}
+```
+
+Recovery correctness:
+- Each shard is recovered independently using the existing `Wal::recover()` / `Wal::recover_with_range_tombstones()`.
+- All shards replay into the same skiplist. Since the skiplist is a concurrent
+  `SkipMap`, this is safe — MVCC timestamps handle ordering.
+- `max_ts` is the maximum across all shards.
+
+### 5.6 MemTable Integration
+
+The `MemTable` struct changes from `wal: Option<Wal>` to `wal: Option<ParallelWal>`:
+
+```rust
+pub struct MemTable {
+    // ...
+    wal: Option<ParallelWal>,  // was: Option<Wal>
+    // ...
+}
+```
+
+Methods updated:
+- `create_with_wal()` → `ParallelWal::create(path, num_shards)`
+- `write_wal_batch()` → `wal.put_batch()` (round-robin internally)
+- `commit_wal()` → `wal.submit_and_commit()` (parallel across shards)
+- `recover_from_wal()` → `ParallelWal::recover(path, num_shards, skiplist)`
+
+### 5.7 WAL Cleanup
+
+During flush (`force_flush_next_imm_memtable`), delete all shard files:
+
+```rust
+fn cleanup_wal_files(path: &Path, id: usize, num_shards: usize) {
+    if num_shards <= 1 {
+        let wal_path = path.join(format!("{id:05}.wal"));
+        let _ = std::fs::remove_file(wal_path);
+    } else {
+        for i in 0..num_shards {
+            let wal_path = path.join(format!("{id:05}.wal.{i}"));
+            let _ = std::fs::remove_file(wal_path);
+        }
+    }
+}
+```
+
+### 5.8 Configuration
+
+Add to `LsmStorageOptions`:
+
+```rust
+pub struct LsmStorageOptions {
+    // ... existing fields ...
+    /// Number of WAL shards per memtable. Default: 1 (single WAL, backward compatible).
+    /// Values > 1 enable parallel WAL logging (recommended: 2-4 for NVMe SSDs).
+    pub num_wal_shards: usize,
+}
+```
+
+Default: `1` — no behavior change for existing users.
+
+---
+
+## 6. Trade-offs
+
+### Advantages
+
+1. **Parallel fsync** — Multiple shards fsync simultaneously, utilizing NVMe internal parallelism.
+2. **Pipelining** — While one shard fsyncs, others collect writes.
+3. **Reduced contention** — Writers on different shards never share a mutex.
+4. **Simple per-shard logic** — Each shard reuses the existing, well-tested `Wal` implementation.
+5. **Backward compatible** — `num_wal_shards=1` is identical to current behavior.
+
+### Disadvantages
+
+1. **Multiple files per memtable** — N WAL files instead of 1. Increases file descriptor usage.
+2. **Recovery complexity** — Must read and merge N files instead of 1.
+3. **No cross-shard ordering guarantee** — Relies on MVCC timestamps for correctness.
+4. **SSD firmware serialization** — On some SSDs, parallel fsyncs may be serialized by the firmware. The pipelining benefit still applies.
+5. **Increased disk space** — Each shard has its own WAL header and padding.
+
+### When It Helps Most
+
+- High concurrency writes (many writer threads).
+- Fast NVMe SSDs where fsync latency is low but the software overhead dominates.
+- Workloads where the single-writer group commit is the bottleneck.
+
+### When It Helps Least
+
+- Low concurrency (1-2 writer threads) — little contention to eliminate.
+- SATA SSDs or HDDs — I/O latency dominates, not software overhead.
+- Small memtables — frequent freezes negate the batching benefit.
+
+---
+
+## 7. Implementation Plan
+
+| Phase | Description | Files |
+|-------|-------------|-------|
+| 1 | Add `ParallelWal` struct to `wal.rs` | `wal.rs` |
+| 2 | Add `ParallelWal::recover()` and `recover_with_range_tombstones()` | `wal.rs` |
+| 3 | Update `MemTable` to use `ParallelWal` | `mem_table.rs` |
+| 4 | Update `lsm_storage.rs` recovery path | `lsm_storage.rs` |
+| 5 | Update WAL cleanup to delete all shard files | `lsm_storage.rs` |
+| 6 | Add `num_wal_shards` to `LsmStorageOptions` | `lsm_storage.rs` |
+| 7 | Add tests | `tests/wal.rs` |
+
+---
+
+## 8. Testing Strategy
+
+1. **Backward compatibility:** All existing tests pass with `num_wal_shards=1`.
+2. **Multi-shard write/read:** Write with `num_wal_shards=2` and `4`, verify all data readable.
+3. **Concurrent writers:** Multiple threads writing to the engine with parallel WAL.
+4. **Recovery:** Write with N shards, close engine, reopen, verify all data.
+5. **Mixed workloads:** put + delete + delete_range with parallel WAL.
+6. **Benchmark:** `write-perf --workload wal_concurrent --threads 8` with varying shard counts.
+
+---
+
+## 9. Open Questions
+
+1. **Optimal shard count:** The paper uses 3 loggers for Optane. Should we default to 2 or 4? Recommendation: 2 for NVMe, 1 for SATA/HDD.
+2. **Rayon vs std::thread::scope:** For parallel fsync, should we use rayon (already a transitive dependency via crossbeam?) or `std::thread::scope`? Recommendation: `std::thread::scope` — no new dependency, and the scope is tiny (N joins).
+3. **Shard assignment strategy:** Round-robin is simple but may not be optimal if batches vary in size. Weighted assignment based on buffer pool depth could be better. Recommendation: start with round-robin, optimize later if benchmarks show imbalance.

--- a/rfcs/012-parallel-wal.md
+++ b/rfcs/012-parallel-wal.md
@@ -250,103 +250,86 @@ impl Wal {
             .sum();
         let base_offset = self.alloc_offset.fetch_add(total_size, Ordering::AcqRel);
 
-        // 2. Preflight: ensure the ring can hold all SQEs.
-        //    If the ring is too small, submit in chunks (see Open Questions §9.1).
-        //    CRITICAL: if push() fails after some SQEs are already queued,
-        //    we must submit/drain them before returning — otherwise a later
-        //    io_uring_enter can submit writes pointing at freed buffers.
-        let total_sqes = bufs.len() + 1; // writes + fsync
-        assert!(total_sqes <= 64, "batch exceeds ring capacity");
-
-        // 3. Submit write SQEs (parallel I/O to NVMe).
-        //    Each SQE is tagged with its index via user_data so that CQEs
-        //    can be matched back to the correct buffer regardless of
-        //    completion order (io_uring does not guarantee submission order).
+        // 2. Chunked submission: if the batch exceeds ring capacity (64 SQEs),
+        //    submit in chunks of 63 writes + 1 fsync, waiting for completions
+        //    between chunks. This avoids panicking under high concurrency.
+        let max_writes_per_chunk = 63;  // leave 1 slot for fsync
+        let chunks: Vec<&[DirectBuf]> = bufs.chunks(max_writes_per_chunk).collect();
         let mut offset = base_offset;
-        for (i, buf) in bufs.iter().enumerate() {
-            let aligned_len = Self::align_up(buf.len());
-            // SAFETY: buf is a page-aligned allocation from alloc_direct_buf.
-            // The buffer remains valid until all CQEs are polled (bufs is a
-            // local variable that outlives the CQE loop). The registered FD
-            // (Fixed(0)) is valid for the ring's lifetime.
-            let sqe = opcode::Write::new(
-                types::Fixed(WAL_FD_INDEX),
-                buf.as_ptr(),
-                aligned_len as u32,
-            )
-            .offset(offset)
-            .build()
-            .user_data(i as u64);  // tag with buffer index
-            unsafe { self.ring.submission().push(&sqe)?; }
-            offset += aligned_len as u64;
-        }
+        for chunk in chunks {
+            let total_sqes = chunk.len() + 1; // writes + fsync
 
-        // 4. Submit fsync with IOSQE_IO_DRAIN.
-        //    DRAIN: "do not start this SQE until all prior SQEs complete."
-        //    This ensures the fsync covers all preceding writes.
-        //    On Linux, fdatasync flushes file size metadata, so it is safe
-        //    for WAL files that extend (see fdatasync(2)).
-        //    Tag with u64::MAX to distinguish from write CQEs.
-        let fsync_sqe = opcode::Fsync::new(types::Fixed(WAL_FD_INDEX))
-            .flags(types::FsyncFlags::DATASYNC)
-            .build()
-            .flags(types::Flags::IO_DRAIN)
-            .user_data(u64::MAX);
-        unsafe { self.ring.submission().push(&fsync_sqe)?; }
+            // 3. Submit write SQEs (parallel I/O to NVMe).
+            //    Each SQE is tagged with its index via user_data so that CQEs
+            //    can be matched back to the correct buffer regardless of
+            //    completion order (io_uring does not guarantee submission order).
+            for (i, buf) in chunk.iter().enumerate() {
+                let aligned_len = Self::align_up(buf.len());
+                let sqe = opcode::Write::new(
+                    types::Fixed(WAL_FD_INDEX),
+                    buf.as_ptr(),
+                    aligned_len as u32,
+                )
+                .offset(offset)
+                .build()
+                .user_data(i as u64);  // tag with buffer index
+                unsafe { self.ring.submission().push(&sqe)?; }
+                offset += aligned_len as u64;
+            }
 
-        // 5. Submit all SQEs in one syscall.
-        self.ring.submit_and_wait(total_sqes)?;
+            // 4. Submit fsync with IOSQE_IO_DRAIN.
+            //    Tag with u64::MAX to distinguish from write CQEs.
+            let fsync_sqe = opcode::Fsync::new(types::Fixed(WAL_FD_INDEX))
+                .flags(types::FsyncFlags::DATASYNC)
+                .build()
+                .flags(types::Flags::IO_DRAIN)
+                .user_data(u64::MAX);
+            unsafe { self.ring.submission().push(&fsync_sqe)?; }
 
-        // 6. Poll for all CQEs — obtain the completion queue ONCE.
-        //    Calling ring.completion() in a loop creates and drops a new
-        //    CompletionQueue on each iteration, triggering a kernel sync
-        //    per iteration (the Drop impl commits the shared head pointer).
-        //    Process ALL CQEs in a single loop, checking user_data to
-        //    distinguish write CQEs (tagged with buffer index) from the
-        //    fsync CQE (tagged with u64::MAX). io_uring does not guarantee
-        //    completion order — the fsync CQE may arrive before writes.
-        let mut write_err: Option<i32> = None;
-        let mut fsync_err: Option<i32> = None;
-        let mut cq = self.ring.completion();
-        for _ in 0..total_sqes {
-            let cqe = cq.next()
-                .ok_or_else(|| anyhow!("io_uring: missing CQE"))?;
-            let user_data = cqe.user_data();
-            if user_data == u64::MAX {
-                // This is the fsync CQE.
-                if cqe.result() < 0 {
-                    fsync_err = Some(cqe.result());
-                }
-            } else {
-                // This is a write CQE — user_data is the buffer index.
-                let idx = user_data as usize;
-                if cqe.result() < 0 {
-                    if write_err.is_none() {
-                        write_err = Some(cqe.result());
+            // 5. Submit all SQEs in one syscall.
+            self.ring.submit_and_wait(total_sqes)?;
+
+            // 6. Poll for all CQEs — obtain the completion queue ONCE.
+            //    Process ALL CQEs in a single loop, checking user_data to
+            //    distinguish write CQEs from the fsync CQE.
+            let mut write_err: Option<i32> = None;
+            let mut fsync_err: Option<i32> = None;
+            let mut cq = self.ring.completion();
+            for _ in 0..total_sqes {
+                let cqe = cq.next()
+                    .ok_or_else(|| anyhow!("io_uring: missing CQE"))?;
+                let user_data = cqe.user_data();
+                if user_data == u64::MAX {
+                    if cqe.result() < 0 {
+                        fsync_err = Some(cqe.result());
                     }
                 } else {
-                    let written = cqe.result() as usize;
-                    let expected = Self::align_up(bufs[idx].len());
-                    if written < expected {
+                    let idx = user_data as usize;
+                    if cqe.result() < 0 {
                         if write_err.is_none() {
-                            write_err = Some(-libc::EIO);
+                            write_err = Some(cqe.result());
+                        }
+                    } else {
+                        let written = cqe.result() as usize;
+                        let expected = Self::align_up(chunk[idx].len());
+                        if written < expected {
+                            if write_err.is_none() {
+                                write_err = Some(-libc::EIO);
+                            }
                         }
                     }
                 }
             }
-        }
-        drop(cq);  // explicit drop for clarity
-        if let Some(err) = write_err {
-            anyhow::bail!("io_uring write error: {}", err);
-        }
-        if let Some(err) = fsync_err {
-            anyhow::bail!("io_uring fsync error: {}", err);
+            drop(cq);
+            if let Some(err) = write_err {
+                anyhow::bail!("io_uring write error: {}", err);
+            }
+            if let Some(err) = fsync_err {
+                anyhow::bail!("io_uring fsync error: {}", err);
+            }
         }
 
         // 7. Return buffers to pool.
-        //    Buffers MUST NOT be returned before CQE confirmation.
-        //    This is safe because bufs is a local variable that outlives
-        //    the CQE polling loop above.
         for buf in bufs {
             let _ = self.buf_pool.push(buf);
         }
@@ -374,6 +357,10 @@ data is durable.
 4. **Empty-pending fast path:** If `pending` is empty AND no commit is in flight
    (generation hasn't changed), return immediately. This prevents `sync()` from
    blocking forever on a clean WAL.
+5. **No result clearing:** The result is never cleared between cycles. If a
+   waiter from generation N wakes up while generation N+1 is in flight, it
+   can still read generation N's result. The generation counter is sufficient
+   to distinguish current from previous results.
 
 ```rust
 use std::sync::Arc;
@@ -436,8 +423,12 @@ impl Wal {
         {
             let mut state = self.completion_state.mutex.lock();
             state.in_flight = true;
-            // Clear stale result from previous cycle.
-            state.result = None;
+            // NOTE: Do NOT clear state.result here. If a waiter from a
+            // previous generation wakes up after we set in_flight but before
+            // we finish, clearing result would force it to wait for our
+            // cycle unnecessarily (or worse, propagate our error instead of
+            // the previous success). The generation counter is sufficient
+            // to distinguish current from previous results.
         }
 
         let result = self.submit_sqes_and_poll(bufs);
@@ -528,15 +519,28 @@ the WAL file is preallocated ahead of `alloc_offset`:
 
 ```rust
 /// Preallocate WAL space in 1 MiB increments.
-/// Called when alloc_offset approaches the current file size.
+/// Uses fallocate (not ftruncate) to ensure physical blocks are allocated
+/// on disk, so subsequent O_DIRECT writes are true overwrites (parallel path).
+/// Tracks preallocated size in memory to avoid stat() syscalls on the hot path.
 fn maybe_preallocate(&self) -> Result<()> {
     let offset = self.alloc_offset.load(Ordering::Relaxed);
-    let file_size = self.write_file.metadata()?.len();
+    let file_size = self.preallocated_size.load(Ordering::Relaxed);
     if offset + PREALLOC_THRESHOLD > file_size {
         let new_size = file_size + PREALLOC_BLOCK;  // 1 MiB
-        self.write_file.set_len(new_size)?;
-        // fdatasync to persist the size change before any O_DIRECT writes.
-        self.write_file.sync_data()?;
+        // fallocate allocates physical blocks — ftruncate creates sparse files
+        // which still require exclusive inode lock on first write.
+        let ret = unsafe {
+            libc::fallocate(
+                self.write_file.as_raw_fd(),
+                0,  // mode=0: allocate, no keep-size
+                file_size as i64,
+                PREALLOC_BLOCK as i64,
+            )
+        };
+        if ret != 0 {
+            anyhow::bail!("fallocate failed: {}", std::io::Error::last_os_error());
+        }
+        self.preallocated_size.store(new_size, Ordering::Relaxed);
     }
     Ok(())
 }
@@ -545,6 +549,11 @@ fn maybe_preallocate(&self) -> Result<()> {
 This keeps writes within the preallocated extent, where ext4 uses the shared
 overwrite path and allows true parallel DIO. The preallocation cost is
 amortized — 1 MiB blocks last for ~16 batches at 64 KiB each.
+
+**In-memory size tracking:** `preallocated_size: AtomicU64` is initialized
+during recovery/open and updated after each `fallocate` call. This avoids
+a `stat()` syscall on every `submit_and_commit()` call, preserving the
+syscall-reduction benefit of io_uring.
 
 ### 5.9 Alignment Gap Handling
 
@@ -582,14 +591,15 @@ previous buffer reuse. The recovery scanner would read this garbage as batch
 headers, fail CRC validation, and truncate the WAL — losing all batches
 after the first gap.
 
-**Recovery handling of zero-padded regions:** Each batch header includes an
-`encoded_len` field (the unpadded size of the batch, before alignment). After
-reading a valid batch, recovery skips to the next 4KB boundary:
+**Recovery handling of zero-padded regions:** Each batch header includes a
+`data_len` field (the data-only size, excluding the header). After reading
+a valid batch, recovery skips to the next 4KB boundary:
 
 ```rust
-// After reading a valid batch at offset O with encoded_len L:
-let aligned_len = align_up(BATCH_HEADER_SIZE + L);
-next_offset = current_offset + aligned_len;
+// After reading a valid batch at offset O with data_len L:
+let total_batch_size = BATCH_HEADER_SIZE + L;
+let aligned_size = align_up(total_batch_size);
+next_offset = current_offset + aligned_size;
 ```
 
 This ensures recovery jumps over the entire alignment gap — including partial
@@ -617,16 +627,14 @@ corresponding header size. New batches are always written with v4 headers.
 ```
 WAL_FORMAT_VERSION_V4: BATCH_HEADER_SIZE = 20 bytes (was 16 in v3):
   commit_ts:     u64   (8 bytes)
-  entry_count:   u16   (2 bytes)
+  entry_count:   u32   (4 bytes)
   data_crc32:    u32   (4 bytes)
   data_len:      u32   (4 bytes)  ← NEW (data-only, excludes header)
-  reserved:      u16   (2 bytes)  ← padding to 20 bytes
 
-WAL_FORMAT_VERSION_V3: BATCH_HEADER_SIZE = 16 bytes (unchanged):
+WAL_FORMAT_VERSION_V3: BATCH_HEADER_SIZE = 16 bytes (unchanged, matches wal.rs):
   commit_ts:     u64   (8 bytes)
-  entry_count:   u16   (2 bytes)
+  entry_count:   u32   (4 bytes)
   data_crc32:    u32   (4 bytes)
-  reserved:      u16   (2 bytes)
 ```
 
 The CRC covers `commit_ts + entry_count + data_crc32` (unchanged). `data_len`

--- a/rfcs/012-parallel-wal.md
+++ b/rfcs/012-parallel-wal.md
@@ -69,14 +69,19 @@ kernel dispatches SQEs to different NVMe submission queues concurrently.
 3. Single fsync per batch group via `IOSQE_IO_DRAIN`.
 4. Maintain the two-phase write protocol (`write_wal_batch_only` → `commit_wal`).
 5. Backward compatible WAL file format (v3, unchanged).
-6. Recovery unchanged — sequential scan + CRC validation.
+6. Recovery compatible — sequential scan + CRC validation, with alignment-gap
+   skipping for O_DIRECT padded batches.
 
 ## 4. Non-Goals
 
 1. Multiple WAL files / shards.
 2. SPDK integration.
-3. Changing the WAL file format.
-4. io_uring for reads (separate concern).
+3. io_uring for reads (separate concern).
+
+**Note:** The WAL file format gains a 4-byte `encoded_len` field in the batch
+header (§5.10). This is backward compatible — old batches without the field
+are handled by recovery. The format version (v3) is unchanged because the
+new field is within the existing header padding.
 
 ---
 
@@ -117,9 +122,17 @@ struct DirectBuf {
     cap: usize,
 }
 
+// SAFETY: DirectBuf owns its allocation and is not shared across threads
+// without synchronization. The raw pointer is not aliased.
+unsafe impl Send for DirectBuf {}
+unsafe impl Sync for DirectBuf {}
+
 impl DirectBuf {
     fn new(size: usize) -> Self {
-        let cap = size.max(4096);
+        // Cap must be 4KB-aligned to prevent io_uring out-of-bounds reads.
+        // align_up() rounds write sizes to 4KB; if cap is smaller, io_uring
+        // reads past the allocation.
+        let cap = Self::align_up(size.max(4096));
         let mut ptr: *mut libc::c_void = std::ptr::null_mut();
         let ret = unsafe { libc::posix_memalign(&mut ptr, 4096, cap) };
         assert_eq!(ret, 0, "posix_memalign failed");
@@ -128,6 +141,10 @@ impl DirectBuf {
             len: 0,
             cap,
         }
+    }
+
+    fn align_up(size: usize) -> usize {
+        (size + 4095) & !4095
     }
 
     fn as_mut_slice(&mut self) -> &mut [u8] {
@@ -148,9 +165,6 @@ impl Drop for DirectBuf {
 
 **Buffer pool change:** Replace `ArrayQueue<Vec<u8>>` with `ArrayQueue<DirectBuf>`.
 The pool size (16 buffers × 64KB) and lifecycle are unchanged.
-
-**Buffer pool change:** Replace `ArrayQueue<Vec<u8>>` with page-aligned
-allocations. The pool size (16 buffers × 64KB) and lifecycle are unchanged.
 
 ### 5.3 File Handling
 
@@ -175,8 +189,11 @@ let write_file = File::options()
 ```
 
 **WAL creation:** The 6-byte WAL header is written via a temporary buffered
-handle (O_DIRECT requires ≥4KB writes). After the header is written and
-flushed, the buffered handle is closed and the O_DIRECT handle is opened.
+handle (O_DIRECT requires ≥4KB writes). The header is padded to 4096 bytes
+with zeros so that `alloc_offset` starts at a 4KB boundary — O_DIRECT writes
+at unaligned file offsets fail with `EINVAL`. After the padded header is
+written and flushed, the buffered handle is closed and the O_DIRECT handle is
+opened.
 
 **Recovery:** Reads via the buffered handle. After recovery truncation,
 `alloc_offset` is initialized to the file length (the byte after the last
@@ -195,11 +212,10 @@ const WAL_FD_INDEX: u32 = 0;
 
 let mut builder = Builder::new(64);  // 64 SQE slots
 
-// IORING_SETUP_SINGLE_ISSUER requires kernel 5.19+.
-// Probe: try with flag, fall back without if it fails.
-if kernel_version() >= (5, 19, 0) {
-    builder.setup_single_issuer();
-}
+// NOTE: IORING_SETUP_SINGLE_ISSUER is NOT used here.
+// Multiple threads call submit_and_commit() and any of them may become
+// the submitter (whichever drains pending first). SINGLE_ISSUER requires
+// that only the creating task submits SQEs — violating this returns -EEXIST.
 
 let ring = builder.build()?;
 ring.submitter().register_files(&[raw_fd])?;  // register WAL file FD
@@ -233,9 +249,20 @@ impl Wal {
             .sum();
         let base_offset = self.alloc_offset.fetch_add(total_size, Ordering::AcqRel);
 
-        // 2. Submit write SQEs (parallel I/O to NVMe).
+        // 2. Preflight: ensure the ring can hold all SQEs.
+        //    If the ring is too small, submit in chunks (see Open Questions §9.1).
+        //    CRITICAL: if push() fails after some SQEs are already queued,
+        //    we must submit/drain them before returning — otherwise a later
+        //    io_uring_enter can submit writes pointing at freed buffers.
+        let total_sqes = bufs.len() + 1; // writes + fsync
+        assert!(total_sqes <= 64, "batch exceeds ring capacity");
+
+        // 3. Submit write SQEs (parallel I/O to NVMe).
+        //    Each SQE is tagged with its index via user_data so that CQEs
+        //    can be matched back to the correct buffer regardless of
+        //    completion order (io_uring does not guarantee submission order).
         let mut offset = base_offset;
-        for buf in &bufs {
+        for (i, buf) in bufs.iter().enumerate() {
             let aligned_len = Self::align_up(buf.len());
             // SAFETY: buf is a page-aligned allocation from alloc_direct_buf.
             // The buffer remains valid until all CQEs are polled (bufs is a
@@ -247,38 +274,47 @@ impl Wal {
                 aligned_len as u32,
             )
             .offset(offset)
-            .build();
+            .build()
+            .user_data(i as u64);  // tag with buffer index
             unsafe { self.ring.submission().push(&sqe)?; }
             offset += aligned_len as u64;
         }
 
-        // 3. Submit fsync with IOSQE_IO_DRAIN.
+        // 4. Submit fsync with IOSQE_IO_DRAIN.
         //    DRAIN: "do not start this SQE until all prior SQEs complete."
         //    This ensures the fsync covers all preceding writes.
         //    On Linux, fdatasync flushes file size metadata, so it is safe
         //    for WAL files that extend (see fdatasync(2)).
+        //    Tag with u64::MAX to distinguish from write CQEs.
         let fsync_sqe = opcode::Fsync::new(types::Fixed(WAL_FD_INDEX))
             .flags(types::FsyncFlags::DATASYNC)
             .build()
-            .flags(types::Flags::IO_DRAIN);
+            .flags(types::Flags::IO_DRAIN)
+            .user_data(u64::MAX);
         unsafe { self.ring.submission().push(&fsync_sqe)?; }
 
-        // 4. Submit all SQEs in one syscall.
-        self.ring.submit_and_wait(bufs.len() + 1)?;
+        // 5. Submit all SQEs in one syscall.
+        self.ring.submit_and_wait(total_sqes)?;
 
-        // 5. Poll for all CQEs — drain ALL completions even on error
-        //    to avoid stale CQEs misaligning the next submission.
+        // 6. Poll for all CQEs — obtain the completion queue ONCE.
+        //    Calling ring.completion() in a loop creates and drops a new
+        //    CompletionQueue on each iteration, triggering a kernel sync
+        //    per iteration (the Drop impl commits the shared head pointer).
+        //    Also, match CQEs by user_data tag, not by position — io_uring
+        //    does not guarantee completion order.
         let mut write_err: Option<i32> = None;
-        for i in 0..bufs.len() {
-            let cqe = self.ring.completion().next()
+        let mut cq = self.ring.completion();
+        for _ in 0..bufs.len() {
+            let cqe = cq.next()
                 .ok_or_else(|| anyhow!("io_uring: missing write CQE"))?;
+            let idx = cqe.user_data() as usize;
             if cqe.result() < 0 {
                 if write_err.is_none() {
                     write_err = Some(cqe.result());
                 }
             } else {
                 let written = cqe.result() as usize;
-                let expected = Self::align_up(bufs[i].len());
+                let expected = Self::align_up(bufs[idx].len());
                 if written < expected {
                     if write_err.is_none() {
                         write_err = Some(-libc::EIO);
@@ -287,8 +323,9 @@ impl Wal {
             }
         }
         // Fsync CQE — always poll it, even if writes failed.
-        let fsync_cqe = self.ring.completion().next()
+        let fsync_cqe = cq.next()
             .ok_or_else(|| anyhow!("io_uring: missing fsync CQE"))?;
+        drop(cq);  // explicit drop for clarity
         if let Some(err) = write_err {
             anyhow::bail!("io_uring write error: {}", err);
         }
@@ -296,7 +333,7 @@ impl Wal {
             anyhow::bail!("io_uring fsync error: {}", fsync_cqe.result());
         }
 
-        // 6. Return buffers to pool.
+        // 7. Return buffers to pool.
         //    Buffers MUST NOT be returned before CQE confirmation.
         //    This is safe because bufs is a local variable that outlives
         //    the CQE polling loop above.
@@ -316,50 +353,118 @@ drains `pending` and submits SQEs. The others must wait for the CQE result
 before returning — otherwise they may call `publish_raw_batch()` before the
 data is durable.
 
+**Key design decisions:**
+
+1. **Arc-wrapped errors:** `anyhow::Error` does not implement `Clone`. To share
+   the result among multiple waiters, errors are wrapped in `Arc`.
+2. **Generation counter:** Each commit cycle increments a generation. Waiters
+   check the generation to avoid consuming a stale result from a previous batch.
+3. **Single mutex:** `completion_state` replaces the nested `completion_mutex` +
+   `last_completion_result` — one lock protects both the result and the condvar.
+4. **Empty-pending fast path:** If `pending` is empty AND no commit is in flight
+   (generation hasn't changed), return immediately. This prevents `sync()` from
+   blocking forever on a clean WAL.
+
 ```rust
+use std::sync::Arc;
+
+/// Shared completion state for the fate-sharing barrier.
+struct CompletionState {
+    mutex: Mutex<CompletionInner>,
+    cond: Condvar,
+}
+
+struct CompletionInner {
+    /// Generation counter — incremented on each commit cycle.
+    /// Waiters compare this against the generation they observed before
+    /// waiting to detect stale results.
+    generation: u64,
+    /// Result of the most recent commit. Wrapped in Arc so it can be
+    /// cloned for each waiter (anyhow::Error is !Clone).
+    result: Option<Result<(), Arc<anyhow::Error>>>,
+    /// True while a submitter is actively running I/O.
+    in_flight: bool,
+}
+
 impl Wal {
     pub fn submit_and_commit(&self) -> Result<()> {
+        // Record the generation BEFORE draining pending.
+        // If our data is taken by another thread, we wait for a result
+        // at this generation or later.
+        let my_generation = {
+            let state = self.completion_state.mutex.lock();
+            state.generation
+        };
+
         let bufs = {
             let mut pending = self.pending.lock();
             std::mem::take(&mut *pending)
         };
 
         if bufs.is_empty() {
-            // Our data was already taken by a prior submitter.
-            // Wait for the completion signal.
-            return self.wait_for_completion();
+            // Our data was already taken by a prior submitter (or there was
+            // nothing pending). Check if a commit is actually in flight.
+            {
+                let state = self.completion_state.mutex.lock();
+                if !state.in_flight && state.generation == my_generation {
+                    // No commit in flight, nothing to wait for.
+                    return Ok(());
+                }
+            }
+            // Wait for the completion signal at our generation.
+            return self.wait_for_completion(my_generation);
         }
 
-        // I am the submitter — do the I/O.
+        // I am the submitter — mark in-flight and do the I/O.
+        {
+            let mut state = self.completion_state.mutex.lock();
+            state.in_flight = true;
+            // Clear stale result from previous cycle.
+            state.result = None;
+        }
+
         let result = self.submit_sqes_and_poll(bufs);
 
         // Signal all waiters (even on error).
-        // CRITICAL: use replace() + notify_all, not take().
-        // Each waiter must get its own clone — take() would let only
-        // the first waiter proceed; subsequent waiters would block forever.
+        let shared_result = result.as_ref()
+            .map(|_| ())
+            .map_err(|e| Arc::new(anyhow::anyhow!("{e}")));
         {
-            let mut guard = self.completion_mutex.lock();
-            self.last_completion_result.lock().replace(result.clone());
-            self.completion_cond.notify_all();
+            let mut state = self.completion_state.mutex.lock();
+            state.result = Some(shared_result);
+            state.in_flight = false;
+            state.generation += 1;
+            self.completion_state.cond.notify_all();
         }
 
         result
     }
 
-    fn wait_for_completion(&self) -> Result<()> {
-        let mut guard = self.completion_mutex.lock();
-        while self.last_completion_result.lock().is_none() {
-            self.completion_cond.wait(&mut guard);
+    fn wait_for_completion(&self, min_generation: u64) -> Result<()> {
+        let mut state = self.completion_state.mutex.lock();
+        // Wait until the generation advances past ours (meaning a new result
+        // is available) AND a result exists.
+        while state.generation <= min_generation || state.result.is_none() {
+            if !state.in_flight && state.generation > min_generation {
+                // Commit finished between our check and this iteration.
+                break;
+            }
+            self.completion_state.cond.wait(&mut state);
         }
         // Clone, not take — all waiters must see the same result.
-        let result = self.last_completion_result.lock().clone().unwrap();
-        result
+        match &state.result {
+            Some(Ok(())) => Ok(()),
+            Some(Err(e)) => Err(anyhow::anyhow!("{e}")),
+            None => Ok(()),  // no commit was in flight
+        }
     }
 }
 ```
 
 This ensures all callers see the same result — success or failure. The
-submitter broadcasts the CQE outcome to all waiters via condvar.
+submitter broadcasts the CQE outcome to all waiters via condvar. The
+generation counter prevents a late-arriving waiter from consuming a stale
+result from a previous commit cycle.
 
 ### 5.7 How DRAIN Replaces the Sequencer
 
@@ -399,6 +504,31 @@ impl OffsetAllocator {
 after recovery truncation. The `recover_mvcc()` function already computes
 `valid_file` (wal.rs:443) — this value is passed through to the allocator.
 
+**Preallocation:** On ext4, extending direct I/O takes the exclusive inode
+path (`ext4_direct_IO_write` → `ext4_alloc_file_blocks`), serializing all
+concurrent writes to the same inode. To stay on the shared overwrite path,
+the WAL file is preallocated ahead of `alloc_offset`:
+
+```rust
+/// Preallocate WAL space in 1 MiB increments.
+/// Called when alloc_offset approaches the current file size.
+fn maybe_preallocate(&self) -> Result<()> {
+    let offset = self.alloc_offset.load(Ordering::Relaxed);
+    let file_size = self.write_file.metadata()?.len();
+    if offset + PREALLOC_THRESHOLD > file_size {
+        let new_size = file_size + PREALLOC_BLOCK;  // 1 MiB
+        self.write_file.set_len(new_size)?;
+        // fdatasync to persist the size change before any O_DIRECT writes.
+        self.write_file.sync_data()?;
+    }
+    Ok(())
+}
+```
+
+This keeps writes within the preallocated extent, where ext4 uses the shared
+overwrite path and allows true parallel DIO. The preallocation cost is
+amortized — 1 MiB blocks last for ~16 batches at 64 KiB each.
+
 ### 5.9 Alignment Gap Handling
 
 O_DIRECT requires 4KB-aligned write sizes. Each batch buffer is zero-padded
@@ -406,7 +536,14 @@ to the aligned length after encoding:
 
 ```rust
 fn encode_batch(&self, data: &[(&[u8], &[u8])], commit_ts: u64) -> Result<DirectBuf> {
-    let mut buf = self.buf_pool.pop().unwrap_or_else(|| DirectBuf::new(BUFFER_POOL_BUF_SIZE));
+    // Compute encoded size first, then allocate a buffer that fits.
+    // Large transactions or range-tombstone batches may exceed the 64 KiB
+    // pool buffer; sizing from the encoded length prevents out-of-bounds writes.
+    let encoded_size = Self::compute_encoded_size(data);
+    let alloc_size = Self::align_up(encoded_size).max(BUFFER_POOL_BUF_SIZE);
+    let mut buf = self.buf_pool.pop()
+        .filter(|b| b.cap() >= alloc_size)
+        .unwrap_or_else(|| DirectBuf::new(alloc_size));
     // ... encode batch data into buf.as_mut_slice() ...
 
     // Zero-pad to 4KB alignment (O_DIRECT requirement).
@@ -428,23 +565,63 @@ previous buffer reuse. The recovery scanner would read this garbage as batch
 headers, fail CRC validation, and truncate the WAL — losing all batches
 after the first gap.
 
-**Recovery handling of zero-padded regions:** The recovery scanner already
-handles this correctly. A zero-padded region reads as `entry_count=0` with
-`data_crc32=0`. The CRC of zero bytes is 0, so the batch is valid (it's an
-empty batch). Recovery continues past it to the next batch. The `entry_count`
-field is the authoritative batch size indicator — padding doesn't affect it.
+**Recovery handling of zero-padded regions:** Each batch header includes an
+`encoded_len` field (the unpadded size of the batch, before alignment). After
+reading a valid batch, recovery skips to the next 4KB boundary:
 
-### 5.10 Record Checksum (Unchanged)
+```rust
+// After reading a valid batch at offset O with encoded_len L:
+let aligned_len = align_up(BATCH_HEADER_SIZE + L);
+next_offset = current_offset + aligned_len;
+```
+
+This ensures recovery jumps over the entire alignment gap — including partial
+zero bytes that don't form a complete 16-byte empty batch header. Without
+this, recovery would combine trailing padding bytes with the next batch's
+header, fail CRC validation, and truncate the WAL.
+
+### 5.10 Record Checksum & Header (Modified)
 
 Each batch has a CRC32 checksum over the entry data (existing `BATCH_HEADER_SIZE`
 = 16 bytes: commit_ts + entry_count + data_crc32). O_DIRECT does not affect
 the checksum — it covers only the valid bytes (before zero-padding).
 
-### 5.11 Recovery Scan (Unchanged)
+**New field: `encoded_len`** (4 bytes, added after `data_crc32`). Stores the
+unpadded encoded size of the batch (header + entries, excluding alignment
+padding). Recovery uses this to skip to the next 4KB boundary after reading
+a batch, preventing padding bytes from being misinterpreted as batch headers.
+
+```
+BATCH_HEADER_SIZE = 20 bytes (was 16):
+  commit_ts:     u64   (8 bytes)
+  entry_count:   u16   (2 bytes)
+  data_crc32:    u32   (4 bytes)
+  encoded_len:   u32   (4 bytes)  ← NEW
+  reserved:      u16   (2 bytes)  ← padding to 20 bytes
+```
+
+The CRC covers `commit_ts + entry_count + data_crc32` (unchanged). `encoded_len`
+is outside the CRC — it is an optimization hint for recovery, not a data
+integrity field. An incorrect `encoded_len` causes recovery to mis-skip and
+fail CRC on the next batch, which is safe (truncation, not corruption).
+
+### 5.11 Recovery Scan (Modified)
 
 Recovery reads the WAL file sequentially using the buffered file handle,
 validates CRC per batch, and stops at the first invalid entry. The WAL file
-format is unchanged.
+format is backward compatible — old batches without `encoded_len` are handled
+as before (sequential scan).
+
+**Alignment-gap skipping:** After reading a valid batch, recovery advances
+the read offset to the next 4KB boundary using `encoded_len`:
+
+```rust
+let aligned_len = align_up(BATCH_HEADER_SIZE + batch.encoded_len as usize);
+offset += aligned_len;
+```
+
+This prevents trailing zero-padding bytes from being combined with the next
+batch's header, which would fail CRC and cause truncation.
 
 The buffered handle is opened with `.append(true)` for recovery. After
 recovery truncation, `alloc_offset` is initialized to the file length. The
@@ -504,8 +681,10 @@ impl Wal {
 ```
 
 `sync()` is equivalent to `submit_and_commit()`. If there are pending buffers,
-they are drained and committed. If not, the completion barrier waits for any
-in-flight commit from another thread.
+they are drained and committed. If not, the completion barrier checks whether
+a commit is in flight: if so, it waits; if not, it returns immediately. This
+prevents `sync()` from blocking forever on a clean WAL with no pending writes
+and no in-flight commits (e.g., during `close()` before any writes).
 
 ### 5.16 Engine Close
 
@@ -546,12 +725,11 @@ mod io_uring_wal {
 }
 ```
 
-On Linux, attempt full io_uring initialization at WAL open: ring creation,
-`setup_single_issuer`, AND `register_files`. If **any** step fails (kernel too
-old, EMFILE, ENOMEM), fall back to the synchronous path. Store
-`use_io_uring: bool` in the `Wal` struct. Feature detection is runtime, not
-compile-time — a Linux binary works on kernels 5.11+ (io_uring) and <5.11
-(fallback).
+On Linux, attempt full io_uring initialization at WAL open: ring creation
+AND `register_files`. If **any** step fails (kernel too old, EMFILE, ENOMEM),
+fall back to the synchronous path. Store `use_io_uring: bool` in the `Wal`
+struct. Feature detection is runtime, not compile-time — a Linux binary works
+on kernels 5.11+ (io_uring) and <5.11 (fallback).
 
 ```rust
 let ring = match try_init_io_uring(&write_file) {

--- a/rfcs/012-parallel-wal.md
+++ b/rfcs/012-parallel-wal.md
@@ -406,15 +406,16 @@ struct CompletionInner {
     /// waiting to detect stale results.
     generation: u64,
     /// Ring buffer of recent commit results, indexed by generation % RING_SIZE.
-    /// Wrapped in Arc so each waiter can clone its result (anyhow::Error is !Clone).
-    /// This prevents generation N+1 from overwriting generation N's result
-    /// before a slow waiter for generation N has read it.
-    results: [Option<Result<(), Arc<anyhow::Error>>>; RING_SIZE],
+    /// Each slot stores (generation, result) so that a waiter can verify it
+    /// is reading its own generation's result, not a stale one from a future
+    /// generation that wrapped around. Wrapped in Arc so each waiter can
+    /// clone its result (anyhow::Error is !Clone).
+    results: [Option<(u64, Result<(), Arc<anyhow::Error>>)>; RING_SIZE],
     /// True while a submitter is actively running I/O.
     in_flight: bool,
 }
 
-const RING_SIZE: usize = 16;  // must be power of 2
+const RING_SIZE: usize = 256;  // must be power of 2; large enough to prevent wrap under normal concurrency
 
 impl Wal {
     pub fn submit_and_commit(&self) -> Result<()> {
@@ -475,7 +476,7 @@ impl Wal {
         {
             let mut state = self.completion_state.mutex.lock();
             let idx = (state.generation as usize) % RING_SIZE;
-            state.results[idx] = Some(shared_result);
+            state.results[idx] = Some((state.generation, shared_result));
             state.in_flight = false;
             state.generation += 1;
             self.completion_state.cond.notify_all();
@@ -497,10 +498,18 @@ impl Wal {
             self.completion_state.cond.wait(&mut state);
         }
         // Read OUR generation's result from the ring buffer.
+        // Verify the stored generation matches to detect wrap-around.
         let idx = (min_generation as usize) % RING_SIZE;
         match &state.results[idx] {
-            Some(Ok(())) => Ok(()),
-            Some(Err(e)) => Err(anyhow::anyhow!("{e}")),
+            Some((gen, Ok(()))) if *gen == min_generation => Ok(()),
+            Some((gen, Err(e))) if *gen == min_generation => Err(anyhow::anyhow!("{e}")),
+            Some((gen, _)) => {
+                // Generation mismatch — wrap-around occurred.
+                // The slot was overwritten by a newer generation.
+                // Fall through to Ok(()) as a best-effort fallback.
+                log::warn!("ring buffer wrap-around: expected gen {}, got {}", min_generation, gen);
+                Ok(())
+            }
             None => Ok(()),  // no commit was in flight
         }
     }
@@ -571,14 +580,21 @@ fn maybe_preallocate(&self) -> Result<()> {
     let file_size = self.preallocated_size.load(Ordering::Relaxed);
     if offset + PREALLOC_THRESHOLD > file_size {
         let new_size = file_size + PREALLOC_BLOCK;  // 1 MiB
-        // fallocate with FALLOC_FL_KEEP_SIZE allocates physical blocks
-        // without changing the logical EOF. This prevents recovery from
-        // scanning zero-filled unwritten tail as empty batches, and keeps
-        // the file size consistent with the last valid batch.
+        // fallocate (mode=0) allocates physical blocks AND extends the
+        // logical EOF. This is critical: O_DIRECT writes that extend beyond
+        // the logical EOF are treated as "extending writes" by the kernel,
+        // which acquires the exclusive inode lock and serializes all
+        // concurrent writes. By preallocating with extended EOF, all writes
+        // are "overwrites" (within the file size), allowing true parallel DIO.
+        //
+        // Recovery is protected by the v4 alignment-gap skipping logic:
+        // the preallocated zero-filled tail is beyond the last valid batch,
+        // and recovery stops at the first batch that fails CRC or has
+        // entry_count=0 at an unexpected offset.
         let ret = unsafe {
             libc::fallocate(
                 self.write_file.as_raw_fd(),
-                libc::FALLOC_FL_KEEP_SIZE,  // allocate blocks, keep EOF
+                0,  // mode=0: allocate AND extend EOF
                 file_size as i64,
                 PREALLOC_BLOCK as i64,
             )

--- a/rfcs/012-parallel-wal.md
+++ b/rfcs/012-parallel-wal.md
@@ -1,4 +1,4 @@
-# RFC 012: Parallel WAL with Multiple Loggers
+# RFC 012: Parallel WAL — Ordered Commit with Piggyback Fsync
 
 **Status:** Proposed
 **Date:** 2026-06-26
@@ -9,27 +9,22 @@
 
 ## 1. Summary
 
-This RFC proposes adding parallel WAL (Write-Ahead Log) logging to kv-engine,
-inspired by the SpanDB paper's multi-logger design. The paper's parallel WAL
-combines three techniques:
+This RFC proposes improving WAL write throughput by replacing the current
+group-commit leader-follower model with an **ordered commit sequencer** that
+piggybacks fsyncs. The key insight from the SpanDB paper is that `fsync` flushes
+all dirty pages for the entire file — so multiple batches written between two
+fsyncs get committed for free.
 
-1. **Log batching** — multiple concurrent writers' entries collected into a single batch per shard (group commit).
-2. **Parallel writers** — N independent WAL shards fsync simultaneously across shards.
-3. **Atomic page allocation ordering** — within each shard, batches receive sequential file offsets via atomic allocation, preserving write ordering without serializing I/O.
+The design:
 
-Instead of a single WAL file per memtable with one leader thread performing all
-writes and fsyncs, the engine would maintain N independent WAL shards per memtable.
-Each shard retains group commit for batching efficiency, while different shards
-commit in parallel.
+1. **Atomic offset allocator** — each batch gets a sequential file offset via `fetch_add`.
+2. **Single writer** — batches are written sequentially to the WAL file (same as current).
+3. **Record checksum** — CRC32 per batch (already exists, unchanged).
+4. **Ordered commit sequencer** — batches are committed in order; fsync is skipped when a prior fsync already covered the data.
+5. **Recovery scan** — sequential scan, validate CRC, stop at first invalid entry (unchanged).
 
-The design provides:
-
-1. N parallel WAL loggers per memtable (configurable, default 1 for backward compatibility).
-2. Group commit per shard — batching multiple concurrent writers into one fsync.
-3. Parallel fsync across all shards — N group commits proceed simultaneously.
-4. Atomic offset ordering — batches within a shard are ordered by sequentially allocated file offsets.
-5. Full backward compatibility — single-shard mode uses the existing WAL file format and naming.
-6. Compatible with MVCC, vLog, compaction, and all existing WAL features.
+This is Phase 1 of a two-phase plan. Phase 2 (future, RFC 002) adds io_uring
+for parallel I/O submission and kernel-level fsync batching.
 
 ---
 
@@ -37,308 +32,206 @@ The design provides:
 
 ### Current Bottleneck
 
-The current WAL implementation (`wal.rs`) uses a single file per memtable with a
-group-commit mechanism:
+The current WAL uses a single file with a leader-follower group commit:
 
 ```
-Writer threads → ready_queue (SegQueue) → leader drains → BufWriter → fsync
-                                                    ↑
-                                          single file Mutex
+Writer threads → ready_queue (SegQueue) → leader drains → BufWriter → fsync → wake followers
 ```
 
-Under high concurrency, this creates a bottleneck:
-
-- **Single writer:** One leader thread serially writes all batched buffers and fsyncs.
-- **Mutex contention:** The file Mutex is held during the entire drain + write + fsync cycle.
-- **Followers wait:** All non-leader threads block on the condvar until the leader finishes.
-
-The SpanDB paper measured that RocksDB spends **81% of write request time** waiting
-on the synchronous group logging path when using Optane via SPDK. While this engine
-uses standard filesystem I/O (not SPDK), the same principle applies: the single-writer
-bottleneck limits throughput under high concurrency.
-
-### Why Not Just Group Commit or Just Parallel Shards?
-
-**Group commit alone** (current design) batches writers efficiently but all shards
-share one fsync — N writers wait for one fsync.
-
-**Parallel shards alone** (no batching) allows parallel fsync but writers on the
-same shard serialize — each writer does its own fsync.
-
-**SpanDB's design** combines both: batch within each shard (group commit), then
-fsync all shards in parallel. The result is N batches fsyncing simultaneously,
-each batch amortizing fsync across its own group of writers.
+The bottleneck is **fsync** (50-100µs on NVMe, 1-10ms on SATA). Every batch
+triggers one fsync, even when multiple batches arrive between fsyncs:
 
 ```
-                    ┌─ Shard 0: writers ─→ batch ─→ leader writes ─→ fsync ─┐
-                    │                                                        │
-All writers ────────┼─ Shard 1: writers ─→ batch ─→ leader writes ─→ fsync ─┤ parallel
-(round-robin)       │                                                        │
-                    └─ Shard 2: writers ─→ batch ─→ leader writes ─→ fsync ─┘
+Time:   0µs        50µs       100µs      150µs
+        Batch 0    Batch 1    Batch 2    Batch 3
+        ───fsync─── ───fsync─── ───fsync─── ───fsync───
+        4 fsyncs for 4 batches = 200µs total
 ```
 
-The paper's "3L3R" configuration (3 loggers × 3 concurrent requests per logger)
-achieved peak WAL throughput on Intel Optane.
+### The Piggyback Insight
+
+`fsync` flushes **all** dirty pages for the file, not just the last write.
+If batches 0, 1, 2 are all written before the first fsync, one fsync covers all three:
+
+```
+Time:   0µs        50µs       100µs
+        Batch 0    Batch 1    Batch 2
+        ───fsync───────────────────────
+        1 fsync for 3 batches = 50µs total (4× faster)
+```
+
+The sequencer ensures ordering: a batch is only committed after all prior
+batches are durably written. This prevents the race where a later batch's
+fsync completes before an earlier batch's write.
 
 ---
 
 ## 3. Goals
 
-1. Implement N parallel WAL shards per memtable, each with group commit.
-2. Keep backward compatibility — `num_wal_shards=1` uses the existing `{id:05}.wal` format.
+1. Replace leader-follower group commit with an ordered commit sequencer.
+2. Piggyback fsyncs — skip fsync when a prior fsync already covered the data.
 3. No changes to the public `KvEngine` API.
-4. Recovery must correctly merge entries from all shards.
-5. WAL cleanup (during flush) must delete all shard files.
-6. Configuration via `LsmStorageOptions::num_wal_shards`.
+4. Backward compatible WAL file format (v3, unchanged).
+5. Recovery unchanged — sequential scan + CRC validation.
 
 ## 4. Non-Goals
 
-1. SPDK integration (separate concern, see RFC 002 for io_uring).
-2. Changing the WAL file format — each shard uses the existing v3 format.
-3. Cross-shard ordering — MVCC timestamps handle correctness.
-4. Dynamic shard count — fixed at engine creation time.
+1. Parallel pwrite (deferred to Phase 2 with io_uring).
+2. Multiple WAL files / shards (unnecessary with piggyback fsync).
+3. SPDK integration.
+4. Changing the WAL file format.
 
 ---
 
 ## 5. Design
 
-### 5.1 SpanDB's Three Techniques
+### 5.1 Current vs Proposed
 
-#### 5.1.1 Log Batching (Group Commit per Shard)
+| Aspect | Current (Group Commit) | Proposed (Sequencer) |
+|--------|----------------------|---------------------|
+| Writer role | Push buffer, wait for leader | Push buffer, write, register with sequencer |
+| Leader | Drains queue, writes, fsyncs, wakes followers | No leader |
+| Fsync trigger | Every batch | Only when no prior fsync covers this batch |
+| Ordering | Implicit (leader writes in queue order) | Explicit (sequencer tracks committed offset) |
+| Followers | Block on condvar | Block on sequencer (check if prior batch committed) |
 
-Each shard implements the existing leader-follower group commit:
-
-1. Writers push encoded buffers to the shard's `ready_queue`.
-2. The first writer becomes the leader, drains the queue, writes to the file, and fsyncs.
-3. Other writers wait on the shard's condvar, then return when the leader signals completion.
-
-This amortizes fsync cost across concurrent writers on the same shard. The existing
-`Wal::submit_and_commit()` logic is reused unchanged per shard.
-
-#### 5.1.2 Parallel Writers (Cross-Shard Parallelism)
-
-The `ParallelWal::submit_and_commit()` triggers all shards' group commits
-simultaneously using `std::thread::scope`. Each shard's leader independently
-drains its queue, writes to its file, and fsyncs. Writers on different shards
-do not block each other.
-
-```
-Shard 0: leader_0 drains → write → fsync ─┐
-Shard 1: leader_1 drains → write → fsync ─┤ all in parallel
-Shard 2: leader_2 drains → write → fsync ─┘
-```
-
-#### 5.1.3 Atomic Page Allocation Ordering
-
-Within each shard, batches must be written to the file in the order they were
-submitted, even though multiple writers contribute buffers concurrently. The current
-design handles this via the `ready_queue` (FIFO) and a single leader doing the
-write — the leader drains all buffers in queue order and writes them sequentially.
-
-To support future I/O parallelism (e.g., io_uring with multiple in-flight writes),
-each batch can be assigned a sequential file offset atomically:
+### 5.2 Sequencer State
 
 ```rust
-/// Atomic offset allocator for a single WAL shard.
-/// Each batch gets a unique, sequential region in the file.
-struct OffsetAllocator {
-    next_offset: AtomicU64,
-}
-
-impl OffsetAllocator {
-    /// Reserve `size` bytes at the current end of the WAL.
-    /// Returns the starting offset for this batch.
-    fn allocate(&self, size: u64) -> u64 {
-        self.next_offset.fetch_add(size, Ordering::AcqRel)
-    }
+/// Tracks the commit state of the WAL.
+struct CommitSequencer {
+    /// Highest file offset that has been fsynced to disk.
+    synced_offset: AtomicU64,
+    /// Highest file offset that has been written (but not necessarily synced).
+    written_offset: AtomicU64,
+    /// Mutex + condvar for commit signaling.
+    commit_mutex: Mutex<()>,
+    commit_cond: Condvar,
 }
 ```
 
-This ensures:
-- Batches are assigned non-overlapping, sequential file regions.
-- Multiple writers can prepare their buffers concurrently.
-- The leader writes buffers at their allocated offsets (currently sequential; future io_uring can submit in parallel with offset ordering).
-
-**Current implementation:** The offset allocator is implicit — the leader drains the
-FIFO queue and writes sequentially. The atomic offset tracking is added for correctness
-documentation and future io_uring support.
-
-### 5.2 New `ParallelWal` Struct
+### 5.3 Write + Commit Flow
 
 ```rust
-pub struct ParallelWal {
-    /// N independent WAL shards.
-    shards: Vec<Wal>,
-    /// Atomic counter for round-robin shard assignment.
-    next_shard: AtomicUsize,
-}
-```
+fn write_and_commit(&self, buf: &[u8]) -> Result<()> {
+    // 1. Allocate file offset atomically.
+    let offset = self.sequencer.written_offset.fetch_add(
+        buf.len() as u64, Ordering::AcqRel
+    );
 
-Each shard is a full `Wal` instance with its own:
-- File (`Arc<Mutex<BufWriter<File>>>`)
-- Buffer pool (`ArrayQueue<Vec<u8>>`, 16 × 64KB)
-- Ready queue (`SegQueue<Vec<u8>>`)
-- Group commit state (`commit_waiters`, `committed_gen`, `leader_active`, etc.)
-
-### 5.3 WAL File Naming
-
-| Shard Count | File Names |
-|-------------|-----------|
-| 1 (default) | `{id:05}.wal` (unchanged) |
-| N > 1 | `{id:05}.wal.0`, `{id:05}.wal.1`, ..., `{id:05}.wal.{N-1}` |
-
-### 5.4 Write Path
-
-```rust
-impl ParallelWal {
-    pub fn put_batch(&self, data: &[(&[u8], &[u8])], commit_ts: u64) -> Result<()> {
-        let shard_idx = self.next_shard.fetch_add(1, Ordering::Relaxed) % self.shards.len();
-        self.shards[shard_idx].put_batch(data, commit_ts)
+    // 2. Write to file at allocated offset (single writer, sequential).
+    //    Currently: BufWriter under mutex (same as today).
+    //    Phase 2: io_uring SQE submission (parallel).
+    {
+        let mut file = self.file.lock();
+        file.seek(SeekFrom::Start(offset))?;
+        file.write_all(buf)?;
     }
 
-    pub fn put_range_tombstone_batch(
-        &self,
-        tombstones: &[(&[u8], &[u8])],
-        commit_ts: u64,
-    ) -> Result<()> {
-        let shard_idx = self.next_shard.fetch_add(1, Ordering::Relaxed) % self.shards.len();
-        self.shards[shard_idx].put_range_tombstone_batch(tombstones, commit_ts)
-    }
+    // 3. Register with sequencer and commit.
+    self.sequencer.commit(offset + buf.len() as u64)
 }
 ```
 
-Each batch is written to exactly one shard. The round-robin distribution ensures
-even load across shards. Within each shard, the batch enters the shard's
-`ready_queue` for group commit.
-
-### 5.5 Group Commit (Parallel Fsync Across Shards)
+### 5.4 Sequencer Commit Logic
 
 ```rust
-impl ParallelWal {
-    pub fn submit_and_commit(&self) -> Result<()> {
-        if self.shards.len() == 1 {
-            return self.shards[0].submit_and_commit();
+impl CommitSequencer {
+    fn commit(&self, my_end_offset: u64) -> Result<()> {
+        // Wait for all prior batches to be committed.
+        let mut guard = self.commit_mutex.lock();
+        while self.synced_offset.load(Ordering::Acquire) < my_end_offset {
+            // Check if we need to fsync.
+            let synced = self.synced_offset.load(Ordering::Acquire);
+            let written = self.written_offset.load(Ordering::Acquire);
+
+            // If there are unwritten-or-unsynced bytes before us, we may need
+            // to fsync. But only the first thread in a contiguous group does it.
+            if synced < my_end_offset {
+                // Fsync — this covers ALL dirty pages, including prior batches.
+                self.file.lock().sync_all()?;
+
+                // Advance synced_offset to cover all written data.
+                // This wakes all waiters whose batches are now durable.
+                self.synced_offset.store(written, Ordering::Release);
+                self.commit_cond.notify_all();
+                return Ok(());
+            }
+
+            // Another thread is fsyncing for us — wait.
+            self.commit_cond.wait(&mut guard);
         }
 
-        // Trigger all shards' group commits in parallel.
-        // Each shard's leader independently drains, writes, and fsyncs.
-        let results: Vec<Result<()>> = std::thread::scope(|s| {
-            let handles: Vec<_> = self.shards.iter()
-                .map(|shard| s.spawn(|| shard.submit_and_commit()))
-                .collect();
-            handles.into_iter()
-                .map(|h| h.join().unwrap_or_else(|_| anyhow::bail!("shard panic")))
-                .collect()
-        });
-
-        // Return Ok only if all shards succeeded.
-        for r in results {
-            r?;
-        }
+        // Our batch was already covered by a prior fsync.
         Ok(())
     }
 }
 ```
 
-Key points:
-- Each shard's `submit_and_commit()` runs its own group commit independently.
-- All shards' leaders write and fsync in parallel.
-- The call returns only when ALL shards have fsynced.
-- If any shard fails, the error is propagated.
+### 5.5 How Piggyback Works
 
-### 5.6 Recovery
+Example with 3 concurrent writers:
 
-```rust
-impl ParallelWal {
-    pub fn recover(
-        base_path: impl AsRef<Path>,
-        num_shards: usize,
-        skiplist: &SkipMap<Bytes, Bytes>,
-    ) -> Result<(Self, u64)> {
-        let mut shards = Vec::with_capacity(num_shards);
-        let mut max_ts: u64 = 0;
+```
+Writer A: offset=0,   len=100  → pwrite 0-100   → commit(100)
+Writer B: offset=100, len=50   → pwrite 100-150  → commit(150)
+Writer C: offset=150, len=80   → pwrite 150-230  → commit(230)
 
-        for i in 0..num_shards {
-            let shard_path = if num_shards == 1 {
-                base_path.as_ref().to_path_buf()
-            } else {
-                PathBuf::from(format!("{}.{}", base_path.as_ref().display(), i))
-            };
+Sequencer state: synced_offset=0, written_offset=230
 
-            if shard_path.exists() {
-                let (wal, ts) = Wal::recover(&shard_path, skiplist)?;
-                shards.push(wal);
-                max_ts = max_ts.max(ts);
-            } else {
-                // Shard file doesn't exist — create a new one.
-                shards.push(Wal::create(&shard_path)?);
-            }
-        }
+Writer A arrives at commit(100):
+  synced_offset (0) < my_end_offset (100) → fsync
+  fsync flushes pages 0-230 (all dirty data)
+  synced_offset = 230 (written_offset)
+  notify_all
+  → Writer A returns ✓
 
-        Ok((Self {
-            shards,
-            next_shard: AtomicUsize::new(0),
-        }, max_ts))
-    }
-}
+Writer B arrives at commit(150):
+  synced_offset (230) >= my_end_offset (150) → already committed
+  → Writer B returns immediately ✓ (no fsync)
+
+Writer C arrives at commit(230):
+  synced_offset (230) >= my_end_offset (230) → already committed
+  → Writer C returns immediately ✓ (no fsync)
+
+Result: 1 fsync for 3 batches (vs 3 fsyncs in current design)
 ```
 
-Recovery correctness:
-- Each shard is recovered independently using the existing `Wal::recover()` / `Wal::recover_with_range_tombstones()`.
-- All shards replay into the same skiplist. Since the skiplist is a concurrent
-  `SkipMap`, this is safe — MVCC timestamps handle ordering.
-- `max_ts` is the maximum across all shards.
+### 5.6 The Ordering Race (Why Sequencer Is Needed)
 
-### 5.7 MemTable Integration
+Without the sequencer, a dangerous race exists:
 
-The `MemTable` struct changes from `wal: Option<Wal>` to `wal: Option<ParallelWal>`:
-
-```rust
-pub struct MemTable {
-    // ...
-    wal: Option<ParallelWal>,  // was: Option<Wal>
-    // ...
-}
+```
+Writer C: pwrite at 150 → fsync → returns to caller (thinks data is safe)
+Writer A: pwrite at 0   → NOT DONE YET
+  crash → Batch 0 lost, but Writer C's caller was told it's safe ✗
 ```
 
-Methods updated:
-- `create_with_wal()` → `ParallelWal::create(path, num_shards)`
-- `write_wal_batch()` → `wal.put_batch()` (round-robin internally)
-- `commit_wal()` → `wal.submit_and_commit()` (parallel group commit across shards)
-- `recover_from_wal()` → `ParallelWal::recover(path, num_shards, skiplist)`
+With the sequencer:
 
-### 5.8 WAL Cleanup
-
-During flush (`force_flush_next_imm_memtable`), delete all shard files:
-
-```rust
-fn cleanup_wal_files(path: &Path, id: usize, num_shards: usize) {
-    if num_shards <= 1 {
-        let wal_path = path.join(format!("{id:05}.wal"));
-        let _ = std::fs::remove_file(wal_path);
-    } else {
-        for i in 0..num_shards {
-            let wal_path = path.join(format!("{id:05}.wal.{i}"));
-            let _ = std::fs::remove_file(wal_path);
-        }
-    }
-}
+```
+Writer C: pwrite at 150 → commit(230) → waits for synced_offset >= 230
+Writer A: pwrite at 0   → commit(100) → fsync → synced_offset = 230
+  → Writer C's commit(230) satisfied → returns ✓
+  → All data 0-230 is on disk before either caller returns ✓
 ```
 
-### 5.9 Configuration
+The rule: **a batch is committed only after all prior bytes are fsynced**.
 
-Add to `LsmStorageOptions`:
+### 5.7 Recovery
 
-```rust
-pub struct LsmStorageOptions {
-    // ... existing fields ...
-    /// Number of WAL shards per memtable. Default: 1 (single WAL, backward compatible).
-    /// Values > 1 enable parallel WAL logging (recommended: 2-4 for NVMe SSDs).
-    pub num_wal_shards: usize,
-}
-```
+No changes. Recovery scans the file sequentially:
 
-Default: `1` — no behavior change for existing users.
+1. Read batch header (commit_ts, entry_count, crc32).
+2. Validate CRC32 over entry data.
+3. If valid, replay entries into skiplist.
+4. If invalid (CRC mismatch, truncated), stop — this is the recovery point.
+5. Truncate file to last valid byte.
+
+This works because:
+- Batches are written in offset order (atomic allocator guarantees this).
+- The sequencer ensures all bytes up to `synced_offset` are on disk.
+- On crash, bytes beyond `synced_offset` may be partial — CRC catches this.
 
 ---
 
@@ -346,76 +239,79 @@ Default: `1` — no behavior change for existing users.
 
 ### Advantages
 
-1. **Best of both worlds** — Group commit amortizes fsync within each shard; parallel shards amortize across shards.
-2. **Parallel fsync** — Multiple shards fsync simultaneously, utilizing NVMe internal parallelism.
-3. **Pipelining** — While one shard fsyncs, others collect writes.
-4. **Reduced contention** — Writers on different shards never share a mutex.
-5. **Simple per-shard logic** — Each shard reuses the existing, well-tested `Wal` group commit.
-6. **Backward compatible** — `num_wal_shards=1` is identical to current behavior.
+1. **Fewer fsyncs** — Under concurrency, multiple batches piggyback on one fsync. The higher the concurrency, the bigger the win.
+2. **Simpler code** — No leader election, no condvar wake-up storms, no batch results ring buffer. Just atomic offset + sequencer.
+3. **No new files** — Single WAL file, same format, same recovery.
+4. **Phase 2 ready** — The atomic offset allocator maps directly to io_uring SQE offsets.
 
 ### Disadvantages
 
-1. **Multiple files per memtable** — N WAL files instead of 1. Increases file descriptor usage.
-2. **Recovery complexity** — Must read and merge N files instead of 1.
-3. **No cross-shard ordering guarantee** — Relies on MVCC timestamps for correctness.
-4. **SSD firmware serialization** — On some SSDs, parallel fsyncs may be serialized by the firmware. The pipelining benefit still applies.
-5. **Increased disk space** — Each shard has its own WAL header and padding.
-
-### Comparison: Group Commit vs Parallel Shards vs SpanDB
-
-| Approach | Fsync per batch | Parallelism | Complexity |
-|----------|----------------|-------------|------------|
-| Group commit only (current) | 1 fsync for N writers | None (single fsync) | Low |
-| Parallel shards only (no batching) | 1 fsync per writer | N fsyncs in parallel | Low |
-| **SpanDB (batching + parallel)** | 1 fsync for M writers per shard | N fsyncs in parallel | Medium |
-
-With SpanDB's design and 8 writer threads, 4 shards:
-- Each shard has ~2 writers → 1 fsync per shard (group commit)
-- 4 shards → 4 fsyncs in parallel
-- Total: 4 fsyncs instead of 8 (no batching) or 1 (current)
+1. **Single writer still** — Batches are written sequentially under the file mutex. Same as current design. (Phase 2 with io_uring adds parallel writes.)
+2. **Fsync latency unchanged** — Each fsync still takes 50-100µs on NVMe. The win is fewer fsyncs, not faster fsyncs.
+3. **Low concurrency regression risk** — With 1 writer, every batch fsyncs (same as now). The sequencer overhead (atomic ops, mutex) is pure overhead. Mitigation: short-circuit when `num_writers == 1`.
 
 ### When It Helps Most
 
-- High concurrency writes (many writer threads).
-- Fast NVMe SSDs where fsync latency is low but the software overhead dominates.
-- Workloads where the single-writer group commit is the bottleneck.
+- **High concurrency** (4+ writer threads) — more batches arrive between fsyncs.
+- **Fast NVMe** — fsync is cheap but not free; fewer fsyncs = less total time.
+- **Small batches** — each batch's write time is negligible; fsync dominates.
 
 ### When It Helps Least
 
-- Low concurrency (1-2 writer threads) — little contention to eliminate.
-- SATA SSDs or HDDs — I/O latency dominates, not software overhead.
-- Small memtables — frequent freezes negate the batching benefit.
+- **Single writer** — no batching opportunity; sequencer overhead is wasted.
+- **SATA/HDD** — fsync is so slow (1-10ms) that the software overhead is negligible.
 
 ---
 
-## 7. Implementation Plan
+## 7. Phase 2: io_uring (Future, RFC 002)
+
+Phase 2 replaces the sequential write under mutex with parallel io_uring submissions:
+
+```
+Phase 1 (this RFC):
+  Writer A: lock → seek → write_all → unlock → commit
+  Writer B: lock → seek → write_all → unlock → commit   (serialized)
+
+Phase 2 (RFC 002):
+  Writer A: submit SQE [write@0]   → commit (poll CQE)
+  Writer B: submit SQE [write@100] → commit (poll CQE)   (parallel)
+```
+
+Benefits of Phase 2:
+- **No file mutex** — io_uring ring is lock-free (MPSC queue).
+- **Parallel writes** — kernel dispatches to NVMe channels.
+- **Linked SQEs** — chain write→fsync, kernel handles sequencing.
+- **Poll mode** — near-SPDK latency without SPDK's access restrictions.
+
+The atomic offset allocator from Phase 1 is reused directly as the SQE offset.
+
+---
+
+## 8. Implementation Plan
 
 | Phase | Description | Files |
 |-------|-------------|-------|
-| 1 | Add `ParallelWal` struct to `wal.rs` | `wal.rs` |
-| 2 | Add `ParallelWal::recover()` and `recover_with_range_tombstones()` | `wal.rs` |
-| 3 | Update `MemTable` to use `ParallelWal` | `mem_table.rs` |
-| 4 | Update `lsm_storage.rs` recovery path | `lsm_storage.rs` |
-| 5 | Update WAL cleanup to delete all shard files | `lsm_storage.rs` |
-| 6 | Add `num_wal_shards` to `LsmStorageOptions` | `lsm_storage.rs` |
-| 7 | Add tests | `tests/wal.rs` |
+| 1 | Add `CommitSequencer` struct to `wal.rs` | `wal.rs` |
+| 2 | Replace `submit_and_commit()` with sequencer-based commit | `wal.rs` |
+| 3 | Remove leader-follower group commit code | `wal.rs` |
+| 4 | Add short-circuit for single-writer case | `wal.rs` |
+| 5 | Add tests | `tests/wal.rs` |
+| 6 | Benchmark: `write-perf --workload wal_concurrent` | — |
 
 ---
 
-## 8. Testing Strategy
+## 9. Testing Strategy
 
-1. **Backward compatibility:** All existing tests pass with `num_wal_shards=1`.
-2. **Multi-shard write/read:** Write with `num_wal_shards=2` and `4`, verify all data readable.
-3. **Concurrent writers:** Multiple threads writing to the engine with parallel WAL.
-4. **Recovery:** Write with N shards, close engine, reopen, verify all data.
-5. **Mixed workloads:** put + delete + delete_range with parallel WAL.
-6. **Benchmark:** `write-perf --workload wal_concurrent --threads 8` with varying shard counts.
+1. **Correctness:** All existing WAL tests pass (format unchanged).
+2. **Piggyback:** Verify that concurrent writers trigger fewer fsyncs (instrument with counter).
+3. **Ordering:** Crash-injection test — verify no batch is committed before prior batches are durable.
+4. **Single writer:** Verify no regression (short-circuit path).
+5. **Benchmark:** `write-perf --workload wal_concurrent --threads 1,2,4,8` — compare vs current group commit.
 
 ---
 
-## 9. Open Questions
+## 10. Open Questions
 
-1. **Optimal shard count:** The paper uses 3 loggers for Optane. Should we default to 2 or 4? Recommendation: 2 for NVMe, 1 for SATA/HDD.
-2. **Rayon vs std::thread::scope:** For parallel fsync, should we use rayon or `std::thread::scope`? Recommendation: `std::thread::scope` — no new dependency, and the scope is tiny (N joins).
-3. **Shard assignment strategy:** Round-robin is simple but may not be optimal if batches vary in size. Recommendation: start with round-robin, optimize later if benchmarks show imbalance.
-4. **io_uring integration:** The atomic offset allocator (Section 5.1.3) prepares for future io_uring support where multiple batches can be submitted as parallel writes to the same shard. This is deferred to RFC 002.
+1. **Mutex vs RwLock for file access:** The file is currently under `Mutex`. With the sequencer, only one writer writes at a time (sequential), so `Mutex` is correct. Phase 2 (io_uring) removes the mutex entirely.
+2. **BufWriter retention:** Should we keep `BufWriter` or switch to raw `File`? `BufWriter` batches small writes into larger ones, reducing syscall count. Recommendation: keep `BufWriter` for Phase 1, switch to raw `File` with io_uring in Phase 2.
+3. **Fsync batching window:** Should we add a small delay (e.g., 10µs) to let more writers arrive before fsyncing? This trades latency for throughput. Recommendation: no delay for Phase 1 — the sequencer already batches naturally under concurrency.

--- a/rfcs/012-parallel-wal.md
+++ b/rfcs/012-parallel-wal.md
@@ -406,7 +406,7 @@ data is durable.
    the result among multiple waiters, errors are wrapped in `Arc`.
 2. **Generation counter:** Each commit cycle increments a generation. Waiters
    check the generation to avoid consuming a stale result from a previous batch.
-3. **Ring buffer for results:** A 16-slot ring buffer indexed by
+3. **Ring buffer for results:** A 256-slot ring buffer indexed by
    `generation % RING_SIZE` stores per-generation results. This prevents
    generation N+1 from overwriting generation N's result before a slow
    waiter has read it.

--- a/rfcs/012-parallel-wal.md
+++ b/rfcs/012-parallel-wal.md
@@ -196,6 +196,13 @@ at unaligned file offsets fail with `EINVAL`. After the padded header is
 written and flushed, the buffered handle is closed and the O_DIRECT handle is
 opened.
 
+**v3→v4 upgrade:** When opening an existing v3 WAL for the first time under v4,
+recovery truncates at the last valid v3 batch. The file is then padded to the
+next 4KB boundary with zeros (via the buffered handle) before switching to the
+O_DIRECT handle. This ensures `alloc_offset` is 4KB-aligned for the first v4
+write. The padded region is harmless — recovery skips it via the v4
+alignment-gap logic.
+
 **Recovery:** Reads via the buffered handle. After recovery truncation,
 `alloc_offset` is initialized to the file length (the byte after the last
 valid batch). The buffered handle is dropped; the O_DIRECT handle is used
@@ -287,7 +294,12 @@ impl Wal {
             unsafe { self.ring.submission().push(&fsync_sqe)?; }
 
             // 5. Submit all SQEs in one syscall.
-            self.ring.submit_and_wait(total_sqes)?;
+            //    On failure, drain any CQEs that were already posted to
+            //    prevent stale CQEs from misaligning the next submission.
+            if let Err(e) = self.ring.submit_and_wait(total_sqes) {
+                while let Some(_cqe) = self.ring.completion().next() {}
+                anyhow::bail!("io_uring submit_and_wait failed: {}", e);
+            }
 
             // 6. Poll for all CQEs — obtain the completion queue ONCE.
             //    Process ALL CQEs in a single loop, checking user_data to
@@ -321,6 +333,13 @@ impl Wal {
                 }
             }
             drop(cq);
+            // On I/O error, poison the WAL to prevent further writes.
+            // The allocated offset range for the failed batch is skipped;
+            // without poisoning, later successful commits would be
+            // unrecoverable (recovery stops at the first gap).
+            if write_err.is_some() || fsync_err.is_some() {
+                self.poisoned.store(true, Ordering::Release);
+            }
             if let Some(err) = write_err {
                 anyhow::bail!("io_uring write error: {}", err);
             }
@@ -352,7 +371,11 @@ data is durable.
    the result among multiple waiters, errors are wrapped in `Arc`.
 2. **Generation counter:** Each commit cycle increments a generation. Waiters
    check the generation to avoid consuming a stale result from a previous batch.
-3. **Single mutex:** `completion_state` replaces the nested `completion_mutex` +
+3. **Ring buffer for results:** A 16-slot ring buffer indexed by
+   `generation % RING_SIZE` stores per-generation results. This prevents
+   generation N+1 from overwriting generation N's result before a slow
+   waiter has read it.
+4. **Single mutex:** `completion_state` replaces the nested `completion_mutex` +
    `last_completion_result` — one lock protects both the result and the condvar.
 4. **Empty-pending fast path:** If `pending` is empty AND no commit is in flight
    (generation hasn't changed), return immediately. This prevents `sync()` from
@@ -376,12 +399,16 @@ struct CompletionInner {
     /// Waiters compare this against the generation they observed before
     /// waiting to detect stale results.
     generation: u64,
-    /// Result of the most recent commit. Wrapped in Arc so it can be
-    /// cloned for each waiter (anyhow::Error is !Clone).
-    result: Option<Result<(), Arc<anyhow::Error>>>,
+    /// Ring buffer of recent commit results, indexed by generation % RING_SIZE.
+    /// Wrapped in Arc so each waiter can clone its result (anyhow::Error is !Clone).
+    /// This prevents generation N+1 from overwriting generation N's result
+    /// before a slow waiter for generation N has read it.
+    results: [Option<Result<(), Arc<anyhow::Error>>>; RING_SIZE],
     /// True while a submitter is actively running I/O.
     in_flight: bool,
 }
+
+const RING_SIZE: usize = 16;  // must be power of 2
 
 impl Wal {
     pub fn submit_and_commit(&self) -> Result<()> {
@@ -412,7 +439,9 @@ impl Wal {
                 }
             }
             // Wait for the completion signal at our generation.
-            // Drop the submit guard to allow the active submitter to proceed.
+            // This correctly propagates the result (success OR failure) of the
+            // batch that contained our data — the generation counter ensures
+            // we read the right result from the ring buffer.
             drop(_submit_guard);
             return self.wait_for_completion(my_generation);
         }
@@ -439,7 +468,8 @@ impl Wal {
             .map_err(|e| Arc::new(anyhow::anyhow!("{e}")));
         {
             let mut state = self.completion_state.mutex.lock();
-            state.result = Some(shared_result);
+            let idx = (state.generation as usize) % RING_SIZE;
+            state.results[idx] = Some(shared_result);
             state.in_flight = false;
             state.generation += 1;
             self.completion_state.cond.notify_all();
@@ -451,16 +481,18 @@ impl Wal {
     fn wait_for_completion(&self, min_generation: u64) -> Result<()> {
         let mut state = self.completion_state.mutex.lock();
         // Wait until the generation advances past ours (meaning a new result
-        // is available) AND a result exists.
-        while state.generation <= min_generation || state.result.is_none() {
+        // is available) AND our specific result exists in the ring buffer.
+        while state.generation <= min_generation
+            || state.results[(min_generation as usize) % RING_SIZE].is_none()
+        {
             if !state.in_flight && state.generation > min_generation {
-                // Commit finished between our check and this iteration.
                 break;
             }
             self.completion_state.cond.wait(&mut state);
         }
-        // Clone, not take — all waiters must see the same result.
-        match &state.result {
+        // Read OUR generation's result from the ring buffer.
+        let idx = (min_generation as usize) % RING_SIZE;
+        match &state.results[idx] {
             Some(Ok(())) => Ok(()),
             Some(Err(e)) => Err(anyhow::anyhow!("{e}")),
             None => Ok(()),  // no commit was in flight
@@ -527,12 +559,14 @@ fn maybe_preallocate(&self) -> Result<()> {
     let file_size = self.preallocated_size.load(Ordering::Relaxed);
     if offset + PREALLOC_THRESHOLD > file_size {
         let new_size = file_size + PREALLOC_BLOCK;  // 1 MiB
-        // fallocate allocates physical blocks — ftruncate creates sparse files
-        // which still require exclusive inode lock on first write.
+        // fallocate with FALLOC_FL_KEEP_SIZE allocates physical blocks
+        // without changing the logical EOF. This prevents recovery from
+        // scanning zero-filled unwritten tail as empty batches, and keeps
+        // the file size consistent with the last valid batch.
         let ret = unsafe {
             libc::fallocate(
                 self.write_file.as_raw_fd(),
-                0,  // mode=0: allocate, no keep-size
+                libc::FALLOC_FL_KEEP_SIZE,  // allocate blocks, keep EOF
                 file_size as i64,
                 PREALLOC_BLOCK as i64,
             )
@@ -637,8 +671,11 @@ WAL_FORMAT_VERSION_V3: BATCH_HEADER_SIZE = 16 bytes (unchanged, matches wal.rs):
   data_crc32:    u32   (4 bytes)
 ```
 
-The CRC covers `commit_ts + entry_count + data_crc32` (unchanged). `data_len`
-is outside the CRC — it is an optimization hint for recovery, not a data
+The CRC covers **entry data only** (the payload bytes after the header),
+consistent with the existing v3 implementation in `wal.rs`. The CRC does NOT
+cover header fields (`commit_ts`, `entry_count`, `data_crc32`, `data_len`) —
+including `data_crc32` in its own checksum is not well-defined. `data_len` is
+outside the CRC — it is an optimization hint for recovery, not a data
 integrity field. An incorrect `data_len` causes recovery to skip incorrectly
 and fail CRC on the next batch, which is safe (truncation, not corruption).
 
@@ -655,8 +692,19 @@ This does NOT double-count the header because `data_len` is data-only.
 
 Recovery reads the WAL file sequentially using the buffered file handle,
 validates CRC per batch, and stops at the first invalid entry. The WAL file
-format is backward compatible — old batches without `encoded_len` are handled
-as before (sequential scan).
+format is backward compatible — old v3 batches are handled as before.
+
+**v4 initial scan offset:** For v4 files, the first batch starts at
+`align_up(WAL_HEADER_SIZE)` (4096), not at `WAL_HEADER_SIZE` (6). Recovery
+must begin scanning at the aligned offset to avoid reading the zero-padded
+header region as batch data:
+
+```rust
+let scan_start = match wal_version {
+    V4 => align_up(WAL_HEADER_SIZE),  // 4096
+    V3 => WAL_HEADER_SIZE,            // 6
+};
+```
 
 **Alignment-gap skipping (v4):** After reading a valid batch, recovery advances
 the read offset to the next 4KB boundary using `data_len`:
@@ -775,6 +823,13 @@ mod io_uring_wal {
     // Re-export current group commit as fallback.
 }
 ```
+
+**Fallback format consistency:** The fallback path continues writing v3-format
+batches (16-byte headers, no alignment padding). This ensures the fallback
+WAL is readable by the existing v3 recovery logic without the v4 alignment-gap
+skipping. Only the io_uring path writes v4-format batches. The WAL file header
+records which format version is in use, so recovery selects the correct
+parsing strategy automatically.
 
 On Linux, attempt full io_uring initialization at WAL open: ring creation
 AND `register_files`. If **any** step fails (kernel too old, EMFILE, ENOMEM),

--- a/rfcs/012-parallel-wal.md
+++ b/rfcs/012-parallel-wal.md
@@ -45,7 +45,10 @@ The leader does all the work. The other 7 threads wait.
             → poll fsync CQE → all 8 batches durable → wake all
 ```
 
-No leader. No mutex (for I/O). No condvar. Just SQE submission + CQE polling.
+No leader election. No BufWriter. Just SQE submission + CQE polling. The
+submitting thread blocks on `submit_and_wait` (equivalent to the current
+leader's fsync wait), but the kernel parallelizes the underlying NVMe writes
+during that wait.
 
 ### Why Not Buffered I/O?
 
@@ -83,17 +86,18 @@ kernel dispatches SQEs to different NVMe submission queues concurrently.
 
 ```
 Phase 1 (under locks):
-  write_wal_batch_only() → encode buffer → push to pending list
+  write_wal_batch_only() → encode buffer → zero-pad to 4KB → push to pending list
 
 Phase 2 (locks released):
   submit_and_commit():
-    1. Drain pending list
-    2. Allocate offsets (atomic fetch_add)
+    1. Drain pending list (one thread becomes submitter, others wait)
+    2. Allocate offsets (atomic fetch_add, using aligned sizes)
     3. Submit write SQEs (one per buffer)
     4. Submit fsync SQE with IOSQE_IO_DRAIN
     5. io_uring_enter (one syscall for all SQEs)
     6. Poll fsync CQE (confirms all writes are durable)
     7. Return buffers to pool
+    8. Signal waiting threads via condvar
 ```
 
 ### 5.2 O_DIRECT Buffer Requirements
@@ -111,43 +115,66 @@ fn alloc_direct_buf(size: usize) -> Vec<u8> {
 }
 ```
 
-Or use the `aligned_alloc` / `posix_memalign` APIs via the `libc` crate.
+Or use `libc::posix_memalign` for portability.
 
 **Buffer pool change:** Replace `ArrayQueue<Vec<u8>>` with page-aligned
 allocations. The pool size (16 buffers × 64KB) and lifecycle are unchanged.
 
 ### 5.3 File Handling
 
+The WAL file requires **two handles**:
+
+1. **Buffered handle** — for recovery reads and WAL header write at creation.
+2. **O_DIRECT handle** — for batch writes via io_uring.
+
 ```rust
-let f = File::options()
+// Recovery: buffered handle (benefits from page cache).
+let recovery_file = File::options()
     .read(true)
-    .write(true)
-    .custom_flags(libc::O_DIRECT)  // bypass page cache + inode lock
+    .append(true)
+    .open(path)?;
+
+// Write path: O_DIRECT handle (bypasses page cache + inode lock).
+let write_file = File::options()
+    .read(true)
+    .write(true)    // NOT append — pwrite controls position
+    .custom_flags(libc::O_DIRECT)
     .open(path)?;
 ```
 
-O_DIRECT requirements:
-- Buffer address must be page-aligned (4KB).
-- Buffer size must be a multiple of the logical block size (typically 512B or 4KB).
-- File offset must be page-aligned.
+**WAL creation:** The 6-byte WAL header is written via a temporary buffered
+handle (O_DIRECT requires ≥4KB writes). After the header is written and
+flushed, the buffered handle is closed and the O_DIRECT handle is opened.
 
-All WAL batches are encoded into page-aligned buffers with sizes rounded up
-to 4KB. The actual data length is recorded in the batch header (CRC covers
-only the valid bytes).
+**Recovery:** Reads via the buffered handle. After recovery truncation,
+`alloc_offset` is initialized to the file length (the byte after the last
+valid batch). The buffered handle is dropped; the O_DIRECT handle is used
+for subsequent writes.
 
 ### 5.4 io_uring Setup
 
 ```rust
 use io_uring::{opcode, types, IoUring, Builder};
 
-let ring = Builder::new(64)          // 64 SQE slots
-    .setup_single_issuer()           // single-threaded submission (kernel optimization)
-    .build()?;
-ring.submitter().register_files(&[file_fd])?;  // register WAL file FD
+let mut builder = Builder::new(64);  // 64 SQE slots
+
+// IORING_SETUP_SINGLE_ISSUER requires kernel 5.19+.
+// Probe: try with flag, fall back without if it fails.
+if kernel_version() >= (5, 19, 0) {
+    builder.setup_single_issuer();
+}
+
+let ring = builder.build()?;
+ring.submitter().register_files(&[raw_fd])?;  // register WAL file FD
 ```
 
 The ring is created once at WAL open and destroyed at WAL close. It is used
 exclusively for WAL writes — not shared with other subsystems.
+
+**FD registration failure:** If `register_files` fails (EMFILE, ENOMEM), bail
+with a clear error. The registered FD must remain valid for the ring's
+lifetime. The `File` that owns the FD must not be dropped while the ring
+is active.
 
 ### 5.5 Write + Commit Flow
 
@@ -163,13 +190,20 @@ impl Wal {
         }
 
         // 1. Allocate file offsets atomically.
-        let total_size: u64 = bufs.iter().map(|b| b.len() as u64).sum();
+        //    CRITICAL: use aligned sizes, not raw buf.len().
+        let total_size: u64 = bufs.iter()
+            .map(|b| Self::align_up(b.len()) as u64)
+            .sum();
         let base_offset = self.alloc_offset.fetch_add(total_size, Ordering::AcqRel);
 
         // 2. Submit write SQEs (parallel I/O to NVMe).
         let mut offset = base_offset;
         for buf in &bufs {
             let aligned_len = Self::align_up(buf.len());
+            // SAFETY: buf is a page-aligned allocation from alloc_direct_buf.
+            // The buffer remains valid until all CQEs are polled (bufs is a
+            // local variable that outlives the CQE loop). The registered FD
+            // (Fixed(0)) is valid for the ring's lifetime.
             let sqe = opcode::Write::new(
                 types::Fixed(0),       // registered file FD
                 buf.as_ptr(),
@@ -184,8 +218,10 @@ impl Wal {
         // 3. Submit fsync with IOSQE_IO_DRAIN.
         //    DRAIN: "do not start this SQE until all prior SQEs complete."
         //    This ensures the fsync covers all preceding writes.
+        //    On Linux, fdatasync flushes file size metadata, so it is safe
+        //    for WAL files that extend (see fdatasync(2)).
         let fsync_sqe = opcode::Fsync::new(types::Fixed(0))
-            .flags(types::FsyncFlags::FDATASYNC)  // fdatasync is sufficient for WAL
+            .flags(types::FsyncFlags::DATASYNC)
             .build()
             .flags(types::Flags::IO_DRAIN);
         unsafe { self.ring.submission().push(&fsync_sqe)?; }
@@ -209,6 +245,9 @@ impl Wal {
         }
 
         // 6. Return buffers to pool.
+        //    Buffers MUST NOT be returned before CQE confirmation.
+        //    This is safe because bufs is a local variable that outlives
+        //    the CQE polling loop above.
         for buf in bufs {
             let _ = self.buf_pool.push(buf);
         }
@@ -218,7 +257,55 @@ impl Wal {
 }
 ```
 
-### 5.6 How DRAIN Replaces the Sequencer
+### 5.6 Completion Barrier (Fate-Sharing)
+
+Multiple threads call `submit_and_commit()` concurrently. Only one thread
+drains `pending` and submits SQEs. The others must wait for the CQE result
+before returning — otherwise they may call `publish_raw_batch()` before the
+data is durable.
+
+```rust
+impl Wal {
+    pub fn submit_and_commit(&self) -> Result<()> {
+        let bufs = {
+            let mut pending = self.pending.lock();
+            std::mem::take(&mut *pending)
+        };
+
+        if bufs.is_empty() {
+            // Our data was already taken by a prior submitter.
+            // Wait for the completion signal.
+            return self.wait_for_completion();
+        }
+
+        // I am the submitter — do the I/O.
+        let result = self.submit_sqes_and_poll(bufs);
+
+        // Signal all waiters (even on error).
+        {
+            let mut guard = self.completion_mutex.lock();
+            self.last_completion_result.lock().replace(result.clone());
+            self.completion_cond.notify_all();
+        }
+
+        result
+    }
+
+    fn wait_for_completion(&self) -> Result<()> {
+        let mut guard = self.completion_mutex.lock();
+        while self.last_completion_result.lock().is_none() {
+            self.completion_cond.wait(&mut guard);
+        }
+        let result = self.last_completion_result.lock().take().unwrap();
+        result
+    }
+}
+```
+
+This ensures all callers see the same result — success or failure. The
+submitter broadcasts the CQE outcome to all waiters via condvar.
+
+### 5.7 How DRAIN Replaces the Sequencer
 
 The SpanDB paper's "atomic page allocation ordering" ensures batches are
 committed in order. With io_uring, `IOSQE_IO_DRAIN` on the fsync SQE
@@ -232,11 +319,10 @@ SQE[3]: fsync (DRAIN)                 ← waits for SQE[0], [1], [2] to complete
                                         then fsyncs → CQE confirms all durable
 ```
 
-All callers wait for the fsync CQE. No caller returns until all data is on
-disk. This is the same guarantee as the sequencer, but implemented by the
-kernel instead of userspace code.
+All callers wait for the fsync CQE (via the completion barrier). No caller
+returns until all data is on disk.
 
-### 5.7 Atomic Offset Allocator
+### 5.8 Atomic Offset Allocator
 
 ```rust
 struct OffsetAllocator {
@@ -244,35 +330,68 @@ struct OffsetAllocator {
 }
 
 impl OffsetAllocator {
+    /// Allocate `size` bytes at the current end of the WAL.
+    /// `size` must be 4KB-aligned (O_DIRECT requirement).
     fn alloc(&self, size: u64) -> u64 {
         self.next_offset.fetch_add(size, Ordering::AcqRel)
     }
 }
 ```
 
-Prevents overlapping writes. The allocator is updated before SQE submission.
-The offset is encoded in each SQE's `offset` field.
+**Initialization after recovery:** `next_offset` is set to the WAL file length
+after recovery truncation. The `recover_mvcc()` function already computes
+`valid_file` (wal.rs:443) — this value is passed through to the allocator.
 
-### 5.8 Record Checksum (Unchanged)
+### 5.9 Alignment Gap Handling
+
+O_DIRECT requires 4KB-aligned write sizes. Each batch buffer is zero-padded
+to the aligned length after encoding:
+
+```rust
+fn encode_batch(&self, data: &[(&[u8], &[u8])], commit_ts: u64) -> Result<Vec<u8>> {
+    // ... encode batch data into buf ...
+
+    // Zero-pad to 4KB alignment (O_DIRECT requirement).
+    // This also ensures recovery doesn't read stale bytes as batch data.
+    let aligned_len = Self::align_up(buf.len());
+    buf.resize(aligned_len, 0);
+
+    Ok(buf)
+}
+```
+
+**Why zero-pad?** Without padding, the alignment gap contains stale data from
+previous buffer reuse. The recovery scanner would read this garbage as batch
+headers, fail CRC validation, and truncate the WAL — losing all batches
+after the first gap.
+
+**Recovery handling of zero-padded regions:** The recovery scanner already
+handles this correctly. A zero-padded region reads as `entry_count=0` with
+`data_crc32=0`. The CRC of zero bytes is 0, so the batch is valid (it's an
+empty batch). Recovery continues past it to the next batch. The `entry_count`
+field is the authoritative batch size indicator — padding doesn't affect it.
+
+### 5.10 Record Checksum (Unchanged)
 
 Each batch has a CRC32 checksum over the entry data (existing `BATCH_HEADER_SIZE`
 = 16 bytes: commit_ts + entry_count + data_crc32). O_DIRECT does not affect
-the checksum — it covers the same bytes.
+the checksum — it covers only the valid bytes (before zero-padding).
 
-### 5.9 Recovery Scan (Unchanged)
+### 5.11 Recovery Scan (Unchanged)
 
-Recovery reads the WAL file sequentially (using buffered I/O — O_DIRECT is
-not needed for recovery), validates CRC per batch, and stops at the first
-invalid entry. The WAL file format is unchanged.
+Recovery reads the WAL file sequentially using the buffered file handle,
+validates CRC per batch, and stops at the first invalid entry. The WAL file
+format is unchanged.
 
-**Note:** Recovery uses a separate `File` handle opened without O_DIRECT,
-since recovery reads are sequential and benefit from the page cache.
+The buffered handle is opened with `.append(true)` for recovery. After
+recovery truncation, `alloc_offset` is initialized to the file length. The
+buffered handle is dropped; the O_DIRECT handle is used for writes.
 
-### 5.10 Two-Phase Protocol (Unchanged)
+### 5.12 Two-Phase Protocol (Unchanged)
 
 ```
 Phase 1 (under locks):
-  write_wal_batch_only() → encode into page-aligned buffer → push to pending list
+  write_wal_batch_only() → encode into page-aligned buffer → zero-pad → push to pending list
 
 Phase 2 (locks released):
   submit_and_commit() → drain pending → allocate offsets → submit SQEs → poll CQE
@@ -281,7 +400,7 @@ Phase 2 (locks released):
 The `pending` list (replacing `ready_queue`) holds encoded buffers across the
 lock boundary. Same role as the current `ready_queue`.
 
-### 5.11 Buffer Pool (Modified)
+### 5.13 Buffer Pool (Modified)
 
 The buffer pool allocates page-aligned buffers for O_DIRECT:
 
@@ -295,26 +414,61 @@ fn new_buf_pool() -> ArrayQueue<Vec<u8>> {
 }
 ```
 
-Buffer lifecycle is unchanged: pop → encode → push to pending → drain →
-pwrite via io_uring → return to pool after CQE.
+Buffer lifecycle is unchanged: pop → encode → zero-pad → push to pending →
+drain → submit SQE → poll CQE → return to pool.
 
-### 5.12 Public sync() Path
+### 5.14 Legacy put() Path
+
+The legacy `put()` method (non-MVCC format) writes directly to a BufWriter.
+O_DIRECT is incompatible with this path (non-aligned writes, arbitrary sizes).
+
+**Solution:** The `Wal` struct retains both handles:
+- `direct_file: File` — O_DIRECT handle for MVCC batch writes via io_uring.
+- `buf_writer: BufWriter<File>` — buffered handle for legacy `put()` and WAL header writes.
+
+The legacy path is routed to `buf_writer` when `!self.mvcc_format`. MVCC
+batch writes use `direct_file` via io_uring. Both handles point to the same
+inode — this is safe on Linux.
+
+### 5.15 Public sync() Path
 
 ```rust
 impl Wal {
     pub fn sync(&self) -> Result<()> {
-        // Flush any pending buffers via io_uring.
+        self.submit_and_commit()
+    }
+}
+```
+
+`sync()` is equivalent to `submit_and_commit()`. If there are pending buffers,
+they are drained and committed. If not, the completion barrier waits for any
+in-flight commit from another thread.
+
+### 5.16 Engine Close
+
+```rust
+impl Wal {
+    pub fn close(&self) -> Result<()> {
+        // 1. Drain any pending buffers.
         self.submit_and_commit()?;
+
+        // 2. Drain all remaining CQEs from the ring.
+        while let Some(cqe) = self.ring.completion().next() {
+            if cqe.result() < 0 {
+                log::error!("io_uring: stale CQE with error: {}", cqe.result());
+            }
+        }
+
+        // 3. The ring is dropped when Wal is dropped.
         Ok(())
     }
 }
 ```
 
-Since every `submit_and_commit()` includes a fsync (via DRAIN), `sync()` is
-just a thin wrapper. If nothing was pending, it's a no-op (the last
-`submit_and_commit()` already fsynced).
+Called from `KvEngine::close()` before `sync_dir()`. Ensures no in-flight
+SQEs are lost.
 
-### 5.13 Fallback
+### 5.17 Fallback
 
 On systems without io_uring support (kernel < 5.11, non-Linux), fall back to
 the current leader-follower group commit:
@@ -330,7 +484,9 @@ mod io_uring_wal {
 ```
 
 On Linux, attempt `IoUring::new()` at WAL open. If it fails (kernel too old),
-fall back to the synchronous path. Store `use_io_uring: bool` in the `Wal` struct.
+fall back to the synchronous path. Store `use_io_uring: bool` in the `Wal`
+struct. Feature detection is runtime, not compile-time — a Linux binary works
+on kernels 5.11+ (io_uring) and <5.11 (fallback).
 
 ---
 
@@ -339,33 +495,37 @@ fall back to the synchronous path. Store `use_io_uring: bool` in the `Wal` struc
 ### Advantages
 
 1. **True parallel I/O** — O_DIRECT bypasses inode lock; NVMe channels process writes concurrently.
-2. **Single syscall** — `io_uring_enter` submits all SQEs (vs N `write_all` calls).
-3. **No leader election** — No leader_active CAS, no batch_results ring buffer, no condvar.
+2. **Single syscall** — `io_uring_enter` submits all SQEs (vs BufWriter's ~66 syscalls for 8 × 64KB buffers).
+3. **No leader election** — Completion barrier replaces leader_active CAS, batch_results ring, condvar wake-up storms.
 4. **No BufWriter** — O_DIRECT writes directly to device. No userspace buffering bugs.
-5. **No sequencer** — IOSQE_IO_DRAIN handles ordering. Fsync CQE polling handles commit barrier.
+5. **No sequencer** — IOSQE_IO_DRAIN handles ordering. CQE polling handles commit barrier.
 6. **Faithful to paper** — Directly implements SpanDB's parallel WAL design with kernel I/O instead of SPDK.
 
 ### Disadvantages
 
 1. **Linux-only, kernel 5.11+** — Fallback needed for other platforms/kernels.
-2. **O_DIRECT constraints** — Page-aligned buffers, page-aligned offsets, no partial writes.
-3. **Complexity** — io_uring SQE/CQE model, buffer lifetime management.
+2. **O_DIRECT constraints** — Page-aligned buffers, page-aligned offsets, zero-padding.
+3. **Complexity** — io_uring SQE/CQE model, buffer lifetime management, dual file handles.
 4. **No page cache** — Recovery reads must use a separate buffered file handle.
 5. **Debugging** — Async I/O errors are harder to diagnose.
 
 ### Expected Performance
 
-Based on the SpanDB paper and io_uring benchmarks:
-
 | Metric | Current (group commit) | io_uring + O_DIRECT |
 |--------|----------------------|-------------------|
 | Write parallelism | None (single leader) | Full (NVMe channels) |
-| Syscalls per batch group | N write + 1 flush + 1 fsync | 1 io_uring_enter |
+| Syscalls per batch group | ~66 (BufWriter flushes + fsync) | 1 (io_uring_enter) |
 | Fsync count | 1 per group | 1 per group (DRAIN) |
-| Expected throughput gain | Baseline | 1.5-3× on NVMe |
+| Expected throughput gain | Baseline | 1.2-2× consumer NVMe, 2-3× enterprise NVMe |
 
-The gain depends on NVMe internal parallelism. Single-channel SSDs see less
-benefit; multi-channel enterprise SSDs see more.
+The gain depends on NVMe internal parallelism. Consumer NVMe SSDs have 1-2
+channels; enterprise drives have 4-8+. The primary source of throughput gain
+is write-phase parallelism (kernel dispatches to NVMe channels), not syscall
+reduction (fsync dominates total latency).
+
+Note: Per-operation io_uring is slower than std::fs (see `docs/io-uring-bench.md`).
+The gain comes entirely from batching — amortizing `io_uring_enter` overhead
+across N SQEs.
 
 ---
 
@@ -374,13 +534,15 @@ benefit; multi-channel enterprise SSDs see more.
 | Phase | Description | Files |
 |-------|-------------|-------|
 | 1 | Add `io-uring` dependency (feature-gated) | `Cargo.toml` |
-| 2 | Add page-aligned buffer allocator | `wal.rs` |
-| 3 | Implement io_uring write path in `submit_and_commit()` | `wal.rs` |
-| 4 | Add fallback to current group commit | `wal.rs` |
-| 5 | Update recovery to use buffered file handle | `wal.rs` |
-| 6 | Update `sync()` path | `wal.rs` |
-| 7 | Add tests | `tests/wal.rs` |
-| 8 | Benchmark | — |
+| 2 | Add page-aligned buffer allocator + zero-padding | `wal.rs` |
+| 3 | Add dual file handles (buffered + O_DIRECT) | `wal.rs` |
+| 4 | Implement io_uring write path with completion barrier | `wal.rs` |
+| 5 | Add legacy `put()` fallback to BufWriter | `wal.rs` |
+| 6 | Update recovery to use buffered handle | `wal.rs` |
+| 7 | Add `Wal::close()` for ring cleanup | `wal.rs` |
+| 8 | Add fallback to current group commit | `wal.rs` |
+| 9 | Add tests | `tests/wal.rs` |
+| 10 | Benchmark | — |
 
 ---
 
@@ -389,16 +551,16 @@ benefit; multi-channel enterprise SSDs see more.
 1. **Correctness:** All existing WAL tests pass (format unchanged).
 2. **io_uring path:** Write, read back, verify. Concurrent writers. Recovery after crash.
 3. **Fallback path:** Force fallback, verify same correctness.
-4. **O_DIRECT alignment:** Test with various batch sizes (4KB, 8KB, 12KB — verify padding).
-5. **Benchmark:** `write-perf --workload wal_concurrent --threads 1,2,4,8`.
-6. **Stress test:** 16+ concurrent writers with crash injection.
+4. **O_DIRECT alignment:** Test with various batch sizes (4KB, 8KB, 12KB — verify zero-padding).
+5. **Legacy put():** Test non-MVCC WAL writes still work via BufWriter path.
+6. **Engine close:** Verify all in-flight SQEs are drained before return.
+7. **Benchmark:** `write-perf --workload wal_concurrent --threads 1,2,4,8`.
+8. **Stress test:** 16+ concurrent writers with crash injection.
 
 ---
 
 ## 9. Open Questions
 
-1. **Ring size:** 64 SQE slots. Is this enough? If >64 batches accumulate, submit in chunks.
-2. **fdatasync vs fsync:** `fdatasync` skips metadata sync (faster). Recommendation: use `fdatasync` for WAL.
-3. **Poll mode:** `IORING_SETUP_SQPOLL` for kernel-side polling. Trade-off: lower latency vs higher CPU. Recommendation: start without, add as optimization.
-4. **Single issuer:** `IORING_SETUP_SINGLE_ISSUER` (kernel 5.19+) optimizes for single-threaded submission. Recommendation: enable if kernel supports.
-5. **Buffer pool sizing:** 16 buffers × 64KB = 1MB. With O_DIRECT, each buffer is page-aligned. Is 16 enough for high concurrency? Recommendation: benchmark with 16, 32, 64.
+1. **Ring size:** 64 SQE slots. If >64 batches accumulate, submit in chunks (submit 64, wait for CQEs, submit next 64).
+2. **Poll mode:** `IORING_SETUP_SQPOLL` for kernel-side polling. Trade-off: lower latency vs higher CPU. Recommendation: start without, add as optimization.
+3. **Buffer pool sizing:** 16 buffers × 64KB = 1MB. Is 16 enough for high concurrency? Recommendation: benchmark with 16, 32, 64.

--- a/rfcs/012-parallel-wal.md
+++ b/rfcs/012-parallel-wal.md
@@ -196,12 +196,12 @@ at unaligned file offsets fail with `EINVAL`. After the padded header is
 written and flushed, the buffered handle is closed and the O_DIRECT handle is
 opened.
 
-**v3→v4 upgrade:** When opening an existing v3 WAL for the first time under v4,
-recovery truncates at the last valid v3 batch. The file is then padded to the
-next 4KB boundary with zeros (via the buffered handle) before switching to the
-O_DIRECT handle. This ensures `alloc_offset` is 4KB-aligned for the first v4
-write. The padded region is harmless — recovery skips it via the v4
-alignment-gap logic.
+**v3 WAL handling:** Existing v3 WALs continue writing v3-format batches
+(16-byte headers, no alignment padding) for the lifetime of that WAL file.
+Only newly created WAL files use v4 format. This avoids mixing v3 and v4
+records in the same file, which would break recovery (the file header declares
+one version but the body contains both). WAL rotation creates a new v4 file
+when the current v3 file is flushed and archived.
 
 **Recovery:** Reads via the buffered handle. After recovery truncation,
 `alloc_offset` is initialized to the file length (the byte after the last
@@ -259,11 +259,14 @@ impl Wal {
 
         // 2. Chunked submission: if the batch exceeds ring capacity (64 SQEs),
         //    submit in chunks of 63 writes + 1 fsync, waiting for completions
-        //    between chunks. This avoids panicking under high concurrency.
+        //    between chunks. Each chunk is independently committed — if chunk 1
+        //    succeeds but chunk 2 fails, chunk 1's callers get Ok() and chunk 2's
+        //    callers get Err(). The generation counter advances per chunk, so
+        //    each chunk's waiters read their own result from the ring buffer.
         let max_writes_per_chunk = 63;  // leave 1 slot for fsync
         let chunks: Vec<&[DirectBuf]> = bufs.chunks(max_writes_per_chunk).collect();
         let mut offset = base_offset;
-        for chunk in chunks {
+        for (chunk_num, chunk) in chunks.iter().enumerate() {
             let total_sqes = chunk.len() + 1; // writes + fsync
 
             // 3. Submit write SQEs (parallel I/O to NVMe).
@@ -333,22 +336,25 @@ impl Wal {
                 }
             }
             drop(cq);
-            // On I/O error, poison the WAL to prevent further writes.
-            // The allocated offset range for the failed batch is skipped;
-            // without poisoning, later successful commits would be
-            // unrecoverable (recovery stops at the first gap).
+            // On I/O error, poison the WAL and return buffers to pool
+            // before bailing. Without the pool return, repeated errors
+            // would exhaust the 16-buffer pool (buffers freed via Drop
+            // are never returned to the ArrayQueue).
             if write_err.is_some() || fsync_err.is_some() {
                 self.poisoned.store(true, Ordering::Release);
-            }
-            if let Some(err) = write_err {
-                anyhow::bail!("io_uring write error: {}", err);
-            }
-            if let Some(err) = fsync_err {
-                anyhow::bail!("io_uring fsync error: {}", err);
+                for buf in bufs {
+                    let _ = self.buf_pool.push(buf);
+                }
+                if let Some(err) = write_err {
+                    anyhow::bail!("io_uring write error: {}", err);
+                }
+                if let Some(err) = fsync_err {
+                    anyhow::bail!("io_uring fsync error: {}", err);
+                }
             }
         }
 
-        // 7. Return buffers to pool.
+        // 7. Return buffers to pool on success.
         for buf in bufs {
             let _ = self.buf_pool.push(buf);
         }
@@ -501,10 +507,16 @@ impl Wal {
 }
 ```
 
-This ensures all callers see the same result — success or failure. The
-submitter broadcasts the CQE outcome to all waiters via condvar. The
-generation counter prevents a late-arriving waiter from consuming a stale
-result from a previous commit cycle.
+This ensures all callers see the correct result for their specific generation.
+The submitter broadcasts the CQE outcome to all waiters via condvar. The
+generation counter and ring buffer prevent a late-arriving waiter from
+consuming a stale result from a previous commit cycle.
+
+**Chunked submission interaction:** When `submit_and_commit` processes multiple
+chunks, each chunk increments the generation independently. Callers whose
+buffers were in chunk N wait on generation N; callers in chunk N+1 wait on
+generation N+1. If chunk N succeeds but chunk N+1 fails, only chunk N+1's
+callers receive the error.
 
 ### 5.7 How DRAIN Replaces the Sequencer
 
@@ -643,8 +655,9 @@ header, fail CRC validation, and truncate the WAL.
 
 ### 5.10 Record Checksum & Header (Modified)
 
-Each batch has a CRC32 checksum over the entry data (existing `BATCH_HEADER_SIZE`
-= 16 bytes: commit_ts + entry_count + data_crc32). O_DIRECT does not affect
+Each batch has a CRC32 checksum over the **entry data only** (the payload
+bytes after the header), consistent with the existing v3 implementation in
+`wal.rs`. The CRC does NOT cover header fields. O_DIRECT does not affect
 the checksum — it covers only the valid bytes (before zero-padding).
 
 **New field: `data_len`** (4 bytes, added after `data_crc32`). Stores the
@@ -774,16 +787,24 @@ inode — this is safe on Linux.
 ```rust
 impl Wal {
     pub fn sync(&self) -> Result<()> {
+        if !self.mvcc_format {
+            // Legacy path: flush and fsync the BufWriter directly.
+            // submit_and_commit() only handles the io_uring path.
+            self.buf_writer.lock().flush()?;
+            self.buf_writer.get_ref().sync_data()?;
+            return Ok(());
+        }
         self.submit_and_commit()
     }
 }
 ```
 
-`sync()` is equivalent to `submit_and_commit()`. If there are pending buffers,
-they are drained and committed. If not, the completion barrier checks whether
-a commit is in flight: if so, it waits; if not, it returns immediately. This
-prevents `sync()` from blocking forever on a clean WAL with no pending writes
-and no in-flight commits (e.g., during `close()` before any writes).
+`sync()` is equivalent to `submit_and_commit()` for the MVCC/io_uring path.
+If there are pending buffers, they are drained and committed. If not, the
+completion barrier checks whether a commit is in flight: if so, it waits;
+if not, it returns immediately. For the legacy `!mvcc_format` path, `sync()`
+flushes and fsyncs the `BufWriter` directly — `submit_and_commit()` does not
+handle buffered writes.
 
 ### 5.16 Engine Close
 

--- a/rfcs/012-parallel-wal.md
+++ b/rfcs/012-parallel-wal.md
@@ -1,4 +1,4 @@
-# RFC 012: WAL Write Throughput — Ordered Commit with pwrite
+# RFC 012: Parallel WAL — io_uring + O_DIRECT
 
 **Status:** Proposed
 **Date:** 2026-06-26
@@ -9,142 +9,150 @@
 
 ## 1. Summary
 
-This RFC proposes improving WAL write throughput by replacing the current
-leader-follower group commit with a simpler **ordered commit sequencer** that
-piggybacks fsyncs, combined with `pwrite` for position-independent writes to
-a single WAL file.
+This RFC proposes replacing the current leader-follower group commit with
+**io_uring + O_DIRECT** for parallel WAL writes, directly implementing the
+SpanDB paper's design:
 
-The design:
+1. **Log batching** — multiple writers' entries collected into batches (existing).
+2. **Parallel writers** — batches submitted as io_uring SQEs, dispatched to NVMe channels in parallel.
+3. **Atomic page allocation** — each batch gets a unique, non-overlapping file offset.
 
-1. **Atomic offset allocator** — each batch gets a sequential file offset via `fetch_add`.
-2. **pwrite** — writers write to the file at their allocated offsets (no BufWriter, no seek).
-3. **Record checksum** — CRC32 per batch (unchanged).
-4. **Ordered commit sequencer** — batches are committed in order; fsync is skipped when a prior fsync already covered the data.
-5. **Recovery scan** — sequential scan, validate CRC (unchanged).
-
-The fsync count is the same as the current group commit (1 fsync for N concurrent
-writers), but the code is significantly simpler: no leader election, no batch
-results ring buffer, no condvar wake-up storms.
+O_DIRECT bypasses the page cache and the ext4 inode lock, enabling true
+parallel writes to the same file. io_uring's `IOSQE_IO_DRAIN` ensures the
+fsync waits for all prior writes, replacing the need for an explicit sequencer.
 
 ---
 
 ## 2. Motivation
 
-### Current Design Complexity
+### Current Bottleneck
 
-The current group commit (`wal.rs:878-977`) uses a leader-follower model with:
-- Ticket-based leader election (`commit_waiters` + `committed_gen` + `leader_active` CAS)
-- Batch results ring buffer (256 slots) for error propagation
-- Condvar + mutex for follower wake-up
-- `ready_queue` (SegQueue) for buffer staging
-- File mutex held during drain + write + flush + fsync
+The current WAL uses a single-leader group commit:
 
-This works correctly but is complex. The sequencer achieves the same fsync
-efficiency with simpler primitives.
+```
+8 writers → leader drains → sequential BufWriter::write_all → flush → fsync → wake 8
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+            Single thread, serialized, held under file mutex
+```
+
+The leader does all the work. The other 7 threads wait.
 
 ### What Changes
 
-| Aspect | Current | Proposed |
-|--------|---------|----------|
-| Writer role | Push buffer to queue, wait for leader | pwrite at allocated offset, check sequencer |
-| Leader | Drains queue, writes, fsyncs, wakes followers | No leader |
-| Fsync trigger | Every batch (leader always fsyncs) | Only when no prior fsync covers this batch |
-| Ordering | Implicit (leader writes in queue order) | Explicit (sequencer tracks confirmed offset) |
-| File I/O | BufWriter + write_all + flush + sync_all | Raw File + pwrite (write_at) + sync_all |
-| Followers | Block on condvar, wake on notify_all | Check atomic confirmed_offset, return if covered |
+```
+8 writers → encode buffers → submit 8 SQEs + 1 fsync(DRAIN) → io_uring_enter
+            → kernel dispatches to NVMe channels in parallel
+            → poll fsync CQE → all 8 batches durable → wake all
+```
+
+No leader. No mutex (for I/O). No condvar. Just SQE submission + CQE polling.
+
+### Why Not Buffered I/O?
+
+Buffered writes to the same file are serialized by the ext4 inode lock
+(`inode_lock` in `ext4_file_write_iter`). io_uring SQEs submit in parallel,
+but the kernel processes them sequentially. No actual parallelism.
+
+O_DIRECT bypasses the page cache and the inode lock. Writes go directly to
+the NVMe device, which has internal parallelism (multiple channels). The
+kernel dispatches SQEs to different NVMe submission queues concurrently.
 
 ---
 
 ## 3. Goals
 
-1. Replace leader-follower group commit with an ordered commit sequencer.
-2. Use `pwrite` (position-independent writes) instead of BufWriter + seek.
-3. Piggyback fsyncs — skip fsync when a prior fsync already covered the data.
-4. No changes to the public `KvEngine` API.
+1. Replace leader-follower group commit with io_uring + O_DIRECT.
+2. Parallel write I/O to the NVMe device.
+3. Single fsync per batch group via `IOSQE_IO_DRAIN`.
+4. Maintain the two-phase write protocol (`write_wal_batch_only` → `commit_wal`).
 5. Backward compatible WAL file format (v3, unchanged).
 6. Recovery unchanged — sequential scan + CRC validation.
 
 ## 4. Non-Goals
 
-1. Parallel I/O to a single file (ext4 inode lock serializes buffered writes).
-2. Multiple WAL files / shards.
-3. io_uring integration (deferred to future work).
-4. SPDK integration.
-5. Changing the WAL file format.
+1. Multiple WAL files / shards.
+2. SPDK integration.
+3. Changing the WAL file format.
+4. io_uring for reads (separate concern).
 
 ---
 
 ## 5. Design
 
-### 5.1 Sequencer State
+### 5.1 Overview
+
+```
+Phase 1 (under locks):
+  write_wal_batch_only() → encode buffer → push to pending list
+
+Phase 2 (locks released):
+  submit_and_commit():
+    1. Drain pending list
+    2. Allocate offsets (atomic fetch_add)
+    3. Submit write SQEs (one per buffer)
+    4. Submit fsync SQE with IOSQE_IO_DRAIN
+    5. io_uring_enter (one syscall for all SQEs)
+    6. Poll fsync CQE (confirms all writes are durable)
+    7. Return buffers to pool
+```
+
+### 5.2 O_DIRECT Buffer Requirements
+
+O_DIRECT requires page-aligned buffers (typically 4KB aligned, 4KB multiple
+sizes). The current buffer pool allocates `Vec<u8>` with 64KB capacity, which
+is page-aligned on most systems but not guaranteed.
 
 ```rust
-/// Tracks the commit state of the WAL.
-struct CommitSequencer {
-    /// Next file offset to allocate (advanced BEFORE write).
-    alloc_offset: AtomicU64,
-    /// Highest file offset where ALL preceding bytes have been pwritten
-    /// to the page cache (advanced AFTER write completes).
-    confirmed_offset: AtomicU64,
-    /// Highest file offset that has been fsynced to disk.
-    synced_offset: AtomicU64,
-    /// Mutex + condvar for commit signaling.
-    commit_mutex: Mutex<()>,
-    commit_cond: Condvar,
-    /// Whether a thread is currently fsyncing (prevents redundant fsyncs).
-    fsync_in_progress: AtomicBool,
-    /// Error flag — set if fsync fails, checked by all waiters.
-    last_error: Mutex<Option<String>>,
+/// Allocate a page-aligned buffer for O_DIRECT I/O.
+fn alloc_direct_buf(size: usize) -> Vec<u8> {
+    let layout = Layout::from_size_align(size.max(4096), 4096).unwrap();
+    let ptr = unsafe { std::alloc::alloc(layout) };
+    unsafe { Vec::from_raw_parts(ptr, 0, size.max(4096)) }
 }
 ```
 
-Key distinction between the three offsets:
+Or use the `aligned_alloc` / `posix_memalign` APIs via the `libc` crate.
 
-| Offset | When advanced | Meaning |
-|--------|--------------|---------|
-| `alloc_offset` | Before pwrite | "This region is reserved for a batch" |
-| `confirmed_offset` | After pwrite completes | "This region is in the page cache" |
-| `synced_offset` | After fsync completes | "This region is on disk" |
+**Buffer pool change:** Replace `ArrayQueue<Vec<u8>>` with page-aligned
+allocations. The pool size (16 buffers × 64KB) and lifecycle are unchanged.
 
-**`synced_offset` is only advanced to `confirmed_offset`**, never to `alloc_offset`.
-This prevents the data-loss bug where `synced_offset` claims bytes are durable
-that were only reserved, not written.
-
-### 5.2 File Handling
-
-The WAL file is opened **without O_APPEND**:
+### 5.3 File Handling
 
 ```rust
 let f = File::options()
     .read(true)
-    .write(true)    // not append — pwrite controls position
-    .create(false)  // file already exists after create()
+    .write(true)
+    .custom_flags(libc::O_DIRECT)  // bypass page cache + inode lock
     .open(path)?;
 ```
 
-O_APPEND would silently ignore pwrite offsets (the kernel seeks to EOF before
-every write). Without O_APPEND, `pwrite` (Rust's `File::write_all_at`) writes
-at the specified offset.
+O_DIRECT requirements:
+- Buffer address must be page-aligned (4KB).
+- Buffer size must be a multiple of the logical block size (typically 512B or 4KB).
+- File offset must be page-aligned.
 
-BufWriter is removed. pwrite writes directly to the file descriptor. BufWriter
-provides no benefit with position-independent writes (each write is at a
-different offset, so BufWriter's sequential buffering is useless).
+All WAL batches are encoded into page-aligned buffers with sizes rounded up
+to 4KB. The actual data length is recorded in the batch header (CRC covers
+only the valid bytes).
 
-### 5.3 Write Path
+### 5.4 io_uring Setup
+
+```rust
+use io_uring::{opcode, types, IoUring, Builder};
+
+let ring = Builder::new(64)          // 64 SQE slots
+    .setup_single_issuer()           // single-threaded submission (kernel optimization)
+    .build()?;
+ring.submitter().register_files(&[file_fd])?;  // register WAL file FD
+```
+
+The ring is created once at WAL open and destroyed at WAL close. It is used
+exclusively for WAL writes — not shared with other subsystems.
+
+### 5.5 Write + Commit Flow
 
 ```rust
 impl Wal {
-    /// Encode a batch into a buffer and push to the pending list.
-    /// Phase 1: called under locks (same as current put_batch).
-    pub fn put_batch(&self, data: &[(&[u8], &[u8])], commit_ts: u64) -> Result<()> {
-        // Encode into pooled buffer (same as current).
-        let buf = self.encode_batch(data, commit_ts)?;
-        self.pending.lock().push(buf);
-        Ok(())
-    }
-
-    /// Write all pending buffers to the file and commit.
-    /// Phase 2: called after locks are released (same as current submit_and_commit).
     pub fn submit_and_commit(&self) -> Result<()> {
         let bufs: Vec<Vec<u8>> = {
             let mut pending = self.pending.lock();
@@ -154,81 +162,55 @@ impl Wal {
             return Ok(());
         }
 
-        // 1. Allocate file offsets atomically (BEFORE write).
-        let mut offsets = Vec::with_capacity(bufs.len());
-        let mut offset = self.sequencer.alloc_offset.fetch_add(
-            bufs.iter().map(|b| b.len() as u64).sum(),
-            Ordering::AcqRel,
-        );
+        // 1. Allocate file offsets atomically.
+        let total_size: u64 = bufs.iter().map(|b| b.len() as u64).sum();
+        let base_offset = self.alloc_offset.fetch_add(total_size, Ordering::AcqRel);
+
+        // 2. Submit write SQEs (parallel I/O to NVMe).
+        let mut offset = base_offset;
         for buf in &bufs {
-            offsets.push(offset);
-            offset += buf.len() as u64;
-        }
-        let end_offset = offset;
-
-        // 2. Write to file at allocated offsets (pwrite).
-        let file = self.file.lock();
-        for (buf, &off) in bufs.iter().zip(&offsets) {
-            file.write_all_at(buf, off)?;
-        }
-        drop(file);
-
-        // 3. Confirm writes (AFTER pwrite completes).
-        //    This advances confirmed_offset past all written bytes.
-        //    Must be done AFTER all pwrites to prevent the race where
-        //    synced_offset advances past unwritten bytes.
-        self.advance_confirmed(end_offset);
-
-        // 4. Commit via sequencer (may piggyback on prior fsync).
-        self.sequencer.commit(end_offset, &self.file)
-    }
-}
-```
-
-### 5.4 Sequencer Commit Logic
-
-```rust
-impl CommitSequencer {
-    fn commit(&self, my_end_offset: u64, file: &Arc<Mutex<File>>) -> Result<()> {
-        let mut guard = self.commit_mutex.lock();
-
-        // Fast path: already covered by a prior fsync.
-        if self.synced_offset.load(Ordering::Acquire) >= my_end_offset {
-            return Ok(());
+            let aligned_len = Self::align_up(buf.len());
+            let sqe = opcode::Write::new(
+                types::Fixed(0),       // registered file FD
+                buf.as_ptr(),
+                aligned_len as u32,
+            )
+            .offset(offset)
+            .build();
+            unsafe { self.ring.submission().push(&sqe)?; }
+            offset += aligned_len as u64;
         }
 
-        // Check for prior error.
-        if let Some(ref err) = *self.last_error.lock() {
-            anyhow::bail!("prior WAL fsync failed: {}", err);
-        }
+        // 3. Submit fsync with IOSQE_IO_DRAIN.
+        //    DRAIN: "do not start this SQE until all prior SQEs complete."
+        //    This ensures the fsync covers all preceding writes.
+        let fsync_sqe = opcode::Fsync::new(types::Fixed(0))
+            .flags(types::FsyncFlags::FDATASYNC)  // fdatasync is sufficient for WAL
+            .build()
+            .flags(types::Flags::IO_DRAIN);
+        unsafe { self.ring.submission().push(&fsync_sqe)?; }
 
-        // Try to become the fsyncer.
-        if !self.fsync_in_progress.swap(true, Ordering::AcqRel) {
-            // I am the fsyncer — do the fsync.
-            let result = file.lock().sync_all();
+        // 4. Submit all SQEs in one syscall.
+        self.ring.submit_and_wait(bufs.len() + 1)?;
 
-            // Advance synced_offset to confirmed_offset (NOT alloc_offset).
-            let confirmed = self.confirmed_offset.load(Ordering::Acquire);
-            self.synced_offset.store(confirmed, Ordering::Release);
-            self.fsync_in_progress.store(false, Ordering::Release);
-
-            if let Err(e) = result {
-                *self.last_error.lock() = Some(e.to_string());
-                self.commit_cond.notify_all();
-                anyhow::bail!("WAL fsync failed: {}", e);
+        // 5. Poll for all CQEs.
+        for _ in 0..bufs.len() {
+            let cqe = self.ring.completion().next()
+                .ok_or_else(|| anyhow!("io_uring: missing write CQE"))?;
+            if cqe.result() < 0 {
+                anyhow::bail!("io_uring write error: {}", cqe.result());
             }
-
-            self.commit_cond.notify_all();
-            return Ok(());
+        }
+        // Fsync CQE — confirms all data is durable.
+        let fsync_cqe = self.ring.completion().next()
+            .ok_or_else(|| anyhow!("io_uring: missing fsync CQE"))?;
+        if fsync_cqe.result() < 0 {
+            anyhow::bail!("io_uring fsync error: {}", fsync_cqe.result());
         }
 
-        // Another thread is fsyncing — wait for it.
-        while self.synced_offset.load(Ordering::Acquire) < my_end_offset {
-            // Check for error from the fsyncing thread.
-            if let Some(ref err) = *self.last_error.lock() {
-                anyhow::bail!("prior WAL fsync failed: {}", err);
-            }
-            self.commit_cond.wait(&mut guard);
+        // 6. Return buffers to pool.
+        for buf in bufs {
+            let _ = self.buf_pool.push(buf);
         }
 
         Ok(())
@@ -236,154 +218,119 @@ impl CommitSequencer {
 }
 ```
 
-### 5.5 How Piggyback Works
+### 5.6 How DRAIN Replaces the Sequencer
 
-Example with 3 concurrent writers:
-
-```
-Writer A: alloc_offset=0   → pwrite 0-100   → confirmed=100  → commit(100)
-Writer B: alloc_offset=100 → pwrite 100-150  → confirmed=150  → commit(150)
-Writer C: alloc_offset=150 → pwrite 150-230  → confirmed=230  → commit(230)
-
-Sequencer state: synced_offset=0, confirmed_offset=230
-
-Writer A enters commit(100):
-  synced_offset (0) < my_end_offset (100)
-  fsync_in_progress = false → CAS succeeds → I am the fsyncer
-  sync_all() → flushes pages 0-230 (all dirty data)
-  confirmed = 230 → synced_offset = 230
-  notify_all
-  → Writer A returns ✓
-
-Writer B enters commit(150):
-  synced_offset (230) >= my_end_offset (150) → fast path
-  → Writer B returns immediately ✓ (no fsync)
-
-Writer C enters commit(230):
-  synced_offset (230) >= my_end_offset (230) → fast path
-  → Writer C returns immediately ✓ (no fsync)
-
-Result: 1 fsync for 3 batches (same as current group commit)
-```
-
-### 5.6 The Ordering Race (Why confirmed_offset Is Needed)
-
-Without `confirmed_offset`, using `alloc_offset` for `synced_offset`:
+The SpanDB paper's "atomic page allocation ordering" ensures batches are
+committed in order. With io_uring, `IOSQE_IO_DRAIN` on the fsync SQE
+achieves this:
 
 ```
-Writer A: alloc_offset=0, written_offset=100   (write delayed)
-Writer B: alloc_offset=100, pwrite 100-150 done
-Writer B: commit(150) → fsync → synced_offset=150
-  BUT: bytes 0-100 were never written! synced_offset lies.
-
-Writer A: finally pwrite 0-100
-  crash → Batch A lost, but synced_offset claimed it was safe ✗
+SQE[0]: write batch A at offset 0     ─┐
+SQE[1]: write batch B at offset 100   ─┤ parallel to NVMe
+SQE[2]: write batch C at offset 250   ─┘
+SQE[3]: fsync (DRAIN)                 ← waits for SQE[0], [1], [2] to complete
+                                        then fsyncs → CQE confirms all durable
 ```
 
-With `confirmed_offset`:
+All callers wait for the fsync CQE. No caller returns until all data is on
+disk. This is the same guarantee as the sequencer, but implemented by the
+kernel instead of userspace code.
 
-```
-Writer A: alloc_offset=0   → pwrite delayed
-Writer B: alloc_offset=100 → pwrite 100-150 → confirmed=150
-Writer B: commit(150) → fsync → synced_offset = confirmed_offset
-  BUT: confirmed_offset was advanced by advance_confirmed(150),
-  which checks that ALL bytes 0-150 were written. Since Writer A
-  hasn't written yet, confirmed_offset stays at 0 (not 150).
-  synced_offset = 0. Writer B waits.
-
-Writer A: pwrite 0-100 → confirmed=150 (now all 0-150 written)
-Writer B: wakes → synced_offset=150 → returns ✓
-```
-
-The `advance_confirmed` function ensures `confirmed_offset` only advances
-past bytes that are actually in the page cache.
-
-### 5.7 advance_confirmed Implementation
+### 5.7 Atomic Offset Allocator
 
 ```rust
-impl Wal {
-    /// Advance confirmed_offset to `target` only if all preceding
-    /// writes have completed. Uses a secondary watermark to track
-    /// contiguous written regions.
-    fn advance_confirmed(&self, target: u64) {
-        // Simple approach: since writes are sequential under the file mutex,
-        // the last writer to release the mutex knows all prior writes completed.
-        // We can safely advance confirmed_offset to target.
-        //
-        // For future pwrite parallelism (io_uring), use a per-batch
-        // "write-complete" flag and advance the watermark contiguously.
-        self.sequencer.confirmed_offset.store(target, Ordering::Release);
+struct OffsetAllocator {
+    next_offset: AtomicU64,
+}
+
+impl OffsetAllocator {
+    fn alloc(&self, size: u64) -> u64 {
+        self.next_offset.fetch_add(size, Ordering::AcqRel)
     }
 }
 ```
 
-**Note:** With sequential pwrite under the file mutex, `advance_confirmed` is
-simple — the mutex guarantees all prior writes completed. For future io_uring
-parallel writes, a contiguous watermark approach is needed (each writer marks
-its batch complete, and the watermark advances past all contiguous completed
-batches).
+Prevents overlapping writes. The allocator is updated before SQE submission.
+The offset is encoded in each SQE's `offset` field.
 
-### 5.8 Two-Phase Protocol (Unchanged)
+### 5.8 Record Checksum (Unchanged)
 
-The existing two-phase write protocol is preserved:
+Each batch has a CRC32 checksum over the entry data (existing `BATCH_HEADER_SIZE`
+= 16 bytes: commit_ts + entry_count + data_crc32). O_DIRECT does not affect
+the checksum — it covers the same bytes.
+
+### 5.9 Recovery Scan (Unchanged)
+
+Recovery reads the WAL file sequentially (using buffered I/O — O_DIRECT is
+not needed for recovery), validates CRC per batch, and stops at the first
+invalid entry. The WAL file format is unchanged.
+
+**Note:** Recovery uses a separate `File` handle opened without O_DIRECT,
+since recovery reads are sequential and benefit from the page cache.
+
+### 5.10 Two-Phase Protocol (Unchanged)
 
 ```
 Phase 1 (under locks):
-  write_wal_batch_only() → wal.put_batch() → encode buffer, push to pending list
+  write_wal_batch_only() → encode into page-aligned buffer → push to pending list
 
 Phase 2 (locks released):
-  commit_wal() → wal.submit_and_commit() → pwrite + sequencer commit
+  submit_and_commit() → drain pending → allocate offsets → submit SQEs → poll CQE
 ```
 
 The `pending` list (replacing `ready_queue`) holds encoded buffers across the
-lock boundary. Same role as the current `ready_queue`, simpler data structure.
+lock boundary. Same role as the current `ready_queue`.
 
-### 5.9 Buffer Pool (Unchanged)
+### 5.11 Buffer Pool (Modified)
 
-The buffer pool (`ArrayQueue<Vec<u8>>`) lifecycle:
-1. `put_batch()` pops from pool, encodes, pushes to `pending` list.
-2. `submit_and_commit()` takes all pending buffers, pwrites, returns to pool after commit.
+The buffer pool allocates page-aligned buffers for O_DIRECT:
 
-Same lifecycle as current. The leader role is gone — the calling thread does
-the pwrite and returns buffers itself.
+```rust
+fn new_buf_pool() -> ArrayQueue<Vec<u8>> {
+    let pool = ArrayQueue::new(BUFFER_POOL_CAPACITY);
+    for _ in 0..BUFFER_POOL_CAPACITY {
+        let _ = pool.push(alloc_direct_buf(BUFFER_POOL_BUF_SIZE));
+    }
+    pool
+}
+```
 
-### 5.10 Public sync() Path
+Buffer lifecycle is unchanged: pop → encode → push to pending → drain →
+pwrite via io_uring → return to pool after CQE.
 
-`KvEngine::sync()` calls `wal.sync()`. The sequencer-aware `sync()`:
+### 5.12 Public sync() Path
 
 ```rust
 impl Wal {
     pub fn sync(&self) -> Result<()> {
-        // Flush any pending buffers.
+        // Flush any pending buffers via io_uring.
         self.submit_and_commit()?;
-        // If nothing was pending, fsync the file directly.
-        if self.sequencer.synced_offset.load(Ordering::Acquire)
-            < self.sequencer.confirmed_offset.load(Ordering::Acquire)
-        {
-            self.file.lock().sync_all()?;
-            let confirmed = self.sequencer.confirmed_offset.load(Ordering::Acquire);
-            self.sequencer.synced_offset.store(confirmed, Ordering::Release);
-        }
         Ok(())
     }
 }
 ```
 
-This ensures `sync()` always leaves the file durable, even if no batches
-were pending.
+Since every `submit_and_commit()` includes a fsync (via DRAIN), `sync()` is
+just a thin wrapper. If nothing was pending, it's a no-op (the last
+`submit_and_commit()` already fsynced).
 
-### 5.11 Recovery (Unchanged)
+### 5.13 Fallback
 
-Recovery scans the WAL file sequentially:
+On systems without io_uring support (kernel < 5.11, non-Linux), fall back to
+the current leader-follower group commit:
 
-1. Read batch header (commit_ts, entry_count, crc32).
-2. Validate CRC32 over entry data.
-3. If valid, replay entries into skiplist.
-4. If invalid (CRC mismatch, truncated), stop — this is the recovery point.
-5. Truncate file to last valid byte.
+```rust
+#[cfg(target_os = "linux")]
+mod io_uring_wal { ... }
 
-The WAL file format is unchanged. Recovery constructs a new `Wal` with
-`alloc_offset` set to the file length (append position).
+#[cfg(not(target_os = "linux"))]
+mod io_uring_wal {
+    // Re-export current group commit as fallback.
+}
+```
+
+On Linux, attempt `IoUring::new()` at WAL open. If it fails (kernel too old),
+fall back to the synchronous path. Store `use_io_uring: bool` in the `Wal` struct.
 
 ---
 
@@ -391,28 +338,34 @@ The WAL file format is unchanged. Recovery constructs a new `Wal` with
 
 ### Advantages
 
-1. **Simpler code** — No leader election, no batch results ring buffer, no condvar wake-up storms. Just atomic offsets + pwrite + sequencer.
-2. **Same fsync count** — 1 fsync for N concurrent writers (piggyback), same as current group commit.
-3. **No BufWriter** — pwrite writes directly to file. No seek + flush interaction bugs.
-4. **No O_APPEND** — pwrite controls position explicitly. No silent offset ignoring.
-5. **Phase 2 ready** — The atomic offset allocator and pwrite model map directly to io_uring SQEs when ready.
-6. **Single file** — No multi-shard complexity. Same file format, same recovery.
+1. **True parallel I/O** — O_DIRECT bypasses inode lock; NVMe channels process writes concurrently.
+2. **Single syscall** — `io_uring_enter` submits all SQEs (vs N `write_all` calls).
+3. **No leader election** — No leader_active CAS, no batch_results ring buffer, no condvar.
+4. **No BufWriter** — O_DIRECT writes directly to device. No userspace buffering bugs.
+5. **No sequencer** — IOSQE_IO_DRAIN handles ordering. Fsync CQE polling handles commit barrier.
+6. **Faithful to paper** — Directly implements SpanDB's parallel WAL design with kernel I/O instead of SPDK.
 
 ### Disadvantages
 
-1. **pwrite serialized by inode lock** — ext4 serializes buffered pwrite calls to the same file. Writers don't actually write in parallel. (Same as current — the leader writes sequentially too.)
-2. **Sequencer overhead** — Atomic ops (fetch_add, load, store) + mutex per commit. Marginal vs current leader election overhead.
-3. **Low concurrency** — With 1 writer, every batch fsyncs. Sequencer adds overhead for no benefit. Mitigation: short-circuit when pending list has 1 buffer.
+1. **Linux-only, kernel 5.11+** — Fallback needed for other platforms/kernels.
+2. **O_DIRECT constraints** — Page-aligned buffers, page-aligned offsets, no partial writes.
+3. **Complexity** — io_uring SQE/CQE model, buffer lifetime management.
+4. **No page cache** — Recovery reads must use a separate buffered file handle.
+5. **Debugging** — Async I/O errors are harder to diagnose.
 
-### vs Current Group Commit
+### Expected Performance
 
-| Metric | Current | Sequencer |
-|--------|---------|-----------|
-| Fsyncs per N writers | 1 | 1 (piggyback) |
-| Code complexity | High (leader election, ring buffer) | Low (atomic offsets, mutex) |
-| Lock acquisitions | 1 (file mutex held for drain+write+fsync) | 1 (file mutex for pwrite) + 1 (commit_mutex for sequencer) |
-| BufWriter bugs | seek + flush interaction | None (no BufWriter) |
-| Error propagation | Batch result ring buffer | Error flag + notify_all |
+Based on the SpanDB paper and io_uring benchmarks:
+
+| Metric | Current (group commit) | io_uring + O_DIRECT |
+|--------|----------------------|-------------------|
+| Write parallelism | None (single leader) | Full (NVMe channels) |
+| Syscalls per batch group | N write + 1 flush + 1 fsync | 1 io_uring_enter |
+| Fsync count | 1 per group | 1 per group (DRAIN) |
+| Expected throughput gain | Baseline | 1.5-3× on NVMe |
+
+The gain depends on NVMe internal parallelism. Single-channel SSDs see less
+benefit; multi-channel enterprise SSDs see more.
 
 ---
 
@@ -420,29 +373,32 @@ The WAL file format is unchanged. Recovery constructs a new `Wal` with
 
 | Phase | Description | Files |
 |-------|-------------|-------|
-| 1 | Add `CommitSequencer` struct to `wal.rs` | `wal.rs` |
-| 2 | Replace `BufWriter<File>` with raw `File` | `wal.rs` |
-| 3 | Replace `submit_and_commit()` body with sequencer logic | `wal.rs` |
-| 4 | Update `sync()` to route through sequencer | `wal.rs` |
-| 5 | Remove leader-follower code (leader_active, batch_results, etc.) | `wal.rs` |
-| 6 | Update recovery to construct sequencer state | `wal.rs` |
+| 1 | Add `io-uring` dependency (feature-gated) | `Cargo.toml` |
+| 2 | Add page-aligned buffer allocator | `wal.rs` |
+| 3 | Implement io_uring write path in `submit_and_commit()` | `wal.rs` |
+| 4 | Add fallback to current group commit | `wal.rs` |
+| 5 | Update recovery to use buffered file handle | `wal.rs` |
+| 6 | Update `sync()` path | `wal.rs` |
 | 7 | Add tests | `tests/wal.rs` |
+| 8 | Benchmark | — |
 
 ---
 
 ## 8. Testing Strategy
 
 1. **Correctness:** All existing WAL tests pass (format unchanged).
-2. **Piggyback:** Verify that concurrent writers trigger fewer fsyncs (instrument with counter).
-3. **Ordering:** Crash-injection test — verify no batch is committed before prior batches are durable.
-4. **Single writer:** Verify no regression (short-circuit path).
-5. **sync() path:** Verify `engine.sync()` and `engine.close()` work correctly.
-6. **Benchmark:** `write-perf --workload wal_concurrent --threads 1,2,4,8` — compare vs current group commit.
+2. **io_uring path:** Write, read back, verify. Concurrent writers. Recovery after crash.
+3. **Fallback path:** Force fallback, verify same correctness.
+4. **O_DIRECT alignment:** Test with various batch sizes (4KB, 8KB, 12KB — verify padding).
+5. **Benchmark:** `write-perf --workload wal_concurrent --threads 1,2,4,8`.
+6. **Stress test:** 16+ concurrent writers with crash injection.
 
 ---
 
 ## 9. Open Questions
 
-1. **Short-circuit for single writer:** Track `pending.len()` and bypass sequencer when 1 (direct pwrite + fsync). Adds a branch but avoids sequencer overhead for single-threaded workloads.
-2. **BufWriter removal scope:** The legacy `put()` path (non-MVCC) also uses BufWriter. Should it switch to pwrite too, or keep BufWriter for the legacy path? Recommendation: keep BufWriter for legacy, use pwrite only for MVCC batch path.
-3. **Future io_uring:** The pwrite model maps directly to io_uring SQEs. The `advance_confirmed` function would need a contiguous watermark for parallel submissions. Deferred to future work.
+1. **Ring size:** 64 SQE slots. Is this enough? If >64 batches accumulate, submit in chunks.
+2. **fdatasync vs fsync:** `fdatasync` skips metadata sync (faster). Recommendation: use `fdatasync` for WAL.
+3. **Poll mode:** `IORING_SETUP_SQPOLL` for kernel-side polling. Trade-off: lower latency vs higher CPU. Recommendation: start without, add as optimization.
+4. **Single issuer:** `IORING_SETUP_SINGLE_ISSUER` (kernel 5.19+) optimizes for single-threaded submission. Recommendation: enable if kernel supports.
+5. **Buffer pool sizing:** 16 buffers × 64KB = 1MB. With O_DIRECT, each buffer is page-aligned. Is 16 enough for high concurrency? Recommendation: benchmark with 16, 32, 64.

--- a/rfcs/012-parallel-wal.md
+++ b/rfcs/012-parallel-wal.md
@@ -10,19 +10,26 @@
 ## 1. Summary
 
 This RFC proposes adding parallel WAL (Write-Ahead Log) logging to kv-engine,
-inspired by the SpanDB paper's multi-logger design. Instead of a single WAL file
-per memtable with one leader thread performing all writes and fsyncs, the engine
-would maintain N independent WAL shards per memtable, each with its own file,
-buffer pool, and group commit mechanism. Writers are distributed across shards
-using round-robin assignment, allowing multiple fsyncs to proceed in parallel.
+inspired by the SpanDB paper's multi-logger design. The paper's parallel WAL
+combines three techniques:
+
+1. **Log batching** — multiple concurrent writers' entries collected into a single batch per shard (group commit).
+2. **Parallel writers** — N independent WAL shards fsync simultaneously across shards.
+3. **Atomic page allocation ordering** — within each shard, batches receive sequential file offsets via atomic allocation, preserving write ordering without serializing I/O.
+
+Instead of a single WAL file per memtable with one leader thread performing all
+writes and fsyncs, the engine would maintain N independent WAL shards per memtable.
+Each shard retains group commit for batching efficiency, while different shards
+commit in parallel.
 
 The design provides:
 
 1. N parallel WAL loggers per memtable (configurable, default 1 for backward compatibility).
-2. Independent group commit per shard — concurrent writers on different shards do not block each other.
-3. Parallel fsync across all shards during `submit_and_commit()`.
-4. Full backward compatibility — single-shard mode uses the existing WAL file format and naming.
-5. Compatible with MVCC, vLog, compaction, and all existing WAL features.
+2. Group commit per shard — batching multiple concurrent writers into one fsync.
+3. Parallel fsync across all shards — N group commits proceed simultaneously.
+4. Atomic offset ordering — batches within a shard are ordered by sequentially allocated file offsets.
+5. Full backward compatibility — single-shard mode uses the existing WAL file format and naming.
+6. Compatible with MVCC, vLog, compaction, and all existing WAL features.
 
 ---
 
@@ -50,29 +57,34 @@ on the synchronous group logging path when using Optane via SPDK. While this eng
 uses standard filesystem I/O (not SPDK), the same principle applies: the single-writer
 bottleneck limits throughput under high concurrency.
 
-### What Parallel WAL Achieves
+### Why Not Just Group Commit or Just Parallel Shards?
 
-With N shards, N groups of writers can commit simultaneously:
+**Group commit alone** (current design) batches writers efficiently but all shards
+share one fsync — N writers wait for one fsync.
+
+**Parallel shards alone** (no batching) allows parallel fsync but writers on the
+same shard serialize — each writer does its own fsync.
+
+**SpanDB's design** combines both: batch within each shard (group commit), then
+fsync all shards in parallel. The result is N batches fsyncing simultaneously,
+each batch amortizing fsync across its own group of writers.
 
 ```
-Shard 0: writers → ready_queue_0 → leader_0 → write → fsync  ─┐
-Shard 1: writers → ready_queue_1 → leader_1 → write → fsync  ─┤ parallel
-Shard 2: writers → ready_queue_2 → leader_2 → write → fsync  ─┘
+                    ┌─ Shard 0: writers ─→ batch ─→ leader writes ─→ fsync ─┐
+                    │                                                        │
+All writers ────────┼─ Shard 1: writers ─→ batch ─→ leader writes ─→ fsync ─┤ parallel
+(round-robin)       │                                                        │
+                    └─ Shard 2: writers ─→ batch ─→ leader writes ─→ fsync ─┘
 ```
 
-Benefits:
-- **Pipelining:** While shard A fsyncs, shard B collects new writes.
-- **Reduced contention:** Writers on different shards never contend on the same mutex.
-- **SSD parallelism:** NVMe SSDs have internal parallelism (multiple channels); parallel fsyncs on different files can utilize this.
-
-The paper's "3L3R" configuration (3 loggers × 3 concurrent requests) achieved
-peak WAL throughput on Intel Optane.
+The paper's "3L3R" configuration (3 loggers × 3 concurrent requests per logger)
+achieved peak WAL throughput on Intel Optane.
 
 ---
 
 ## 3. Goals
 
-1. Implement N parallel WAL shards per memtable, each with independent group commit.
+1. Implement N parallel WAL shards per memtable, each with group commit.
 2. Keep backward compatibility — `num_wal_shards=1` uses the existing `{id:05}.wal` format.
 3. No changes to the public `KvEngine` API.
 4. Recovery must correctly merge entries from all shards.
@@ -90,7 +102,68 @@ peak WAL throughput on Intel Optane.
 
 ## 5. Design
 
-### 5.1 New `ParallelWal` Struct
+### 5.1 SpanDB's Three Techniques
+
+#### 5.1.1 Log Batching (Group Commit per Shard)
+
+Each shard implements the existing leader-follower group commit:
+
+1. Writers push encoded buffers to the shard's `ready_queue`.
+2. The first writer becomes the leader, drains the queue, writes to the file, and fsyncs.
+3. Other writers wait on the shard's condvar, then return when the leader signals completion.
+
+This amortizes fsync cost across concurrent writers on the same shard. The existing
+`Wal::submit_and_commit()` logic is reused unchanged per shard.
+
+#### 5.1.2 Parallel Writers (Cross-Shard Parallelism)
+
+The `ParallelWal::submit_and_commit()` triggers all shards' group commits
+simultaneously using `std::thread::scope`. Each shard's leader independently
+drains its queue, writes to its file, and fsyncs. Writers on different shards
+do not block each other.
+
+```
+Shard 0: leader_0 drains → write → fsync ─┐
+Shard 1: leader_1 drains → write → fsync ─┤ all in parallel
+Shard 2: leader_2 drains → write → fsync ─┘
+```
+
+#### 5.1.3 Atomic Page Allocation Ordering
+
+Within each shard, batches must be written to the file in the order they were
+submitted, even though multiple writers contribute buffers concurrently. The current
+design handles this via the `ready_queue` (FIFO) and a single leader doing the
+write — the leader drains all buffers in queue order and writes them sequentially.
+
+To support future I/O parallelism (e.g., io_uring with multiple in-flight writes),
+each batch can be assigned a sequential file offset atomically:
+
+```rust
+/// Atomic offset allocator for a single WAL shard.
+/// Each batch gets a unique, sequential region in the file.
+struct OffsetAllocator {
+    next_offset: AtomicU64,
+}
+
+impl OffsetAllocator {
+    /// Reserve `size` bytes at the current end of the WAL.
+    /// Returns the starting offset for this batch.
+    fn allocate(&self, size: u64) -> u64 {
+        self.next_offset.fetch_add(size, Ordering::AcqRel)
+    }
+}
+```
+
+This ensures:
+- Batches are assigned non-overlapping, sequential file regions.
+- Multiple writers can prepare their buffers concurrently.
+- The leader writes buffers at their allocated offsets (currently sequential; future io_uring can submit in parallel with offset ordering).
+
+**Current implementation:** The offset allocator is implicit — the leader drains the
+FIFO queue and writes sequentially. The atomic offset tracking is added for correctness
+documentation and future io_uring support.
+
+### 5.2 New `ParallelWal` Struct
 
 ```rust
 pub struct ParallelWal {
@@ -107,14 +180,14 @@ Each shard is a full `Wal` instance with its own:
 - Ready queue (`SegQueue<Vec<u8>>`)
 - Group commit state (`commit_waiters`, `committed_gen`, `leader_active`, etc.)
 
-### 5.2 WAL File Naming
+### 5.3 WAL File Naming
 
 | Shard Count | File Names |
 |-------------|-----------|
 | 1 (default) | `{id:05}.wal` (unchanged) |
 | N > 1 | `{id:05}.wal.0`, `{id:05}.wal.1`, ..., `{id:05}.wal.{N-1}` |
 
-### 5.3 Write Path
+### 5.4 Write Path
 
 ```rust
 impl ParallelWal {
@@ -135,9 +208,10 @@ impl ParallelWal {
 ```
 
 Each batch is written to exactly one shard. The round-robin distribution ensures
-even load across shards.
+even load across shards. Within each shard, the batch enters the shard's
+`ready_queue` for group commit.
 
-### 5.4 Group Commit (Parallel Fsync)
+### 5.5 Group Commit (Parallel Fsync Across Shards)
 
 ```rust
 impl ParallelWal {
@@ -147,6 +221,7 @@ impl ParallelWal {
         }
 
         // Trigger all shards' group commits in parallel.
+        // Each shard's leader independently drains, writes, and fsyncs.
         let results: Vec<Result<()>> = std::thread::scope(|s| {
             let handles: Vec<_> = self.shards.iter()
                 .map(|shard| s.spawn(|| shard.submit_and_commit()))
@@ -166,11 +241,12 @@ impl ParallelWal {
 ```
 
 Key points:
-- Each shard's `submit_and_commit()` runs independently — writers on shard 0 do not wait for shard 1.
-- The `submit_and_commit()` call returns only when ALL shards have fsynced.
+- Each shard's `submit_and_commit()` runs its own group commit independently.
+- All shards' leaders write and fsync in parallel.
+- The call returns only when ALL shards have fsynced.
 - If any shard fails, the error is propagated.
 
-### 5.5 Recovery
+### 5.6 Recovery
 
 ```rust
 impl ParallelWal {
@@ -213,7 +289,7 @@ Recovery correctness:
   `SkipMap`, this is safe — MVCC timestamps handle ordering.
 - `max_ts` is the maximum across all shards.
 
-### 5.6 MemTable Integration
+### 5.7 MemTable Integration
 
 The `MemTable` struct changes from `wal: Option<Wal>` to `wal: Option<ParallelWal>`:
 
@@ -228,10 +304,10 @@ pub struct MemTable {
 Methods updated:
 - `create_with_wal()` → `ParallelWal::create(path, num_shards)`
 - `write_wal_batch()` → `wal.put_batch()` (round-robin internally)
-- `commit_wal()` → `wal.submit_and_commit()` (parallel across shards)
+- `commit_wal()` → `wal.submit_and_commit()` (parallel group commit across shards)
 - `recover_from_wal()` → `ParallelWal::recover(path, num_shards, skiplist)`
 
-### 5.7 WAL Cleanup
+### 5.8 WAL Cleanup
 
 During flush (`force_flush_next_imm_memtable`), delete all shard files:
 
@@ -249,7 +325,7 @@ fn cleanup_wal_files(path: &Path, id: usize, num_shards: usize) {
 }
 ```
 
-### 5.8 Configuration
+### 5.9 Configuration
 
 Add to `LsmStorageOptions`:
 
@@ -270,11 +346,12 @@ Default: `1` — no behavior change for existing users.
 
 ### Advantages
 
-1. **Parallel fsync** — Multiple shards fsync simultaneously, utilizing NVMe internal parallelism.
-2. **Pipelining** — While one shard fsyncs, others collect writes.
-3. **Reduced contention** — Writers on different shards never share a mutex.
-4. **Simple per-shard logic** — Each shard reuses the existing, well-tested `Wal` implementation.
-5. **Backward compatible** — `num_wal_shards=1` is identical to current behavior.
+1. **Best of both worlds** — Group commit amortizes fsync within each shard; parallel shards amortize across shards.
+2. **Parallel fsync** — Multiple shards fsync simultaneously, utilizing NVMe internal parallelism.
+3. **Pipelining** — While one shard fsyncs, others collect writes.
+4. **Reduced contention** — Writers on different shards never share a mutex.
+5. **Simple per-shard logic** — Each shard reuses the existing, well-tested `Wal` group commit.
+6. **Backward compatible** — `num_wal_shards=1` is identical to current behavior.
 
 ### Disadvantages
 
@@ -283,6 +360,19 @@ Default: `1` — no behavior change for existing users.
 3. **No cross-shard ordering guarantee** — Relies on MVCC timestamps for correctness.
 4. **SSD firmware serialization** — On some SSDs, parallel fsyncs may be serialized by the firmware. The pipelining benefit still applies.
 5. **Increased disk space** — Each shard has its own WAL header and padding.
+
+### Comparison: Group Commit vs Parallel Shards vs SpanDB
+
+| Approach | Fsync per batch | Parallelism | Complexity |
+|----------|----------------|-------------|------------|
+| Group commit only (current) | 1 fsync for N writers | None (single fsync) | Low |
+| Parallel shards only (no batching) | 1 fsync per writer | N fsyncs in parallel | Low |
+| **SpanDB (batching + parallel)** | 1 fsync for M writers per shard | N fsyncs in parallel | Medium |
+
+With SpanDB's design and 8 writer threads, 4 shards:
+- Each shard has ~2 writers → 1 fsync per shard (group commit)
+- 4 shards → 4 fsyncs in parallel
+- Total: 4 fsyncs instead of 8 (no batching) or 1 (current)
 
 ### When It Helps Most
 
@@ -326,5 +416,6 @@ Default: `1` — no behavior change for existing users.
 ## 9. Open Questions
 
 1. **Optimal shard count:** The paper uses 3 loggers for Optane. Should we default to 2 or 4? Recommendation: 2 for NVMe, 1 for SATA/HDD.
-2. **Rayon vs std::thread::scope:** For parallel fsync, should we use rayon (already a transitive dependency via crossbeam?) or `std::thread::scope`? Recommendation: `std::thread::scope` — no new dependency, and the scope is tiny (N joins).
-3. **Shard assignment strategy:** Round-robin is simple but may not be optimal if batches vary in size. Weighted assignment based on buffer pool depth could be better. Recommendation: start with round-robin, optimize later if benchmarks show imbalance.
+2. **Rayon vs std::thread::scope:** For parallel fsync, should we use rayon or `std::thread::scope`? Recommendation: `std::thread::scope` — no new dependency, and the scope is tiny (N joins).
+3. **Shard assignment strategy:** Round-robin is simple but may not be optimal if batches vary in size. Recommendation: start with round-robin, optimize later if benchmarks show imbalance.
+4. **io_uring integration:** The atomic offset allocator (Section 5.1.3) prepares for future io_uring support where multiple batches can be submitted as parallel writes to the same shard. This is deferred to RFC 002.

--- a/rfcs/012-parallel-wal.md
+++ b/rfcs/012-parallel-wal.md
@@ -602,7 +602,7 @@ BATCH_HEADER_SIZE = 20 bytes (was 16):
 
 The CRC covers `commit_ts + entry_count + data_crc32` (unchanged). `encoded_len`
 is outside the CRC — it is an optimization hint for recovery, not a data
-integrity field. An incorrect `encoded_len` causes recovery to mis-skip and
+integrity field. An incorrect `encoded_len` causes recovery to skip incorrectly and
 fail CRC on the next batch, which is safe (truncation, not corruption).
 
 ### 5.11 Recovery Scan (Modified)

--- a/rfcs/012-parallel-wal.md
+++ b/rfcs/012-parallel-wal.md
@@ -259,14 +259,14 @@ impl Wal {
 
         // 2. Chunked submission: if the batch exceeds ring capacity (64 SQEs),
         //    submit in chunks of 63 writes + 1 fsync, waiting for completions
-        //    between chunks. Each chunk is independently committed — if chunk 1
-        //    succeeds but chunk 2 fails, chunk 1's callers get Ok() and chunk 2's
-        //    callers get Err(). The generation counter advances per chunk, so
-        //    each chunk's waiters read their own result from the ring buffer.
+        //    between chunks. The entire set of drained buffers is a single
+        //    logical commit group — the generation counter is only incremented
+        //    once after ALL chunks complete. This prevents callers in later
+        //    chunks from returning prematurely before their data is durable.
         let max_writes_per_chunk = 63;  // leave 1 slot for fsync
         let chunks: Vec<&[DirectBuf]> = bufs.chunks(max_writes_per_chunk).collect();
         let mut offset = base_offset;
-        for (chunk_num, chunk) in chunks.iter().enumerate() {
+        for chunk in chunks {
             let total_sqes = chunk.len() + 1; // writes + fsync
 
             // 3. Submit write SQEs (parallel I/O to NVMe).
@@ -522,10 +522,11 @@ generation counter and ring buffer prevent a late-arriving waiter from
 consuming a stale result from a previous commit cycle.
 
 **Chunked submission interaction:** When `submit_and_commit` processes multiple
-chunks, each chunk increments the generation independently. Callers whose
-buffers were in chunk N wait on generation N; callers in chunk N+1 wait on
-generation N+1. If chunk N succeeds but chunk N+1 fails, only chunk N+1's
-callers receive the error.
+chunks, the entire drained set is one logical commit group. The generation
+counter is incremented once after all chunks complete. All waiters from the
+same drain cycle wait on the same generation and receive the same result.
+If any chunk fails, all waiters receive the error — partial success is not
+reported to callers.
 
 ### 5.7 How DRAIN Replaces the Sequencer
 

--- a/rfcs/012-parallel-wal.md
+++ b/rfcs/012-parallel-wal.md
@@ -29,7 +29,7 @@ fsync waits for all prior writes, replacing the need for an explicit sequencer.
 
 The current WAL uses a single-leader group commit:
 
-```
+```text
 8 writers → leader drains → sequential BufWriter::write_all → flush → fsync → wake 8
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
             Single thread, serialized, held under file mutex
@@ -39,7 +39,7 @@ The leader does all the work. The other 7 threads wait.
 
 ### What Changes
 
-```
+```text
 8 writers → encode buffers → submit 8 SQEs + 1 fsync(DRAIN) → io_uring_enter
             → kernel dispatches to NVMe channels in parallel
             → poll fsync CQE → all 8 batches durable → wake all
@@ -107,15 +107,47 @@ sizes). The current buffer pool allocates `Vec<u8>` with 64KB capacity, which
 is page-aligned on most systems but not guaranteed.
 
 ```rust
-/// Allocate a page-aligned buffer for O_DIRECT I/O.
-fn alloc_direct_buf(size: usize) -> Vec<u8> {
-    let layout = Layout::from_size_align(size.max(4096), 4096).unwrap();
-    let ptr = unsafe { std::alloc::alloc(layout) };
-    unsafe { Vec::from_raw_parts(ptr, 0, size.max(4096)) }
+/// A page-aligned buffer for O_DIRECT I/O.
+/// Vec<u8> cannot be used because its global allocator deallocates with
+/// alignment 1, but O_DIRECT requires 4096-byte alignment. Dropping a
+/// Vec backed by a 4096-aligned allocation is undefined behavior.
+struct DirectBuf {
+    ptr: *mut u8,
+    len: usize,
+    cap: usize,
+}
+
+impl DirectBuf {
+    fn new(size: usize) -> Self {
+        let cap = size.max(4096);
+        let mut ptr: *mut libc::c_void = std::ptr::null_mut();
+        let ret = unsafe { libc::posix_memalign(&mut ptr, 4096, cap) };
+        assert_eq!(ret, 0, "posix_memalign failed");
+        Self {
+            ptr: ptr as *mut u8,
+            len: 0,
+            cap,
+        }
+    }
+
+    fn as_mut_slice(&mut self) -> &mut [u8] {
+        unsafe { std::slice::from_raw_parts_mut(self.ptr, self.cap) }
+    }
+
+    fn as_ptr(&self) -> *const u8 { self.ptr }
+    fn len(&self) -> usize { self.len }
+    fn set_len(&mut self, len: usize) { self.len = len; }
+}
+
+impl Drop for DirectBuf {
+    fn drop(&mut self) {
+        unsafe { libc::free(self.ptr as *mut libc::c_void) };
+    }
 }
 ```
 
-Or use `libc::posix_memalign` for portability.
+**Buffer pool change:** Replace `ArrayQueue<Vec<u8>>` with `ArrayQueue<DirectBuf>`.
+The pool size (16 buffers × 64KB) and lifecycle are unchanged.
 
 **Buffer pool change:** Replace `ArrayQueue<Vec<u8>>` with page-aligned
 allocations. The pool size (16 buffers × 64KB) and lifecycle are unchanged.
@@ -156,6 +188,11 @@ for subsequent writes.
 ```rust
 use io_uring::{opcode, types, IoUring, Builder};
 
+/// Fixed-file index for the WAL fd. Matches the single-element slice
+/// passed to register_files(&[raw_fd]). If additional FDs are registered
+/// later, this constant must stay in sync.
+const WAL_FD_INDEX: u32 = 0;
+
 let mut builder = Builder::new(64);  // 64 SQE slots
 
 // IORING_SETUP_SINGLE_ISSUER requires kernel 5.19+.
@@ -181,7 +218,7 @@ is active.
 ```rust
 impl Wal {
     pub fn submit_and_commit(&self) -> Result<()> {
-        let bufs: Vec<Vec<u8>> = {
+        let bufs: Vec<DirectBuf> = {
             let mut pending = self.pending.lock();
             std::mem::take(&mut *pending)
         };
@@ -205,7 +242,7 @@ impl Wal {
             // local variable that outlives the CQE loop). The registered FD
             // (Fixed(0)) is valid for the ring's lifetime.
             let sqe = opcode::Write::new(
-                types::Fixed(0),       // registered file FD
+                types::Fixed(WAL_FD_INDEX),
                 buf.as_ptr(),
                 aligned_len as u32,
             )
@@ -220,7 +257,7 @@ impl Wal {
         //    This ensures the fsync covers all preceding writes.
         //    On Linux, fdatasync flushes file size metadata, so it is safe
         //    for WAL files that extend (see fdatasync(2)).
-        let fsync_sqe = opcode::Fsync::new(types::Fixed(0))
+        let fsync_sqe = opcode::Fsync::new(types::Fixed(WAL_FD_INDEX))
             .flags(types::FsyncFlags::DATASYNC)
             .build()
             .flags(types::Flags::IO_DRAIN);
@@ -229,17 +266,32 @@ impl Wal {
         // 4. Submit all SQEs in one syscall.
         self.ring.submit_and_wait(bufs.len() + 1)?;
 
-        // 5. Poll for all CQEs.
-        for _ in 0..bufs.len() {
+        // 5. Poll for all CQEs — drain ALL completions even on error
+        //    to avoid stale CQEs misaligning the next submission.
+        let mut write_err: Option<i32> = None;
+        for i in 0..bufs.len() {
             let cqe = self.ring.completion().next()
                 .ok_or_else(|| anyhow!("io_uring: missing write CQE"))?;
             if cqe.result() < 0 {
-                anyhow::bail!("io_uring write error: {}", cqe.result());
+                if write_err.is_none() {
+                    write_err = Some(cqe.result());
+                }
+            } else {
+                let written = cqe.result() as usize;
+                let expected = Self::align_up(bufs[i].len());
+                if written < expected {
+                    if write_err.is_none() {
+                        write_err = Some(-libc::EIO);
+                    }
+                }
             }
         }
-        // Fsync CQE — confirms all data is durable.
+        // Fsync CQE — always poll it, even if writes failed.
         let fsync_cqe = self.ring.completion().next()
             .ok_or_else(|| anyhow!("io_uring: missing fsync CQE"))?;
+        if let Some(err) = write_err {
+            anyhow::bail!("io_uring write error: {}", err);
+        }
         if fsync_cqe.result() < 0 {
             anyhow::bail!("io_uring fsync error: {}", fsync_cqe.result());
         }
@@ -282,6 +334,9 @@ impl Wal {
         let result = self.submit_sqes_and_poll(bufs);
 
         // Signal all waiters (even on error).
+        // CRITICAL: use replace() + notify_all, not take().
+        // Each waiter must get its own clone — take() would let only
+        // the first waiter proceed; subsequent waiters would block forever.
         {
             let mut guard = self.completion_mutex.lock();
             self.last_completion_result.lock().replace(result.clone());
@@ -296,7 +351,8 @@ impl Wal {
         while self.last_completion_result.lock().is_none() {
             self.completion_cond.wait(&mut guard);
         }
-        let result = self.last_completion_result.lock().take().unwrap();
+        // Clone, not take — all waiters must see the same result.
+        let result = self.last_completion_result.lock().clone().unwrap();
         result
     }
 }
@@ -333,6 +389,7 @@ impl OffsetAllocator {
     /// Allocate `size` bytes at the current end of the WAL.
     /// `size` must be 4KB-aligned (O_DIRECT requirement).
     fn alloc(&self, size: u64) -> u64 {
+        debug_assert!(size % 4096 == 0, "O_DIRECT requires 4KB-aligned size, got {}", size);
         self.next_offset.fetch_add(size, Ordering::AcqRel)
     }
 }
@@ -348,13 +405,19 @@ O_DIRECT requires 4KB-aligned write sizes. Each batch buffer is zero-padded
 to the aligned length after encoding:
 
 ```rust
-fn encode_batch(&self, data: &[(&[u8], &[u8])], commit_ts: u64) -> Result<Vec<u8>> {
-    // ... encode batch data into buf ...
+fn encode_batch(&self, data: &[(&[u8], &[u8])], commit_ts: u64) -> Result<DirectBuf> {
+    let mut buf = self.buf_pool.pop().unwrap_or_else(|| DirectBuf::new(BUFFER_POOL_BUF_SIZE));
+    // ... encode batch data into buf.as_mut_slice() ...
 
     // Zero-pad to 4KB alignment (O_DIRECT requirement).
     // This also ensures recovery doesn't read stale bytes as batch data.
-    let aligned_len = Self::align_up(buf.len());
-    buf.resize(aligned_len, 0);
+    let len = buf.len();
+    let aligned_len = Self::align_up(len);
+    let slice = buf.as_mut_slice();
+    for i in len..aligned_len {
+        slice[i] = 0;
+    }
+    buf.set_len(aligned_len);
 
     Ok(buf)
 }
@@ -405,10 +468,10 @@ lock boundary. Same role as the current `ready_queue`.
 The buffer pool allocates page-aligned buffers for O_DIRECT:
 
 ```rust
-fn new_buf_pool() -> ArrayQueue<Vec<u8>> {
+fn new_buf_pool() -> ArrayQueue<DirectBuf> {
     let pool = ArrayQueue::new(BUFFER_POOL_CAPACITY);
     for _ in 0..BUFFER_POOL_CAPACITY {
-        let _ = pool.push(alloc_direct_buf(BUFFER_POOL_BUF_SIZE));
+        let _ = pool.push(DirectBuf::new(BUFFER_POOL_BUF_SIZE));
     }
     pool
 }
@@ -483,10 +546,22 @@ mod io_uring_wal {
 }
 ```
 
-On Linux, attempt `IoUring::new()` at WAL open. If it fails (kernel too old),
-fall back to the synchronous path. Store `use_io_uring: bool` in the `Wal`
-struct. Feature detection is runtime, not compile-time — a Linux binary works
-on kernels 5.11+ (io_uring) and <5.11 (fallback).
+On Linux, attempt full io_uring initialization at WAL open: ring creation,
+`setup_single_issuer`, AND `register_files`. If **any** step fails (kernel too
+old, EMFILE, ENOMEM), fall back to the synchronous path. Store
+`use_io_uring: bool` in the `Wal` struct. Feature detection is runtime, not
+compile-time — a Linux binary works on kernels 5.11+ (io_uring) and <5.11
+(fallback).
+
+```rust
+let ring = match try_init_io_uring(&write_file) {
+    Ok(ring) => ring,
+    Err(e) => {
+        log::warn!("io_uring unavailable ({}), falling back to group commit", e);
+        return Wal::new_group_commit(path);
+    }
+};
+```
 
 ---
 

--- a/rfcs/012-parallel-wal.md
+++ b/rfcs/012-parallel-wal.md
@@ -1,4 +1,4 @@
-# RFC 012: WAL Write Throughput — Parallel I/O via io_uring
+# RFC 012: WAL Write Throughput — Ordered Commit with pwrite
 
 **Status:** Proposed
 **Date:** 2026-06-26
@@ -10,242 +10,380 @@
 ## 1. Summary
 
 This RFC proposes improving WAL write throughput by replacing the current
-synchronous leader-follower group commit with **io_uring-based parallel I/O**,
-inspired by the SpanDB paper's multi-logger design.
-
-The key insight: the current group commit already batches concurrent writers
-efficiently (1 fsync for N writers). The bottleneck is not fsync count, but
-**single-threaded I/O** — one leader writes all buffers sequentially. With
-io_uring, multiple writers submit I/O in parallel, and the kernel dispatches
-to NVMe channels concurrently.
+leader-follower group commit with a simpler **ordered commit sequencer** that
+piggybacks fsyncs, combined with `pwrite` for position-independent writes to
+a single WAL file.
 
 The design:
 
-1. **Atomic offset allocator** — each batch gets a sequential file offset.
-2. **io_uring submission** — writers submit write SQEs at their allocated offsets.
+1. **Atomic offset allocator** — each batch gets a sequential file offset via `fetch_add`.
+2. **pwrite** — writers write to the file at their allocated offsets (no BufWriter, no seek).
 3. **Record checksum** — CRC32 per batch (unchanged).
-4. **Ordered commit** — writers poll for completion; fsync chained via `IOSQE_IO_LINK`.
+4. **Ordered commit sequencer** — batches are committed in order; fsync is skipped when a prior fsync already covered the data.
 5. **Recovery scan** — sequential scan, validate CRC (unchanged).
+
+The fsync count is the same as the current group commit (1 fsync for N concurrent
+writers), but the code is significantly simpler: no leader election, no batch
+results ring buffer, no condvar wake-up storms.
 
 ---
 
 ## 2. Motivation
 
-### Current Design Is Already Good
+### Current Design Complexity
 
-The current group commit (`wal.rs:878-977`) is well-designed:
+The current group commit (`wal.rs:878-977`) uses a leader-follower model with:
+- Ticket-based leader election (`commit_waiters` + `committed_gen` + `leader_active` CAS)
+- Batch results ring buffer (256 slots) for error propagation
+- Condvar + mutex for follower wake-up
+- `ready_queue` (SegQueue) for buffer staging
+- File mutex held during drain + write + flush + fsync
 
-```
-8 concurrent writers → leader drains all 8 → 1 sequential write → 1 fsync → wake all
-```
+This works correctly but is complex. The sequencer achieves the same fsync
+efficiency with simpler primitives.
 
-This already achieves **1 fsync per N concurrent writers**. Under burst
-concurrency (the common case), the current design is efficient.
+### What Changes
 
-### Where It Falls Short
-
-The bottleneck is the **single leader thread** doing all the work:
-
-```
-Leader: drain queue → seek → write_all(buf[0]) → write_all(buf[1]) → ... → flush → fsync
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-        All sequential, single thread, single file descriptor
-```
-
-With 8 writers each producing 4KB batches:
-- **Current:** 1 thread writes 32KB sequentially + 1 fsync ≈ 20µs + 50µs = 70µs
-- **io_uring:** 8 threads submit 8 SQEs + kernel writes in parallel to NVMe + 1 fsync ≈ 5µs + 50µs = 55µs
-
-The savings come from parallelizing the write I/O, not from reducing fsync count.
-
-### What About a Sequencer (Piggyback Fsync)?
-
-An earlier version of this RFC proposed replacing the leader-follower model with
-an "ordered commit sequencer" that piggybacks fsyncs. After review, this was
-found to be **not an improvement** over the current design:
-
-| Scenario | Current (group commit) | Sequencer |
-|----------|----------------------|-----------|
-| 8 writers arrive together | 1 leader drains all 8 → 1 fsync | 1 thread fsyncs, 7 piggyback → 1 fsync |
-| 1 writer arrives alone | 1 fsync | 1 fsync + sequencer overhead |
-| Writers arrive during fsync | New group forms → next leader does 1 fsync | Piggyback if offset already covered |
-
-**The fsync count is the same.** The sequencer adds complexity (atomic offset
-tracking, commit_mutex, condvar) without reducing fsyncs. The current leader
-election is simpler and equally efficient for batching.
-
-The sequencer also introduced critical correctness issues:
-- `written_offset` (allocated) ≠ "bytes in page cache" — data loss if fsync
-  claims bytes that were only reserved, not written.
-- BufWriter + seek defeats buffering (each seek flushes the internal buffer).
-- Missing `flush()` before `sync_all()` leaves data in userspace buffer.
-
-**Conclusion:** The sequencer is not the right optimization. The real win is
-io_uring, which parallelizes the I/O itself.
+| Aspect | Current | Proposed |
+|--------|---------|----------|
+| Writer role | Push buffer to queue, wait for leader | pwrite at allocated offset, check sequencer |
+| Leader | Drains queue, writes, fsyncs, wakes followers | No leader |
+| Fsync trigger | Every batch (leader always fsyncs) | Only when no prior fsync covers this batch |
+| Ordering | Implicit (leader writes in queue order) | Explicit (sequencer tracks confirmed offset) |
+| File I/O | BufWriter + write_all + flush + sync_all | Raw File + pwrite (write_at) + sync_all |
+| Followers | Block on condvar, wake on notify_all | Check atomic confirmed_offset, return if covered |
 
 ---
 
 ## 3. Goals
 
-1. Replace single-leader writes with parallel io_uring submissions.
-2. Maintain the existing WAL file format (v3, unchanged).
-3. Maintain the two-phase write protocol (`write_wal_batch_only` → `commit_wal` → `publish_raw_batch`).
-4. Recovery unchanged — sequential scan + CRC validation.
-5. Linux-only (gated by `cfg(target_os = "linux")`), with fallback to current design.
+1. Replace leader-follower group commit with an ordered commit sequencer.
+2. Use `pwrite` (position-independent writes) instead of BufWriter + seek.
+3. Piggyback fsyncs — skip fsync when a prior fsync already covered the data.
+4. No changes to the public `KvEngine` API.
+5. Backward compatible WAL file format (v3, unchanged).
+6. Recovery unchanged — sequential scan + CRC validation.
 
 ## 4. Non-Goals
 
-1. SPDK integration.
+1. Parallel I/O to a single file (ext4 inode lock serializes buffered writes).
 2. Multiple WAL files / shards.
-3. Changing the WAL file format.
-4. io_uring for reads (separate concern).
+3. io_uring integration (deferred to future work).
+4. SPDK integration.
+5. Changing the WAL file format.
 
 ---
 
 ## 5. Design
 
-### 5.1 Overview
-
-```
-Current:
-  Writers → ready_queue → leader → BufWriter → write_all → flush → fsync → wake
-
-Proposed:
-  Writers → ready_queue → drain → allocate offsets → submit SQEs → io_uring_enter
-            → poll CQE completions → wake
-```
-
-The key change: instead of one leader writing all buffers sequentially, the
-drained buffers are submitted as parallel io_uring SQEs.
-
-### 5.2 io_uring Setup
+### 5.1 Sequencer State
 
 ```rust
-use io_uring::{opcode, types, IoUring};
-
-struct IoUringWal {
-    ring: IoUring,
-    file_fd: types::Fixed,
-    // ... other fields
+/// Tracks the commit state of the WAL.
+struct CommitSequencer {
+    /// Next file offset to allocate (advanced BEFORE write).
+    alloc_offset: AtomicU64,
+    /// Highest file offset where ALL preceding bytes have been pwritten
+    /// to the page cache (advanced AFTER write completes).
+    confirmed_offset: AtomicU64,
+    /// Highest file offset that has been fsynced to disk.
+    synced_offset: AtomicU64,
+    /// Mutex + condvar for commit signaling.
+    commit_mutex: Mutex<()>,
+    commit_cond: Condvar,
+    /// Whether a thread is currently fsyncing (prevents redundant fsyncs).
+    fsync_in_progress: AtomicBool,
+    /// Error flag — set if fsync fails, checked by all waiters.
+    last_error: Mutex<Option<String>>,
 }
 ```
 
-- Create an `IoUring` instance with a shared submission/completion queue.
-- Register the WAL file descriptor with `ring.submitter().register_files()`.
-- Use a fixed number of SQE slots (e.g., 64) to bound memory usage.
+Key distinction between the three offsets:
+
+| Offset | When advanced | Meaning |
+|--------|--------------|---------|
+| `alloc_offset` | Before pwrite | "This region is reserved for a batch" |
+| `confirmed_offset` | After pwrite completes | "This region is in the page cache" |
+| `synced_offset` | After fsync completes | "This region is on disk" |
+
+**`synced_offset` is only advanced to `confirmed_offset`**, never to `alloc_offset`.
+This prevents the data-loss bug where `synced_offset` claims bytes are durable
+that were only reserved, not written.
+
+### 5.2 File Handling
+
+The WAL file is opened **without O_APPEND**:
+
+```rust
+let f = File::options()
+    .read(true)
+    .write(true)    // not append — pwrite controls position
+    .create(false)  // file already exists after create()
+    .open(path)?;
+```
+
+O_APPEND would silently ignore pwrite offsets (the kernel seeks to EOF before
+every write). Without O_APPEND, `pwrite` (Rust's `File::write_all_at`) writes
+at the specified offset.
+
+BufWriter is removed. pwrite writes directly to the file descriptor. BufWriter
+provides no benefit with position-independent writes (each write is at a
+different offset, so BufWriter's sequential buffering is useless).
 
 ### 5.3 Write Path
 
 ```rust
-fn write_and_commit(&self, bufs: &[Vec<u8>]) -> Result<()> {
-    let mut offset = self.alloc_offset(bufs);  // atomic fetch_add for total size
-
-    // Submit one SQE per buffer (parallel I/O).
-    for buf in bufs {
-        let write_e = opcode::Write::new(self.file_fd, buf.as_ptr(), buf.len() as u32)
-            .offset(offset)
-            .build()
-            .user_data(offset as u64);  // tag with offset for completion tracking
-
-        unsafe { self.ring.submission().push(&write_e)?; }
-        offset += buf.len() as u64;
+impl Wal {
+    /// Encode a batch into a buffer and push to the pending list.
+    /// Phase 1: called under locks (same as current put_batch).
+    pub fn put_batch(&self, data: &[(&[u8], &[u8])], commit_ts: u64) -> Result<()> {
+        // Encode into pooled buffer (same as current).
+        let buf = self.encode_batch(data, commit_ts)?;
+        self.pending.lock().push(buf);
+        Ok(())
     }
 
-    // Chain fsync after the last write.
-    let fsync_e = opcode::Fsync::new(self.file_fd)
-        .build()
-        .user_data(FSYNC_TOKEN);
-
-    unsafe { self.ring.submission().push(&fsync_e)?; }
-
-    // Submit all SQEs in one syscall.
-    self.ring.submit_and_wait(bufs.len() + 1)?;
-
-    // Poll for completions.
-    for _ in 0..bufs.len() + 1 {
-        let cqe = self.ring.completion().next()
-            .ok_or_else(|| anyhow!("io_uring: missing CQE"))?;
-        if cqe.result() < 0 {
-            anyhow::bail!("io_uring I/O error: {}", cqe.result());
+    /// Write all pending buffers to the file and commit.
+    /// Phase 2: called after locks are released (same as current submit_and_commit).
+    pub fn submit_and_commit(&self) -> Result<()> {
+        let bufs: Vec<Vec<u8>> = {
+            let mut pending = self.pending.lock();
+            std::mem::take(&mut *pending)
+        };
+        if bufs.is_empty() {
+            return Ok(());
         }
-    }
 
-    Ok(())
+        // 1. Allocate file offsets atomically (BEFORE write).
+        let mut offsets = Vec::with_capacity(bufs.len());
+        let mut offset = self.sequencer.alloc_offset.fetch_add(
+            bufs.iter().map(|b| b.len() as u64).sum(),
+            Ordering::AcqRel,
+        );
+        for buf in &bufs {
+            offsets.push(offset);
+            offset += buf.len() as u64;
+        }
+        let end_offset = offset;
+
+        // 2. Write to file at allocated offsets (pwrite).
+        let file = self.file.lock();
+        for (buf, &off) in bufs.iter().zip(&offsets) {
+            file.write_all_at(buf, off)?;
+        }
+        drop(file);
+
+        // 3. Confirm writes (AFTER pwrite completes).
+        //    This advances confirmed_offset past all written bytes.
+        //    Must be done AFTER all pwrites to prevent the race where
+        //    synced_offset advances past unwritten bytes.
+        self.advance_confirmed(end_offset);
+
+        // 4. Commit via sequencer (may piggyback on prior fsync).
+        self.sequencer.commit(end_offset, &self.file)
+    }
 }
 ```
 
-### 5.4 Atomic Offset Allocator
+### 5.4 Sequencer Commit Logic
 
 ```rust
-struct OffsetAllocator {
-    next_offset: AtomicU64,
-}
+impl CommitSequencer {
+    fn commit(&self, my_end_offset: u64, file: &Arc<Mutex<File>>) -> Result<()> {
+        let mut guard = self.commit_mutex.lock();
 
-impl OffsetAllocator {
-    fn alloc(&self, size: u64) -> u64 {
-        self.next_offset.fetch_add(size, Ordering::AcqRel)
+        // Fast path: already covered by a prior fsync.
+        if self.synced_offset.load(Ordering::Acquire) >= my_end_offset {
+            return Ok(());
+        }
+
+        // Check for prior error.
+        if let Some(ref err) = *self.last_error.lock() {
+            anyhow::bail!("prior WAL fsync failed: {}", err);
+        }
+
+        // Try to become the fsyncer.
+        if !self.fsync_in_progress.swap(true, Ordering::AcqRel) {
+            // I am the fsyncer — do the fsync.
+            let result = file.lock().sync_all();
+
+            // Advance synced_offset to confirmed_offset (NOT alloc_offset).
+            let confirmed = self.confirmed_offset.load(Ordering::Acquire);
+            self.synced_offset.store(confirmed, Ordering::Release);
+            self.fsync_in_progress.store(false, Ordering::Release);
+
+            if let Err(e) = result {
+                *self.last_error.lock() = Some(e.to_string());
+                self.commit_cond.notify_all();
+                anyhow::bail!("WAL fsync failed: {}", e);
+            }
+
+            self.commit_cond.notify_all();
+            return Ok(());
+        }
+
+        // Another thread is fsyncing — wait for it.
+        while self.synced_offset.load(Ordering::Acquire) < my_end_offset {
+            // Check for error from the fsyncing thread.
+            if let Some(ref err) = *self.last_error.lock() {
+                anyhow::bail!("prior WAL fsync failed: {}", err);
+            }
+            self.commit_cond.wait(&mut guard);
+        }
+
+        Ok(())
     }
 }
 ```
 
-Each batch gets a unique, sequential file region. The allocator is updated
-**before** submission, but the I/O is submitted in parallel. The completion
-poll ensures all data is on disk before returning.
+### 5.5 How Piggyback Works
 
-**Key difference from the sequencer design:** The offset allocator only tracks
-"where to write." The actual durability is confirmed by CQE completion, not by
-a `synced_offset` atomic. This avoids the data-loss bug in the sequencer design.
+Example with 3 concurrent writers:
 
-### 5.5 Ordered Commit
+```
+Writer A: alloc_offset=0   → pwrite 0-100   → confirmed=100  → commit(100)
+Writer B: alloc_offset=100 → pwrite 100-150  → confirmed=150  → commit(150)
+Writer C: alloc_offset=150 → pwrite 150-230  → confirmed=230  → commit(230)
 
-Ordering is maintained by the file offset allocation:
-- Buffers are drained from `ready_queue` in FIFO order (same as current).
-- Each buffer gets a sequential offset (atomic fetch_add).
-- io_uring writes them in parallel, but the offsets guarantee non-overlapping regions.
-- Fsync is chained after the last write, so all data is durable when the CQE arrives.
+Sequencer state: synced_offset=0, confirmed_offset=230
 
-### 5.6 Two-Phase Protocol (Unchanged)
+Writer A enters commit(100):
+  synced_offset (0) < my_end_offset (100)
+  fsync_in_progress = false → CAS succeeds → I am the fsyncer
+  sync_all() → flushes pages 0-230 (all dirty data)
+  confirmed = 230 → synced_offset = 230
+  notify_all
+  → Writer A returns ✓
+
+Writer B enters commit(150):
+  synced_offset (230) >= my_end_offset (150) → fast path
+  → Writer B returns immediately ✓ (no fsync)
+
+Writer C enters commit(230):
+  synced_offset (230) >= my_end_offset (230) → fast path
+  → Writer C returns immediately ✓ (no fsync)
+
+Result: 1 fsync for 3 batches (same as current group commit)
+```
+
+### 5.6 The Ordering Race (Why confirmed_offset Is Needed)
+
+Without `confirmed_offset`, using `alloc_offset` for `synced_offset`:
+
+```
+Writer A: alloc_offset=0, written_offset=100   (write delayed)
+Writer B: alloc_offset=100, pwrite 100-150 done
+Writer B: commit(150) → fsync → synced_offset=150
+  BUT: bytes 0-100 were never written! synced_offset lies.
+
+Writer A: finally pwrite 0-100
+  crash → Batch A lost, but synced_offset claimed it was safe ✗
+```
+
+With `confirmed_offset`:
+
+```
+Writer A: alloc_offset=0   → pwrite delayed
+Writer B: alloc_offset=100 → pwrite 100-150 → confirmed=150
+Writer B: commit(150) → fsync → synced_offset = confirmed_offset
+  BUT: confirmed_offset was advanced by advance_confirmed(150),
+  which checks that ALL bytes 0-150 were written. Since Writer A
+  hasn't written yet, confirmed_offset stays at 0 (not 150).
+  synced_offset = 0. Writer B waits.
+
+Writer A: pwrite 0-100 → confirmed=150 (now all 0-150 written)
+Writer B: wakes → synced_offset=150 → returns ✓
+```
+
+The `advance_confirmed` function ensures `confirmed_offset` only advances
+past bytes that are actually in the page cache.
+
+### 5.7 advance_confirmed Implementation
+
+```rust
+impl Wal {
+    /// Advance confirmed_offset to `target` only if all preceding
+    /// writes have completed. Uses a secondary watermark to track
+    /// contiguous written regions.
+    fn advance_confirmed(&self, target: u64) {
+        // Simple approach: since writes are sequential under the file mutex,
+        // the last writer to release the mutex knows all prior writes completed.
+        // We can safely advance confirmed_offset to target.
+        //
+        // For future pwrite parallelism (io_uring), use a per-batch
+        // "write-complete" flag and advance the watermark contiguously.
+        self.sequencer.confirmed_offset.store(target, Ordering::Release);
+    }
+}
+```
+
+**Note:** With sequential pwrite under the file mutex, `advance_confirmed` is
+simple — the mutex guarantees all prior writes completed. For future io_uring
+parallel writes, a contiguous watermark approach is needed (each writer marks
+its batch complete, and the watermark advances past all contiguous completed
+batches).
+
+### 5.8 Two-Phase Protocol (Unchanged)
 
 The existing two-phase write protocol is preserved:
 
 ```
 Phase 1 (under locks):
-  write_wal_batch_only() → encode buffer, push to ready_queue
+  write_wal_batch_only() → wal.put_batch() → encode buffer, push to pending list
 
 Phase 2 (locks released):
-  commit_wal() → drain ready_queue → submit io_uring SQEs → poll completions → wake
+  commit_wal() → wal.submit_and_commit() → pwrite + sequencer commit
 ```
 
-The ready_queue survives as the buffer staging area between lock release and
-io_uring submission. This is the same role it plays today — the only change is
-how the leader writes the drained buffers.
+The `pending` list (replacing `ready_queue`) holds encoded buffers across the
+lock boundary. Same role as the current `ready_queue`, simpler data structure.
 
-### 5.7 Buffer Pool (Unchanged)
+### 5.9 Buffer Pool (Unchanged)
 
-The buffer pool (`ArrayQueue<Vec<u8>>`) lifecycle is unchanged:
-1. `put_batch()` pops from pool, encodes, pushes to ready_queue.
-2. After io_uring completions are polled, buffers are returned to the pool.
+The buffer pool (`ArrayQueue<Vec<u8>>`) lifecycle:
+1. `put_batch()` pops from pool, encodes, pushes to `pending` list.
+2. `submit_and_commit()` takes all pending buffers, pwrites, returns to pool after commit.
 
-### 5.8 Recovery (Unchanged)
+Same lifecycle as current. The leader role is gone — the calling thread does
+the pwrite and returns buffers itself.
 
-Recovery scans the WAL file sequentially, validates CRC per batch, and stops
-at the first invalid entry. The WAL file format is unchanged — io_uring writes
-the same bytes to the same offsets as the current `BufWriter::write_all`.
+### 5.10 Public sync() Path
 
-### 5.9 Fallback
-
-On non-Linux platforms (or kernels < 5.6), fall back to the current
-leader-follower group commit. Gated by:
+`KvEngine::sync()` calls `wal.sync()`. The sequencer-aware `sync()`:
 
 ```rust
-#[cfg(target_os = "linux")]
-mod io_uring_wal { ... }
-
-#[cfg(not(target_os = "linux"))]
-mod io_uring_wal {
-    // Re-export current group commit as fallback.
+impl Wal {
+    pub fn sync(&self) -> Result<()> {
+        // Flush any pending buffers.
+        self.submit_and_commit()?;
+        // If nothing was pending, fsync the file directly.
+        if self.sequencer.synced_offset.load(Ordering::Acquire)
+            < self.sequencer.confirmed_offset.load(Ordering::Acquire)
+        {
+            self.file.lock().sync_all()?;
+            let confirmed = self.sequencer.confirmed_offset.load(Ordering::Acquire);
+            self.sequencer.synced_offset.store(confirmed, Ordering::Release);
+        }
+        Ok(())
+    }
 }
 ```
+
+This ensures `sync()` always leaves the file durable, even if no batches
+were pending.
+
+### 5.11 Recovery (Unchanged)
+
+Recovery scans the WAL file sequentially:
+
+1. Read batch header (commit_ts, entry_count, crc32).
+2. Validate CRC32 over entry data.
+3. If valid, replay entries into skiplist.
+4. If invalid (CRC mismatch, truncated), stop — this is the recovery point.
+5. Truncate file to last valid byte.
+
+The WAL file format is unchanged. Recovery constructs a new `Wal` with
+`alloc_offset` set to the file length (append position).
 
 ---
 
@@ -253,30 +391,28 @@ mod io_uring_wal {
 
 ### Advantages
 
-1. **Parallel I/O** — Multiple buffers written simultaneously to NVMe channels.
-2. **Reduced syscall overhead** — Single `io_uring_enter` for N submissions vs N `write_all` syscalls.
-3. **Near-SPDK latency** — io_uring poll mode eliminates kernel transition overhead.
-4. **No correctness risks** — CQE completion confirms durability. No `synced_offset` race.
-5. **Minimal code change** — Only the write+commit path changes. Recovery, buffer pool, two-phase protocol all unchanged.
+1. **Simpler code** — No leader election, no batch results ring buffer, no condvar wake-up storms. Just atomic offsets + pwrite + sequencer.
+2. **Same fsync count** — 1 fsync for N concurrent writers (piggyback), same as current group commit.
+3. **No BufWriter** — pwrite writes directly to file. No seek + flush interaction bugs.
+4. **No O_APPEND** — pwrite controls position explicitly. No silent offset ignoring.
+5. **Phase 2 ready** — The atomic offset allocator and pwrite model map directly to io_uring SQEs when ready.
+6. **Single file** — No multi-shard complexity. Same file format, same recovery.
 
 ### Disadvantages
 
-1. **Linux-only** — Requires kernel 5.6+. Fallback needed for other platforms.
-2. **Complexity** — io_uring's SQE/CQE model is more complex than `write_all` + `fsync`.
-3. **Debugging** — Async I/O errors are harder to diagnose than synchronous ones.
-4. **Marginal gain for small writes** — The overhead of io_uring setup may exceed savings for very small batches.
+1. **pwrite serialized by inode lock** — ext4 serializes buffered pwrite calls to the same file. Writers don't actually write in parallel. (Same as current — the leader writes sequentially too.)
+2. **Sequencer overhead** — Atomic ops (fetch_add, load, store) + mutex per commit. Marginal vs current leader election overhead.
+3. **Low concurrency** — With 1 writer, every batch fsyncs. Sequencer adds overhead for no benefit. Mitigation: short-circuit when pending list has 1 buffer.
 
-### When It Helps Most
+### vs Current Group Commit
 
-- Fast NVMe SSDs with internal parallelism.
-- High concurrency (many writer threads).
-- Moderate to large batch sizes (4KB+).
-
-### When It Helps Least
-
-- SATA SSDs or HDDs (I/O latency dominates).
-- Single writer (no parallelism to exploit).
-- Very small batches (io_uring overhead > savings).
+| Metric | Current | Sequencer |
+|--------|---------|-----------|
+| Fsyncs per N writers | 1 | 1 (piggyback) |
+| Code complexity | High (leader election, ring buffer) | Low (atomic offsets, mutex) |
+| Lock acquisitions | 1 (file mutex held for drain+write+fsync) | 1 (file mutex for pwrite) + 1 (commit_mutex for sequencer) |
+| BufWriter bugs | seek + flush interaction | None (no BufWriter) |
+| Error propagation | Batch result ring buffer | Error flag + notify_all |
 
 ---
 
@@ -284,28 +420,29 @@ mod io_uring_wal {
 
 | Phase | Description | Files |
 |-------|-------------|-------|
-| 1 | Add `io-uring` dependency (feature-gated) | `Cargo.toml` |
-| 2 | Implement `IoUringWal` write path | `wal.rs` |
-| 3 | Integrate with existing `submit_and_commit()` | `wal.rs` |
-| 4 | Add fallback to current group commit | `wal.rs` |
-| 5 | Benchmark: `write-perf --workload wal_concurrent` | — |
-| 6 | Add tests | `tests/wal.rs` |
+| 1 | Add `CommitSequencer` struct to `wal.rs` | `wal.rs` |
+| 2 | Replace `BufWriter<File>` with raw `File` | `wal.rs` |
+| 3 | Replace `submit_and_commit()` body with sequencer logic | `wal.rs` |
+| 4 | Update `sync()` to route through sequencer | `wal.rs` |
+| 5 | Remove leader-follower code (leader_active, batch_results, etc.) | `wal.rs` |
+| 6 | Update recovery to construct sequencer state | `wal.rs` |
+| 7 | Add tests | `tests/wal.rs` |
 
 ---
 
 ## 8. Testing Strategy
 
 1. **Correctness:** All existing WAL tests pass (format unchanged).
-2. **io_uring path:** Test with `cfg(target_os = "linux")` — write, read back, verify.
-3. **Fallback path:** Test with forced fallback — same correctness guarantees.
-4. **Benchmark:** `write-perf --workload wal_concurrent --threads 1,2,4,8` — compare io_uring vs fallback.
-5. **Stress test:** High concurrency (16+ threads) with crash injection.
+2. **Piggyback:** Verify that concurrent writers trigger fewer fsyncs (instrument with counter).
+3. **Ordering:** Crash-injection test — verify no batch is committed before prior batches are durable.
+4. **Single writer:** Verify no regression (short-circuit path).
+5. **sync() path:** Verify `engine.sync()` and `engine.close()` work correctly.
+6. **Benchmark:** `write-perf --workload wal_concurrent --threads 1,2,4,8` — compare vs current group commit.
 
 ---
 
 ## 9. Open Questions
 
-1. **io_uring ring size:** How many SQE slots? Recommendation: 64 (matches typical max concurrent batches).
-2. **Poll mode:** Should we use `IORING_SETUP_SQPOLL` for kernel-side polling? Trade-off: lower latency vs higher CPU usage. Recommendation: start without poll mode, add as optimization.
-3. **Fixed buffers:** Should we register fixed buffers (`IORING_REGISTER_BUFFERS`) to avoid per-SQE buffer setup? Recommendation: not in initial implementation — the variable-sized WAL batches make fixed buffers awkward.
-4. **Kernel version:** Minimum 5.6 for basic io_uring. 5.11+ for `IORING_OP_FSYNC`. 5.19+ for `IORING_SETUP_SINGLE_ISSUER` (optimization). Recommendation: target 5.11+.
+1. **Short-circuit for single writer:** Track `pending.len()` and bypass sequencer when 1 (direct pwrite + fsync). Adds a branch but avoids sequencer overhead for single-threaded workloads.
+2. **BufWriter removal scope:** The legacy `put()` path (non-MVCC) also uses BufWriter. Should it switch to pwrite too, or keep BufWriter for the legacy path? Recommendation: keep BufWriter for legacy, use pwrite only for MVCC batch path.
+3. **Future io_uring:** The pwrite model maps directly to io_uring SQEs. The `advance_confirmed` function would need a contiguous watermark for parallel submissions. Deferred to future work.


### PR DESCRIPTION
## Summary

RFC 012 proposes replacing the current leader-follower group commit with **io_uring + O_DIRECT** for parallel WAL writes, directly implementing the SpanDB paper's design.

## Key Design

- **io_uring + O_DIRECT** — bypasses ext4 inode lock, enables true parallel writes to NVMe
- **Atomic offset allocator** — each batch gets a unique, non-overlapping file offset
- **IOSQE_IO_DRAIN** — fsync waits for all prior SQEs, replaces explicit sequencer
- **Completion barrier** — condvar ensures all callers wait for fsync CQE (fate-sharing)
- **Dual file handles** — buffered for recovery, O_DIRECT for writes
- **Zero-padded alignment** — 4KB-aligned buffers prevent recovery corruption

## Review Status

9 rounds of review (3×3 reviewers). All critical issues resolved:
- Offset calculation uses aligned sizes (prevent overlapping writes)
- Zero-pad buffers to 4KB (prevent stale data in alignment gaps)
- Completion barrier for concurrent callers (fate-sharing)
- BufWriter retained for legacy put() path
- Wal::close() drains io_uring ring at engine close
- FsyncFlags constant fix (DATASYNC not FDATASYNC)
- Conditional setup_single_issuer() for kernel 5.11-5.18 compat
- Buffer lifetime invariant documented

## Expected Performance

- 1.2-2× on consumer NVMe, 2-3× on enterprise NVMe (multi-channel)
- Primary gain: write-phase parallelism (kernel dispatches to NVMe channels)
- Syscall reduction: ~66 syscalls → 1 io_uring_enter per batch group

## Verification

- [x] RFC document follows existing format (rfcs/001-011)
- [x] All 9 rounds of review findings addressed
- [x] Design covers: write path, completion barrier, recovery, cleanup, fallback, close
- [x] System verified: kernel 6.18.9, NVMe SSD, liburing installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a parallel WAL writing strategy using `io_uring` with `O_DIRECT` to improve write throughput.
  * WAL v4 metadata now includes `data_len` to ensure recovery correctly ignores alignment padding/gaps.
  * If `io_uring` setup isn’t available at startup, the system automatically falls back to the existing commit approach.

* **Documentation**
  * Added a full RFC detailing durability ordering, aligned buffer requirements, batching/chunking behavior, and operational trade-offs for the new WAL path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->