### PR TITLE
refactor: improve readable helper boundaries

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -12,3 +12,18 @@ slow-timeout = { period = "10s", terminate-after = 4, grace-period = "3s" }
 slow-timeout = { period = "30s", terminate-after = 3, grace-period = "5s" }
 retries = { backoff = "exponential", count = 3, delay = "1s", jitter = true }
 test-threads = "num-cpus"
+
+# All-targets profile: keeps normal tests parallel, but bench binaries are
+# assigned to a serial test group with a much longer timeout.
+[profile.all-targets]
+retries = { backoff = "exponential", count = 3, delay = "1s", jitter = true }
+test-threads = "num-cpus"
+
+[[profile.all-targets.overrides]]
+filter = 'kind(bench)'
+test-group = 'bench-serial'
+slow-timeout = { period = "10m", terminate-after = 1, grace-period = "10s" }
+retries = 0
+
+[test-groups.bench-serial]
+max-threads = 1

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -123,7 +123,18 @@ script = """
 #!/usr/bin/env bash
 set -e
 
-cargo nextest run --workspace --all-features --all-targets
+cargo nextest run --workspace --all-features --lib --bins --tests
+"""
+
+[tasks.test-all-targets]
+category = "Dev - check"
+description = "Run all targets including Criterion benches under the all-targets nextest profile"
+dependencies = ["install-nextest"]
+script = """
+#!/usr/bin/env bash
+set -e
+
+cargo nextest run --workspace --all-features --all-targets -P all-targets
 """
 
 [tasks.check]

--- a/kv-engine/Cargo.toml
+++ b/kv-engine/Cargo.toml
@@ -23,6 +23,9 @@ crossbeam-epoch = "0.9"
 crossbeam-queue = "0.3"
 crossbeam-skiplist = "0.1"
 dashmap = "6"
+
+io-uring = "0.6"
+libc = "0.2"
 log = "0.4"
 logforth = { version = "0.30", features = ["starter-log", "layout-json", "append-async"] }
 nom = "7.1.3"
@@ -32,9 +35,6 @@ rand = "0.8.5"
 rustyline = "18.0.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
-
-io-uring = "0.6"
-libc = "0.2"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -39,6 +39,28 @@ type CompactIterResult = Result<(
 /// (point_ssts, range_only_ssts, vlog_ids, applied_filters)
 type CompactResult = Result<(Vec<Arc<SsTable>>, Vec<Arc<SsTable>>, Vec<u32>, bool)>;
 
+struct CompactionOutputState<'a> {
+    current_first_key: &'a mut Option<Vec<u8>>,
+    current_last_key: &'a mut Option<Vec<u8>>,
+    output_point_ranges: &'a mut Vec<(Vec<u8>, Vec<u8>)>,
+    ret: &'a mut Vec<Arc<SsTable>>,
+    all_vlog_ids: &'a mut Vec<u32>,
+}
+
+struct CompactionEntryState<'a> {
+    seen_below_watermark: &'a mut bool,
+    prev_user_key: &'a mut Vec<u8>,
+}
+
+struct CompactionEntryDecision<'a> {
+    watermark: Option<u64>,
+    compact_to_bottom_level: bool,
+    fragments_for_drop_check: &'a [crate::range_tombstone::RangeTombstoneFragment],
+    decoded_user_key: &'a [u8],
+    key_ts: u64,
+    is_tombstone: bool,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub enum CompactionTask {
     Leveled(LeveledCompactionTask),
@@ -314,9 +336,7 @@ impl LsmStorageInner {
         is_upper_level_compaction: bool,
         merged_fragments: Vec<crate::range_tombstone::RangeTombstoneFragment>,
     ) -> CompactIterResult {
-        use crate::range_tombstone::{
-            find_newest_covering_ts, gc_range_fragments, truncate_fragments,
-        };
+        use crate::range_tombstone::gc_range_fragments;
 
         // Only backfill upper-level (L0/L1/L2) compactions. Data in these
         // levels is recently flushed or recently compacted — likely hot.
@@ -324,10 +344,8 @@ impl LsmStorageInner {
         // evict hotter blocks via force_put.
         let should_backfill = self.options.enable_cache_backfill && is_upper_level_compaction;
         let mut ret = vec![];
-        let mut all_vlog_ids = vec![];
-        let mut builder = SsTableBuilder::new(self.options.block_size);
-        builder.set_collect_blocks(should_backfill);
-        builder.set_prefix_bloom_options(Some(self.options.prefix_bloom.clone()));
+        let mut all_vlog_ids: Vec<u32> = vec![];
+        let mut builder = self.new_compaction_builder(should_backfill);
 
         // Snapshot the watermark once before the loop. When no active readers
         // exist, watermark() returns latest_commit_ts so everything below it
@@ -381,41 +399,26 @@ impl LsmStorageInner {
         let mut current_first_key: Option<Vec<u8>> = None;
         let mut current_last_key: Option<Vec<u8>> = None;
         let mut output_point_ranges: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+        let mut output_state = CompactionOutputState {
+            current_first_key: &mut current_first_key,
+            current_last_key: &mut current_last_key,
+            output_point_ranges: &mut output_point_ranges,
+            ret: &mut ret,
+            all_vlog_ids: &mut all_vlog_ids,
+        };
+        let mut entry_state = CompactionEntryState {
+            seen_below_watermark: &mut seen_below_watermark,
+            prev_user_key: &mut prev_user_key,
+        };
 
         while iter.is_valid() {
             if builder.estimated_size() >= self.options.target_sst_size {
-                // Finalize current SST: attach truncated range tombstones
-                if let (Some(first), Some(last)) =
-                    (current_first_key.as_ref(), current_last_key.as_ref())
-                {
-                    let succ_last = {
-                        let mut v = last.clone();
-                        v.push(0x00);
-                        v
-                    };
-                    let truncated = truncate_fragments(&merged_fragments, first, &succ_last);
-                    if !truncated.is_empty() {
-                        builder.add_range_tombstones(truncated);
-                    }
-                    output_point_ranges.push((first.clone(), succ_last));
-                }
-                current_first_key = None;
-                current_last_key = None;
-
-                all_vlog_ids.extend_from_slice(builder.vlog_file_ids());
-                let sst_id = self.next_sst_id();
-                let (sst, blocks) = builder.build_with_backfill(
-                    sst_id,
-                    Some(self.block_cache.clone()),
-                    self.path_of_sst(sst_id),
+                builder = self.finalize_compaction_output_sst(
+                    builder,
+                    &mut output_state,
+                    &merged_fragments,
+                    should_backfill,
                 )?;
-                if should_backfill {
-                    self.block_cache.backfill(sst_id, blocks);
-                }
-                ret.push(Arc::new(sst));
-                builder = SsTableBuilder::new(self.options.block_size);
-                builder.set_collect_blocks(should_backfill);
-                builder.set_prefix_bloom_options(Some(self.options.prefix_bloom.clone()));
             }
 
             // Detect tombstones: single KvKind::Tombstone byte.
@@ -431,43 +434,17 @@ impl LsmStorageInner {
             key.decode_user_key_into(&mut decoded_user_key);
             let user_key: &[u8] = &decoded_user_key;
 
-            let should_keep = if let Some(wm) = watermark {
-                // New user key group — reset tracking state
-                if user_key != prev_user_key {
-                    prev_user_key.clear();
-                    prev_user_key.extend_from_slice(user_key);
-                    seen_below_watermark = false;
-                }
-
-                if ts > wm {
-                    // Active readers might need this version — always keep
-                    true
-                } else if !seen_below_watermark {
-                    // First version at or below the watermark for this user
-                    // key — keep as the newest visible version. Drop tombstones
-                    // at the bottom level since no reader can see them.
-                    seen_below_watermark = true;
-                    if is_tombstone && compact_to_bottom_level {
-                        false
-                    } else if compact_to_bottom_level
-                        && !fragments_for_drop_check.is_empty()
-                        && find_newest_covering_ts(&fragments_for_drop_check, user_key, wm)
-                            .is_some_and(|rt_ts| ts <= rt_ts)
-                    {
-                        // Covered by a permanent range tombstone — safe to drop
-                        self.rt_stats.note_covered_drop();
-                        false
-                    } else {
-                        true
-                    }
-                } else {
-                    // Older version at or below the watermark — drop
-                    false
-                }
-            } else {
-                // No MVCC — drop tombstones at the bottom level only
-                !is_tombstone || !compact_to_bottom_level
-            };
+            let should_keep = self.should_keep_compaction_entry(
+                CompactionEntryDecision {
+                    watermark,
+                    compact_to_bottom_level,
+                    fragments_for_drop_check: &fragments_for_drop_check,
+                    decoded_user_key: user_key,
+                    key_ts: ts,
+                    is_tombstone,
+                },
+                &mut entry_state,
+            );
 
             let should_drop_for_filter =
                 should_keep && can_publish_filter_deletion && !is_tombstone && {
@@ -482,16 +459,15 @@ impl LsmStorageInner {
                 // Track output SST key range using decoded (raw) user keys,
                 // since range-tombstone fragment boundaries are raw user keys.
                 // Reuses user_key decoded above.
-                if current_first_key.is_none() {
-                    current_first_key = Some(user_key.to_vec());
+                if output_state.current_first_key.is_none() {
+                    *output_state.current_first_key = Some(user_key.to_vec());
                 }
-                if let Some(ref mut last_key) = current_last_key {
+                if let Some(last_key) = output_state.current_last_key {
                     last_key.clear();
                     last_key.extend_from_slice(user_key);
                 } else {
-                    current_last_key = Some(user_key.to_vec());
+                    *output_state.current_last_key = Some(user_key.to_vec());
                 }
-
                 builder.add_raw(iter.key(), iter.raw_value())?;
             } else if should_drop_for_filter {
                 let dropped_bytes = (iter.key().raw_ref().len() + iter.raw_value().len()) as u64;
@@ -502,32 +478,12 @@ impl LsmStorageInner {
 
         // Finalize last SST: attach truncated range tombstones
         if !builder.is_empty() {
-            if let (Some(first), Some(last)) =
-                (current_first_key.as_ref(), current_last_key.as_ref())
-            {
-                let succ_last = {
-                    let mut v = last.clone();
-                    v.push(0x00);
-                    v
-                };
-                let truncated = truncate_fragments(&merged_fragments, first, &succ_last);
-                if !truncated.is_empty() {
-                    builder.add_range_tombstones(truncated);
-                }
-                output_point_ranges.push((first.clone(), succ_last));
-            }
-
-            all_vlog_ids.extend_from_slice(builder.vlog_file_ids());
-            let sst_id = self.next_sst_id();
-            let (sst, blocks) = builder.build_with_backfill(
-                sst_id,
-                Some(self.block_cache.clone()),
-                self.path_of_sst(sst_id),
+            self.finalize_compaction_output_sst(
+                builder,
+                &mut output_state,
+                &merged_fragments,
+                should_backfill,
             )?;
-            if should_backfill {
-                self.block_cache.backfill(sst_id, blocks);
-            }
-            ret.push(Arc::new(sst));
         }
 
         all_vlog_ids.sort_unstable();
@@ -539,6 +495,113 @@ impl LsmStorageInner {
             output_point_ranges,
             gc_dropped_fragments,
         ))
+    }
+
+    fn new_compaction_builder(&self, should_backfill: bool) -> SsTableBuilder {
+        let mut builder = SsTableBuilder::new(self.options.block_size);
+        builder.set_collect_blocks(should_backfill);
+        builder.set_prefix_bloom_options(Some(self.options.prefix_bloom.clone()));
+        builder
+    }
+
+    fn finalize_compaction_output_sst(
+        &self,
+        mut builder: SsTableBuilder,
+        output_state: &mut CompactionOutputState<'_>,
+        merged_fragments: &[crate::range_tombstone::RangeTombstoneFragment],
+        should_backfill: bool,
+    ) -> Result<SsTableBuilder> {
+        if builder.is_empty() {
+            return Ok(builder);
+        }
+
+        if let (Some(first), Some(last)) = (
+            output_state.current_first_key.as_ref(),
+            output_state.current_last_key.as_ref(),
+        ) {
+            let succ_last = {
+                let mut v = last.clone();
+                v.push(0x00);
+                v
+            };
+            let truncated =
+                crate::range_tombstone::truncate_fragments(merged_fragments, first, &succ_last);
+            if !truncated.is_empty() {
+                builder.add_range_tombstones(truncated);
+            }
+            output_state
+                .output_point_ranges
+                .push((first.clone(), succ_last));
+        }
+
+        output_state
+            .all_vlog_ids
+            .extend_from_slice(builder.vlog_file_ids());
+        let sst_id = self.next_sst_id();
+        let (sst, blocks) = builder.build_with_backfill(
+            sst_id,
+            Some(self.block_cache.clone()),
+            self.path_of_sst(sst_id),
+        )?;
+        if should_backfill {
+            self.block_cache.backfill(sst_id, blocks);
+        }
+        output_state.ret.push(Arc::new(sst));
+        *output_state.current_first_key = None;
+        *output_state.current_last_key = None;
+
+        Ok(self.new_compaction_builder(should_backfill))
+    }
+
+    fn should_keep_compaction_entry(
+        &self,
+        decision: CompactionEntryDecision<'_>,
+        entry_state: &mut CompactionEntryState<'_>,
+    ) -> bool {
+        let CompactionEntryDecision {
+            watermark,
+            compact_to_bottom_level,
+            fragments_for_drop_check,
+            decoded_user_key,
+            key_ts,
+            is_tombstone,
+        } = decision;
+        match watermark {
+            Some(wm) => {
+                if decoded_user_key != entry_state.prev_user_key.as_slice() {
+                    entry_state.prev_user_key.clear();
+                    entry_state
+                        .prev_user_key
+                        .extend_from_slice(decoded_user_key);
+                    *entry_state.seen_below_watermark = false;
+                }
+
+                if key_ts > wm {
+                    true
+                } else if !*entry_state.seen_below_watermark {
+                    *entry_state.seen_below_watermark = true;
+                    if is_tombstone && compact_to_bottom_level {
+                        false
+                    } else if compact_to_bottom_level
+                        && !fragments_for_drop_check.is_empty()
+                        && crate::range_tombstone::find_newest_covering_ts(
+                            fragments_for_drop_check,
+                            decoded_user_key,
+                            wm,
+                        )
+                        .is_some_and(|rt_ts| key_ts <= rt_ts)
+                    {
+                        self.rt_stats.note_covered_drop();
+                        false
+                    } else {
+                        true
+                    }
+                } else {
+                    false
+                }
+            }
+            None => !is_tombstone || !compact_to_bottom_level,
+        }
     }
 
     fn compact_from_iters(
@@ -686,158 +749,9 @@ impl LsmStorageInner {
 
     fn compact(&self, task: &CompactionTask) -> CompactResult {
         let state = self.state.load_full();
-
-        // Collect merged range-tombstone fragments from all input SSTs.
-        let (merged_fragments, lower_level) = match task {
-            CompactionTask::Leveled(LeveledCompactionTask {
-                upper_level: _,
-                upper_level_sst_ids,
-                lower_level,
-                lower_level_sst_ids,
-                ..
-            }) => {
-                // Pass None for lower_level: `find_overlapping_ssts` already
-                // includes overlapping range-only SSTs in `lower_level_sst_ids`,
-                // so they are collected via the lower_sst_ids loop. Passing
-                // Some(*lower_level) would pull in ALL range-only SSTs at that
-                // level (including non-overlapping ones), causing duplicates.
-                let frags = self.collect_merged_fragments(
-                    &state,
-                    upper_level_sst_ids,
-                    lower_level_sst_ids,
-                    None,
-                );
-                (frags, Some(*lower_level))
-            }
-            CompactionTask::Simple(SimpleLeveledCompactionTask {
-                upper_level: _,
-                upper_level_sst_ids,
-                lower_level,
-                lower_level_sst_ids,
-                ..
-            }) => {
-                // For Simple compaction, the controller does not use
-                // `find_overlapping_ssts`, so `lower_level_sst_ids` does not
-                // include range-only SSTs. Pass `Some(*lower_level)` to collect
-                // ALL range-only SSTs at the target level.
-                let frags = self.collect_merged_fragments(
-                    &state,
-                    upper_level_sst_ids,
-                    lower_level_sst_ids,
-                    Some(*lower_level),
-                );
-                (frags, Some(*lower_level))
-            }
-            CompactionTask::ForceFullCompaction {
-                l0_sstables,
-                l1_sstables,
-            } => {
-                let frags =
-                    self.collect_merged_fragments(&state, l0_sstables, l1_sstables, Some(1));
-                (frags, Some(1))
-            }
-            CompactionTask::Tiered(t) => {
-                let mut fragment_lists: Vec<&[crate::range_tombstone::RangeTombstoneFragment]> =
-                    Vec::new();
-                for (_, sst_ids) in &t.tiers {
-                    for id in sst_ids {
-                        if let Some(sst) = state.sstables.get(id)
-                            && let Some(frags) = sst.range_tombstone_fragments()
-                            && !frags.is_empty()
-                        {
-                            fragment_lists.push(frags);
-                        }
-                    }
-                }
-                let frags = if fragment_lists.is_empty() {
-                    Vec::new()
-                } else {
-                    crate::range_tombstone::merge_fragment_lists(&fragment_lists)
-                };
-                (frags, None)
-            }
-        };
-
-        // Dispatch to variant-specific compaction logic
-        let (point_ssts, vlog_ids, apply_filters, output_ranges, gc_dropped_fragments) = match task
-        {
-            CompactionTask::Simple(SimpleLeveledCompactionTask {
-                upper_level,
-                upper_level_sst_ids,
-                lower_level: _,
-                lower_level_sst_ids,
-                ..
-            })
-            | CompactionTask::Leveled(LeveledCompactionTask {
-                upper_level,
-                upper_level_sst_ids,
-                lower_level: _,
-                lower_level_sst_ids,
-                ..
-            }) => {
-                if upper_level.is_none() {
-                    self.compact_from_l0_l1(
-                        upper_level_sst_ids,
-                        lower_level_sst_ids,
-                        task.compact_to_bottom_level(),
-                        task.is_upper_level_compaction(),
-                        merged_fragments.clone(),
-                    )?
-                } else {
-                    let mut s_upper = vec![];
-                    for i in upper_level_sst_ids.iter() {
-                        let t = state.sstables[i].clone();
-                        s_upper.push(t);
-                    }
-                    let upper_level_iter = SstConcatIterator::create_and_seek_to_first(s_upper)?;
-
-                    let mut s_lower = vec![];
-                    for i in lower_level_sst_ids.iter() {
-                        let t = state.sstables[i].clone();
-                        s_lower.push(t);
-                    }
-                    let lower_level_iter = SstConcatIterator::create_and_seek_to_first(s_lower)?;
-
-                    self.compact_from_iters(
-                        upper_level_iter,
-                        lower_level_iter,
-                        task.compact_to_bottom_level(),
-                        task.is_upper_level_compaction(),
-                        merged_fragments.clone(),
-                    )?
-                }
-            }
-            CompactionTask::ForceFullCompaction {
-                l0_sstables,
-                l1_sstables,
-            } => self.compact_from_l0_l1(
-                l0_sstables,
-                l1_sstables,
-                task.compact_to_bottom_level(),
-                task.is_upper_level_compaction(),
-                merged_fragments.clone(),
-            )?,
-            CompactionTask::Tiered(t) => {
-                let mut s_iters = vec![];
-                for tier in &t.tiers {
-                    let mut sstables = vec![];
-                    for i in tier.1.iter() {
-                        let t = state.sstables[i].clone();
-                        sstables.push(t);
-                    }
-                    s_iters.push(Box::new(SstConcatIterator::create_and_seek_to_first(
-                        sstables,
-                    )?));
-                }
-                let m_iter = MergeIterator::create(s_iters);
-                self.compact_from_iter(
-                    m_iter,
-                    task.compact_to_bottom_level(),
-                    task.is_upper_level_compaction(),
-                    merged_fragments.clone(),
-                )?
-            }
-        };
+        let (merged_fragments, lower_level) = self.collect_compaction_fragments(&state, task);
+        let (point_ssts, vlog_ids, apply_filters, output_ranges, gc_dropped_fragments) =
+            self.run_compaction_task(&state, task, &merged_fragments)?;
 
         // Build range-only SSTs for gap ranges not covered by point output SSTs.
         // Skip for Tiered compaction: range_only_ssts are not tracked per-tier,
@@ -875,6 +789,169 @@ impl LsmStorageInner {
         Ok((point_ssts, range_only_ssts, vlog_ids, apply_filters))
     }
 
+    fn collect_compaction_fragments(
+        &self,
+        state: &LsmStorageState,
+        task: &CompactionTask,
+    ) -> (
+        Vec<crate::range_tombstone::RangeTombstoneFragment>,
+        Option<usize>,
+    ) {
+        match task {
+            CompactionTask::Leveled(LeveledCompactionTask {
+                upper_level: _,
+                upper_level_sst_ids,
+                lower_level,
+                lower_level_sst_ids,
+                ..
+            }) => {
+                let frags = self.collect_merged_fragments(
+                    state,
+                    upper_level_sst_ids,
+                    lower_level_sst_ids,
+                    None,
+                );
+                (frags, Some(*lower_level))
+            }
+            CompactionTask::Simple(SimpleLeveledCompactionTask {
+                upper_level: _,
+                upper_level_sst_ids,
+                lower_level,
+                lower_level_sst_ids,
+                ..
+            }) => {
+                let frags = self.collect_merged_fragments(
+                    state,
+                    upper_level_sst_ids,
+                    lower_level_sst_ids,
+                    Some(*lower_level),
+                );
+                (frags, Some(*lower_level))
+            }
+            CompactionTask::ForceFullCompaction {
+                l0_sstables,
+                l1_sstables,
+            } => {
+                let frags = self.collect_merged_fragments(state, l0_sstables, l1_sstables, Some(1));
+                (frags, Some(1))
+            }
+            CompactionTask::Tiered(t) => {
+                let mut fragment_lists: Vec<&[crate::range_tombstone::RangeTombstoneFragment]> =
+                    Vec::new();
+                for (_, sst_ids) in &t.tiers {
+                    for id in sst_ids {
+                        if let Some(sst) = state.sstables.get(id)
+                            && let Some(frags) = sst.range_tombstone_fragments()
+                            && !frags.is_empty()
+                        {
+                            fragment_lists.push(frags);
+                        }
+                    }
+                }
+                let frags = if fragment_lists.is_empty() {
+                    Vec::new()
+                } else {
+                    crate::range_tombstone::merge_fragment_lists(&fragment_lists)
+                };
+                (frags, None)
+            }
+        }
+    }
+
+    fn run_compaction_task(
+        &self,
+        state: &LsmStorageState,
+        task: &CompactionTask,
+        merged_fragments: &[crate::range_tombstone::RangeTombstoneFragment],
+    ) -> CompactIterResult {
+        let (point_ssts, vlog_ids, apply_filters, output_ranges, gc_dropped_fragments) = match task
+        {
+            CompactionTask::Simple(SimpleLeveledCompactionTask {
+                upper_level,
+                upper_level_sst_ids,
+                lower_level: _,
+                lower_level_sst_ids,
+                ..
+            })
+            | CompactionTask::Leveled(LeveledCompactionTask {
+                upper_level,
+                upper_level_sst_ids,
+                lower_level: _,
+                lower_level_sst_ids,
+                ..
+            }) => {
+                if upper_level.is_none() {
+                    self.compact_from_l0_l1(
+                        upper_level_sst_ids,
+                        lower_level_sst_ids,
+                        task.compact_to_bottom_level(),
+                        task.is_upper_level_compaction(),
+                        merged_fragments.to_vec(),
+                    )?
+                } else {
+                    let mut s_upper = vec![];
+                    for i in upper_level_sst_ids.iter() {
+                        let t = state.sstables[i].clone();
+                        s_upper.push(t);
+                    }
+                    let upper_level_iter = SstConcatIterator::create_and_seek_to_first(s_upper)?;
+
+                    let mut s_lower = vec![];
+                    for i in lower_level_sst_ids.iter() {
+                        let t = state.sstables[i].clone();
+                        s_lower.push(t);
+                    }
+                    let lower_level_iter = SstConcatIterator::create_and_seek_to_first(s_lower)?;
+
+                    self.compact_from_iters(
+                        upper_level_iter,
+                        lower_level_iter,
+                        task.compact_to_bottom_level(),
+                        task.is_upper_level_compaction(),
+                        merged_fragments.to_vec(),
+                    )?
+                }
+            }
+            CompactionTask::ForceFullCompaction {
+                l0_sstables,
+                l1_sstables,
+            } => self.compact_from_l0_l1(
+                l0_sstables,
+                l1_sstables,
+                task.compact_to_bottom_level(),
+                task.is_upper_level_compaction(),
+                merged_fragments.to_vec(),
+            )?,
+            CompactionTask::Tiered(t) => {
+                let mut s_iters = vec![];
+                for tier in &t.tiers {
+                    let mut sstables = vec![];
+                    for i in tier.1.iter() {
+                        let t = state.sstables[i].clone();
+                        sstables.push(t);
+                    }
+                    s_iters.push(Box::new(SstConcatIterator::create_and_seek_to_first(
+                        sstables,
+                    )?));
+                }
+                let m_iter = MergeIterator::create(s_iters);
+                self.compact_from_iter(
+                    m_iter,
+                    task.compact_to_bottom_level(),
+                    task.is_upper_level_compaction(),
+                    merged_fragments.to_vec(),
+                )?
+            }
+        };
+        Ok((
+            point_ssts,
+            vlog_ids,
+            apply_filters,
+            output_ranges,
+            gc_dropped_fragments,
+        ))
+    }
+
     pub fn force_full_compaction(&self) -> Result<()> {
         let state = self.state.load_full();
         let ssts_to_compact = (&state.l0_sstables, &state.levels[0].1);
@@ -887,116 +964,22 @@ impl LsmStorageInner {
             self.compact(&task)?;
 
         // Collect vLog IDs from input SSTs before unregistering (for GC)
-        let input_vlog_ids: Vec<u32> = if let Some(ref vlog) = self.vlog {
-            let mut ids = Vec::with_capacity(ssts_to_compact.0.len() + ssts_to_compact.1.len());
-            for id in ssts_to_compact.0.iter().chain(ssts_to_compact.1) {
-                if let Some(refs) = vlog.get_sst_references(*id) {
-                    ids.extend(refs);
-                }
-            }
-            ids.sort_unstable();
-            ids.dedup();
-            ids
-        } else {
-            vec![]
-        };
+        let input_sst_ids = ssts_to_compact
+            .0
+            .iter()
+            .chain(ssts_to_compact.1.iter())
+            .copied()
+            .collect::<Vec<_>>();
+        let input_vlog_ids = self.collect_compaction_input_vlog_ids(&input_sst_ids);
 
-        let old_range_only_ids;
-        {
-            let _state_lock = self.state_lock.lock();
-
-            // Re-check filter safety under state_lock. Between the initial
-            // check in compact_from_iter and this publication point, a new
-            // ReadGuard may have been created. Filters are optional cleanup,
-            // so if new readers appeared, skip publishing the filtered result.
-            if apply_filters
-                && self
-                    .mvcc
-                    .as_ref()
-                    .is_some_and(|m| !m.can_publish_filter_deletion())
-            {
-                // Clean up orphan SST files that were built but will not be
-                // published to the LSM state.
-                for sst in new_ssts.iter().chain(new_range_only_ssts.iter()) {
-                    let _ = std::fs::remove_file(self.path_of_sst(sst.sst_id()));
-                }
-                return Ok(());
-            }
-
-            let mut snapshot = self.state.load().as_ref().clone();
-
-            // Unregister vLog references for old SSTs
-            if let Some(ref vlog) = self.vlog {
-                for id in ssts_to_compact.0.iter().chain(ssts_to_compact.1) {
-                    vlog.unregister_sst_references(*id);
-                }
-                // Register vLog references for new point SSTs only.
-                // Range-only SSTs have no point data and no vLog references.
-                for sst in new_ssts.iter() {
-                    vlog.register_sst_references(sst.sst_id(), &compact_vlog_ids);
-                }
-            }
-
-            ssts_to_compact
-                .0
-                .iter()
-                .chain(ssts_to_compact.1)
-                .for_each(|id| {
-                    snapshot.sstables.remove(id);
-                });
-            // Remove old range-only SSTs from level 1 and drop their table entries.
-            old_range_only_ids = if let Some((_, ro_ids)) = snapshot
-                .range_only_ssts
-                .iter_mut()
-                .find(|(lvl, _)| *lvl == 1)
-            {
-                std::mem::take(ro_ids)
-            } else {
-                Vec::new()
-            };
-            for id in &old_range_only_ids {
-                snapshot.sstables.remove(id);
-            }
-
-            let new_sst_ids: Vec<_> = new_ssts.iter().map(|t| t.sst_id()).collect();
-            snapshot.levels[0].1.clone_from(&new_sst_ids);
-            for sst in new_ssts.iter().chain(new_range_only_ssts.iter()) {
-                snapshot.sstables.insert(sst.sst_id(), sst.clone());
-            }
-            // Add range-only SSTs to level 1 (create entry if missing).
-            let new_ro_ids: Vec<usize> = new_range_only_ssts.iter().map(|t| t.sst_id()).collect();
-            if !new_ro_ids.is_empty() {
-                if let Some((_, ro_ids)) = snapshot
-                    .range_only_ssts
-                    .iter_mut()
-                    .find(|(lvl, _)| *lvl == 1)
-                {
-                    ro_ids.extend(new_ro_ids.iter().copied());
-                } else {
-                    snapshot.range_only_ssts.push((1, new_ro_ids));
-                }
-            }
-            let l0_rm = ssts_to_compact.0.iter().collect::<HashSet<_>>();
-            // might have new l0 insert into snapshot.l0_sstables during compact
-            snapshot.l0_sstables.retain(|id| !l0_rm.contains(id));
-
-            self.state.store(Arc::new(snapshot));
-
-            self.sync_dir()?;
-            let new_range_only_sst_ids: Vec<usize> =
-                new_range_only_ssts.iter().map(|t| t.sst_id()).collect();
-            let manifest_record = ManifestRecord::CompactionV3(
-                task,
-                new_sst_ids.clone(),
-                compact_vlog_ids,
-                new_range_only_sst_ids,
-            );
-            self.manifest
-                .as_ref()
-                .expect("manifest initialized")
-                .add_record(&_state_lock, manifest_record)?;
-            self.maybe_snapshot_manifest(&_state_lock)?;
-        }
+        let old_range_only_ids = self.publish_force_full_compaction_result(
+            (ssts_to_compact.0.as_slice(), ssts_to_compact.1.as_slice()),
+            task,
+            &new_ssts,
+            &new_range_only_ssts,
+            &compact_vlog_ids,
+            apply_filters,
+        )?;
 
         let removed_ids: HashSet<usize> = ssts_to_compact
             .0
@@ -1005,16 +988,7 @@ impl LsmStorageInner {
             .chain(old_range_only_ids.iter())
             .copied()
             .collect();
-        for &id in &removed_ids {
-            let path = self.path_of_sst(id);
-            // Ignore NotFound errors — the background flush thread may have
-            // already removed the file during a concurrent operation.
-            match std::fs::remove_file(&path) {
-                std::result::Result::Ok(()) => {}
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                Err(e) => return Err(e.into()),
-            }
-        }
+        self.remove_sst_files(removed_ids.iter().copied())?;
         // Invalidate cached blocks from deleted SSTs via the reverse index.
         self.block_cache.invalidate_ssts(&removed_ids);
 
@@ -1024,6 +998,40 @@ impl LsmStorageInner {
         }
 
         Ok(())
+    }
+
+    fn record_gc_compaction(
+        manifest: Option<&crate::manifest::Manifest>,
+        state_lock: &parking_lot::Mutex<()>,
+        result: crate::vlog::gc::GcResult,
+    ) {
+        if let Some(manifest) = manifest {
+            let _ = manifest.add_record(
+                &state_lock.lock(),
+                ManifestRecord::GcCompaction(
+                    result.old_file_id,
+                    result.new_file_id,
+                    result.keys_rewritten,
+                ),
+            );
+        }
+    }
+
+    fn gc_single_vlog_file(
+        vlog: &Arc<crate::vlog::ValueLog>,
+        inner: &LsmStorageInner,
+        file_id: u32,
+    ) {
+        let gc = GarbageCollector::new(vlog, inner, vlog.options.gc_threshold_ratio);
+        match gc.gc_file(file_id) {
+            std::result::Result::Ok(Some(result)) => {
+                Self::record_gc_compaction(inner.manifest.as_ref(), &inner.state_lock, result);
+            }
+            std::result::Result::Ok(None) => {}
+            std::result::Result::Err(e) => {
+                log::error!("GC error for vlog file {}: {}", file_id, e);
+            }
+        }
     }
 
     /// Run GC on vLog files that were referenced by compacted SSTs.
@@ -1046,25 +1054,7 @@ impl LsmStorageInner {
                     let Some(inner) = weak.upgrade() else {
                         break;
                     };
-                    let gc = GarbageCollector::new(&vlog, &inner, vlog.options.gc_threshold_ratio);
-                    match gc.gc_file(file_id) {
-                        std::result::Result::Ok(Some(result)) => {
-                            if let Some(ref manifest) = inner.manifest {
-                                let _ = manifest.add_record(
-                                    &inner.state_lock.lock(),
-                                    ManifestRecord::GcCompaction(
-                                        result.old_file_id,
-                                        result.new_file_id,
-                                        result.keys_rewritten,
-                                    ),
-                                );
-                            }
-                        }
-                        std::result::Result::Ok(None) => {}
-                        std::result::Result::Err(e) => {
-                            log::error!("GC error for vlog file {}: {}", file_id, e);
-                        }
-                    }
+                    Self::gc_single_vlog_file(&vlog, &inner, file_id);
                 }
                 if let Err(e) = vlog.reclaim_pending_deletions() {
                     log::error!("vLog reclaim error: {}", e);
@@ -1078,26 +1068,8 @@ impl LsmStorageInner {
             }
         } else {
             // Fallback to synchronous GC if weak_self is not set
-            let gc = GarbageCollector::new(&vlog2, self, vlog2.options.gc_threshold_ratio);
             for &file_id in &ids {
-                match gc.gc_file(file_id) {
-                    std::result::Result::Ok(Some(result)) => {
-                        if let Some(ref manifest) = self.manifest {
-                            let _ = manifest.add_record(
-                                &self.state_lock.lock(),
-                                ManifestRecord::GcCompaction(
-                                    result.old_file_id,
-                                    result.new_file_id,
-                                    result.keys_rewritten,
-                                ),
-                            );
-                        }
-                    }
-                    std::result::Result::Ok(None) => {}
-                    std::result::Result::Err(e) => {
-                        log::error!("GC error for vlog file {}: {}", file_id, e);
-                    }
-                }
+                Self::gc_single_vlog_file(&vlog2, self, file_id);
             }
             if let Err(e) = vlog2.reclaim_pending_deletions() {
                 log::error!("vLog reclaim error: {}", e);
@@ -1105,20 +1077,8 @@ impl LsmStorageInner {
         }
     }
 
-    pub(crate) fn trigger_compaction(&self) -> Result<()> {
-        let task = self
-            .compaction_controller
-            .generate_compaction_task(self.state.load_full().as_ref());
-        let Some(t) = task.as_ref() else {
-            return Ok(());
-        };
-        let (new_ssts, new_range_only_ssts, compact_vlog_ids, apply_filters) = self.compact(t)?;
-        let new_sst_ids = new_ssts.iter().map(|x| x.sst_id()).collect::<Vec<_>>();
-        let new_range_only_sst_ids: Vec<usize> =
-            new_range_only_ssts.iter().map(|x| x.sst_id()).collect();
-
-        // Collect input SST IDs for post-compaction GC
-        let input_sst_ids: Vec<usize> = match t {
+    fn collect_compaction_input_sst_ids(task: &CompactionTask) -> Vec<usize> {
+        match task {
             CompactionTask::ForceFullCompaction {
                 l0_sstables,
                 l1_sstables,
@@ -1149,55 +1109,213 @@ impl LsmStorageInner {
                 .iter()
                 .flat_map(|(_, ids)| ids.iter().copied())
                 .collect(),
+        }
+    }
+
+    fn collect_compaction_input_vlog_ids(&self, input_sst_ids: &[usize]) -> Vec<u32> {
+        let Some(ref vlog) = self.vlog else {
+            return vec![];
         };
 
-        // Collect vLog IDs from input SSTs before unregistering (for GC)
-        let input_vlog_ids: Vec<u32> = if let Some(ref vlog) = self.vlog {
-            let mut ids = Vec::with_capacity(input_sst_ids.len());
-            for &sst_id in &input_sst_ids {
-                if let Some(refs) = vlog.get_sst_references(sst_id) {
-                    ids.extend(refs);
-                }
+        let mut ids = Vec::with_capacity(input_sst_ids.len());
+        for &sst_id in input_sst_ids {
+            if let Some(refs) = vlog.get_sst_references(sst_id) {
+                ids.extend(refs);
             }
-            ids.sort_unstable();
-            ids.dedup();
-            ids
-        } else {
-            vec![]
-        };
+        }
+        ids.sort_unstable();
+        ids.dedup();
+        ids
+    }
 
-        // Determine the target level for range-only SST placement
-        let target_level = match t {
+    fn compaction_target_level(task: &CompactionTask) -> Option<usize> {
+        match task {
             CompactionTask::Leveled(LeveledCompactionTask { lower_level, .. })
             | CompactionTask::Simple(SimpleLeveledCompactionTask { lower_level, .. }) => {
                 Some(*lower_level)
             }
             CompactionTask::ForceFullCompaction { .. } => Some(1),
             CompactionTask::Tiered(_) => None,
+        }
+    }
+
+    fn collect_input_range_only_ids(
+        &self,
+        task: &CompactionTask,
+        target_level: Option<usize>,
+        input_sst_ids: &[usize],
+    ) -> Vec<usize> {
+        let Some(level) = target_level else {
+            return Vec::new();
         };
 
-        // Determine range-only SST IDs that were in the input (to remove them)
-        let input_range_only_ids: Vec<usize> = if let Some(level) = target_level {
-            let state = self.state.load();
-            if let Some((_, ro_ids)) = state.range_only_ssts.iter().find(|(lvl, _)| *lvl == level) {
-                match t {
-                    CompactionTask::Simple(_) => {
-                        // Simple compaction compacts the entire level, so all
-                        // range-only SSTs at the target level are inputs.
-                        ro_ids.clone()
-                    }
-                    _ => ro_ids
-                        .iter()
-                        .filter(|id| input_sst_ids.contains(id))
-                        .copied()
-                        .collect(),
-                }
-            } else {
-                Vec::new()
+        let state = self.state.load();
+        let Some((_, ro_ids)) = state.range_only_ssts.iter().find(|(lvl, _)| *lvl == level) else {
+            return Vec::new();
+        };
+
+        match task {
+            CompactionTask::Simple(_) => {
+                // Simple compaction compacts the whole level, so every range-only SST at the
+                // target level is part of the input set.
+                ro_ids.clone()
             }
+            _ => ro_ids
+                .iter()
+                .filter(|id| input_sst_ids.contains(id))
+                .copied()
+                .collect(),
+        }
+    }
+
+    fn remove_sst_files<I>(&self, sst_ids: I) -> Result<()>
+    where
+        I: IntoIterator<Item = usize>,
+    {
+        for id in sst_ids {
+            let path = self.path_of_sst(id);
+            // Ignore NotFound errors — the background flush thread may have
+            // already removed the file during a concurrent operation.
+            match std::fs::remove_file(&path) {
+                std::result::Result::Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e.into()),
+            }
+        }
+        Ok(())
+    }
+
+    fn remove_orphan_compaction_outputs(
+        &self,
+        new_ssts: &[Arc<SsTable>],
+        new_range_only_ssts: &[Arc<SsTable>],
+    ) {
+        for sst in new_ssts.iter().chain(new_range_only_ssts.iter()) {
+            let _ = std::fs::remove_file(self.path_of_sst(sst.sst_id()));
+        }
+    }
+
+    fn publish_force_full_compaction_result(
+        &self,
+        ssts_to_compact: (&[usize], &[usize]),
+        task: CompactionTask,
+        new_ssts: &[Arc<SsTable>],
+        new_range_only_ssts: &[Arc<SsTable>],
+        compact_vlog_ids: &[u32],
+        apply_filters: bool,
+    ) -> Result<Vec<usize>> {
+        let _state_lock = self.state_lock.lock();
+
+        // Re-check filter safety under state_lock. Between the initial
+        // check in compact_from_iter and this publication point, a new
+        // ReadGuard may have been created. Filters are optional cleanup,
+        // so if new readers appeared, skip publishing the filtered result.
+        if apply_filters
+            && self
+                .mvcc
+                .as_ref()
+                .is_some_and(|m| !m.can_publish_filter_deletion())
+        {
+            // Clean up orphan SST files that were built but will not be
+            // published to the LSM state.
+            self.remove_orphan_compaction_outputs(new_ssts, new_range_only_ssts);
+            return Ok(Vec::new());
+        }
+
+        let mut snapshot = self.state.load().as_ref().clone();
+
+        if let Some(ref vlog) = self.vlog {
+            for id in ssts_to_compact.0.iter().chain(ssts_to_compact.1) {
+                vlog.unregister_sst_references(*id);
+            }
+            // Register vLog references for new point SSTs only.
+            // Range-only SSTs have no point data and no vLog references.
+            for sst in new_ssts {
+                vlog.register_sst_references(sst.sst_id(), compact_vlog_ids);
+            }
+        }
+
+        ssts_to_compact
+            .0
+            .iter()
+            .chain(ssts_to_compact.1)
+            .for_each(|id| {
+                snapshot.sstables.remove(id);
+            });
+        // Remove old range-only SSTs from level 1 and drop their table entries.
+        let old_range_only_ids = if let Some((_, ro_ids)) = snapshot
+            .range_only_ssts
+            .iter_mut()
+            .find(|(lvl, _)| *lvl == 1)
+        {
+            std::mem::take(ro_ids)
         } else {
             Vec::new()
         };
+        for id in &old_range_only_ids {
+            snapshot.sstables.remove(id);
+        }
+
+        let new_sst_ids: Vec<_> = new_ssts.iter().map(|t| t.sst_id()).collect();
+        snapshot.levels[0].1.clone_from(&new_sst_ids);
+        for sst in new_ssts.iter().chain(new_range_only_ssts.iter()) {
+            snapshot.sstables.insert(sst.sst_id(), sst.clone());
+        }
+        // Add range-only SSTs to level 1 (create entry if missing).
+        let new_ro_ids: Vec<usize> = new_range_only_ssts.iter().map(|t| t.sst_id()).collect();
+        if !new_ro_ids.is_empty() {
+            if let Some((_, ro_ids)) = snapshot
+                .range_only_ssts
+                .iter_mut()
+                .find(|(lvl, _)| *lvl == 1)
+            {
+                ro_ids.extend(new_ro_ids.iter().copied());
+            } else {
+                snapshot.range_only_ssts.push((1, new_ro_ids));
+            }
+        }
+        let l0_rm = ssts_to_compact.0.iter().collect::<HashSet<_>>();
+        // might have new l0 insert into snapshot.l0_sstables during compact
+        snapshot.l0_sstables.retain(|id| !l0_rm.contains(id));
+
+        self.state.store(Arc::new(snapshot));
+
+        self.sync_dir()?;
+        let manifest_record = ManifestRecord::CompactionV3(
+            task,
+            new_sst_ids,
+            compact_vlog_ids.to_vec(),
+            new_range_only_ssts.iter().map(|t| t.sst_id()).collect(),
+        );
+        self.manifest
+            .as_ref()
+            .expect("manifest initialized")
+            .add_record(&_state_lock, manifest_record)?;
+        self.maybe_snapshot_manifest(&_state_lock)?;
+
+        Ok(old_range_only_ids)
+    }
+
+    pub(crate) fn trigger_compaction(&self) -> Result<()> {
+        let task = self
+            .compaction_controller
+            .generate_compaction_task(self.state.load_full().as_ref());
+        let Some(t) = task.as_ref() else {
+            return Ok(());
+        };
+        let (new_ssts, new_range_only_ssts, compact_vlog_ids, apply_filters) = self.compact(t)?;
+        let new_sst_ids = new_ssts.iter().map(|x| x.sst_id()).collect::<Vec<_>>();
+        let new_range_only_sst_ids: Vec<usize> =
+            new_range_only_ssts.iter().map(|x| x.sst_id()).collect();
+
+        // Collect input SST IDs for post-compaction GC
+        let input_sst_ids = Self::collect_compaction_input_sst_ids(t);
+        let input_vlog_ids = self.collect_compaction_input_vlog_ids(&input_sst_ids);
+        let target_level = Self::compaction_target_level(t);
+
+        // Determine range-only SST IDs that were in the input (to remove them)
+        let input_range_only_ids =
+            self.collect_input_range_only_ids(t, target_level, &input_sst_ids);
 
         let rm_sst_ids = {
             let _state_lock = self.state_lock.lock();
@@ -1211,11 +1329,7 @@ impl LsmStorageInner {
                     .as_ref()
                     .is_some_and(|m| !m.can_publish_filter_deletion())
             {
-                // Clean up orphan SST files that were built but will not be
-                // published to the LSM state.
-                for sst in new_ssts.iter().chain(new_range_only_ssts.iter()) {
-                    let _ = std::fs::remove_file(self.path_of_sst(sst.sst_id()));
-                }
+                self.remove_orphan_compaction_outputs(&new_ssts, &new_range_only_ssts);
                 return Ok(());
             }
 
@@ -1298,16 +1412,7 @@ impl LsmStorageInner {
             .copied()
             .chain(input_range_only_ids.iter().copied())
             .collect();
-        for &id in &removed_ids {
-            let path = self.path_of_sst(id);
-            // Ignore NotFound errors — the background flush thread may have
-            // already removed the file during a concurrent operation.
-            match std::fs::remove_file(&path) {
-                std::result::Result::Ok(()) => {}
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                Err(e) => return Err(e.into()),
-            }
-        }
+        self.remove_sst_files(removed_ids.iter().copied())?;
         // Invalidate cached blocks from deleted SSTs via the reverse index.
         self.block_cache.invalidate_ssts(&removed_ids);
 
@@ -1328,17 +1433,8 @@ impl LsmStorageInner {
         | CompactionOptions::Tiered(_) = self.options.compaction_options
         {
             let this = self.clone();
-            let handle = std::thread::spawn(move || {
-                let ticker = crossbeam_channel::tick(Duration::from_millis(50));
-                loop {
-                    crossbeam_channel::select! {
-                        recv(ticker) -> _ => if let Err(e) = this.trigger_compaction() {
-                            log::error!("compaction failed: {}", e);
-                        },
-                        recv(rx) -> _ => return
-                    }
-                }
-            });
+            let handle =
+                Self::spawn_periodic_thread(rx, move || this.trigger_compaction(), "compaction");
             return Ok(Some(handle));
         }
 
@@ -1359,18 +1455,29 @@ impl LsmStorageInner {
         rx: crossbeam_channel::Receiver<()>,
     ) -> Result<Option<std::thread::JoinHandle<()>>> {
         let this = self.clone();
-        let handle = std::thread::spawn(move || {
+        let handle = Self::spawn_periodic_thread(rx, move || this.trigger_flush(), "flush");
+
+        Ok(Some(handle))
+    }
+
+    fn spawn_periodic_thread<F>(
+        rx: crossbeam_channel::Receiver<()>,
+        mut tick_fn: F,
+        task_name: &'static str,
+    ) -> std::thread::JoinHandle<()>
+    where
+        F: FnMut() -> Result<()> + Send + 'static,
+    {
+        std::thread::spawn(move || {
             let ticker = crossbeam_channel::tick(Duration::from_millis(50));
             loop {
                 crossbeam_channel::select! {
-                    recv(ticker) -> _ => if let Err(e) = this.trigger_flush() {
-                        log::error!("flush failed: {}", e);
+                    recv(ticker) -> _ => if let Err(e) = tick_fn() {
+                        log::error!("{} failed: {}", task_name, e);
                     },
                     recv(rx) -> _ => return
                 }
             }
-        });
-
-        Ok(Some(handle))
+        })
     }
 }

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -1185,6 +1185,7 @@ impl LsmStorageInner {
                 Err(e) => return Err(e.into()),
             }
         }
+
         Ok(())
     }
 

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -972,14 +972,17 @@ impl LsmStorageInner {
             .collect::<Vec<_>>();
         let input_vlog_ids = self.collect_compaction_input_vlog_ids(&input_sst_ids);
 
-        let old_range_only_ids = self.publish_force_full_compaction_result(
+        let Some(old_range_only_ids) = self.publish_force_full_compaction_result(
             (ssts_to_compact.0.as_slice(), ssts_to_compact.1.as_slice()),
             task,
             &new_ssts,
             &new_range_only_ssts,
             &compact_vlog_ids,
             apply_filters,
-        )?;
+        )?
+        else {
+            return Ok(());
+        };
 
         let removed_ids: HashSet<usize> = ssts_to_compact
             .0
@@ -1203,7 +1206,7 @@ impl LsmStorageInner {
         new_range_only_ssts: &[Arc<SsTable>],
         compact_vlog_ids: &[u32],
         apply_filters: bool,
-    ) -> Result<Vec<usize>> {
+    ) -> Result<Option<Vec<usize>>> {
         let _state_lock = self.state_lock.lock();
 
         // Re-check filter safety under state_lock. Between the initial
@@ -1219,7 +1222,7 @@ impl LsmStorageInner {
             // Clean up orphan SST files that were built but will not be
             // published to the LSM state.
             self.remove_orphan_compaction_outputs(new_ssts, new_range_only_ssts);
-            return Ok(Vec::new());
+            return Ok(None);
         }
 
         let mut snapshot = self.state.load().as_ref().clone();
@@ -1293,7 +1296,7 @@ impl LsmStorageInner {
             .add_record(&_state_lock, manifest_record)?;
         self.maybe_snapshot_manifest(&_state_lock)?;
 
-        Ok(old_range_only_ids)
+        Ok(Some(old_range_only_ids))
     }
 
     pub(crate) fn trigger_compaction(&self) -> Result<()> {

--- a/kv-engine/src/lsm_iterator.rs
+++ b/kv-engine/src/lsm_iterator.rs
@@ -163,6 +163,7 @@ impl LsmIterator {
         while iter.is_valid() && iter.key().encoded_user_key() == encoded_user_key {
             iter.next()?;
         }
+
         Ok(())
     }
 
@@ -180,6 +181,7 @@ impl LsmIterator {
         while self.inner.is_valid() && crate::vlog::KvKind::is_tombstone_value(self.inner.value()) {
             self.inner.next()?;
         }
+
         Ok(())
     }
 

--- a/kv-engine/src/lsm_iterator.rs
+++ b/kv-engine/src/lsm_iterator.rs
@@ -127,11 +127,7 @@ impl LsmIterator {
             if crate::vlog::KvKind::is_tombstone_value(iter.value()) {
                 // Point tombstone — skip all versions of this dead user key
                 if TS_ENABLED {
-                    while iter.is_valid()
-                        && iter.key().encoded_user_key() == encoded_user_key.as_slice()
-                    {
-                        iter.next()?;
-                    }
+                    Self::skip_current_user_key_versions(iter, encoded_user_key)?;
                 } else {
                     iter.next()?;
                 }
@@ -151,15 +147,38 @@ impl LsmIterator {
                     .is_some_and(|cover_ts| point_ts <= cover_ts)
                 {
                     // Covered — skip all versions of this user key
-                    while iter.is_valid()
-                        && iter.key().encoded_user_key() == encoded_user_key.as_slice()
-                    {
-                        iter.next()?;
-                    }
+                    Self::skip_current_user_key_versions(iter, encoded_user_key)?;
                     continue;
                 }
             }
             return Ok(());
+        }
+        Ok(())
+    }
+
+    fn skip_current_user_key_versions(
+        iter: &mut LsmIteratorInner,
+        encoded_user_key: &[u8],
+    ) -> Result<()> {
+        while iter.is_valid() && iter.key().encoded_user_key() == encoded_user_key {
+            iter.next()?;
+        }
+        Ok(())
+    }
+
+    fn refresh_cached_user_keys(&mut self) {
+        if !self.inner.is_valid() {
+            return;
+        }
+        self.inner.key().decode_user_key_into(&mut self.user_key);
+        self.encoded_user_key.clear();
+        self.encoded_user_key
+            .extend_from_slice(self.inner.key().encoded_user_key());
+    }
+
+    fn skip_legacy_tombstones(&mut self) -> Result<()> {
+        while self.inner.is_valid() && crate::vlog::KvKind::is_tombstone_value(self.inner.value()) {
+            self.inner.next()?;
         }
         Ok(())
     }
@@ -198,11 +217,7 @@ impl StorageIterator for LsmIterator {
             // Skip all remaining versions of the current user key.
             // Compare encoded prefixes (not decoded) so keys with 0x00 bytes
             // match correctly through the memcomparable encoding layer.
-            while self.inner.is_valid()
-                && self.inner.key().encoded_user_key() == self.encoded_user_key.as_slice()
-            {
-                self.inner.next()?;
-            }
+            Self::skip_current_user_key_versions(&mut self.inner, &self.encoded_user_key)?;
             // Skip tombstones and invisible versions of the next user key(s)
             Self::skip_tombstones(
                 &mut self.inner,
@@ -212,20 +227,10 @@ impl StorageIterator for LsmIterator {
                 &mut self.tmp_decoded_key,
             )?;
             // Update cached user keys (decoded for key(), encoded for next())
-            if self.inner.is_valid() {
-                self.inner.key().decode_user_key_into(&mut self.user_key);
-                self.encoded_user_key.clear();
-                self.encoded_user_key
-                    .extend_from_slice(self.inner.key().encoded_user_key());
-            }
+            self.refresh_cached_user_keys();
         } else {
             self.inner.next()?;
-            // Legacy: skip tombstone values
-            while self.inner.is_valid()
-                && crate::vlog::KvKind::is_tombstone_value(self.inner.value())
-            {
-                self.inner.next()?;
-            }
+            self.skip_legacy_tombstones()?;
         }
 
         Ok(())

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -46,6 +46,31 @@ pub type VersionedCasEntry = (Vec<u8>, u64, Vec<u8>, KvKind, Vec<u8>, KvKind);
 /// Lookup result: `(value, kind, found_internal_key, version_ts)`.
 /// `version_ts` is the MVCC timestamp of the found version (0 when MVCC disabled).
 type LookupResult = (Option<Bytes>, KvKind, Bytes, u64);
+type VersionedCasCandidate = Option<(Vec<u8>, u32)>;
+
+struct BatchGetContext<'a> {
+    bloom_hashes: Vec<u32>,
+    sorted_keys: Vec<(usize, &'a [u8])>,
+    memtable_results: Vec<Option<LookupResult>>,
+}
+
+struct SnapshotReplayData {
+    l0_sstables: Vec<usize>,
+    levels: Vec<(usize, Vec<usize>)>,
+    range_only_ssts: Vec<(usize, Vec<usize>)>,
+    next_sst_id: usize,
+    vlog_references: Vec<(usize, Vec<u32>)>,
+    imm_memtable_ids: Vec<usize>,
+    active_compaction_filters: Vec<InstalledCompactionFilter>,
+    next_compaction_filter_id: u64,
+}
+
+struct LookupSstRawMvccParams<'a> {
+    key: &'a [u8],
+    bloom_hash: u32,
+    read_ts: u64,
+    search_prefix: &'a [u8],
+}
 
 /// Represents the state of the storage engine.
 #[derive(Clone)]
@@ -126,133 +151,15 @@ impl ManifestRecoveryState<'_> {
     /// Replay a single manifest record, updating the recovery state.
     fn replay_manifest_record(&mut self, record: ManifestRecord) -> Result<()> {
         match record {
-            ManifestRecord::NewMemtable(id) => {
-                self.im_memtables.insert(id);
-                self.max_id = std::cmp::max(self.max_id, id);
-            }
-            ManifestRecord::Flush(id) => {
-                if self.compaction_controller.flush_to_l0() {
-                    self.state.l0_sstables.insert(0, id);
-                } else {
-                    self.state.levels.insert(0, (id, vec![id]));
-                }
-                self.im_memtables.remove(&id);
-                self.max_id = std::cmp::max(self.max_id, id);
-            }
-            ManifestRecord::Compaction(task, ids) => {
-                let (new_state, _) = self.compaction_controller.apply_compaction_result(
-                    self.state,
-                    &task,
-                    ids.as_slice(),
-                );
-                *self.state = new_state;
-                self.max_id = std::cmp::max(self.max_id, *ids.last().unwrap_or(&self.max_id));
-            }
-            ManifestRecord::FlushV2(id, vlog_ids) => {
-                if self.compaction_controller.flush_to_l0() {
-                    self.state.l0_sstables.insert(0, id);
-                } else {
-                    self.state.levels.insert(0, (id, vec![id]));
-                }
-                self.im_memtables.remove(&id);
-                self.max_id = std::cmp::max(self.max_id, id);
-                if !vlog_ids.is_empty() {
-                    self.recovered_vlog_refs.insert(id, vlog_ids);
-                }
-            }
+            ManifestRecord::NewMemtable(id) => self.replay_new_memtable(id),
+            ManifestRecord::Flush(id) => self.replay_flush(id),
+            ManifestRecord::Compaction(task, ids) => self.replay_compaction(&task, &ids)?,
+            ManifestRecord::FlushV2(id, vlog_ids) => self.replay_flush_v2(id, vlog_ids),
             ManifestRecord::CompactionV2(task, ids, vlog_ids) => {
-                let (new_state, _) = self.compaction_controller.apply_compaction_result(
-                    self.state,
-                    &task,
-                    ids.as_slice(),
-                );
-                *self.state = new_state;
-                self.max_id = std::cmp::max(self.max_id, *ids.last().unwrap_or(&self.max_id));
-                if !vlog_ids.is_empty()
-                    && let Some((last_id, first_ids)) = ids.split_last()
-                {
-                    for &sst_id in first_ids {
-                        self.recovered_vlog_refs.insert(sst_id, vlog_ids.clone());
-                    }
-                    self.recovered_vlog_refs.insert(*last_id, vlog_ids);
-                }
+                self.replay_compaction_v2(&task, ids, vlog_ids)?
             }
             ManifestRecord::CompactionV3(task, ids, vlog_ids, ro_ids) => {
-                let (new_state, _) = self.compaction_controller.apply_compaction_result(
-                    self.state,
-                    &task,
-                    ids.as_slice(),
-                );
-                *self.state = new_state;
-                self.max_id = std::cmp::max(self.max_id, *ids.last().unwrap_or(&self.max_id));
-                self.max_id = std::cmp::max(self.max_id, *ro_ids.last().unwrap_or(&self.max_id));
-                if !vlog_ids.is_empty()
-                    && let Some((last_id, first_ids)) = ids.split_last()
-                {
-                    for &sst_id in first_ids {
-                        self.recovered_vlog_refs.insert(sst_id, vlog_ids.clone());
-                    }
-                    self.recovered_vlog_refs.insert(*last_id, vlog_ids);
-                }
-                // Track range-only SSTs in the target level.
-                let target_level = match &task {
-                    CompactionTask::Leveled(t) => Some(t.lower_level),
-                    CompactionTask::Simple(t) => Some(t.lower_level),
-                    CompactionTask::ForceFullCompaction { .. } => Some(1),
-                    CompactionTask::Tiered(_) => None,
-                };
-                if let Some(level) = target_level {
-                    self.input_ids_buf.clear();
-                    match &task {
-                        CompactionTask::ForceFullCompaction {
-                            l0_sstables,
-                            l1_sstables,
-                        } => {
-                            self.input_ids_buf
-                                .extend(l0_sstables.iter().chain(l1_sstables.iter()).copied());
-                        }
-                        CompactionTask::Leveled(t) => {
-                            self.input_ids_buf.extend(
-                                t.upper_level_sst_ids
-                                    .iter()
-                                    .chain(t.lower_level_sst_ids.iter())
-                                    .copied(),
-                            );
-                        }
-                        CompactionTask::Simple(t) => {
-                            self.input_ids_buf.extend(
-                                t.upper_level_sst_ids
-                                    .iter()
-                                    .chain(t.lower_level_sst_ids.iter())
-                                    .copied(),
-                            );
-                            if let Some((_, ro_ids_in_state)) = self
-                                .state
-                                .range_only_ssts
-                                .iter()
-                                .find(|(lvl, _)| *lvl == level)
-                            {
-                                self.input_ids_buf.extend(ro_ids_in_state.iter().copied());
-                            }
-                        }
-                        CompactionTask::Tiered(t) => {
-                            self.input_ids_buf
-                                .extend(t.tiers.iter().flat_map(|(_, ids)| ids.iter().copied()));
-                        }
-                    };
-
-                    if let Some((_, existing)) = self
-                        .state
-                        .range_only_ssts
-                        .iter_mut()
-                        .find(|(l, _)| *l == level)
-                    {
-                        existing.retain(|id| !self.input_ids_buf.contains(id));
-                        existing.extend(ro_ids);
-                    } else if !ro_ids.is_empty() {
-                        self.state.range_only_ssts.push((level, ro_ids));
-                    }
-                }
+                self.replay_compaction_v3(&task, ids, vlog_ids, ro_ids)?
             }
             ManifestRecord::NewVlogFile(_id) | ManifestRecord::DeleteVlogFile(_id) => {
                 // vLog file lifecycle — will be handled in vLog recovery
@@ -282,29 +189,187 @@ impl ManifestRecoveryState<'_> {
                 active_compaction_filters,
                 next_compaction_filter_id: snap_next_compaction_filter_id,
                 format_version: _,
-            } => {
-                // Snapshot supersedes all prior records
-                self.state.l0_sstables = snap_l0;
-                self.state.levels = snap_levels;
-                self.state.range_only_ssts = snap_ro;
-                self.max_id = next_sst_id.saturating_sub(1);
-                self.recovered_vlog_refs.clear();
-                for (sst_id, vlog_ids) in snap_vlog_refs {
-                    self.recovered_vlog_refs.insert(sst_id, vlog_ids);
-                }
-                self.im_memtables.clear();
-                for id in snap_imm_ids {
-                    self.im_memtables.insert(id);
-                    self.max_id = self.max_id.max(id);
-                }
-                self.recovered_compaction_filters = active_compaction_filters
-                    .into_iter()
-                    .map(|filter| (filter.id, filter))
-                    .collect();
-                self.next_compaction_filter_id = snap_next_compaction_filter_id;
-            }
+            } => self.replay_snapshot(SnapshotReplayData {
+                l0_sstables: snap_l0,
+                levels: snap_levels,
+                range_only_ssts: snap_ro,
+                next_sst_id,
+                vlog_references: snap_vlog_refs,
+                imm_memtable_ids: snap_imm_ids,
+                active_compaction_filters,
+                next_compaction_filter_id: snap_next_compaction_filter_id,
+            }),
         }
         Ok(())
+    }
+
+    fn replay_new_memtable(&mut self, id: usize) {
+        self.im_memtables.insert(id);
+        self.max_id = std::cmp::max(self.max_id, id);
+    }
+
+    fn replay_flush(&mut self, id: usize) {
+        if self.compaction_controller.flush_to_l0() {
+            self.state.l0_sstables.insert(0, id);
+        } else {
+            self.state.levels.insert(0, (id, vec![id]));
+        }
+        self.im_memtables.remove(&id);
+        self.max_id = std::cmp::max(self.max_id, id);
+    }
+
+    fn replay_flush_v2(&mut self, id: usize, vlog_ids: Vec<u32>) {
+        self.replay_flush(id);
+        if !vlog_ids.is_empty() {
+            self.recovered_vlog_refs.insert(id, vlog_ids);
+        }
+    }
+
+    fn replay_compaction(&mut self, task: &CompactionTask, ids: &[usize]) -> Result<()> {
+        let (new_state, _) = self
+            .compaction_controller
+            .apply_compaction_result(self.state, task, ids);
+        *self.state = new_state;
+        if let Some(&last_id) = ids.last() {
+            self.max_id = std::cmp::max(self.max_id, last_id);
+        }
+        Ok(())
+    }
+
+    fn replay_vlog_refs(&mut self, ids: &[usize], vlog_ids: Vec<u32>) {
+        if let Some((last_id, first_ids)) = ids.split_last() {
+            for &sst_id in first_ids {
+                self.recovered_vlog_refs.insert(sst_id, vlog_ids.clone());
+            }
+            self.recovered_vlog_refs.insert(*last_id, vlog_ids);
+        }
+    }
+
+    fn replay_compaction_v2(
+        &mut self,
+        task: &CompactionTask,
+        ids: Vec<usize>,
+        vlog_ids: Vec<u32>,
+    ) -> Result<()> {
+        self.replay_compaction(task, &ids)?;
+        if !vlog_ids.is_empty() {
+            self.replay_vlog_refs(&ids, vlog_ids);
+        }
+        Ok(())
+    }
+
+    fn replay_compaction_v3(
+        &mut self,
+        task: &CompactionTask,
+        ids: Vec<usize>,
+        vlog_ids: Vec<u32>,
+        ro_ids: Vec<usize>,
+    ) -> Result<()> {
+        self.replay_compaction(task, &ids)?;
+        if !vlog_ids.is_empty() {
+            self.replay_vlog_refs(&ids, vlog_ids);
+        }
+        if let Some(&last_id) = ro_ids.last() {
+            self.max_id = std::cmp::max(self.max_id, last_id);
+        }
+        self.replay_range_only_ssts(task, ro_ids);
+        Ok(())
+    }
+
+    fn replay_range_only_ssts(&mut self, task: &CompactionTask, ro_ids: Vec<usize>) {
+        let target_level = match task {
+            CompactionTask::Leveled(t) => Some(t.lower_level),
+            CompactionTask::Simple(t) => Some(t.lower_level),
+            CompactionTask::ForceFullCompaction { .. } => Some(1),
+            CompactionTask::Tiered(_) => None,
+        };
+        let Some(level) = target_level else {
+            return;
+        };
+
+        self.input_ids_buf.clear();
+        match task {
+            CompactionTask::ForceFullCompaction {
+                l0_sstables,
+                l1_sstables,
+            } => {
+                self.input_ids_buf
+                    .extend(l0_sstables.iter().chain(l1_sstables.iter()).copied());
+            }
+            CompactionTask::Leveled(t) => {
+                self.input_ids_buf.extend(
+                    t.upper_level_sst_ids
+                        .iter()
+                        .chain(t.lower_level_sst_ids.iter())
+                        .copied(),
+                );
+                if let Some((_, ro_ids_in_state)) = self
+                    .state
+                    .range_only_ssts
+                    .iter()
+                    .find(|(lvl, _)| *lvl == level)
+                {
+                    self.input_ids_buf.extend(ro_ids_in_state.iter().copied());
+                }
+            }
+            CompactionTask::Simple(t) => {
+                self.input_ids_buf.extend(
+                    t.upper_level_sst_ids
+                        .iter()
+                        .chain(t.lower_level_sst_ids.iter())
+                        .copied(),
+                );
+                if let Some((_, ro_ids_in_state)) = self
+                    .state
+                    .range_only_ssts
+                    .iter()
+                    .find(|(lvl, _)| *lvl == level)
+                {
+                    self.input_ids_buf.extend(ro_ids_in_state.iter().copied());
+                }
+            }
+            CompactionTask::Tiered(t) => {
+                self.input_ids_buf
+                    .extend(t.tiers.iter().flat_map(|(_, ids)| ids.iter().copied()));
+            }
+        };
+
+        if let Some((_, existing)) = self
+            .state
+            .range_only_ssts
+            .iter_mut()
+            .find(|(l, _)| *l == level)
+        {
+            existing.retain(|id| !self.input_ids_buf.contains(id));
+            existing.extend(ro_ids);
+        } else if !ro_ids.is_empty() {
+            self.state.range_only_ssts.push((level, ro_ids));
+        }
+    }
+
+    fn replay_snapshot(&mut self, snapshot: SnapshotReplayData) {
+        self.state.l0_sstables = snapshot.l0_sstables;
+        self.state.levels = snapshot.levels;
+        self.state.range_only_ssts = snapshot.range_only_ssts;
+        self.max_id = snapshot.next_sst_id.saturating_sub(1);
+
+        self.recovered_vlog_refs.clear();
+        for (sst_id, vlog_ids) in snapshot.vlog_references {
+            self.recovered_vlog_refs.insert(sst_id, vlog_ids);
+        }
+
+        self.im_memtables.clear();
+        for id in snapshot.imm_memtable_ids {
+            self.im_memtables.insert(id);
+            self.max_id = self.max_id.max(id);
+        }
+
+        self.recovered_compaction_filters = snapshot
+            .active_compaction_filters
+            .into_iter()
+            .map(|filter| (filter.id, filter))
+            .collect();
+        self.next_compaction_filter_id = snapshot.next_compaction_filter_id;
     }
 }
 
@@ -1581,37 +1646,64 @@ impl LsmStorageInner {
             return self.batch_get_small(&state, keys, mvcc_read_ts, read_guard);
         }
 
-        // Pre-compute bloom hashes for all keys.
+        let batch_ctx = self.build_batch_get_context(&state, keys, mvcc_read_ts, n);
+        match batch_ctx {
+            Ok(batch_ctx) => self.batch_get_lookup_all(
+                &batch_ctx,
+                &state,
+                mvcc_read_ts,
+                mvcc_read_ts.unwrap_or(u64::MAX),
+            ),
+            Err(e) => {
+                let msg = e.to_string();
+                (0..n).map(|_| Err(anyhow::anyhow!("{msg}"))).collect()
+            }
+        }
+    }
+
+    fn build_batch_get_context<'a>(
+        &self,
+        state: &'a LsmStorageState,
+        keys: &'a [&'a [u8]],
+        mvcc_read_ts: Option<u64>,
+        n: usize,
+    ) -> Result<BatchGetContext<'a>> {
         let bloom_hashes: Vec<u32> = keys
             .iter()
             .map(|k| crate::table::bloom::hash_key(k))
             .collect();
 
-        // Sort keys by raw bytes for SST block locality.
         let mut sorted_indices: Vec<usize> = (0..n).collect();
         sorted_indices.sort_unstable_by(|&a, &b| keys[a].cmp(keys[b]));
         let sorted_keys: Vec<(usize, &[u8])> =
             sorted_indices.iter().map(|&i| (i, keys[i])).collect();
 
-        // Batch memtable lookup for sorted keys.
-        let memtable_results = match self.batch_lookup_memtable(
-            &state,
-            &sorted_keys,
-            &bloom_hashes,
-            mvcc_read_ts,
-            n,
-        ) {
-            Ok(r) => r,
-            Err(e) => {
-                let msg = e.to_string();
-                return (0..n).map(|_| Err(anyhow::anyhow!("{msg}"))).collect();
-            }
-        };
+        let memtable_results =
+            match self.batch_lookup_memtable(state, &sorted_keys, &bloom_hashes, mvcc_read_ts, n) {
+                Ok(r) => r,
+                Err(e) => {
+                    let msg = e.to_string();
+                    anyhow::bail!("{msg}");
+                }
+            };
 
-        // Build output, falling back to SST lookup for keys not found in memtable.
+        Ok(BatchGetContext {
+            bloom_hashes,
+            sorted_keys,
+            memtable_results,
+        })
+    }
+
+    fn batch_get_lookup_all<'a>(
+        &self,
+        batch_ctx: &BatchGetContext<'a>,
+        state: &LsmStorageState,
+        mvcc_read_ts: Option<u64>,
+        read_ts_for_range: u64,
+    ) -> Vec<Result<Option<Bytes>>> {
+        let n = batch_ctx.sorted_keys.len();
         let mut output: Vec<Result<Option<Bytes>>> = Vec::with_capacity(n);
         output.resize_with(n, || Ok(None));
-        let read_ts_for_range = mvcc_read_ts.unwrap_or(u64::MAX);
 
         // Reusable buffer for encoding keys (avoids per-key Vec allocation).
         let mut encode_buf: Vec<u8> = Vec::new();
@@ -1667,7 +1759,6 @@ impl LsmStorageInner {
             Vec::new()
         };
 
-        // Closures that search pre-collected fragments instead of re-discovering per key.
         let get_memtable_range_ts = |user_key: &[u8]| -> Option<u64> {
             if !has_any_rt {
                 return None;
@@ -1695,8 +1786,7 @@ impl LsmStorageInner {
             }
             best_ts
         };
-        // Pre-compute global boundary for SST range tombstone fragments.
-        // This gives an O(1) early-exit before iterating per-fragment sets.
+
         let (sst_rt_global_start, sst_rt_global_end): (Vec<u8>, Vec<u8>) =
             if !sst_rt_frags.is_empty() {
                 let mut min_start: Vec<u8> = sst_rt_frags[0][0].start.as_ref().to_vec();
@@ -1722,16 +1812,12 @@ impl LsmStorageInner {
             if sst_rt_frags.is_empty() {
                 return None;
             }
-            // O(1) global boundary check — skip all fragments if key is
-            // outside the union of all fragment ranges.
             if user_key < sst_rt_global_start.as_slice() || user_key >= sst_rt_global_end.as_slice()
             {
                 return None;
             }
             let mut best_ts: Option<u64> = None;
             for frags in &sst_rt_frags {
-                // O(1) boundary check — skip binary search if key is outside
-                // the fragment range. Fragments are sorted and non-overlapping.
                 if let (Some(first), Some(last)) = (frags.first(), frags.last())
                     && (user_key < first.start.as_ref() || user_key >= last.end.as_ref())
                 {
@@ -1750,18 +1836,15 @@ impl LsmStorageInner {
             best_ts
         };
 
-        // Per-level SST index hint for sorted batch lookups. When consecutive
-        // keys land in the same leveled SST, this skips the O(log S) binary search.
         let mut level_hint: ahash::AHashMap<usize, usize> = ahash::AHashMap::new();
-        // L0 SST hint — when consecutive sorted keys land in the same L0 SST,
-        // checking it first avoids iterating through earlier L0 SSTs.
         let mut l0_hint: usize = 0;
 
-        for &(orig_idx, user_key) in &sorted_keys {
+        for &(orig_idx, user_key) in &batch_ctx.sorted_keys {
             self.rt_stats.note_lookup();
 
-            if let Some((value, kind, found_key, value_ts)) = memtable_results[orig_idx].as_ref() {
-                // Memtable hit — only check range tombstones to see if this value is covered.
+            if let Some((value, kind, found_key, value_ts)) =
+                batch_ctx.memtable_results[orig_idx].as_ref()
+            {
                 let memtable_range_ts = get_memtable_range_ts(user_key);
                 if memtable_range_ts.is_some_and(|rt| *value_ts <= rt) {
                     self.rt_stats.note_hit();
@@ -1772,8 +1855,6 @@ impl LsmStorageInner {
                 continue;
             }
 
-            // No memtable hit — check if a memtable range tombstone covers
-            // everything before falling through to the SST path.
             let memtable_range_ts = get_memtable_range_ts(user_key);
             if memtable_range_ts.is_some_and(|ts| ts >= read_ts_for_range) {
                 self.rt_stats.note_hit();
@@ -1781,7 +1862,6 @@ impl LsmStorageInner {
                 continue;
             }
 
-            // SST path — encode key into reusable buffer.
             let encoded_ref = if self.mvcc.is_some() {
                 encode_buf.clear();
                 crate::key::encode_internal_key_to_buf(&mut encode_buf, user_key, u64::MAX);
@@ -1790,24 +1870,19 @@ impl LsmStorageInner {
                 user_key
             };
 
-            let bloom_hash = bloom_hashes[orig_idx];
+            let bloom_hash = batch_ctx.bloom_hashes[orig_idx];
             let sst_result = self.lookup_sst_raw(
-                &state,
+                state,
                 encoded_ref,
                 bloom_hash,
                 mvcc_read_ts,
                 Some(&mut level_hint),
                 Some(&mut l0_hint),
             );
-            // Combined range tombstone ts — memtable RT may partially cover
-            // older SST versions that the early-out above did not catch.
             let sst_range_ts = get_sst_range_ts(user_key);
             let range_ts = memtable_range_ts.max(sst_range_ts);
             match sst_result {
                 Ok(Some((value, kind, found_key, value_ts))) => {
-                    // Value found in SST — check combined range tombstones.
-                    // The memtable RT may cover an older SST version even
-                    // when it does not cover ALL versions up to read_ts.
                     if range_ts.is_some_and(|rt| value_ts <= rt) {
                         self.rt_stats.note_hit();
                         output[orig_idx] = Ok(None);
@@ -1816,9 +1891,6 @@ impl LsmStorageInner {
                     }
                 }
                 Ok(None) => {
-                    // No point entry found in SSTs — check if a range
-                    // tombstone covers the key (point entry may have been
-                    // removed by compaction, leaving only range metadata).
                     if range_ts.is_some() {
                         self.rt_stats.note_hit();
                     }
@@ -1878,87 +1950,26 @@ impl LsmStorageInner {
             let uk: &[u8] = user_key;
             self.rt_stats.note_lookup();
 
-            // --- Memtable lookup using buffer-reusing variant ---
-            // Avoids per-key Bytes allocation for seek key.
-            let mut memtable_hit: Option<(Option<Bytes>, KvKind, Vec<u8>, u64)> = None;
-
-            if let Some(read_ts) = mvcc_read_ts {
-                // Active memtable — reuse seek_buf.
-                if let Some((raw, found_key)) = state.memtable.get_versioned_with_buf(
+            let memtable_hit = self.batch_get_small_memtable_hit(
+                state,
+                uk,
+                bloom_hashes[i],
+                mvcc_read_ts,
+                has_imm_memtables,
+                &mut seek_buf,
+            );
+            let memtable_rt = if has_any_memtable_rt {
+                self.batch_get_small_memtable_range_ts(
+                    state,
                     uk,
-                    read_ts,
-                    bloom_hashes[i],
-                    &mut seek_buf,
-                ) {
-                    let (val, kind) = Self::parse_value_kind(raw);
-                    let vts = crate::key::extract_ts(&found_key).unwrap_or(0);
-                    memtable_hit = Some((val, kind, found_key, vts));
-                }
-                // Immutable memtables — only if active missed.
-                if memtable_hit.is_none() && has_imm_memtables {
-                    for m in state.imm_memtables.iter() {
-                        if let Some((raw, found_key)) =
-                            m.get_versioned_with_buf(uk, read_ts, bloom_hashes[i], &mut seek_buf)
-                        {
-                            let (val, kind) = Self::parse_value_kind(raw);
-                            let vts = crate::key::extract_ts(&found_key).unwrap_or(0);
-                            memtable_hit = Some((val, kind, found_key, vts));
-                            break;
-                        }
-                    }
-                }
+                    read_ts_for_range,
+                    has_active_rt,
+                    &active_rt_frags,
+                    has_imm_rt,
+                )
             } else {
-                // Non-MVCC path.
-                if let Some(raw) = state.memtable.get_raw_with_hash(uk, bloom_hashes[i]) {
-                    let (val, kind) = Self::parse_value_kind(raw);
-                    memtable_hit = Some((val, kind, uk.to_vec(), 0));
-                }
-                if memtable_hit.is_none() && has_imm_memtables {
-                    for m in state.imm_memtables.iter() {
-                        if let Some(raw) = m.get_raw_with_hash(uk, bloom_hashes[i]) {
-                            let (val, kind) = Self::parse_value_kind(raw);
-                            memtable_hit = Some((val, kind, uk.to_vec(), 0));
-                            break;
-                        }
-                    }
-                }
-            }
-
-            // Check memtable range tombstones for this key (inline, no closure).
-            let mut memtable_rt: Option<u64> = None;
-            if has_any_memtable_rt {
-                if has_active_rt
-                    && let (Some(first), Some(last)) =
-                        (active_rt_frags.first(), active_rt_frags.last())
-                    && uk >= first.start.as_ref()
-                    && uk < last.end.as_ref()
-                {
-                    memtable_rt = crate::range_tombstone::find_newest_covering_ts(
-                        &active_rt_frags,
-                        uk,
-                        read_ts_for_range,
-                    );
-                }
-                if has_imm_rt {
-                    for m in &state.imm_memtables {
-                        if let Some(imm) = m.imm_range_tombstones() {
-                            let frags = imm.fragments();
-                            if let (Some(first), Some(last)) = (frags.first(), frags.last())
-                                && uk >= first.start.as_ref()
-                                && uk < last.end.as_ref()
-                            {
-                                memtable_rt = memtable_rt.max(
-                                    crate::range_tombstone::find_newest_covering_ts(
-                                        frags,
-                                        uk,
-                                        read_ts_for_range,
-                                    ),
-                                );
-                            }
-                        }
-                    }
-                }
-            }
+                None
+            };
 
             if let Some((value, kind, found_key, value_ts)) = memtable_hit {
                 // Check memtable range tombstones (cheap — no SST iteration).
@@ -1998,9 +2009,12 @@ impl LsmStorageInner {
                 Some(&mut l0_hint),
             ) {
                 Ok(Some((value, kind, found_key, value_ts))) => {
-                    // SST range tombstones — iterates L0 + levels + range-only SSTs.
-                    let sst_range_ts = self.newest_sst_range_ts(state, uk, read_ts_for_range);
-                    let range_ts = memtable_rt.max(sst_range_ts);
+                    let range_ts = self.batch_get_small_sst_range_ts(
+                        state,
+                        uk,
+                        read_ts_for_range,
+                        memtable_rt,
+                    );
                     if range_ts.is_some_and(|rt| value_ts <= rt) {
                         self.rt_stats.note_hit();
                         output[i] = Ok(None);
@@ -2023,6 +2037,105 @@ impl LsmStorageInner {
         }
 
         output
+    }
+
+    fn batch_get_small_memtable_hit(
+        &self,
+        state: &LsmStorageState,
+        uk: &[u8],
+        bloom_hash: u32,
+        mvcc_read_ts: Option<u64>,
+        has_imm_memtables: bool,
+        seek_buf: &mut Vec<u8>,
+    ) -> Option<(Option<Bytes>, KvKind, Vec<u8>, u64)> {
+        if let Some(read_ts) = mvcc_read_ts {
+            if let Some((raw, found_key)) = state
+                .memtable
+                .get_versioned_with_buf(uk, read_ts, bloom_hash, seek_buf)
+            {
+                let (val, kind) = Self::parse_value_kind(raw);
+                let vts = crate::key::extract_ts(&found_key).unwrap_or(0);
+                return Some((val, kind, found_key, vts));
+            }
+            if has_imm_memtables {
+                for m in &state.imm_memtables {
+                    if let Some((raw, found_key)) =
+                        m.get_versioned_with_buf(uk, read_ts, bloom_hash, seek_buf)
+                    {
+                        let (val, kind) = Self::parse_value_kind(raw);
+                        let vts = crate::key::extract_ts(&found_key).unwrap_or(0);
+                        return Some((val, kind, found_key, vts));
+                    }
+                }
+            }
+        } else {
+            if let Some(raw) = state.memtable.get_raw_with_hash(uk, bloom_hash) {
+                let (val, kind) = Self::parse_value_kind(raw);
+                return Some((val, kind, uk.to_vec(), 0));
+            }
+            if has_imm_memtables {
+                for m in &state.imm_memtables {
+                    if let Some(raw) = m.get_raw_with_hash(uk, bloom_hash) {
+                        let (val, kind) = Self::parse_value_kind(raw);
+                        return Some((val, kind, uk.to_vec(), 0));
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    fn batch_get_small_memtable_range_ts(
+        &self,
+        state: &LsmStorageState,
+        uk: &[u8],
+        read_ts_for_range: u64,
+        has_active_rt: bool,
+        active_rt_frags: &[crate::range_tombstone::RangeTombstoneFragment],
+        has_imm_rt: bool,
+    ) -> Option<u64> {
+        let mut memtable_rt: Option<u64> = None;
+        if has_active_rt
+            && let (Some(first), Some(last)) = (active_rt_frags.first(), active_rt_frags.last())
+            && uk >= first.start.as_ref()
+            && uk < last.end.as_ref()
+        {
+            memtable_rt = crate::range_tombstone::find_newest_covering_ts(
+                active_rt_frags,
+                uk,
+                read_ts_for_range,
+            );
+        }
+        if has_imm_rt {
+            for m in &state.imm_memtables {
+                if let Some(imm) = m.imm_range_tombstones() {
+                    let frags = imm.fragments();
+                    if let (Some(first), Some(last)) = (frags.first(), frags.last())
+                        && uk >= first.start.as_ref()
+                        && uk < last.end.as_ref()
+                    {
+                        memtable_rt =
+                            memtable_rt.max(crate::range_tombstone::find_newest_covering_ts(
+                                frags,
+                                uk,
+                                read_ts_for_range,
+                            ));
+                    }
+                }
+            }
+        }
+        memtable_rt
+    }
+
+    fn batch_get_small_sst_range_ts(
+        &self,
+        state: &LsmStorageState,
+        uk: &[u8],
+        read_ts_for_range: u64,
+        memtable_rt: Option<u64>,
+    ) -> Option<u64> {
+        let sst_range_ts = self.newest_sst_range_ts(state, uk, read_ts_for_range);
+        memtable_rt.max(sst_range_ts)
     }
 
     /// Resolve a `(value, KvKind)` pair from a lookup into a final `Option<Bytes>`.
@@ -2145,35 +2258,72 @@ impl LsmStorageInner {
         let encoded = crate::key::encode_internal_key(user_key, ts);
         let bloom_hash = crate::table::bloom::hash_key(user_key);
 
-        // Check active + immutable memtables (exact key match, no version scan)
-        if let Some(raw) = state.memtable.get_raw_exact_with_hash(&encoded, bloom_hash) {
+        if let Some(raw) = self.lookup_exact_version_in_memtables(&state, &encoded, bloom_hash) {
             return Ok(Self::parse_value_kind(raw));
         }
-        for m in state.imm_memtables.iter() {
-            if let Some(raw) = m.get_raw_exact_with_hash(&encoded, bloom_hash) {
-                return Ok(Self::parse_value_kind(raw));
-            }
+        if let Some(raw) = self.lookup_exact_version_in_ssts(&state, &encoded, bloom_hash)? {
+            return Ok(Self::parse_value_kind(raw));
         }
 
-        // SST lookup — use point_get which seeks to the exact key.
-        // With the full internal key, point_get positions at the exact version
-        // (or the nearest one). We then verify the found key matches exactly.
-        for id in state.l0_sstables.iter() {
-            if let Some(s) = state.sstables.get(id)
-                && let Some((raw, found_key)) =
-                    s.point_get_with_hash_and_key(&encoded, bloom_hash, None)?
-                && found_key == encoded
-            {
-                return Ok(Self::parse_value_kind(raw));
+        Ok((None, KvKind::Inline))
+    }
+
+    fn lookup_exact_version_in_memtables(
+        &self,
+        state: &LsmStorageState,
+        encoded: &[u8],
+        bloom_hash: u32,
+    ) -> Option<Bytes> {
+        if let Some(raw) = state.memtable.get_raw_exact_with_hash(encoded, bloom_hash) {
+            return Some(raw);
+        }
+        for m in &state.imm_memtables {
+            if let Some(raw) = m.get_raw_exact_with_hash(encoded, bloom_hash) {
+                return Some(raw);
             }
         }
-        for (_, sst_ids) in state.levels.iter() {
-            // Leveled SSTs have non-overlapping key ranges, but a user
-            // key's versions can span adjacent SSTs. Binary search to find
-            // the rightmost candidate, then scan left while the SST's
-            // last_key still carries the same user key prefix.
-            let user_key_prefix = crate::key::encoded_user_key_prefix(&encoded)
-                .expect("encoded key must have valid user key prefix");
+        None
+    }
+
+    fn lookup_exact_version_in_ssts(
+        &self,
+        state: &LsmStorageState,
+        encoded: &[u8],
+        bloom_hash: u32,
+    ) -> Result<Option<Bytes>> {
+        if let Some(raw) = self.lookup_exact_version_in_l0_ssts(state, encoded, bloom_hash)? {
+            return Ok(Some(raw));
+        }
+        self.lookup_exact_version_in_leveled_ssts(state, encoded, bloom_hash)
+    }
+
+    fn lookup_exact_version_in_l0_ssts(
+        &self,
+        state: &LsmStorageState,
+        encoded: &[u8],
+        bloom_hash: u32,
+    ) -> Result<Option<Bytes>> {
+        for id in &state.l0_sstables {
+            if let Some(s) = state.sstables.get(id)
+                && let Some((raw, found_key)) =
+                    s.point_get_with_hash_and_key(encoded, bloom_hash, None)?
+                && found_key == encoded
+            {
+                return Ok(Some(raw));
+            }
+        }
+        Ok(None)
+    }
+
+    fn lookup_exact_version_in_leveled_ssts(
+        &self,
+        state: &LsmStorageState,
+        encoded: &[u8],
+        bloom_hash: u32,
+    ) -> Result<Option<Bytes>> {
+        let user_key_prefix = crate::key::encoded_user_key_prefix(encoded)
+            .expect("encoded key must have valid user key prefix");
+        for (_, sst_ids) in &state.levels {
             let idx = sst_ids.partition_point(|id| {
                 let sst = state.sstables.get(id).expect("SST must exist");
                 match sst.first_key() {
@@ -2190,15 +2340,14 @@ impl LsmStorageInner {
                     break;
                 }
                 if let Some((raw, found_key)) =
-                    sst.point_get_with_hash_and_key(&encoded, bloom_hash, None)?
+                    sst.point_get_with_hash_and_key(encoded, bloom_hash, None)?
                     && found_key == encoded
                 {
-                    return Ok(Self::parse_value_kind(raw));
+                    return Ok(Some(raw));
                 }
             }
         }
-
-        Ok((None, KvKind::Inline))
+        Ok(None)
     }
 
     /// Get a value at a specific read timestamp (used by transactions).
@@ -2343,15 +2492,7 @@ impl LsmStorageInner {
                         t.clone(),
                         KeySlice::from_slice(&seek),
                     )?;
-                    if s.is_valid() {
-                        let seek_user_key = crate::key::encoded_user_key_prefix(&seek);
-                        while s.is_valid()
-                            && crate::key::encoded_user_key_prefix(s.key().raw_ref())
-                                == seek_user_key
-                        {
-                            s.next()?;
-                        }
-                    }
+                    Self::advance_past_lower_excluded(&mut s, &seek)?;
                     s
                 }
                 Bound::Unbounded => SsTableIterator::create_and_seek_to_first(t.clone())?,
@@ -2399,15 +2540,7 @@ impl LsmStorageInner {
                             KeySlice::from_slice(&seek),
                             vlog.clone(),
                         )?;
-                        if iter.is_valid() {
-                            let seek_user_key = crate::key::encoded_user_key_prefix(&seek);
-                            while iter.is_valid()
-                                && crate::key::encoded_user_key_prefix(iter.key().raw_ref())
-                                    == seek_user_key
-                            {
-                                iter.next()?;
-                            }
-                        }
+                        Self::advance_past_lower_excluded(&mut iter, &seek)?;
                         iter
                     }
                     Bound::Unbounded => SstConcatIterator::create_and_seek_to_first_with_vlog(
@@ -2430,15 +2563,7 @@ impl LsmStorageInner {
                             ss_tables,
                             KeySlice::from_slice(&seek),
                         )?;
-                        if iter.is_valid() {
-                            let seek_user_key = crate::key::encoded_user_key_prefix(&seek);
-                            while iter.is_valid()
-                                && crate::key::encoded_user_key_prefix(iter.key().raw_ref())
-                                    == seek_user_key
-                            {
-                                iter.next()?;
-                            }
-                        }
+                        Self::advance_past_lower_excluded(&mut iter, &seek)?;
                         iter
                     }
                     Bound::Unbounded => SstConcatIterator::create_and_seek_to_first(ss_tables)?,
@@ -2449,95 +2574,8 @@ impl LsmStorageInner {
         let m_iter = MergeIterator::create(concat_iters);
         let two_m = TwoMergeIterator::create(two_l0_iter, m_iter)?;
 
-        // Build merged range-tombstone fragments from all memtables.
-        // Active memtable: private per-scan fragments (no shared cache).
-        // Immutable memtables: shared cached fragments (borrowed, not cloned).
-        // Fast path: skip active memtable tombstones if the scan range
-        // doesn't overlap any tombstone span. O(1) skipmap bounds check.
-        let has_active = !state.memtable.range_tombstones().is_empty()
-            && match upper {
-                Bound::Unbounded => true,
-                _ => state
-                    .memtable
-                    .range_tombstones()
-                    .range_could_overlap(lower, upper),
-            };
-        let has_imm = state
-            .imm_memtables
-            .iter()
-            .any(|m| m.imm_range_tombstones().is_some());
-        let has_sst_rt = state
-            .l0_sstables
-            .iter()
-            .chain(state.levels.iter().flat_map(|(_, ids)| ids))
-            .chain(state.range_only_ssts.iter().flat_map(|(_, ids)| ids))
-            .any(|id| {
-                state
-                    .sstables
-                    .get(id)
-                    .is_some_and(|s| s.has_range_tombstones())
-            });
-        let range_ts_iter = if has_active || has_imm || has_sst_rt {
-            let active_frags = if has_active {
-                state.memtable.range_tombstones().cached_fragments()
-            } else {
-                std::sync::Arc::new(Vec::new())
-            };
-            let mut lists: Vec<&[crate::range_tombstone::RangeTombstoneFragment]> =
-                Vec::with_capacity(1 + state.imm_memtables.len());
-            if !active_frags.is_empty() {
-                lists.push(&active_frags);
-            }
-            for m in &state.imm_memtables {
-                if let Some(imm) = m.imm_range_tombstones() {
-                    let frags = imm.fragments();
-                    if !frags.is_empty() {
-                        lists.push(frags);
-                    }
-                }
-            }
-            // Collect SST range-tombstone fragments (including range-only SSTs).
-            for id in state
-                .l0_sstables
-                .iter()
-                .chain(state.levels.iter().flat_map(|(_, ids)| ids))
-                .chain(state.range_only_ssts.iter().flat_map(|(_, ids)| ids))
-            {
-                if let Some(sst) = state.sstables.get(id)
-                    && let Some(frags) = sst.range_tombstone_fragments()
-                    && !frags.is_empty()
-                {
-                    lists.push(frags);
-                }
-            }
-            if lists.is_empty() {
-                None
-            } else {
-                let merged = crate::range_tombstone::merge_fragment_lists(&lists);
-                if merged.is_empty() {
-                    None
-                } else {
-                    // Check if the scan range overlaps any fragment.
-                    // If not, skip creating the iterator entirely — avoids
-                    // per-entry function call overhead when there's no coverage.
-                    let overlaps = Self::scan_overlaps_fragments(lower, upper, &merged);
-                    if !overlaps {
-                        None
-                    } else {
-                        let mut rt_iter =
-                            crate::range_tombstone::RangeTombstoneIterator::new(Arc::from(merged));
-                        // Position cursor at the scan's lower bound to skip
-                        // fragments entirely before the scan range. O(log F).
-                        if let Bound::Included(key) | Bound::Excluded(key) = lower {
-                            rt_iter.seek_to(key);
-                        }
-                        Some(rt_iter)
-                    }
-                }
-            }
-        } else {
-            None
-        };
+        let range_ts_iter =
+            self.build_scan_range_tombstone_iterator(&state, lower, upper, prefix_hint);
 
         let lit = LsmIterator::new(two_m, Self::into_vec(upper), mvcc_read_ts, range_ts_iter)?;
 
@@ -2590,6 +2628,120 @@ impl LsmStorageInner {
         true
     }
 
+    fn advance_past_lower_excluded<I>(iter: &mut I, seek: &[u8]) -> Result<()>
+    where
+        for<'a> I: StorageIterator<KeyType<'a> = KeySlice<'a>>,
+    {
+        if !iter.is_valid() {
+            return Ok(());
+        }
+
+        let seek_user_key = crate::key::encoded_user_key_prefix(seek)
+            .expect("encoded lower bound must have a valid user key prefix");
+        while iter.is_valid()
+            && crate::key::encoded_user_key_prefix(iter.key().raw_ref()) == Some(seek_user_key)
+        {
+            iter.next()?;
+        }
+        Ok(())
+    }
+
+    fn build_scan_range_tombstone_iterator(
+        &self,
+        state: &LsmStorageState,
+        lower: Bound<&[u8]>,
+        upper: Bound<&[u8]>,
+        prefix_hint: Option<&[u8]>,
+    ) -> Option<crate::range_tombstone::RangeTombstoneIterator> {
+        // Build merged range-tombstone fragments from all memtables.
+        // Active memtable: private per-scan fragments (no shared cache).
+        // Immutable memtables: shared cached fragments (borrowed, not cloned).
+        // Fast path: skip active memtable tombstones if the scan range
+        // doesn't overlap any tombstone span. O(1) skipmap bounds check.
+        let has_active = !state.memtable.range_tombstones().is_empty()
+            && match upper {
+                Bound::Unbounded => true,
+                _ => state
+                    .memtable
+                    .range_tombstones()
+                    .range_could_overlap(lower, upper),
+            };
+        let has_imm = state
+            .imm_memtables
+            .iter()
+            .any(|m| m.imm_range_tombstones().is_some());
+        let has_sst_rt = state
+            .l0_sstables
+            .iter()
+            .chain(state.levels.iter().flat_map(|(_, ids)| ids))
+            .chain(state.range_only_ssts.iter().flat_map(|(_, ids)| ids))
+            .any(|id| {
+                state
+                    .sstables
+                    .get(id)
+                    .is_some_and(|s| s.has_range_tombstones())
+            });
+        if !(has_active || has_imm || has_sst_rt) {
+            return None;
+        }
+
+        let active_frags = if has_active {
+            state.memtable.range_tombstones().cached_fragments()
+        } else {
+            std::sync::Arc::new(Vec::new())
+        };
+        let mut lists: Vec<&[crate::range_tombstone::RangeTombstoneFragment]> =
+            Vec::with_capacity(1 + state.imm_memtables.len());
+        if !active_frags.is_empty() {
+            lists.push(&active_frags);
+        }
+        for m in &state.imm_memtables {
+            if let Some(imm) = m.imm_range_tombstones() {
+                let frags = imm.fragments();
+                if !frags.is_empty() {
+                    lists.push(frags);
+                }
+            }
+        }
+        // Collect SST range-tombstone fragments (including range-only SSTs).
+        for id in state
+            .l0_sstables
+            .iter()
+            .chain(state.levels.iter().flat_map(|(_, ids)| ids))
+            .chain(state.range_only_ssts.iter().flat_map(|(_, ids)| ids))
+        {
+            if let Some(sst) = state.sstables.get(id)
+                && self.options.prefix_bloom.enabled
+                && let Some(prefix) = prefix_hint
+                && !sst.may_contain_prefix(prefix)
+            {
+                continue;
+            }
+            if let Some(sst) = state.sstables.get(id)
+                && let Some(frags) = sst.range_tombstone_fragments()
+                && !frags.is_empty()
+            {
+                lists.push(frags);
+            }
+        }
+        if lists.is_empty() {
+            return None;
+        }
+
+        let merged = crate::range_tombstone::merge_fragment_lists(&lists);
+        if merged.is_empty() || !Self::scan_overlaps_fragments(lower, upper, &merged) {
+            return None;
+        }
+
+        let mut rt_iter = crate::range_tombstone::RangeTombstoneIterator::new(Arc::from(merged));
+        // Position cursor at the scan's lower bound to skip fragments entirely
+        // before the scan range. O(log F).
+        if let Bound::Included(key) | Bound::Excluded(key) = lower {
+            rt_iter.seek_to(key);
+        }
+        Some(rt_iter)
+    }
+
     /// Write a batch through MVCC (used by transaction commit).
     pub(crate) fn mvcc_write_batch(&self, entries: &[(&[u8], &[u8], bool)]) -> Result<()> {
         let mvcc = self.mvcc.as_ref().expect("mvcc_write_batch requires MVCC");
@@ -2620,6 +2772,211 @@ impl LsmStorageInner {
         let mut write_set = std::collections::HashSet::new();
         write_set.insert(bytes::Bytes::copy_from_slice(key));
         mvcc.record_committed_txn(commit_ts, write_set, 0);
+    }
+
+    fn write_batch_key<T: AsRef<[u8]>>(record: &WriteBatchRecord<T>) -> &[u8] {
+        match record {
+            WriteBatchRecord::Put(key, _) | WriteBatchRecord::Del(key) => key.as_ref(),
+            WriteBatchRecord::DelRange(_, _) => unreachable!(),
+        }
+    }
+
+    fn validate_write_batch_keys<T: AsRef<[u8]>>(batch: &[WriteBatchRecord<T>]) -> Result<()> {
+        for record in batch {
+            Self::validate_key_size(Self::write_batch_key(record))?;
+        }
+        Ok(())
+    }
+
+    fn dedup_write_batch_indices<T: AsRef<[u8]>>(
+        batch: &[WriteBatchRecord<T>],
+    ) -> Option<Vec<usize>> {
+        if batch.len() <= 1 {
+            return None;
+        }
+
+        let mut seen = std::collections::HashSet::with_capacity(batch.len());
+        let mut has_duplicate_keys = false;
+        for record in batch {
+            if !seen.insert(Self::write_batch_key(record)) {
+                has_duplicate_keys = true;
+                break;
+            }
+        }
+        if !has_duplicate_keys {
+            return None;
+        }
+
+        let mut last_op = std::collections::HashMap::with_capacity(batch.len());
+        for (idx, record) in batch.iter().enumerate() {
+            last_op.insert(Self::write_batch_key(record), idx);
+        }
+
+        let mut indices: Vec<_> = last_op.values().copied().collect();
+        indices.sort_unstable();
+        Some(indices)
+    }
+
+    fn collect_range_batch_entries<T: AsRef<[u8]>>(
+        batch: &[WriteBatchRecord<T>],
+    ) -> Vec<(&[u8], &[u8])> {
+        batch
+            .iter()
+            .filter_map(|r| {
+                if let WriteBatchRecord::DelRange(start, end) = r {
+                    Some((start.as_ref(), end.as_ref()))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    fn range_batch_write<T: AsRef<[u8]>>(&self, batch: &[WriteBatchRecord<T>]) -> Result<()> {
+        anyhow::ensure!(
+            !self.options.serializable,
+            "delete_range is not supported with serializable mode in the MVP"
+        );
+        anyhow::ensure!(
+            self.vlog.is_none(),
+            "delete_range is not supported when value-log (vlog) is enabled in the MVP"
+        );
+
+        let entries = Self::collect_range_batch_entries(batch);
+        for (start, end) in &entries {
+            Self::validate_key_size(start)?;
+            Self::validate_key_size(end)?;
+            anyhow::ensure!(
+                start < end,
+                "invalid range: start ({:?}) must be less than end ({:?})",
+                start,
+                end
+            );
+        }
+
+        let (memtable, rt_ts) = {
+            let _guard = self.active_memtable_lock.read();
+            let state = self.state.load_full();
+            let ts = if let Some(ref mvcc) = self.mvcc {
+                mvcc.write_range_batch_wal_only(&entries, &state.memtable)?
+            } else {
+                state
+                    .memtable
+                    .put_range_tombstone_batch_wal_only(&entries, 0, 0)?;
+                0
+            };
+            (state.memtable.clone(), ts)
+        };
+        memtable.commit_wal()?;
+        memtable.publish_range_tombstones(&entries, rt_ts, 0)?;
+        if rt_ts > 0
+            && let Some(ref mvcc) = self.mvcc
+        {
+            mvcc.advance_ts(rt_ts);
+        }
+        self.try_freeze_memtable()
+    }
+
+    fn build_point_batch_entries<'a, T: AsRef<[u8]>>(
+        batch: &'a [WriteBatchRecord<T>],
+        dedup_indices: Option<&'a [usize]>,
+    ) -> Vec<(&'a [u8], &'a [u8], bool)> {
+        match dedup_indices {
+            Some(indices) => indices
+                .iter()
+                .map(|&idx| match &batch[idx] {
+                    WriteBatchRecord::Put(key, value) => (key.as_ref(), value.as_ref(), false),
+                    WriteBatchRecord::Del(key) => (key.as_ref(), &[] as &[u8], true),
+                    WriteBatchRecord::DelRange(_, _) => unreachable!(),
+                })
+                .collect(),
+            None => batch
+                .iter()
+                .map(|record| match record {
+                    WriteBatchRecord::Put(key, value) => (key.as_ref(), value.as_ref(), false),
+                    WriteBatchRecord::Del(key) => (key.as_ref(), &[] as &[u8], true),
+                    WriteBatchRecord::DelRange(_, _) => unreachable!(),
+                })
+                .collect(),
+        }
+    }
+
+    fn build_non_mvcc_batch_entries<T: AsRef<[u8]>>(
+        batch: &[WriteBatchRecord<T>],
+        dedup_indices: Option<&[usize]>,
+    ) -> Vec<(bytes::Bytes, bytes::Bytes)> {
+        let mut data = Vec::with_capacity(dedup_indices.map_or(batch.len(), <[usize]>::len));
+        match dedup_indices {
+            Some(indices) => {
+                for &idx in indices {
+                    match &batch[idx] {
+                        WriteBatchRecord::Del(key) => {
+                            data.push((
+                                bytes::Bytes::copy_from_slice(key.as_ref()),
+                                bytes::Bytes::from_static(crate::mvcc::TOMBSTONE_VALUE),
+                            ));
+                        }
+                        WriteBatchRecord::Put(key, value) => {
+                            let mut p = Vec::with_capacity(1 + value.as_ref().len());
+                            p.push(crate::vlog::KvKind::Inline as u8);
+                            p.extend_from_slice(value.as_ref());
+                            data.push((
+                                bytes::Bytes::copy_from_slice(key.as_ref()),
+                                bytes::Bytes::from(p),
+                            ));
+                        }
+                        WriteBatchRecord::DelRange(_, _) => unreachable!(),
+                    }
+                }
+            }
+            None => {
+                for record in batch {
+                    match record {
+                        WriteBatchRecord::Del(key) => {
+                            data.push((
+                                bytes::Bytes::copy_from_slice(key.as_ref()),
+                                bytes::Bytes::from_static(crate::mvcc::TOMBSTONE_VALUE),
+                            ));
+                        }
+                        WriteBatchRecord::Put(key, value) => {
+                            let mut p = Vec::with_capacity(1 + value.as_ref().len());
+                            p.push(crate::vlog::KvKind::Inline as u8);
+                            p.extend_from_slice(value.as_ref());
+                            data.push((
+                                bytes::Bytes::copy_from_slice(key.as_ref()),
+                                bytes::Bytes::from(p),
+                            ));
+                        }
+                        WriteBatchRecord::DelRange(_, _) => unreachable!(),
+                    }
+                }
+            }
+        }
+        data
+    }
+
+    fn build_serializable_write_set<T: AsRef<[u8]>>(
+        batch: &[WriteBatchRecord<T>],
+        dedup_indices: Option<&[usize]>,
+    ) -> std::collections::HashSet<bytes::Bytes> {
+        let mut write_set = std::collections::HashSet::with_capacity(
+            dedup_indices.map_or(batch.len(), <[usize]>::len),
+        );
+        match dedup_indices {
+            Some(indices) => {
+                for &idx in indices {
+                    write_set.insert(bytes::Bytes::copy_from_slice(Self::write_batch_key(
+                        &batch[idx],
+                    )));
+                }
+            }
+            None => {
+                for record in batch {
+                    write_set.insert(bytes::Bytes::copy_from_slice(Self::write_batch_key(record)));
+                }
+            }
+        }
+        write_set
     }
 
     pub(crate) fn mvcc_write_batch_inner(&self, entries: &[(&[u8], &[u8], bool)]) -> Result<u64> {
@@ -2948,14 +3305,45 @@ impl LsmStorageInner {
         mut level_hint: Option<&mut ahash::AHashMap<usize, usize>>,
         mut l0_hint: Option<&mut usize>,
     ) -> Result<Option<LookupResult>> {
-        // For MVCC: accumulate the newest visible version across ALL levels
-        // (L0 + L1+) before returning. A key's versions may be split across
-        // levels after compaction, so we must check every level.
-        let mut best: Option<(Bytes, u64, Vec<u8>)> = None;
+        match mvcc_read_ts {
+            Some(read_ts) => {
+                let search_prefix = crate::key::encoded_user_key_prefix(key).ok_or_else(|| {
+                    anyhow::anyhow!("invalid encoded internal key ({} bytes)", key.len())
+                })?;
+                self.lookup_sst_raw_mvcc(
+                    state,
+                    LookupSstRawMvccParams {
+                        key,
+                        bloom_hash,
+                        read_ts,
+                        search_prefix,
+                    },
+                    &mut level_hint,
+                    &mut l0_hint,
+                )
+            }
+            None => {
+                self.lookup_sst_raw_non_mvcc(state, key, bloom_hash, &mut level_hint, &mut l0_hint)
+            }
+        }
+    }
 
-        // L0 SSTs — may overlap, check each one.
-        // For sorted batch lookups, check the previously-hit L0 SST first
-        // since consecutive keys often land in the same L0 SST.
+    fn lookup_sst_raw_mvcc(
+        &self,
+        state: &LsmStorageState,
+        params: LookupSstRawMvccParams<'_>,
+        level_hint: &mut Option<&mut ahash::AHashMap<usize, usize>>,
+        l0_hint: &mut Option<&mut usize>,
+    ) -> Result<Option<LookupResult>> {
+        let LookupSstRawMvccParams {
+            key,
+            bloom_hash,
+            read_ts,
+            search_prefix,
+        } = params;
+        let mut best: Option<(Bytes, u64, Vec<u8>)> = None;
+        let mut best_l0: Option<usize> = None;
+
         let l0_hint_val = l0_hint.as_ref().and_then(|h| {
             if **h < state.l0_sstables.len() {
                 Some(**h)
@@ -2963,213 +3351,184 @@ impl LsmStorageInner {
                 None
             }
         });
-        let mut best_l0: Option<usize> = None;
-        if let Some(read_ts) = mvcc_read_ts {
-            // Check hinted L0 SST first for an O(1) fast path.
-            if let Some(hi) = l0_hint_val
-                && let Some(s) = state
-                    .l0_sstables
-                    .get(hi)
-                    .and_then(|id| state.sstables.get(id))
-                && best
-                    .as_ref()
-                    .is_none_or(|(_, best_ts, _)| s.max_ts() > *best_ts)
-                && let Some((raw, found_key)) =
-                    s.point_get_with_hash_and_key(key, bloom_hash, Some(read_ts))?
+        if let Some(hi) = l0_hint_val
+            && let Some(s) = state
+                .l0_sstables
+                .get(hi)
+                .and_then(|id| state.sstables.get(id))
+            && best
+                .as_ref()
+                .is_none_or(|(_, best_ts, _)| s.max_ts() > *best_ts)
+            && let Some((raw, found_key)) =
+                s.point_get_with_hash_and_key(key, bloom_hash, Some(read_ts))?
+        {
+            let ts = crate::key::extract_ts(&found_key).unwrap_or(0);
+            if best.as_ref().is_none_or(|(_, best_ts, _)| ts > *best_ts) {
+                best = Some((raw, ts, found_key));
+                best_l0 = Some(hi);
+            }
+        }
+        for (i, id) in state.l0_sstables.iter().enumerate() {
+            if l0_hint_val.is_some_and(|hi| hi == i) {
+                continue;
+            }
+            let s = match state.sstables.get(id) {
+                Some(s) => s,
+                None => continue,
+            };
+            if let Some((_, best_ts, _)) = best
+                && s.max_ts() <= best_ts
+            {
+                continue;
+            }
+            if let Some((raw, found_key)) =
+                s.point_get_with_hash_and_key(key, bloom_hash, Some(read_ts))?
             {
                 let ts = crate::key::extract_ts(&found_key).unwrap_or(0);
                 if best.as_ref().is_none_or(|(_, best_ts, _)| ts > *best_ts) {
                     best = Some((raw, ts, found_key));
-                    best_l0 = Some(hi);
-                }
-            }
-            for (i, id) in state.l0_sstables.iter().enumerate() {
-                // Skip the hinted SST — already checked above.
-                if l0_hint_val.is_some_and(|hi| hi == i) {
-                    continue;
-                }
-                let s = match state.sstables.get(id) {
-                    Some(s) => s,
-                    None => continue,
-                };
-                // Skip SSTs that cannot contain a newer version than what
-                // we already found (max_ts is the highest ts in this SST).
-                if let Some((_, best_ts, _)) = best
-                    && s.max_ts() <= best_ts
-                {
-                    continue;
-                }
-                if let Some((raw, found_key)) =
-                    s.point_get_with_hash_and_key(key, bloom_hash, Some(read_ts))?
-                {
-                    let ts = crate::key::extract_ts(&found_key).unwrap_or(0);
-                    if best.as_ref().is_none_or(|(_, best_ts, _)| ts > *best_ts) {
-                        best = Some((raw, ts, found_key));
-                        best_l0 = Some(i);
-                    }
-                }
-            }
-        } else {
-            // Check hinted L0 SST first for an O(1) fast path.
-            if let Some(hi) = l0_hint_val
-                && let Some(s) = state
-                    .l0_sstables
-                    .get(hi)
-                    .and_then(|id| state.sstables.get(id))
-                && let Some(raw) = s.point_get_with_hash(key, bloom_hash)?
-            {
-                let (val, kind) = Self::parse_value_kind(raw);
-                // Update hint before returning for next lookup.
-                if let Some(ref mut h) = l0_hint {
-                    **h = hi;
-                }
-                return Ok(Some((val, kind, Bytes::copy_from_slice(key), 0)));
-            }
-            for (i, id) in state.l0_sstables.iter().enumerate() {
-                // Skip the hinted SST — already probed above.
-                if l0_hint_val.is_some_and(|hi| hi == i) {
-                    continue;
-                }
-                if let Some(s) = state.sstables.get(id)
-                    && let Some(raw) = s.point_get_with_hash(key, bloom_hash)?
-                {
-                    let (val, kind) = Self::parse_value_kind(raw);
-                    // Update hint before returning for next lookup.
-                    if let Some(ref mut h) = l0_hint {
-                        **h = i;
-                    }
-                    return Ok(Some((val, kind, Bytes::copy_from_slice(key), 0)));
+                    best_l0 = Some(i);
                 }
             }
         }
-        if let Some(ref mut h) = l0_hint
+        if let Some(h) = l0_hint.as_mut()
             && let Some(idx) = best_l0
         {
             **h = idx;
         }
-        // Leveled SSTs — with MVCC, accumulate the newest version across
-        // all levels without returning early.
-        let search_prefix = mvcc_read_ts
-            .map(|_| {
-                crate::key::encoded_user_key_prefix(key).ok_or_else(|| {
-                    anyhow::anyhow!("invalid encoded internal key ({} bytes)", key.len())
-                })
-            })
-            .transpose()?;
-        for (level_idx, (_, sst_ids)) in state.levels.iter().enumerate() {
-            if let Some(read_ts) = mvcc_read_ts {
-                // Leveled SSTs (L1+) have non-overlapping user key ranges.
-                // Binary search on user key prefix to find the rightmost
-                // candidate, then scan left while the SST's last_key still
-                // carries the same user key prefix — compaction may split a
-                // key's versions across multiple adjacent SSTs.
-                let search_prefix =
-                    search_prefix.expect("search_prefix must be present when mvcc_read_ts is Some");
 
-                // O(1) hint check: if the hinted SST's range still covers
-                // the key, skip the binary search entirely.
-                let try_hint = || -> Option<usize> {
-                    let hint = level_hint.as_ref()?.get(&level_idx)?;
-                    if *hint >= sst_ids.len() {
-                        return None;
-                    }
-                    let sst = state.sstables.get(&sst_ids[*hint])?;
-                    let fk = sst.first_key()?;
-                    if fk.encoded_user_key() > search_prefix {
-                        return None;
-                    }
-                    let lk = sst.last_key()?;
-                    if lk.encoded_user_key() < search_prefix {
-                        return None;
-                    }
-                    // Return hint + 1 as upper bound for (0..idx).rev() loop
-                    // so the hinted SST itself is included in the scan.
-                    Some(*hint + 1)
-                };
-                let idx = try_hint().unwrap_or_else(|| {
-                    sst_ids.partition_point(|id| {
-                        let sst = state
-                            .sstables
-                            .get(id)
-                            .expect("SST must exist in sstables map");
-                        match sst.first_key() {
-                            Some(fk) => fk.encoded_user_key() <= search_prefix,
-                            None => false,
-                        }
-                    })
-                });
-                if let Some(ref mut hint) = level_hint {
-                    hint.insert(level_idx, idx.saturating_sub(1));
+        for (level_idx, (_, sst_ids)) in state.levels.iter().enumerate() {
+            // Leveled SSTs (L1+) have non-overlapping user key ranges.
+            // Binary search on user key prefix to find the rightmost
+            // candidate, then scan left while the SST's last_key still
+            // carries the same user key prefix — compaction may split a
+            // key's versions across multiple adjacent SSTs.
+            let try_hint = || -> Option<usize> {
+                let hint = level_hint.as_ref()?.get(&level_idx)?;
+                if *hint >= sst_ids.len() {
+                    return None;
                 }
-                for i in (0..idx).rev() {
+                let sst = state.sstables.get(&sst_ids[*hint])?;
+                let fk = sst.first_key()?;
+                if fk.encoded_user_key() > search_prefix {
+                    return None;
+                }
+                let lk = sst.last_key()?;
+                if lk.encoded_user_key() < search_prefix {
+                    return None;
+                }
+                Some(*hint + 1)
+            };
+            let idx = try_hint().unwrap_or_else(|| {
+                sst_ids.partition_point(|id| {
                     let sst = state
                         .sstables
-                        .get(&sst_ids[i])
+                        .get(id)
                         .expect("SST must exist in sstables map");
-                    let Some(last_key) = sst.last_key() else {
-                        continue;
-                    };
-                    if last_key.encoded_user_key() < search_prefix {
-                        break;
-                    }
-                    // Remaining SSTs are sorted descending by key prefix;
-                    // Skip SSTs that cannot contain a newer version.
-                    // max_ts is NOT monotonically ordered across leveled SSTs
-                    // (different SSTs cover different key ranges), so we must
-                    // continue scanning rather than breaking.
-                    if let Some((_, best_ts, _)) = best
-                        && sst.max_ts() <= best_ts
-                    {
-                        continue;
-                    }
-                    if let Some((raw, found_key)) =
-                        sst.point_get_with_hash_and_key(key, bloom_hash, Some(read_ts))?
-                    {
-                        let ts = crate::key::extract_ts(&found_key).unwrap_or(0);
-                        if best.as_ref().is_none_or(|(_, best_ts, _)| ts > *best_ts) {
-                            best = Some((raw, ts, found_key));
-                        }
-                    }
-                }
-            } else {
-                // O(1) hint check for non-MVCC path.
-                let try_hint = || -> Option<usize> {
-                    let hint = level_hint.as_ref()?.get(&level_idx)?;
-                    if *hint >= sst_ids.len() {
-                        return None;
-                    }
-                    let sst = state.sstables.get(&sst_ids[*hint])?;
-                    let fk = sst.first_key()?;
-                    let lk = sst.last_key()?;
-                    if key < fk.raw_ref() || key > lk.raw_ref() {
-                        return None;
-                    }
-                    Some(*hint + 1)
-                };
-                let idx = try_hint().unwrap_or_else(|| {
-                    sst_ids.partition_point(|id| match state.sstables[id].first_key() {
-                        Some(fk) => fk.raw_ref() <= key,
+                    match sst.first_key() {
+                        Some(fk) => fk.encoded_user_key() <= search_prefix,
                         None => false,
-                    })
-                });
-                if let Some(ref mut hint) = level_hint {
-                    hint.insert(level_idx, idx.saturating_sub(1));
+                    }
+                })
+            });
+            if let Some(hint) = level_hint.as_mut() {
+                hint.insert(level_idx, idx.saturating_sub(1));
+            }
+            for i in (0..idx).rev() {
+                let sst = state
+                    .sstables
+                    .get(&sst_ids[i])
+                    .expect("SST must exist in sstables map");
+                let Some(last_key) = sst.last_key() else {
+                    continue;
+                };
+                if last_key.encoded_user_key() < search_prefix {
+                    break;
                 }
-                if idx == 0 {
+                if let Some((_, best_ts, _)) = best
+                    && sst.max_ts() <= best_ts
+                {
                     continue;
                 }
-                let candidate_idx = idx - 1;
-                if let Some(s) = state.sstables.get(&sst_ids[candidate_idx])
-                    && let Some(raw) = s.point_get_with_hash(key, bloom_hash)?
+                if let Some((raw, found_key)) =
+                    sst.point_get_with_hash_and_key(key, bloom_hash, Some(read_ts))?
                 {
-                    let (val, kind) = Self::parse_value_kind(raw);
-                    return Ok(Some((val, kind, Bytes::copy_from_slice(key), 0)));
+                    let ts = crate::key::extract_ts(&found_key).unwrap_or(0);
+                    if best.as_ref().is_none_or(|(_, best_ts, _)| ts > *best_ts) {
+                        best = Some((raw, ts, found_key));
+                    }
                 }
             }
         }
         if let Some((raw, best_ts, found_key)) = best {
             let (val, kind) = Self::parse_value_kind(raw);
             return Ok(Some((val, kind, Bytes::from(found_key), best_ts)));
+        }
+
+        Ok(None)
+    }
+
+    fn lookup_sst_raw_non_mvcc(
+        &self,
+        state: &LsmStorageState,
+        key: &[u8],
+        bloom_hash: u32,
+        level_hint: &mut Option<&mut ahash::AHashMap<usize, usize>>,
+        l0_hint: &mut Option<&mut usize>,
+    ) -> Result<Option<LookupResult>> {
+        let l0_hint_val = l0_hint.as_ref().and_then(|h| {
+            if **h < state.l0_sstables.len() {
+                Some(**h)
+            } else {
+                None
+            }
+        });
+        if let Some(hi) = l0_hint_val
+            && let Some(s) = state
+                .l0_sstables
+                .get(hi)
+                .and_then(|id| state.sstables.get(id))
+            && let Some(raw) = s.point_get_with_hash(key, bloom_hash)?
+        {
+            let (val, kind) = Self::parse_value_kind(raw);
+            if let Some(h) = l0_hint.as_mut() {
+                **h = hi;
+            }
+            return Ok(Some((val, kind, Bytes::copy_from_slice(key), 0)));
+        }
+        for (i, id) in state.l0_sstables.iter().enumerate() {
+            if l0_hint_val.is_some_and(|hi| hi == i) {
+                continue;
+            }
+            if let Some(s) = state.sstables.get(id)
+                && let Some(raw) = s.point_get_with_hash(key, bloom_hash)?
+            {
+                let (val, kind) = Self::parse_value_kind(raw);
+                if let Some(h) = l0_hint.as_mut() {
+                    **h = i;
+                }
+                return Ok(Some((val, kind, Bytes::copy_from_slice(key), 0)));
+            }
+        }
+
+        for (level_idx, (_, sst_ids)) in state.levels.iter().enumerate() {
+            let idx = sst_ids.partition_point(|id| match state.sstables[id].first_key() {
+                Some(fk) => fk.raw_ref() <= key,
+                None => false,
+            });
+            if let Some(hint) = level_hint.as_mut() {
+                hint.insert(level_idx, idx.saturating_sub(1));
+            }
+            if idx == 0 {
+                continue;
+            }
+            let candidate_idx = idx - 1;
+            if let Some(s) = state.sstables.get(&sst_ids[candidate_idx])
+                && let Some(raw) = s.point_get_with_hash(key, bloom_hash)?
+            {
+                let (val, kind) = Self::parse_value_kind(raw);
+                return Ok(Some((val, kind, Bytes::copy_from_slice(key), 0)));
+            }
         }
 
         Ok(None)
@@ -3327,46 +3686,53 @@ impl LsmStorageInner {
         entries: &[VersionedCasEntry],
     ) -> Result<Vec<bool>> {
         let _lock = self.state_lock.lock();
-
-        // Phase 1: Lookups under read lock — check exact version.
-        // Carry pre-computed (encoded, bloom_hash) forward so Phase 2 can
-        // reuse them without re-encoding or re-hashing.
-        let mut candidates: Vec<Option<(Vec<u8>, u32)>> = Vec::with_capacity(entries.len());
-        {
-            let state = self.state.load_full();
-            let mut encode_buf = Vec::with_capacity(64);
-            for (user_key, ts, old, old_kind, _, _) in entries {
-                encode_buf.clear();
-                crate::key::encode_internal_key_to_buf(&mut encode_buf, user_key, *ts);
-                let bloom_hash = crate::table::bloom::hash_key(user_key);
-                // Check memtable + imm_memtables for the exact version
-                let current = std::iter::once(&state.memtable)
-                    .chain(state.imm_memtables.iter())
-                    .find_map(|m| {
-                        m.get_raw_exact_with_hash(&encode_buf, bloom_hash)
-                            .map(Self::parse_value_kind)
-                    });
-                let matches = match current {
-                    Some((val, kind)) => Self::values_match(&val, kind, old, *old_kind),
-                    None => {
-                        let (val, kind) = self.get_with_kind_at_ts(user_key, *ts)?;
-                        Self::values_match(&val, kind, old, *old_kind)
-                    }
-                };
-                candidates.push(if matches {
-                    Some((encode_buf.clone(), bloom_hash))
-                } else {
-                    None
-                });
-            }
-        }
-
-        // Phase 2: Re-verify and write under exclusive lock
         let _mt_guard = self.active_memtable_lock.write();
         let state = self.state.load_full();
 
+        let candidates = self.collect_versioned_cas_candidates(entries)?;
+        self.apply_versioned_cas_writes(&state, entries, candidates)
+    }
+
+    fn collect_versioned_cas_candidates(
+        &self,
+        entries: &[VersionedCasEntry],
+    ) -> Result<Vec<VersionedCasCandidate>> {
+        let state = self.state.load_full();
+        let mut candidates: Vec<VersionedCasCandidate> = Vec::with_capacity(entries.len());
+        let mut encode_buf = Vec::with_capacity(64);
+        for (user_key, ts, old, old_kind, _, _) in entries {
+            encode_buf.clear();
+            crate::key::encode_internal_key_to_buf(&mut encode_buf, user_key, *ts);
+            let bloom_hash = crate::table::bloom::hash_key(user_key);
+            let current = std::iter::once(&state.memtable)
+                .chain(state.imm_memtables.iter())
+                .find_map(|m| {
+                    m.get_raw_exact_with_hash(&encode_buf, bloom_hash)
+                        .map(Self::parse_value_kind)
+                });
+            let matches = match current {
+                Some((val, kind)) => Self::values_match(&val, kind, old, *old_kind),
+                None => {
+                    let (val, kind) = self.get_with_kind_at_ts(user_key, *ts)?;
+                    Self::values_match(&val, kind, old, *old_kind)
+                }
+            };
+            candidates.push(if matches {
+                Some((encode_buf.clone(), bloom_hash))
+            } else {
+                None
+            });
+        }
+        Ok(candidates)
+    }
+
+    fn apply_versioned_cas_writes(
+        &self,
+        state: &LsmStorageState,
+        entries: &[VersionedCasEntry],
+        mut candidates: Vec<Option<(Vec<u8>, u32)>>,
+    ) -> Result<Vec<bool>> {
         let mut results = vec![false; entries.len()];
-        // Store owned encoded keys to avoid lifetime issues.
         let mut writes: Vec<(Vec<u8>, Vec<u8>)> = Vec::with_capacity(entries.len());
 
         for (i, (_, _, old, old_kind, new, new_kind)) in entries.iter().enumerate() {
@@ -3374,7 +3740,6 @@ impl LsmStorageInner {
                 continue;
             };
 
-            // Re-verify against the memtable using the pre-computed key
             let mut still_matches = true;
             if let Some(raw) = state.memtable.get_raw_exact_with_hash(&encoded, bloom_hash) {
                 let (current_val, current_kind) = Self::parse_value_kind(raw);
@@ -3382,8 +3747,7 @@ impl LsmStorageInner {
             }
 
             if still_matches {
-                let prefixed = Self::encode_kind_value(*new_kind, new);
-                writes.push((encoded, prefixed));
+                writes.push((encoded, Self::encode_kind_value(*new_kind, new)));
                 results[i] = true;
             }
         }
@@ -3419,109 +3783,12 @@ impl LsmStorageInner {
             "mixed point/range batches are not supported in the MVP"
         );
 
-        // Range-only batch: allocate a single commit_ts for all entries.
         if has_range {
-            anyhow::ensure!(
-                !self.options.serializable,
-                "delete_range is not supported with serializable mode in the MVP"
-            );
-            anyhow::ensure!(
-                self.vlog.is_none(),
-                "delete_range is not supported when value-log (vlog) is enabled in the MVP"
-            );
-            let entries: Vec<(&[u8], &[u8])> = batch
-                .iter()
-                .filter_map(|r| {
-                    if let WriteBatchRecord::DelRange(start, end) = r {
-                        Some((start.as_ref(), end.as_ref()))
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-            for (start, end) in &entries {
-                Self::validate_key_size(start)?;
-                Self::validate_key_size(end)?;
-                anyhow::ensure!(
-                    start < end,
-                    "invalid range: start ({:?}) must be less than end ({:?})",
-                    start,
-                    end
-                );
-            }
-            // H3: Write to WAL buffer only under the lock, then release
-            // the lock before syncing. Publish to memtable after sync succeeds.
-            let (memtable, rt_ts) = {
-                let _guard = self.active_memtable_lock.read();
-                let state = self.state.load_full();
-                let ts = if let Some(ref mvcc) = self.mvcc {
-                    mvcc.write_range_batch_wal_only(&entries, &state.memtable)?
-                } else {
-                    state
-                        .memtable
-                        .put_range_tombstone_batch_wal_only(&entries, 0, 0)?;
-                    0
-                };
-                (state.memtable.clone(), ts)
-            };
-            memtable.commit_wal()?;
-            // Publish range tombstones AFTER WAL sync succeeds.
-            memtable.publish_range_tombstones(&entries, rt_ts, 0)?;
-            // Advance current_ts AFTER publish.
-            if rt_ts > 0
-                && let Some(ref mvcc) = self.mvcc
-            {
-                mvcc.advance_ts(rt_ts);
-            }
-            return self.try_freeze_memtable();
+            return self.range_batch_write(batch);
         }
 
-        // Validate key sizes before any writes.
-        for record in batch {
-            let key = match record {
-                WriteBatchRecord::Del(k) => k.as_ref(),
-                WriteBatchRecord::Put(k, _) => k.as_ref(),
-                WriteBatchRecord::DelRange(_, _) => unreachable!(),
-            };
-            Self::validate_key_size(key)?;
-        }
-        // Most benchmark and application batches contain unique keys. Avoid
-        // building and sorting a full last-op map on that hot path.
-        let mut has_duplicate_keys = false;
-        if batch.len() > 1 {
-            let mut seen = std::collections::HashSet::with_capacity(batch.len());
-            for record in batch {
-                let key = match record {
-                    WriteBatchRecord::Del(k) => k.as_ref(),
-                    WriteBatchRecord::Put(k, _) => k.as_ref(),
-                    WriteBatchRecord::DelRange(_, _) => unreachable!(),
-                };
-                if !seen.insert(key) {
-                    has_duplicate_keys = true;
-                    break;
-                }
-            }
-        }
-
-        let dedup_indices = if has_duplicate_keys {
-            // Deduplicate: keep only the last operation per user key.
-            let mut last_op = std::collections::HashMap::with_capacity(batch.len());
-            for (idx, record) in batch.iter().enumerate() {
-                let key = match record {
-                    WriteBatchRecord::Del(k) => k.as_ref(),
-                    WriteBatchRecord::Put(k, _) => k.as_ref(),
-                    WriteBatchRecord::DelRange(_, _) => unreachable!(),
-                };
-                last_op.insert(key, idx);
-            }
-
-            // Sort indices to preserve original insertion order.
-            let mut indices: Vec<_> = last_op.values().copied().collect();
-            indices.sort_unstable();
-            Some(indices)
-        } else {
-            None
-        };
+        Self::validate_write_batch_keys(batch)?;
+        let dedup_indices = Self::dedup_write_batch_indices(batch);
 
         // Defer serializable txn recording until after commit_wal succeeds.
         let mut txn_info: Option<(u64, std::collections::HashSet<bytes::Bytes>)> = None;
@@ -3542,113 +3809,22 @@ impl LsmStorageInner {
             let state = self.state.load_full();
             if let Some(ref mvcc) = self.mvcc {
                 // MVCC path: allocate a single commit_ts for the entire batch.
-                let entries: Vec<(&[u8], &[u8], bool)> =
-                    if let Some(indices) = dedup_indices.as_ref() {
-                        indices
-                            .iter()
-                            .map(|&idx| match &batch[idx] {
-                                WriteBatchRecord::Put(key, value) => {
-                                    (key.as_ref(), value.as_ref(), false)
-                                }
-                                WriteBatchRecord::Del(key) => (key.as_ref(), &[] as &[u8], true),
-                                WriteBatchRecord::DelRange(_, _) => unreachable!(),
-                            })
-                            .collect()
-                    } else {
-                        batch
-                            .iter()
-                            .map(|record| match record {
-                                WriteBatchRecord::Put(key, value) => {
-                                    (key.as_ref(), value.as_ref(), false)
-                                }
-                                WriteBatchRecord::Del(key) => (key.as_ref(), &[] as &[u8], true),
-                                WriteBatchRecord::DelRange(_, _) => unreachable!(),
-                            })
-                            .collect()
-                    };
+                let entries = Self::build_point_batch_entries(batch, dedup_indices.as_deref());
                 // WAL-only: do NOT publish to skiplist yet.
                 let (commit_ts, data) = mvcc.write_batch_wal_only(&entries, &state.memtable)?;
                 mvcc_commit_ts = commit_ts;
                 // Defer record_committed_txn until after commit_wal succeeds
                 // so that failed WAL syncs don't poison serializable validation.
                 if self.options.serializable && commit_ts > 0 {
-                    let mut write_set = std::collections::HashSet::with_capacity(
-                        dedup_indices
-                            .as_ref()
-                            .map_or(batch.len(), std::vec::Vec::len),
-                    );
-                    if let Some(indices) = dedup_indices.as_ref() {
-                        for &idx in indices {
-                            let key = match &batch[idx] {
-                                WriteBatchRecord::Put(k, _) => k.as_ref(),
-                                WriteBatchRecord::Del(k) => k.as_ref(),
-                                WriteBatchRecord::DelRange(_, _) => unreachable!(),
-                            };
-                            write_set.insert(bytes::Bytes::copy_from_slice(key));
-                        }
-                    } else {
-                        for record in batch {
-                            let key = match record {
-                                WriteBatchRecord::Put(k, _) => k.as_ref(),
-                                WriteBatchRecord::Del(k) => k.as_ref(),
-                                WriteBatchRecord::DelRange(_, _) => unreachable!(),
-                            };
-                            write_set.insert(bytes::Bytes::copy_from_slice(key));
-                        }
-                    }
-                    txn_info = Some((commit_ts, write_set));
+                    txn_info = Some((
+                        commit_ts,
+                        Self::build_serializable_write_set(batch, dedup_indices.as_deref()),
+                    ));
                 }
                 (state.memtable.clone(), data)
             } else {
                 // Non-MVCC path: write raw user keys to WAL only.
-                let mut data = Vec::with_capacity(
-                    dedup_indices
-                        .as_ref()
-                        .map_or(batch.len(), std::vec::Vec::len),
-                );
-                if let Some(indices) = dedup_indices.as_ref() {
-                    for &idx in indices {
-                        match &batch[idx] {
-                            WriteBatchRecord::Del(key) => {
-                                data.push((
-                                    bytes::Bytes::copy_from_slice(key.as_ref()),
-                                    bytes::Bytes::from_static(crate::mvcc::TOMBSTONE_VALUE),
-                                ));
-                            }
-                            WriteBatchRecord::Put(key, value) => {
-                                let mut p = Vec::with_capacity(1 + value.as_ref().len());
-                                p.push(crate::vlog::KvKind::Inline as u8);
-                                p.extend_from_slice(value.as_ref());
-                                data.push((
-                                    bytes::Bytes::copy_from_slice(key.as_ref()),
-                                    bytes::Bytes::from(p),
-                                ));
-                            }
-                            WriteBatchRecord::DelRange(_, _) => unreachable!(),
-                        }
-                    }
-                } else {
-                    for record in batch {
-                        match record {
-                            WriteBatchRecord::Del(key) => {
-                                data.push((
-                                    bytes::Bytes::copy_from_slice(key.as_ref()),
-                                    bytes::Bytes::from_static(crate::mvcc::TOMBSTONE_VALUE),
-                                ));
-                            }
-                            WriteBatchRecord::Put(key, value) => {
-                                let mut p = Vec::with_capacity(1 + value.as_ref().len());
-                                p.push(crate::vlog::KvKind::Inline as u8);
-                                p.extend_from_slice(value.as_ref());
-                                data.push((
-                                    bytes::Bytes::copy_from_slice(key.as_ref()),
-                                    bytes::Bytes::from(p),
-                                ));
-                            }
-                            WriteBatchRecord::DelRange(_, _) => unreachable!(),
-                        }
-                    }
-                }
+                let data = Self::build_non_mvcc_batch_entries(batch, dedup_indices.as_deref());
                 let publish_data = crate::mvcc::DeferredBatchPublish::from_entries(data);
                 publish_data
                     .with_borrowed_refs(|refs| state.memtable.write_wal_batch_only(refs))?;

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -297,14 +297,6 @@ impl ManifestRecoveryState<'_> {
             } => {
                 self.input_ids_buf
                     .extend(l0_sstables.iter().chain(l1_sstables.iter()).copied());
-                if let Some((_, ro_ids_in_state)) = self
-                    .state
-                    .range_only_ssts
-                    .iter()
-                    .find(|(lvl, _)| *lvl == level)
-                {
-                    self.input_ids_buf.extend(ro_ids_in_state.iter().copied());
-                }
             }
             CompactionTask::Leveled(t) => {
                 self.input_ids_buf.extend(
@@ -313,14 +305,6 @@ impl ManifestRecoveryState<'_> {
                         .chain(t.lower_level_sst_ids.iter())
                         .copied(),
                 );
-                if let Some((_, ro_ids_in_state)) = self
-                    .state
-                    .range_only_ssts
-                    .iter()
-                    .find(|(lvl, _)| *lvl == level)
-                {
-                    self.input_ids_buf.extend(ro_ids_in_state.iter().copied());
-                }
             }
             CompactionTask::Simple(t) => {
                 self.input_ids_buf.extend(
@@ -2587,8 +2571,7 @@ impl LsmStorageInner {
         let m_iter = MergeIterator::create(concat_iters);
         let two_m = TwoMergeIterator::create(two_l0_iter, m_iter)?;
 
-        let range_ts_iter =
-            self.build_scan_range_tombstone_iterator(&state, lower, upper);
+        let range_ts_iter = self.build_scan_range_tombstone_iterator(&state, lower, upper);
 
         let lit = LsmIterator::new(two_m, Self::into_vec(upper), mvcc_read_ts, range_ts_iter)?;
 
@@ -3530,9 +3513,29 @@ impl LsmStorageInner {
         }
 
         for (level_idx, (_, sst_ids)) in state.levels.iter().enumerate() {
-            let idx = sst_ids.partition_point(|id| match state.sstables[id].first_key() {
-                Some(fk) => fk.raw_ref() <= key,
-                None => false,
+            // O(1) fast path: check the hinted SST first — for sorted
+            // batch lookups, consecutive keys often land in the same SST.
+            let try_hint = || -> Option<usize> {
+                let hint = level_hint.as_ref()?.get(&level_idx)?;
+                if *hint >= sst_ids.len() {
+                    return None;
+                }
+                let sst = state.sstables.get(&sst_ids[*hint])?;
+                let fk = sst.first_key()?;
+                if fk.raw_ref() > key {
+                    return None;
+                }
+                let lk = sst.last_key()?;
+                if lk.raw_ref() < key {
+                    return None;
+                }
+                Some(*hint + 1)
+            };
+            let idx = try_hint().unwrap_or_else(|| {
+                sst_ids.partition_point(|id| match state.sstables[id].first_key() {
+                    Some(fk) => fk.raw_ref() <= key,
+                    None => false,
+                })
             });
             if let Some(hint) = level_hint.as_mut() {
                 hint.insert(level_idx, idx.saturating_sub(1));

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -2636,12 +2636,16 @@ impl LsmStorageInner {
             return Ok(());
         }
 
-        let seek_user_key = crate::key::encoded_user_key_prefix(seek)
-            .expect("encoded lower bound must have a valid user key prefix");
-        while iter.is_valid()
-            && crate::key::encoded_user_key_prefix(iter.key().raw_ref()) == Some(seek_user_key)
-        {
-            iter.next()?;
+        if let Some(seek_user_key) = crate::key::encoded_user_key_prefix(seek) {
+            while iter.is_valid()
+                && crate::key::encoded_user_key_prefix(iter.key().raw_ref()) == Some(seek_user_key)
+            {
+                iter.next()?;
+            }
+        } else {
+            while iter.is_valid() && iter.key().raw_ref() == seek {
+                iter.next()?;
+            }
         }
         Ok(())
     }

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -233,6 +233,7 @@ impl ManifestRecoveryState<'_> {
         if let Some(&last_id) = ids.last() {
             self.max_id = std::cmp::max(self.max_id, last_id);
         }
+
         Ok(())
     }
 
@@ -255,6 +256,7 @@ impl ManifestRecoveryState<'_> {
         if !vlog_ids.is_empty() {
             self.replay_vlog_refs(&ids, vlog_ids);
         }
+
         Ok(())
     }
 
@@ -2290,6 +2292,7 @@ impl LsmStorageInner {
                 return Some(raw);
             }
         }
+
         None
     }
 
@@ -2320,6 +2323,7 @@ impl LsmStorageInner {
                 return Ok(Some(raw));
             }
         }
+
         Ok(None)
     }
 
@@ -2355,6 +2359,7 @@ impl LsmStorageInner {
                 }
             }
         }
+
         Ok(None)
     }
 
@@ -2583,7 +2588,7 @@ impl LsmStorageInner {
         let two_m = TwoMergeIterator::create(two_l0_iter, m_iter)?;
 
         let range_ts_iter =
-            self.build_scan_range_tombstone_iterator(&state, lower, upper, prefix_hint);
+            self.build_scan_range_tombstone_iterator(&state, lower, upper);
 
         let lit = LsmIterator::new(two_m, Self::into_vec(upper), mvcc_read_ts, range_ts_iter)?;
 
@@ -2655,6 +2660,7 @@ impl LsmStorageInner {
                 iter.next()?;
             }
         }
+
         Ok(())
     }
 
@@ -2663,7 +2669,6 @@ impl LsmStorageInner {
         state: &LsmStorageState,
         lower: Bound<&[u8]>,
         upper: Bound<&[u8]>,
-        prefix_hint: Option<&[u8]>,
     ) -> Option<crate::range_tombstone::RangeTombstoneIterator> {
         // Build merged range-tombstone fragments from all memtables.
         // Active memtable: private per-scan fragments (no shared cache).
@@ -2716,25 +2721,23 @@ impl LsmStorageInner {
             }
         }
         // Collect SST range-tombstone fragments (including range-only SSTs).
+        // Range tombstones are not indexed by prefix bloom filters, so only
+        // check has_range_tombstones() — the prefix bloom is irrelevant here.
         for id in state
             .l0_sstables
             .iter()
             .chain(state.levels.iter().flat_map(|(_, ids)| ids))
             .chain(state.range_only_ssts.iter().flat_map(|(_, ids)| ids))
         {
-            if let Some(sst) = state.sstables.get(id)
-                && self.options.prefix_bloom.enabled
-                && let Some(prefix) = prefix_hint
-                && !sst.has_range_tombstones()
-                && !sst.may_contain_prefix(prefix)
-            {
-                continue;
-            }
-            if let Some(sst) = state.sstables.get(id)
-                && let Some(frags) = sst.range_tombstone_fragments()
-                && !frags.is_empty()
-            {
-                lists.push(frags);
+            if let Some(sst) = state.sstables.get(id) {
+                if !sst.has_range_tombstones() {
+                    continue;
+                }
+                if let Some(frags) = sst.range_tombstone_fragments()
+                    && !frags.is_empty()
+                {
+                    lists.push(frags);
+                }
             }
         }
         if lists.is_empty() {
@@ -2798,6 +2801,7 @@ impl LsmStorageInner {
         for record in batch {
             Self::validate_key_size(Self::write_batch_key(record))?;
         }
+
         Ok(())
     }
 
@@ -2827,6 +2831,7 @@ impl LsmStorageInner {
 
         let mut indices: Vec<_> = last_op.values().copied().collect();
         indices.sort_unstable();
+
         Some(indices)
     }
 
@@ -3736,6 +3741,7 @@ impl LsmStorageInner {
                 None
             });
         }
+
         Ok(candidates)
     }
 

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -295,6 +295,14 @@ impl ManifestRecoveryState<'_> {
             } => {
                 self.input_ids_buf
                     .extend(l0_sstables.iter().chain(l1_sstables.iter()).copied());
+                if let Some((_, ro_ids_in_state)) = self
+                    .state
+                    .range_only_ssts
+                    .iter()
+                    .find(|(lvl, _)| *lvl == level)
+                {
+                    self.input_ids_buf.extend(ro_ids_in_state.iter().copied());
+                }
             }
             CompactionTask::Leveled(t) => {
                 self.input_ids_buf.extend(
@@ -2717,6 +2725,7 @@ impl LsmStorageInner {
             if let Some(sst) = state.sstables.get(id)
                 && self.options.prefix_bloom.enabled
                 && let Some(prefix) = prefix_hint
+                && !sst.has_range_tombstones()
                 && !sst.may_contain_prefix(prefix)
             {
                 continue;

--- a/kv-engine/src/manifest.rs
+++ b/kv-engine/src/manifest.rs
@@ -95,65 +95,9 @@ impl Manifest {
     /// If MANIFEST is missing but MANIFEST_SNAPSHOT exists, creates a new empty MANIFEST.
     pub fn recover(path: impl AsRef<Path>) -> Result<(Self, Vec<ManifestRecord>)> {
         let path = path.as_ref();
-        let snapshot_path = Self::snapshot_path(path);
-
-        let mut records = Vec::new();
-        let tmp_path = snapshot_path.with_extension("tmp");
-
-        // Check for MANIFEST_SNAPSHOT first, then MANIFEST_SNAPSHOT.tmp.
-        // The tmp file exists if the process crashed after truncating MANIFEST
-        // but before renaming the tmp file into place.
-        let snapshot_buf = if snapshot_path.exists() {
-            Some(fs::read(&snapshot_path).context("failed to read MANIFEST_SNAPSHOT")?)
-        } else if tmp_path.exists() {
-            // Tmp file exists but wasn't renamed — rename it now to complete
-            // the handoff that was interrupted by the crash.
-            let buf = fs::read(&tmp_path).context("failed to read MANIFEST_SNAPSHOT.tmp")?;
-            // Validate it's valid JSON before renaming
-            let _: ManifestRecord =
-                serde_json::from_slice(&buf).context("failed to validate MANIFEST_SNAPSHOT.tmp")?;
-            fs::rename(&tmp_path, &snapshot_path)
-                .context("failed to rename MANIFEST_SNAPSHOT.tmp to MANIFEST_SNAPSHOT")?;
-            Some(buf)
-        } else {
-            None
-        };
-
-        if let Some(buf) = snapshot_buf {
-            let record: ManifestRecord =
-                serde_json::from_slice(&buf).context("failed to deserialize MANIFEST_SNAPSHOT")?;
-            records.push(record);
-        }
-
-        // Read manifest file (may be empty after snapshot truncation, or missing if
-        // snapshot was renamed after manifest was deleted). Any records here are
-        // post-snapshot records safe to replay on top of the snapshot state.
-        let manifest_exists = path.exists();
-        let mut f = if manifest_exists {
-            File::options()
-                .read(true)
-                .append(true)
-                .open(path)
-                .context("failed to open recover manifest")?
-        } else {
-            File::options()
-                .create_new(true)
-                .read(true)
-                .append(true)
-                .open(path)
-                .context("failed to create new manifest after snapshot")?
-        };
-
-        let mut buf = Vec::new();
-        f.read_to_end(&mut buf)?;
-
-        if !buf.is_empty() {
-            let manifest_records =
-                serde_json::Deserializer::from_slice(&buf).into_iter::<ManifestRecord>();
-            for record in manifest_records {
-                records.push(record?);
-            }
-        }
+        let mut records = Self::recover_snapshot_record(path)?;
+        let mut f = Self::open_recovery_manifest(path)?;
+        Self::recover_manifest_records(&mut f, &mut records)?;
 
         Ok((
             Self {
@@ -236,6 +180,88 @@ impl Manifest {
             .parent()
             .unwrap_or(Path::new("."))
             .join("MANIFEST_SNAPSHOT")
+    }
+
+    fn snapshot_tmp_path(manifest_path: &Path) -> PathBuf {
+        Self::snapshot_path(manifest_path).with_extension("tmp")
+    }
+
+    fn recover_snapshot_record(path: &Path) -> Result<Vec<ManifestRecord>> {
+        let Some(snapshot_buf) = Self::read_snapshot_buffer(path)? else {
+            return Ok(Vec::new());
+        };
+
+        let record: ManifestRecord = serde_json::from_slice(&snapshot_buf)
+            .context("failed to deserialize MANIFEST_SNAPSHOT")?;
+        Ok(vec![record])
+    }
+
+    fn read_snapshot_buffer(path: &Path) -> Result<Option<Vec<u8>>> {
+        let snapshot_path = Self::snapshot_path(path);
+        let tmp_path = Self::snapshot_tmp_path(path);
+
+        // Check for MANIFEST_SNAPSHOT first, then MANIFEST_SNAPSHOT.tmp.
+        // The tmp file exists if the process crashed after truncating MANIFEST
+        // but before renaming the tmp file into place.
+        if snapshot_path.exists() {
+            return Ok(Some(
+                fs::read(&snapshot_path).context("failed to read MANIFEST_SNAPSHOT")?,
+            ));
+        }
+
+        if tmp_path.exists() {
+            return Self::recover_tmp_snapshot(&tmp_path, &snapshot_path).map(Some);
+        }
+
+        Ok(None)
+    }
+
+    fn recover_tmp_snapshot(tmp_path: &Path, snapshot_path: &Path) -> Result<Vec<u8>> {
+        // Tmp file exists but wasn't renamed — rename it now to complete
+        // the handoff that was interrupted by the crash.
+        let buf = fs::read(tmp_path).context("failed to read MANIFEST_SNAPSHOT.tmp")?;
+        // Validate it's valid JSON before renaming
+        let _: ManifestRecord =
+            serde_json::from_slice(&buf).context("failed to validate MANIFEST_SNAPSHOT.tmp")?;
+        fs::rename(tmp_path, snapshot_path)
+            .context("failed to rename MANIFEST_SNAPSHOT.tmp to MANIFEST_SNAPSHOT")?;
+        Ok(buf)
+    }
+
+    fn open_recovery_manifest(path: &Path) -> Result<File> {
+        // The manifest may be empty after snapshot truncation, or missing if the
+        // snapshot rename completed after the old manifest was deleted.
+        if path.exists() {
+            return File::options()
+                .read(true)
+                .append(true)
+                .open(path)
+                .context("failed to open recover manifest");
+        }
+
+        File::options()
+            .create_new(true)
+            .read(true)
+            .append(true)
+            .open(path)
+            .context("failed to create new manifest after snapshot")
+    }
+
+    fn recover_manifest_records(file: &mut File, records: &mut Vec<ManifestRecord>) -> Result<()> {
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf)?;
+
+        if buf.is_empty() {
+            return Ok(());
+        }
+
+        let manifest_records =
+            serde_json::Deserializer::from_slice(&buf).into_iter::<ManifestRecord>();
+        for record in manifest_records {
+            records.push(record?);
+        }
+
+        Ok(())
     }
 
     /// take a record of the changes in the LsmStorageState

--- a/kv-engine/src/manifest.rs
+++ b/kv-engine/src/manifest.rs
@@ -199,10 +199,20 @@ impl Manifest {
     fn read_snapshot_buffer(path: &Path) -> Result<Option<Vec<u8>>> {
         let snapshot_path = Self::snapshot_path(path);
         let tmp_path = Self::snapshot_tmp_path(path);
+        let manifest_empty_or_missing = match fs::metadata(path) {
+            std::result::Result::Ok(meta) => meta.len() == 0,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => true,
+            Err(err) => return Err(err).context("failed to stat MANIFEST"),
+        };
 
-        // Check for MANIFEST_SNAPSHOT first, then MANIFEST_SNAPSHOT.tmp.
-        // The tmp file exists if the process crashed after truncating MANIFEST
-        // but before renaming the tmp file into place.
+        // Only recover the tmp snapshot after MANIFEST was truncated or is
+        // missing. If MANIFEST still has data, the tmp file may have been
+        // written before truncation and replaying both would duplicate or
+        // stale snapshot history.
+        if tmp_path.exists() && manifest_empty_or_missing {
+            return Self::recover_tmp_snapshot(&tmp_path, &snapshot_path).map(Some);
+        }
+
         if snapshot_path.exists() {
             return Ok(Some(
                 fs::read(&snapshot_path).context("failed to read MANIFEST_SNAPSHOT")?,
@@ -210,7 +220,7 @@ impl Manifest {
         }
 
         if tmp_path.exists() {
-            return Self::recover_tmp_snapshot(&tmp_path, &snapshot_path).map(Some);
+            return Ok(None);
         }
 
         Ok(None)

--- a/kv-engine/src/manifest.rs
+++ b/kv-engine/src/manifest.rs
@@ -193,6 +193,7 @@ impl Manifest {
 
         let record: ManifestRecord = serde_json::from_slice(&snapshot_buf)
             .context("failed to deserialize MANIFEST_SNAPSHOT")?;
+
         Ok(vec![record])
     }
 
@@ -235,6 +236,7 @@ impl Manifest {
             serde_json::from_slice(&buf).context("failed to validate MANIFEST_SNAPSHOT.tmp")?;
         fs::rename(tmp_path, snapshot_path)
             .context("failed to rename MANIFEST_SNAPSHOT.tmp to MANIFEST_SNAPSHOT")?;
+
         Ok(buf)
     }
 

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -468,8 +468,12 @@ impl MemTable {
         read_ts: u64,
         bloom_hash: u32,
     ) -> Option<(Bytes, Vec<u8>)> {
-        let mut seek_buf = Vec::new();
-        self.get_versioned_with_buf(user_key, read_ts, bloom_hash, &mut seek_buf)
+        thread_local! {
+            static SEEK_BUF: std::cell::RefCell<Vec<u8>> = const { std::cell::RefCell::new(Vec::new()) };
+        }
+        SEEK_BUF.with(|buf| {
+            self.get_versioned_with_buf(user_key, read_ts, bloom_hash, &mut buf.borrow_mut())
+        })
     }
 
     /// Version-aware lookup that reuses an encode buffer to avoid per-key

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -468,38 +468,8 @@ impl MemTable {
         read_ts: u64,
         bloom_hash: u32,
     ) -> Option<(Bytes, Vec<u8>)> {
-        if self.is_empty() {
-            return None;
-        }
-        if !self.bloom.may_contain_hash(bloom_hash) {
-            return None;
-        }
-        let seek_key = Bytes::from(crate::key::encode_internal_key(user_key, u64::MAX));
-        let seek_prefix = crate::key::encoded_user_key_prefix(&seek_key)
-            .expect("seek_key is newly encoded and guaranteed to be well-formed");
-        let mut range = self.map.range::<Bytes, _>(seek_key.clone()..);
-        for entry in range.by_ref() {
-            let found_key = entry.key();
-            if let Some(found_user_key) = crate::key::encoded_user_key_prefix(found_key) {
-                if found_user_key != seek_prefix {
-                    break;
-                }
-            } else {
-                break;
-            }
-            let ts_opt = crate::key::extract_ts(found_key);
-            debug_assert!(
-                !crate::key::TS_ENABLED || ts_opt.is_some(),
-                "corrupt MVCC key missing timestamp: {} bytes",
-                found_key.len()
-            );
-            let ts = ts_opt.unwrap_or(0);
-            if ts > read_ts {
-                continue;
-            }
-            return Some((entry.value().clone(), found_key.to_vec()));
-        }
-        None
+        let mut seek_buf = Vec::new();
+        self.get_versioned_with_buf(user_key, read_ts, bloom_hash, &mut seek_buf)
     }
 
     /// Version-aware lookup that reuses an encode buffer to avoid per-key
@@ -569,36 +539,13 @@ impl MemTable {
         let mut results = Vec::with_capacity(sorted_keys.len());
         let mut seek_buf: Vec<u8> = Vec::new();
         for &(orig_idx, user_key) in sorted_keys {
-            // Bloom filter check — skip skiplist entirely on negative.
-            if !self.bloom.may_contain_hash(bloom_hashes[orig_idx]) {
-                continue;
-            }
-            // Encode seek key into reusable buffer.
-            seek_buf.clear();
-            crate::key::encode_internal_key_to_buf(&mut seek_buf, user_key, u64::MAX);
-            let seek_prefix = match crate::key::encoded_user_key_prefix(&seek_buf) {
-                Some(p) => p,
-                None => continue,
-            };
-            let mut range = self.map.range::<[u8], _>((
-                std::ops::Bound::Included(seek_buf.as_slice()),
-                std::ops::Bound::Unbounded,
-            ));
-            for entry in range.by_ref() {
-                let found_key = entry.key();
-                if let Some(found_uk) = crate::key::encoded_user_key_prefix(found_key) {
-                    if found_uk != seek_prefix {
-                        break;
-                    }
-                } else {
-                    break;
-                }
-                let ts = crate::key::extract_ts(found_key).unwrap_or(0);
-                if ts > read_ts {
-                    continue;
-                }
-                results.push((orig_idx, entry.value().clone(), found_key.clone()));
-                break;
+            if let Some((value, found_key)) = self.get_versioned_with_buf(
+                user_key,
+                read_ts,
+                bloom_hashes[orig_idx],
+                &mut seek_buf,
+            ) {
+                results.push((orig_idx, value, Bytes::from(found_key)));
             }
         }
         results

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -810,6 +810,7 @@ impl SsTable {
         if user_key < fk || user_key > lk {
             return None;
         }
+
         Some(hinted)
     }
 
@@ -901,6 +902,7 @@ impl SsTable {
         if blk_iter.is_valid() && blk_iter.key().raw_ref() == key {
             return Some((blk_iter.value_bytes(), blk_iter.key().raw_ref().to_vec()));
         }
+
         None
     }
 

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -753,6 +753,22 @@ impl SsTable {
         bloom_hash: u32,
         read_ts: Option<u64>,
     ) -> Result<Option<(Bytes, Vec<u8>)>> {
+        if !self.should_probe_point_key(key, bloom_hash) {
+            return Ok(None);
+        }
+
+        let (blk_idx, blk_iter) = self.seek_point_get_block_iter(key)?;
+        if TS_ENABLED {
+            return self.point_get_mvcc_match(key, read_ts, blk_idx, blk_iter);
+        }
+
+        if let Some(found) = Self::point_get_non_mvcc_match(key, &blk_iter) {
+            return Ok(Some(found));
+        }
+        Ok(None)
+    }
+
+    fn should_probe_point_key(&self, key: &[u8], bloom_hash: u32) -> bool {
         // Key range check — compare encoded keys (byte-order preserved).
         // With MVCC, the search key uses ts=u64::MAX (smallest encoded form for the
         // user key), so it may sort before the SST's first_key. We skip the range
@@ -762,45 +778,43 @@ impl SsTable {
             && let (Some(first), Some(last)) = (self.first_key.as_ref(), self.last_key.as_ref())
             && (key < first.raw_ref() || key > last.raw_ref())
         {
-            return Ok(None);
+            return false;
         }
-        // Bloom filter check.  The caller precomputes hash_key(raw_user_key),
+
+        // Bloom filter check. The caller precomputes hash_key(raw_user_key),
         // which equals hash_key(decode(encode(user_key, MAX))) — the same hash
-        // the bloom filter was built with.  Use it directly for both MVCC and
-        // non-MVCC paths, avoiding a redundant decode + rehash per SST probe.
+        // the bloom filter was built with.
         if let Some(ref bloom) = self.bloom
             && !bloom.may_contain(bloom_hash)
         {
-            return Ok(None);
+            return false;
         }
-        // Defensive guard: meta-only SSTs have empty block_meta
-        if self.block_meta.is_empty() {
-            return Ok(None);
-        }
-        // O(1) fast path: check if the key falls within the last hinted
-        // block's range. For sorted batch lookups, consecutive keys often
-        // land in the same block, avoiding a full O(log N) binary search.
-        //
+
+        !self.block_meta.is_empty()
+    }
+
+    fn hinted_block_idx_for_key(&self, key: &[u8]) -> Option<usize> {
         // Compare user-key prefixes only (stripping the MVCC timestamp suffix)
         // so the hint works correctly in MVCC mode where the search key
         // carries u64::MAX but block metadata keys carry real timestamps.
-        let try_hint = || -> Option<usize> {
-            let hinted = self
-                .last_block_hint
-                .load(std::sync::atomic::Ordering::Relaxed);
-            if hinted >= self.block_meta.len() {
-                return None;
-            }
-            let meta = &self.block_meta[hinted];
-            let fk = meta.first_key.encoded_user_key();
-            let lk = meta.last_key.encoded_user_key();
-            let user_key = crate::key::encoded_user_key_prefix(key).unwrap_or(key);
-            if user_key < fk || user_key > lk {
-                return None;
-            }
-            Some(hinted)
-        };
-        let mut blk_idx = match try_hint() {
+        let hinted = self
+            .last_block_hint
+            .load(std::sync::atomic::Ordering::Relaxed);
+        if hinted >= self.block_meta.len() {
+            return None;
+        }
+        let meta = &self.block_meta[hinted];
+        let fk = meta.first_key.encoded_user_key();
+        let lk = meta.last_key.encoded_user_key();
+        let user_key = crate::key::encoded_user_key_prefix(key).unwrap_or(key);
+        if user_key < fk || user_key > lk {
+            return None;
+        }
+        Some(hinted)
+    }
+
+    fn initial_point_get_block_idx(&self, key: &[u8]) -> usize {
+        match self.hinted_block_idx_for_key(key) {
             Some(hinted) => hinted,
             None => {
                 let idx = self.find_block_idx(KeySlice::from_slice(key));
@@ -808,10 +822,16 @@ impl SsTable {
                     .store(idx, std::sync::atomic::Ordering::Relaxed);
                 idx
             }
-        };
-        let mut block = self.read_block_cached(blk_idx)?;
-        let mut blk_iter =
-            crate::block::BlockIterator::create_and_seek_to_key(block, KeySlice::from_slice(key));
+        }
+    }
+
+    fn seek_point_get_block_iter(
+        &self,
+        key: &[u8],
+    ) -> Result<(usize, crate::block::BlockIterator)> {
+        let mut blk_idx = self.initial_point_get_block_idx(key);
+        let mut blk_iter = self.read_block_iter_for_key(blk_idx, key)?;
+
         // If the block iterator is positioned before the target key (can happen
         // when encoded keys shift block boundaries), advance to subsequent blocks.
         while !blk_iter.is_valid() || blk_iter.key().raw_ref() < key {
@@ -819,60 +839,69 @@ impl SsTable {
             if blk_idx >= self.num_of_blocks() {
                 break;
             }
-            block = self.read_block_cached(blk_idx)?;
-            blk_iter = crate::block::BlockIterator::create_and_seek_to_key(
-                block,
-                KeySlice::from_slice(key),
-            );
+            blk_iter = self.read_block_iter_for_key(blk_idx, key)?;
         }
-        if TS_ENABLED {
-            let seek_uk = crate::key::encoded_user_key_prefix(key).unwrap_or(key);
-            // Scan forward through versions of the same user key (newest
-            // first due to inverted timestamp ordering) to find the newest
-            // version visible at `read_ts`.  May span multiple blocks.
-            loop {
-                while blk_iter.is_valid() {
-                    let found_key = blk_iter.key();
-                    let found_uk = found_key.encoded_user_key();
-                    if found_uk != seek_uk {
-                        // Different user key — no more versions in this block.
-                        // Check if a later block might have more versions (can
-                        // happen when encoded keys shift block boundaries).
-                        break;
-                    }
-                    let ts = found_key.ts();
-                    if read_ts.is_none_or(|rts| ts <= rts) {
-                        return Ok(Some((blk_iter.value_bytes(), found_key.raw_ref().to_vec())));
-                    }
-                    // This version is too new — advance to the next version
-                    blk_iter.next();
+
+        Ok((blk_idx, blk_iter))
+    }
+
+    fn read_block_iter_for_key(
+        &self,
+        blk_idx: usize,
+        key: &[u8],
+    ) -> Result<crate::block::BlockIterator> {
+        let block = self.read_block_cached(blk_idx)?;
+        Ok(crate::block::BlockIterator::create_and_seek_to_key(
+            block,
+            KeySlice::from_slice(key),
+        ))
+    }
+
+    fn point_get_mvcc_match(
+        &self,
+        key: &[u8],
+        read_ts: Option<u64>,
+        mut blk_idx: usize,
+        mut blk_iter: crate::block::BlockIterator,
+    ) -> Result<Option<(Bytes, Vec<u8>)>> {
+        let seek_uk = crate::key::encoded_user_key_prefix(key).unwrap_or(key);
+
+        loop {
+            while blk_iter.is_valid() {
+                let found_key = blk_iter.key();
+                let found_uk = found_key.encoded_user_key();
+                if found_uk != seek_uk {
+                    break;
                 }
-                // The current block had only too-new versions or a different
-                // user key.  Try the next block in case the user key spans a
-                // block boundary.
-                if !blk_iter.is_valid() {
-                    blk_idx += 1;
-                    if blk_idx >= self.num_of_blocks() {
-                        break;
-                    }
-                    block = self.read_block_cached(blk_idx)?;
-                    blk_iter = crate::block::BlockIterator::create_and_seek_to_key(
-                        block,
-                        KeySlice::from_slice(key),
-                    );
-                    // Continue the outer loop to scan this new block
-                    continue;
+                let ts = found_key.ts();
+                if read_ts.is_none_or(|rts| ts <= rts) {
+                    return Ok(Some((blk_iter.value_bytes(), found_key.raw_ref().to_vec())));
                 }
-                // Different user key — no point checking later blocks
+                blk_iter.next();
+            }
+
+            if blk_iter.is_valid() {
                 break;
             }
-        } else if blk_iter.is_valid() && blk_iter.key().raw_ref() == key {
-            return Ok(Some((
-                blk_iter.value_bytes(),
-                blk_iter.key().raw_ref().to_vec(),
-            )));
+
+            blk_idx += 1;
+            if blk_idx >= self.num_of_blocks() {
+                break;
+            }
+            blk_iter = self.read_block_iter_for_key(blk_idx, key)?;
         }
+
         Ok(None)
+    }
+
+    fn point_get_non_mvcc_match(
+        key: &[u8],
+        blk_iter: &crate::block::BlockIterator,
+    ) -> Option<(Bytes, Vec<u8>)> {
+        if blk_iter.is_valid() && blk_iter.key().raw_ref() == key {
+            return Some((blk_iter.value_bytes(), blk_iter.key().raw_ref().to_vec()));
+        }
+        None
     }
 
     /// Get number of data blocks.

--- a/kv-engine/src/vlog/mod.rs
+++ b/kv-engine/src/vlog/mod.rs
@@ -739,39 +739,24 @@ impl ValueLog {
     /// Attempt to delete any pending vLog files that are no longer
     /// referenced by any SST.
     pub fn reclaim_pending_deletions(&self) -> Result<usize> {
-        let mut to_process: Vec<PendingDeletion> = {
-            let mut pending = self.pending_deletions.lock();
-            std::mem::take(&mut *pending)
-        };
-        to_process.sort_unstable_by_key(|p| p.file_id);
-        to_process.dedup_by_key(|p| p.file_id);
+        let to_process = self.take_pending_deletions();
 
         let mut remaining = Vec::new();
         let mut deleted = 0usize;
         let mut first_err = None;
         for entry in to_process {
-            if self
-                .get_ssts_referencing(entry.file_id)
-                .unwrap_or_default()
-                .is_empty()
-            {
-                match self.remove_file(entry.file_id) {
-                    Ok(()) => deleted += 1,
-                    Err(e) => {
-                        if first_err.is_none() {
-                            first_err = Some(e);
-                        }
-                        remaining.push(entry);
+            match self.try_reclaim_pending_deletion(&entry) {
+                Ok(true) => deleted += 1,
+                Ok(false) => remaining.push(entry),
+                Err(e) => {
+                    if first_err.is_none() {
+                        first_err = Some(e);
                     }
+                    remaining.push(entry);
                 }
-            } else {
-                remaining.push(entry);
             }
         }
-        {
-            let mut pending = self.pending_deletions.lock();
-            pending.extend(remaining);
-        }
+        self.restore_pending_deletions(remaining);
         match first_err {
             Some(e) => Err(e),
             None => Ok(deleted),
@@ -786,20 +771,51 @@ impl ValueLog {
         &self,
         preserve: &std::collections::HashSet<u32>,
     ) -> Result<usize> {
+        let orphans = self.collect_orphan_vlog_file_ids(preserve)?;
+        let mut deleted = 0;
+        for file_id in orphans {
+            if self.remove_file(file_id).is_ok() {
+                deleted += 1;
+            }
+        }
+        Ok(deleted)
+    }
+
+    fn take_pending_deletions(&self) -> Vec<PendingDeletion> {
+        let mut to_process: Vec<PendingDeletion> = {
+            let mut pending = self.pending_deletions.lock();
+            std::mem::take(&mut *pending)
+        };
+        to_process.sort_unstable_by_key(|p| p.file_id);
+        to_process.dedup_by_key(|p| p.file_id);
+        to_process
+    }
+
+    fn restore_pending_deletions(&self, remaining: Vec<PendingDeletion>) {
+        let mut pending = self.pending_deletions.lock();
+        pending.extend(remaining);
+    }
+
+    fn try_reclaim_pending_deletion(&self, entry: &PendingDeletion) -> Result<bool> {
+        if !self
+            .get_ssts_referencing(entry.file_id)
+            .unwrap_or_default()
+            .is_empty()
+        {
+            return Ok(false);
+        }
+        self.remove_file(entry.file_id)?;
+        Ok(true)
+    }
+
+    fn collect_orphan_vlog_file_ids(
+        &self,
+        preserve: &std::collections::HashSet<u32>,
+    ) -> Result<Vec<u32>> {
         let mut orphans = Vec::new();
         for entry in std::fs::read_dir(&self.path)? {
             let entry = entry?;
-            if !entry.file_type()?.is_file() {
-                continue;
-            }
-            let name = entry.file_name();
-            let Some(name_str) = name.to_str() else {
-                continue;
-            };
-            let Some(stem) = name_str.strip_suffix(".vlog") else {
-                continue;
-            };
-            let Ok(file_id) = stem.parse::<u32>() else {
+            let Some(file_id) = Self::parse_vlog_file_id(&entry)? else {
                 continue;
             };
             if !preserve.contains(&file_id)
@@ -811,13 +827,24 @@ impl ValueLog {
                 orphans.push(file_id);
             }
         }
-        let mut deleted = 0;
-        for file_id in orphans {
-            if self.remove_file(file_id).is_ok() {
-                deleted += 1;
-            }
+        Ok(orphans)
+    }
+
+    fn parse_vlog_file_id(entry: &std::fs::DirEntry) -> Result<Option<u32>> {
+        if !entry.file_type()?.is_file() {
+            return Ok(None);
         }
-        Ok(deleted)
+        let name = entry.file_name();
+        let Some(name_str) = name.to_str() else {
+            return Ok(None);
+        };
+        let Some(stem) = name_str.strip_suffix(".vlog") else {
+            return Ok(None);
+        };
+        let Ok(file_id) = stem.parse::<u32>() else {
+            return Ok(None);
+        };
+        Ok(Some(file_id))
     }
 
     /// Record the result of a GC compaction for stats tracking.

--- a/kv-engine/src/vlog/mod.rs
+++ b/kv-engine/src/vlog/mod.rs
@@ -805,6 +805,7 @@ impl ValueLog {
             return Ok(false);
         }
         self.remove_file(entry.file_id)?;
+
         Ok(true)
     }
 
@@ -827,6 +828,7 @@ impl ValueLog {
                 orphans.push(file_id);
             }
         }
+
         Ok(orphans)
     }
 
@@ -844,6 +846,7 @@ impl ValueLog {
         let Ok(file_id) = stem.parse::<u32>() else {
             return Ok(None);
         };
+
         Ok(Some(file_id))
     }
 

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -680,11 +680,7 @@ impl Wal {
         let data_len = data.len();
         let mut max_ts: u64 = 0;
         let is_v4 = wal_version >= WAL_FORMAT_VERSION_V4;
-        let batch_hdr_size = if is_v4 {
-            V4_BATCH_HEADER_SIZE
-        } else {
-            BATCH_HEADER_SIZE
-        };
+        let batch_hdr_size = Self::wal_batch_header_size(is_v4);
 
         while data.remaining() >= batch_hdr_size {
             let before_batch = data.clone();
@@ -695,123 +691,18 @@ impl Wal {
             let data_len_field = if is_v4 { data.get_u32() as usize } else { 0 };
             handler.reset_range_ordinals();
 
-            // v4: reject all-zero pages (preallocated but unwritten). Without
-            // this check, fallocate'd zeros pass CRC(empty) and recovery treats
-            // the page as a valid empty batch, advancing into unwritten space.
-            if is_v4 && commit_ts == 0 && entry_count == 0 && data_crc32 == 0 && data_len_field == 0
-            {
+            if Self::is_zero_v4_batch(is_v4, commit_ts, entry_count, data_crc32, data_len_field) {
                 data = before_batch;
                 break;
             }
 
             let entries_start = data.remaining();
-            let min_entry_size = if is_v3 { 3 } else { 4 };
-            if entry_count > entries_start / min_entry_size {
+            let Some(expected_size) =
+                Self::validate_mvcc_batch_entries(&data, entry_count, entries_start, is_v3)
+            else {
                 data = before_batch;
                 break;
-            }
-
-            // Validate all entries fit and compute expected_size.
-            let mut expected_size: usize = 0;
-            let mut ok = true;
-            for _ in 0..entry_count {
-                if is_v3 {
-                    if entries_start - expected_size < 1 {
-                        ok = false;
-                        break;
-                    }
-                    let kind = data[expected_size];
-                    expected_size += 1;
-                    match kind {
-                        0 => {
-                            // Put: [key_len:2][key][value_len:2][value]
-                            if entries_start - expected_size < 4 {
-                                ok = false;
-                                break;
-                            }
-                            let pos = expected_size;
-                            let key_size = (&data[pos..pos + 2]).get_u16() as usize;
-                            if entries_start - expected_size < 4 + key_size {
-                                ok = false;
-                                break;
-                            }
-                            let val_size =
-                                (&data[pos + 2 + key_size..pos + 4 + key_size]).get_u16() as usize;
-                            if entries_start - expected_size < 4 + key_size + val_size {
-                                ok = false;
-                                break;
-                            }
-                            expected_size += 4 + key_size + val_size;
-                        }
-                        1 => {
-                            // PointTombstone: [key_len:2][key]
-                            if entries_start - expected_size < 2 {
-                                ok = false;
-                                break;
-                            }
-                            let pos = expected_size;
-                            let key_size = (&data[pos..pos + 2]).get_u16() as usize;
-                            if entries_start - expected_size < 2 + key_size {
-                                ok = false;
-                                break;
-                            }
-                            expected_size += 2 + key_size;
-                        }
-                        2 => {
-                            // RangeTombstone: [start_len:2][start][end_len:2][end]
-                            if entries_start - expected_size < 4 {
-                                ok = false;
-                                break;
-                            }
-                            let pos = expected_size;
-                            let start_size = (&data[pos..pos + 2]).get_u16() as usize;
-                            if entries_start - expected_size < 4 + start_size {
-                                ok = false;
-                                break;
-                            }
-                            let end_size = (&data[pos + 2 + start_size..pos + 4 + start_size])
-                                .get_u16() as usize;
-                            if entries_start - expected_size < 4 + start_size + end_size {
-                                ok = false;
-                                break;
-                            }
-                            expected_size += 4 + start_size + end_size;
-                        }
-                        _ => {
-                            ok = false;
-                            break;
-                        }
-                    }
-                } else {
-                    // v2: [key_len:2][key][value_len:2][value]
-                    if entries_start - expected_size < 4 {
-                        ok = false;
-                        break;
-                    }
-                    let pos = expected_size;
-                    let key_size = (&data[pos..pos + 2]).get_u16() as usize;
-                    if entries_start - expected_size < 4 + key_size {
-                        ok = false;
-                        break;
-                    }
-                    let val_size =
-                        (&data[pos + 2 + key_size..pos + 4 + key_size]).get_u16() as usize;
-                    if entries_start - expected_size < 4 + key_size + val_size {
-                        ok = false;
-                        break;
-                    }
-                    expected_size += 4 + key_size + val_size;
-                }
-                if expected_size > entries_start {
-                    ok = false;
-                    break;
-                }
-            }
-
-            if !ok || expected_size > entries_start {
-                data = before_batch;
-                break;
-            }
+            };
 
             // Validate CRC32 over the entry data.
             let entry_data = &data[..expected_size];
@@ -829,81 +720,261 @@ impl Wal {
                 break;
             }
 
-            // Replay entries into handler using zero-copy Bytes slices.
-            let mut entry_buf = data.split_to(expected_size);
-            for _ in 0..entry_count {
-                if is_v3 {
-                    let kind = entry_buf.get_u8();
-                    match kind {
-                        0 => {
-                            // Put
-                            let key_size = entry_buf.get_u16() as usize;
-                            let key = entry_buf.split_to(key_size);
-                            let value_size = entry_buf.get_u16() as usize;
-                            let value = entry_buf.split_to(value_size);
-                            handler.handle_put(key, value)?;
-                        }
-                        1 => {
-                            // PointTombstone
-                            let key_size = entry_buf.get_u16() as usize;
-                            let key = entry_buf.split_to(key_size);
-                            handler.handle_point_tombstone(key)?;
-                        }
-                        2 => {
-                            // RangeTombstone
-                            let start_size = entry_buf.get_u16() as usize;
-                            let start = entry_buf.split_to(start_size);
-                            let end_size = entry_buf.get_u16() as usize;
-                            let end = entry_buf.split_to(end_size);
-                            handler.handle_range_tombstone(start, end, commit_ts)?;
-                        }
-                        _ => {
-                            anyhow::bail!("unknown WAL v3 entry kind: {}", kind);
-                        }
-                    }
-                } else {
-                    // v2: untyped entries
-                    let key_size = entry_buf.get_u16() as usize;
-                    let key = entry_buf.split_to(key_size);
-                    let value_size = entry_buf.get_u16() as usize;
-                    let value = entry_buf.split_to(value_size);
-                    handler.handle_put(key, value)?;
-                }
-            }
+            Self::replay_mvcc_batch_entries(
+                &mut data,
+                expected_size,
+                entry_count,
+                is_v3,
+                commit_ts,
+                handler,
+            )?;
             if commit_ts > max_ts {
                 max_ts = commit_ts;
             }
 
-            // v4: skip alignment gap — advance past zero-padding to next 4KB boundary.
-            if is_v4 {
-                let total_batch_size = batch_hdr_size + data_len_field;
-                let aligned_size = DirectBuf::align_up(total_batch_size);
-                let consumed = expected_size + batch_hdr_size;
-                if aligned_size > consumed {
-                    let skip = aligned_size - consumed;
-                    if data.remaining() >= skip {
-                        data.advance(skip);
-                    } else {
-                        data.advance(data.remaining());
-                    }
-                }
+            Self::skip_v4_batch_alignment_gap(
+                &mut data,
+                is_v4,
+                batch_hdr_size,
+                data_len_field,
+                expected_size,
+            );
+        }
+
+        Self::truncate_recovered_wal_file(&f, is_v4, data_len, data.remaining(), file_len)?;
+
+        Ok((f, max_ts))
+    }
+
+    fn wal_batch_header_size(is_v4: bool) -> usize {
+        if is_v4 {
+            V4_BATCH_HEADER_SIZE
+        } else {
+            BATCH_HEADER_SIZE
+        }
+    }
+
+    fn is_zero_v4_batch(
+        is_v4: bool,
+        commit_ts: u64,
+        entry_count: usize,
+        data_crc32: u32,
+        data_len_field: usize,
+    ) -> bool {
+        // Reject all-zero pages (preallocated but unwritten). Without this
+        // check, fallocate'd zeros pass CRC(empty) and recovery treats the
+        // page as a valid empty batch, advancing into unwritten space.
+        is_v4 && commit_ts == 0 && entry_count == 0 && data_crc32 == 0 && data_len_field == 0
+    }
+
+    fn validate_mvcc_batch_entries(
+        data: &Bytes,
+        entry_count: usize,
+        entries_start: usize,
+        is_v3: bool,
+    ) -> Option<usize> {
+        let min_entry_size = if is_v3 { 3 } else { 4 };
+        if entry_count > entries_start / min_entry_size {
+            return None;
+        }
+
+        let mut expected_size = 0usize;
+        for _ in 0..entry_count {
+            expected_size = if is_v3 {
+                Self::validate_v3_entry_size(data, entries_start, expected_size)?
+            } else {
+                Self::validate_v2_entry_size(data, entries_start, expected_size)?
+            };
+
+            if expected_size > entries_start {
+                return None;
             }
         }
 
-        // Truncate file to the last valid byte.
+        Some(expected_size)
+    }
+
+    fn validate_v3_entry_size(
+        data: &Bytes,
+        entries_start: usize,
+        expected_size: usize,
+    ) -> Option<usize> {
+        if entries_start.checked_sub(expected_size)? < 1 {
+            return None;
+        }
+
+        let kind = data[expected_size];
+        let after_kind = expected_size + 1;
+        match kind {
+            0 => Self::validate_put_entry_size(data, entries_start, after_kind),
+            1 => Self::validate_point_tombstone_entry_size(data, entries_start, after_kind),
+            2 => Self::validate_range_tombstone_entry_size(data, entries_start, after_kind),
+            _ => None,
+        }
+    }
+
+    fn validate_v2_entry_size(
+        data: &Bytes,
+        entries_start: usize,
+        expected_size: usize,
+    ) -> Option<usize> {
+        Self::validate_put_entry_size(data, entries_start, expected_size)
+    }
+
+    fn validate_put_entry_size(data: &Bytes, entries_start: usize, pos: usize) -> Option<usize> {
+        if entries_start.checked_sub(pos)? < 4 {
+            return None;
+        }
+        let key_size = (&data[pos..pos + 2]).get_u16() as usize;
+        if entries_start.checked_sub(pos)? < 4 + key_size {
+            return None;
+        }
+        let val_size = (&data[pos + 2 + key_size..pos + 4 + key_size]).get_u16() as usize;
+        if entries_start.checked_sub(pos)? < 4 + key_size + val_size {
+            return None;
+        }
+        Some(pos + 4 + key_size + val_size)
+    }
+
+    fn validate_point_tombstone_entry_size(
+        data: &Bytes,
+        entries_start: usize,
+        pos: usize,
+    ) -> Option<usize> {
+        if entries_start.checked_sub(pos)? < 2 {
+            return None;
+        }
+        let key_size = (&data[pos..pos + 2]).get_u16() as usize;
+        if entries_start.checked_sub(pos)? < 2 + key_size {
+            return None;
+        }
+        Some(pos + 2 + key_size)
+    }
+
+    fn validate_range_tombstone_entry_size(
+        data: &Bytes,
+        entries_start: usize,
+        pos: usize,
+    ) -> Option<usize> {
+        if entries_start.checked_sub(pos)? < 4 {
+            return None;
+        }
+        let start_size = (&data[pos..pos + 2]).get_u16() as usize;
+        if entries_start.checked_sub(pos)? < 4 + start_size {
+            return None;
+        }
+        let end_size = (&data[pos + 2 + start_size..pos + 4 + start_size]).get_u16() as usize;
+        if entries_start.checked_sub(pos)? < 4 + start_size + end_size {
+            return None;
+        }
+        Some(pos + 4 + start_size + end_size)
+    }
+
+    fn replay_mvcc_batch_entries<H: RecoveryHandler>(
+        data: &mut Bytes,
+        expected_size: usize,
+        entry_count: usize,
+        is_v3: bool,
+        commit_ts: u64,
+        handler: &mut H,
+    ) -> Result<()> {
+        let mut entry_buf = data.split_to(expected_size);
+        for _ in 0..entry_count {
+            if is_v3 {
+                Self::replay_v3_entry(&mut entry_buf, commit_ts, handler)?;
+            } else {
+                Self::replay_v2_entry(&mut entry_buf, handler)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn replay_v3_entry<H: RecoveryHandler>(
+        entry_buf: &mut Bytes,
+        commit_ts: u64,
+        handler: &mut H,
+    ) -> Result<()> {
+        let kind = entry_buf.get_u8();
+        match kind {
+            0 => Self::replay_put_entry(entry_buf, handler),
+            1 => Self::replay_point_tombstone_entry(entry_buf, handler),
+            2 => Self::replay_range_tombstone_entry(entry_buf, commit_ts, handler),
+            _ => anyhow::bail!("unknown WAL v3 entry kind: {}", kind),
+        }
+    }
+
+    fn replay_v2_entry<H: RecoveryHandler>(entry_buf: &mut Bytes, handler: &mut H) -> Result<()> {
+        Self::replay_put_entry(entry_buf, handler)
+    }
+
+    fn replay_put_entry<H: RecoveryHandler>(entry_buf: &mut Bytes, handler: &mut H) -> Result<()> {
+        let key_size = entry_buf.get_u16() as usize;
+        let key = entry_buf.split_to(key_size);
+        let value_size = entry_buf.get_u16() as usize;
+        let value = entry_buf.split_to(value_size);
+        handler.handle_put(key, value)
+    }
+
+    fn replay_point_tombstone_entry<H: RecoveryHandler>(
+        entry_buf: &mut Bytes,
+        handler: &mut H,
+    ) -> Result<()> {
+        let key_size = entry_buf.get_u16() as usize;
+        let key = entry_buf.split_to(key_size);
+        handler.handle_point_tombstone(key)
+    }
+
+    fn replay_range_tombstone_entry<H: RecoveryHandler>(
+        entry_buf: &mut Bytes,
+        commit_ts: u64,
+        handler: &mut H,
+    ) -> Result<()> {
+        let start_size = entry_buf.get_u16() as usize;
+        let start = entry_buf.split_to(start_size);
+        let end_size = entry_buf.get_u16() as usize;
+        let end = entry_buf.split_to(end_size);
+        handler.handle_range_tombstone(start, end, commit_ts)
+    }
+
+    fn skip_v4_batch_alignment_gap(
+        data: &mut Bytes,
+        is_v4: bool,
+        batch_hdr_size: usize,
+        data_len_field: usize,
+        expected_size: usize,
+    ) {
+        if !is_v4 {
+            return;
+        }
+
+        let total_batch_size = batch_hdr_size + data_len_field;
+        let aligned_size = DirectBuf::align_up(total_batch_size);
+        let consumed = expected_size + batch_hdr_size;
+        if aligned_size > consumed {
+            let skip = aligned_size - consumed;
+            data.advance(data.remaining().min(skip));
+        }
+    }
+
+    fn truncate_recovered_wal_file(
+        f: &File,
+        is_v4: bool,
+        data_len: usize,
+        remaining_data: usize,
+        file_len: u64,
+    ) -> Result<()> {
         let scan_start = if is_v4 {
             DirectBuf::align_up(WAL_HEADER_SIZE)
         } else {
             WAL_HEADER_SIZE
         };
-        let valid_data = data_len - data.remaining();
+        let valid_data = data_len - remaining_data;
         let valid_file = scan_start + valid_data;
         if (valid_file as u64) < file_len {
             f.set_len(valid_file as u64)?;
             f.sync_all()?;
         }
-
-        Ok((f, max_ts))
+        Ok(())
     }
 
     /// Parse a legacy-format WAL file, delegating each recovered entry to the
@@ -1318,12 +1389,7 @@ impl Wal {
     /// the CAS loop to become the leader itself.
     pub fn submit_and_commit(&self, ticket: u64) -> Result<()> {
         if !self.mvcc_format {
-            let mut file = self.buffered_file.lock();
-            file.flush().context("failed to flush WAL")?;
-            file.get_ref()
-                .sync_all()
-                .context("failed to sync WAL to disk")?;
-            return Ok(());
+            return self.flush_legacy_wal();
         }
 
         let next_ticket = self.next_ticket.load(Ordering::Acquire);
@@ -1352,61 +1418,10 @@ impl Wal {
                 .is_ok();
 
             if is_leader {
-                // We are the leader. Drain pending and do I/O.
-                let ticketed_bufs = {
-                    let mut pending = self.pending.lock();
-                    std::mem::take(&mut *pending)
-                };
-
-                if ticketed_bufs.is_empty() {
-                    // A leader with no pending buffers while our ticket is still
-                    // not durable indicates the caller supplied an uncovered
-                    // ticket or state became inconsistent. Surface it instead
-                    // of spinning on an empty drain loop.
-                    let err_msg = format!(
-                        "invariant violation: no pending WAL buffers for undurable ticket {ticket}"
-                    );
-                    let mut state = self.completion_state.mutex.lock();
-                    state.last_error = Some(Arc::new(anyhow::anyhow!("{err_msg}")));
-                    self.submitting.store(false, Ordering::Release);
-                    self.completion_state.cond.notify_all();
-                    return Err(anyhow::anyhow!("{err_msg}"));
-                } else {
-                    let max_ticket = ticketed_bufs.last().unwrap().ticket;
-                    let result = self.submit_sqes_and_poll(ticketed_bufs);
-
-                    if result.is_err() {
-                        self.poisoned.store(true, Ordering::Release);
-                    }
-
-                    {
-                        let mut state = self.completion_state.mutex.lock();
-                        if let Err(ref e) = result {
-                            state.last_error = Some(Arc::new(anyhow::anyhow!("{e}")));
-                        } else {
-                            state.last_error = None;
-                            self.completion_state
-                                .durable_ticket
-                                .store(max_ticket + 1, Ordering::Release);
-                        }
-                        self.submitting.store(false, Ordering::Release);
-                        self.completion_state.cond.notify_all();
-                    }
-
-                    result?;
-                }
+                self.submit_as_leader(ticket)?;
             } else {
                 // Follower path: wait until the leader commits our ticket.
-                let mut state = self.completion_state.mutex.lock();
-                while self.completion_state.durable_ticket.load(Ordering::Acquire) <= ticket {
-                    if let Some(ref e) = state.last_error {
-                        return Err(anyhow::anyhow!("{e}"));
-                    }
-                    if !self.submitting.load(Ordering::Acquire) {
-                        break;
-                    }
-                    self.completion_state.cond.wait(&mut state);
-                }
+                self.wait_for_ticket_durability(ticket)?;
                 // Our ticket is durable — return success. Don't check
                 // last_error: a subsequent leader's failure should not
                 // affect data that was already committed.
@@ -1419,6 +1434,78 @@ impl Wal {
                 return Ok(());
             }
         }
+    }
+
+    fn flush_legacy_wal(&self) -> Result<()> {
+        let mut file = self.buffered_file.lock();
+        file.flush().context("failed to flush WAL")?;
+        file.get_ref()
+            .sync_all()
+            .context("failed to sync WAL to disk")?;
+        Ok(())
+    }
+
+    fn submit_as_leader(&self, ticket: u64) -> Result<()> {
+        let ticketed_bufs = self.drain_pending_ticketed_bufs();
+        if ticketed_bufs.is_empty() {
+            return self.fail_empty_leader_drain(ticket);
+        }
+
+        let max_ticket = ticketed_bufs.last().unwrap().ticket;
+        let result = self.submit_sqes_and_poll(ticketed_bufs);
+        self.publish_submit_result(max_ticket, &result);
+        result
+    }
+
+    fn drain_pending_ticketed_bufs(&self) -> Vec<TicketedBuf> {
+        let mut pending = self.pending.lock();
+        std::mem::take(&mut *pending)
+    }
+
+    fn fail_empty_leader_drain(&self, ticket: u64) -> Result<()> {
+        // A leader with no pending buffers while our ticket is still not
+        // durable indicates the caller supplied an uncovered ticket or state
+        // became inconsistent. Surface it instead of spinning on an empty
+        // drain loop.
+        let err_msg =
+            format!("invariant violation: no pending WAL buffers for undurable ticket {ticket}");
+        let mut state = self.completion_state.mutex.lock();
+        state.last_error = Some(Arc::new(anyhow::anyhow!("{err_msg}")));
+        self.submitting.store(false, Ordering::Release);
+        self.completion_state.cond.notify_all();
+        Err(anyhow::anyhow!("{err_msg}"))
+    }
+
+    fn publish_submit_result(&self, max_ticket: u64, result: &Result<()>) {
+        if result.is_err() {
+            self.poisoned.store(true, Ordering::Release);
+        }
+
+        let mut state = self.completion_state.mutex.lock();
+        if let Err(e) = result {
+            state.last_error = Some(Arc::new(anyhow::anyhow!("{e}")));
+        } else {
+            state.last_error = None;
+            self.completion_state
+                .durable_ticket
+                .store(max_ticket + 1, Ordering::Release);
+        }
+        self.submitting.store(false, Ordering::Release);
+        self.completion_state.cond.notify_all();
+    }
+
+    fn wait_for_ticket_durability(&self, ticket: u64) -> Result<()> {
+        let mut state = self.completion_state.mutex.lock();
+        while self.completion_state.durable_ticket.load(Ordering::Acquire) <= ticket {
+            if let Some(ref e) = state.last_error {
+                return Err(anyhow::anyhow!("{e}"));
+            }
+            if !self.submitting.load(Ordering::Acquire) {
+                break;
+            }
+            self.completion_state.cond.wait(&mut state);
+        }
+        Ok(())
     }
 
     /// Submit DirectBuf buffers as io_uring SQEs, poll CQEs for completion.

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -833,6 +833,7 @@ impl Wal {
         if entries_start.checked_sub(pos)? < 4 + key_size + val_size {
             return None;
         }
+
         Some(pos + 4 + key_size + val_size)
     }
 
@@ -848,6 +849,7 @@ impl Wal {
         if entries_start.checked_sub(pos)? < 2 + key_size {
             return None;
         }
+
         Some(pos + 2 + key_size)
     }
 
@@ -867,6 +869,7 @@ impl Wal {
         if entries_start.checked_sub(pos)? < 4 + start_size + end_size {
             return None;
         }
+
         Some(pos + 4 + start_size + end_size)
     }
 
@@ -1392,6 +1395,12 @@ impl Wal {
             return self.flush_legacy_wal();
         }
 
+        // Fast-path: ticket already durable — avoid unnecessary atomic loads
+        // and the CAS loop entirely.
+        if self.completion_state.durable_ticket.load(Ordering::Acquire) > ticket {
+            return Ok(());
+        }
+
         let next_ticket = self.next_ticket.load(Ordering::Acquire);
         if next_ticket == 0 {
             return Ok(());
@@ -1442,6 +1451,7 @@ impl Wal {
         file.get_ref()
             .sync_all()
             .context("failed to sync WAL to disk")?;
+
         Ok(())
     }
 
@@ -1459,6 +1469,7 @@ impl Wal {
 
     fn drain_pending_ticketed_bufs(&self) -> Vec<TicketedBuf> {
         let mut pending = self.pending.lock();
+
         std::mem::take(&mut *pending)
     }
 
@@ -1473,6 +1484,7 @@ impl Wal {
         state.last_error = Some(Arc::new(anyhow::anyhow!("{err_msg}")));
         self.submitting.store(false, Ordering::Release);
         self.completion_state.cond.notify_all();
+
         Err(anyhow::anyhow!("{err_msg}"))
     }
 
@@ -1505,6 +1517,7 @@ impl Wal {
             }
             self.completion_state.cond.wait(&mut state);
         }
+
         Ok(())
     }
 

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -1488,7 +1488,7 @@ impl Wal {
             state.last_error = None;
             self.completion_state
                 .durable_ticket
-                .store(max_ticket + 1, Ordering::Release);
+                .fetch_max(max_ticket + 1, Ordering::Release);
         }
         self.submitting.store(false, Ordering::Release);
         self.completion_state.cond.notify_all();


### PR DESCRIPTION
## Summary

Refactor several dense core paths into smaller helpers and clean up the readability-driven clippy fallout.

## Changes
- split long helper-heavy paths in `lsm_storage.rs`, `compact.rs`, `wal.rs`, `manifest.rs`, `table.rs`, `mem_table.rs`, `lsm_iterator.rs`, and `vlog/mod.rs`
- keep the normal `cargo make test` path focused on lib, bin, and test targets
- add a dedicated nextest `all-targets` profile that runs bench binaries serially with longer timeouts
- keep `cargo make test-all-targets` available for the full all-targets workflow

## Verification
- [x] `cargo make check`
- [x] `cargo nextest run --workspace --all-features --all-targets -E 'not kind(bench)'`
- [x] `cargo test --workspace --all-features --benches --no-run`
- [x] benchmark binaries start and list cases successfully (`deleterange_benchmarks`, `vlog_benchmarks`, `wal_bench`)

## Notes
- `--all-targets` under nextest was timing out because Criterion bench binaries were being run like normal tests; the new profile isolates those bench targets into a serial group with a long timeout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and correctness across compaction, manifest recovery, write batching, MVCC/versioned reads, and vLog GC cleanup.
  * Fixed edge cases involving tombstones, exact-version lookups, range tombstones, and WAL recovery/validation to make reads and recovery more consistent.
* **Chores**
  * Updated test execution to better separate standard runs from full-target benchmark runs.
  * Added a dedicated benchmark test profile to run benchmark binaries serially with safer timeouts and no retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->