### PR TITLE
feat: add chaos-testing harness (RFC 013 Phase 1)

### DIFF
--- a/chaos-todo.md
+++ b/chaos-todo.md
@@ -1,26 +1,22 @@
 # Chaos Testing — TODOs & Known Issues
 
-## Known Issue: force_flush + SIGKILL → data loss
+## Resolved: flush crash-path false failure
 
-**Symptom:** After `force_flush()` (or auto-flush via small `target_sst_size`) followed by SIGKILL, reopening the database returns **0 keys**. All WAL-recovered data is lost.
+**Original symptom:** After repeated `force_flush()` calls followed by SIGKILL, the chaos harness reported `LostDurableWrite` for committed keys.
 
-**Status:** Reproducible. Not yet root-caused.
+**Root cause:** This was **not** a flush durability failure. It was two read-path / SST-encoding bugs:
 
-| Crash method | force_flush | Result |
-|---|---|---|
-| `drop(engine)` (in-process) | Yes | 100/100 keys recovered |
-| SIGKILL (real process death) | No | 100/100 keys recovered (WAL-only) |
-| SIGKILL | Yes | 0/keys recovered |
+1. MVCC SST point-get used whole-key bloom pruning on reopened flushed SSTs, so `get()` could false-negative while `scan()` still saw the data.
+2. Empty immutable memtables could be flushed into invalid empty SSTs, and range-only SSTs were encoded/opened with assumptions that made point/iterator paths treat them like point-bearing SSTs.
 
-**Hypothesis:** io_uring O_DIRECT write may not survive SIGKILL even after CQE completion + `fdatasync(2)`. The v4 WAL uses registered fds and fixed buffers. When the process is killed, the kernel cancels in-flight I/O. Completed CQEs might report success before data reaches the storage device under O_DIRECT semantics.
+**Fix status:** Resolved on this branch.
 
-**Workaround:** All current chaos scenarios avoid `force_flush()` and use small values (below `target_sst_size`) so no auto-flush triggers. Flush-boundary testing is deferred to the Phase 3 whitebox failpoint layer.
+**Validated:**
+- WAL-only chaos scenario passes after SIGKILL.
+- Manifest-snapshot chaos scenario passes after repeated flushes + SIGKILL.
+- Full `cargo test -q --package kv-engine` passes.
 
-**Investigation needed:**
-- Reproduce with a minimal io_uring O_DIRECT test program (no kv-engine involved)
-- Test with `sync_file_range` vs `fdatasync` after O_DIRECT writes
-- Check if the issue reproduces on ext4 vs XFS vs btrfs
-- Check kernel version dependency
+**Current workaround / policy:** Timing-sensitive flush-boundary crash windows should still move to deterministic Phase 3 failpoints instead of relying on process kill timing.
 
 ## Phase 2: Scenario Expansion (not started)
 

--- a/chaos-todo.md
+++ b/chaos-todo.md
@@ -4,16 +4,18 @@
 
 **Original symptom:** After repeated `force_flush()` calls followed by SIGKILL, the chaos harness reported `LostDurableWrite` for committed keys.
 
-**Root cause:** This was **not** a flush durability failure. It was two read-path / SST-encoding bugs:
+**Root cause:** This was **not** a flush durability failure. It was a combination of:
 
-1. MVCC SST point-get used whole-key bloom pruning on reopened flushed SSTs, so `get()` could false-negative while `scan()` still saw the data.
-2. Empty immutable memtables could be flushed into invalid empty SSTs, and range-only SSTs were encoded/opened with assumptions that made point/iterator paths treat them like point-bearing SSTs.
+1. Persisted SST whole-key bloom hashing used `ahash` in a way that was not stable across processes, so a child-process write plus parent/restart-process reopen could make `get()` false-negative while `scan()` still saw the data.
+2. Empty immutable memtables could be flushed into invalid empty SSTs.
+3. Range-only / zero-point SSTs were encoded/opened with assumptions that made point/iterator paths treat them like point-bearing SSTs.
 
 **Fix status:** Resolved on this branch.
 
 **Validated:**
 - WAL-only chaos scenario passes after SIGKILL.
 - Manifest-snapshot chaos scenario passes after repeated flushes + SIGKILL.
+- Cross-process persisted-bloom regression passes.
 - Full `cargo test -q --package kv-engine` passes.
 
 **Current workaround / policy:** Timing-sensitive flush-boundary crash windows should still move to deterministic Phase 3 failpoints instead of relying on process kill timing.

--- a/chaos-todo.md
+++ b/chaos-todo.md
@@ -1,0 +1,51 @@
+# Chaos Testing — TODOs & Known Issues
+
+## Known Issue: force_flush + SIGKILL → data loss
+
+**Symptom:** After `force_flush()` (or auto-flush via small `target_sst_size`) followed by SIGKILL, reopening the database returns **0 keys**. All WAL-recovered data is lost.
+
+**Status:** Reproducible. Not yet root-caused.
+
+| Crash method | force_flush | Result |
+|---|---|---|
+| `drop(engine)` (in-process) | Yes | 100/100 keys recovered |
+| SIGKILL (real process death) | No | 100/100 keys recovered (WAL-only) |
+| SIGKILL | Yes | 0/keys recovered |
+
+**Hypothesis:** io_uring O_DIRECT write may not survive SIGKILL even after CQE completion + `fdatasync(2)`. The v4 WAL uses registered fds and fixed buffers. When the process is killed, the kernel cancels in-flight I/O. Completed CQEs might report success before data reaches the storage device under O_DIRECT semantics.
+
+**Workaround:** All current chaos scenarios avoid `force_flush()` and use small values (below `target_sst_size`) so no auto-flush triggers. Flush-boundary testing is deferred to the Phase 3 whitebox failpoint layer.
+
+**Investigation needed:**
+- Reproduce with a minimal io_uring O_DIRECT test program (no kv-engine involved)
+- Test with `sync_file_range` vs `fdatasync` after O_DIRECT writes
+- Check if the issue reproduces on ext4 vs XFS vs btrfs
+- Check kernel version dependency
+
+## Phase 2: Scenario Expansion (not started)
+
+- [ ] Range tombstone scenario — write + delete_range, kill, ensure covered keys stay deleted
+- [ ] vLog scenario — enable value separation, write large values, kill, ensure no dangling values
+- [ ] Compaction scenarios — leveled + tiered compaction, kill mid-compaction, validate
+- [ ] Second reopen pass — reopen, write more, reopen again to catch latent metadata issues
+
+## Phase 3: Whitebox Failpoints (not started)
+
+- [ ] Feature-gated failpoint registry (`chaos::failpoint` module behind `chaos-testing`)
+- [ ] Instrumentation targets:
+  - `wal.after_batch_encode`
+  - `wal.after_submit_before_wait`
+  - `wal.after_fsync_before_publish`
+  - `manifest.after_append_before_sync`
+  - `manifest.after_snapshot_tmp_sync`
+  - `flush.after_sst_sync_before_manifest`
+  - `compaction.after_output_sync_before_manifest`
+- [ ] Deterministic flush-boundary tests using failpoints instead of SIGKILL timing
+- [ ] Deterministic manifest-snapshot tests using failpoints
+
+## Minor Improvements
+
+- [ ] Pass file paths as `OsStr` instead of `to_str().unwrap()` in parent harness
+- [ ] Add nextest config overrides for chaos tests (slow-timeout, retries)
+- [ ] Add `cargo make test-chaos` task
+- [ ] Run chaos tests in nightly CI only (not PR default)

--- a/kv-engine/Cargo.toml
+++ b/kv-engine/Cargo.toml
@@ -9,6 +9,7 @@ ignored = ["arc-swap", "crossbeam-epoch"]
 
 [features]
 bench = []
+chaos-testing = []
 
 [dependencies]
 TinyUFO = "0.8"
@@ -60,3 +61,8 @@ required-features = ["bench"]
 [[bench]]
 name = "wal_bench"
 harness = false
+
+[[bin]]
+name = "chaos-child"
+path = "src/bin/chaos-child.rs"
+required-features = ["chaos-testing"]

--- a/kv-engine/src/bin/bloom-crossproc-writer.rs
+++ b/kv-engine/src/bin/bloom-crossproc-writer.rs
@@ -1,0 +1,27 @@
+use kv_engine::lsm_storage::{KvEngine, LsmStorageOptions};
+
+fn main() {
+    let Some(path) = std::env::args().nth(1) else {
+        eprintln!("usage: bloom-crossproc-writer <db-path>");
+        std::process::exit(2);
+    };
+
+    let mut opts = LsmStorageOptions::default_for_test();
+    opts.enable_wal = true;
+    opts.manifest_snapshot_threshold_bytes = 256;
+
+    let engine = KvEngine::open(path, opts).expect("open writer db");
+    for i in 0..100u32 {
+        let key = format!("k_{i:010}");
+        let value = if i % 2 == 0 {
+            format!("v_{i}")
+        } else {
+            "y".repeat(1000)
+        };
+        engine.put(key.as_bytes(), value.as_bytes()).expect("put");
+        if i % 10 == 9 {
+            engine.force_flush().expect("force_flush");
+        }
+    }
+    engine.close().expect("close writer db");
+}

--- a/kv-engine/src/bin/chaos-child.rs
+++ b/kv-engine/src/bin/chaos-child.rs
@@ -2,8 +2,8 @@
 
 mod wrapper;
 
-use wrapper::kv_engine_wrapper::chaos::scenarios::{self, ScenarioConfig};
 use wrapper::kv_engine_wrapper::chaos::control_log::ControlLogWriter;
+use wrapper::kv_engine_wrapper::chaos::scenarios::{self, ScenarioConfig};
 use wrapper::kv_engine_wrapper::lsm_storage::KvEngine;
 
 fn main() {
@@ -47,7 +47,9 @@ fn child_main(args: &[String]) -> Result<(), String> {
     match scenario.as_str() {
         "wal-only" => scenarios::wal_only_restart(&engine, &mut log, &config, seed)?,
         "flush-boundary" => scenarios::flush_boundary(&engine, &mut log, &config, seed)?,
-        "manifest-snapshot" => scenarios::manifest_snapshot_churn(&engine, &mut log, &config, seed)?,
+        "manifest-snapshot" => {
+            scenarios::manifest_snapshot_churn(&engine, &mut log, &config, seed)?
+        }
         _ => unreachable!(),
     }
 

--- a/kv-engine/src/bin/chaos-child.rs
+++ b/kv-engine/src/bin/chaos-child.rs
@@ -1,0 +1,68 @@
+#![cfg(feature = "chaos-testing")]
+
+mod wrapper;
+
+use wrapper::kv_engine_wrapper::chaos::scenarios::{self, ScenarioConfig};
+use wrapper::kv_engine_wrapper::chaos::control_log::ControlLogWriter;
+use wrapper::kv_engine_wrapper::lsm_storage::KvEngine;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if !args.iter().any(|a| a == "--child") {
+        return; // pass as test when no --child flag
+    }
+    if let Err(e) = child_main(&args) {
+        eprintln!("chaos-child: fatal: {e}");
+        std::process::exit(1);
+    }
+}
+
+fn child_main(args: &[String]) -> Result<(), String> {
+    // Parse args
+    let scenario = get_arg(args, "--scenario").ok_or("missing --scenario")?;
+    let seed: u64 = get_arg(args, "--seed")
+        .ok_or("missing --seed")?
+        .parse()
+        .map_err(|_| "invalid --seed")?;
+    let db_path = get_arg(args, "--db-path").ok_or("missing --db-path")?;
+    let log_path = get_arg(args, "--control-log-path").ok_or("missing --control-log-path")?;
+
+    // Look up scenario config
+    let config = match scenario.as_str() {
+        "wal-only" => ScenarioConfig::wal_only(),
+        "flush-boundary" => ScenarioConfig::flush_boundary(),
+        "manifest-snapshot" => ScenarioConfig::manifest_snapshot(),
+        other => return Err(format!("unknown scenario: {other}")),
+    };
+
+    // Open the database
+    let engine = KvEngine::open(db_path.as_str(), config.storage_options.clone())
+        .map_err(|e| format!("KvEngine::open failed: {e}"))?;
+
+    // Create the control log writer
+    let mut log = ControlLogWriter::new(log_path.as_str())
+        .map_err(|e| format!("ControlLogWriter::new failed: {e}"))?;
+
+    // Run the scenario
+    match scenario.as_str() {
+        "wal-only" => scenarios::wal_only_restart(&engine, &mut log, &config, seed)?,
+        "flush-boundary" => scenarios::flush_boundary(&engine, &mut log, &config, seed)?,
+        "manifest-snapshot" => scenarios::manifest_snapshot_churn(&engine, &mut log, &config, seed)?,
+        _ => unreachable!(),
+    }
+
+    // Close cleanly
+    engine.close().map_err(|e| format!("close failed: {e}"))?;
+    eprintln!("chaos-child: scenario '{scenario}' completed successfully (seed={seed})");
+    Ok(())
+}
+
+fn get_arg(args: &[String], name: &str) -> Option<String> {
+    args.windows(2).find_map(|w| {
+        if w[0] == name {
+            Some(w[1].clone())
+        } else {
+            None
+        }
+    })
+}

--- a/kv-engine/src/bin/chaos-child.rs
+++ b/kv-engine/src/bin/chaos-child.rs
@@ -53,9 +53,8 @@ fn child_main(args: &[String]) -> Result<(), String> {
         _ => unreachable!(),
     }
 
-    // Close cleanly
-    engine.close().map_err(|e| format!("close failed: {e}"))?;
-    eprintln!("chaos-child: scenario '{scenario}' completed successfully (seed={seed})");
+    // Keep the child alive until the parent sends SIGKILL after the sync point.
+    std::thread::park();
     Ok(())
 }
 

--- a/kv-engine/src/cache.rs
+++ b/kv-engine/src/cache.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashSet;
 
+// In-memory only. Do not reuse ahash-derived values in persisted formats.
 use ahash::{AHashMap, AHashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/kv-engine/src/chaos/control_log.rs
+++ b/kv-engine/src/chaos/control_log.rs
@@ -1,0 +1,305 @@
+//! Control log for chaos-testing.
+//!
+//! The control log is a separate, independently-fsynced file outside the database
+//! directory. It records operation intents and durability boundaries so the parent
+//! harness can distinguish operations that were externally committed at crash time
+//! from those that were not — without relying on the database under test.
+
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+
+/// A single record in the control log.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ControlLogRecord {
+    pub op_id: u64,
+    pub kind: OperationKind,
+    pub checkpoint: Checkpoint,
+    pub ts_ns: u128,
+}
+
+/// The kind of an operation being performed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum OperationKind {
+    /// Insert or update a single key.
+    Put {
+        key: String,
+        /// The actual value (as a string; for Phase 1 all values are printable ASCII).
+        value: String,
+    },
+    /// Delete a single key.
+    Delete { key: String },
+    /// Delete a range of keys.
+    DeleteRange { start: String, end: String },
+    /// Issue a write_batch of records.
+    WriteBatch { entries: Vec<BatchEntry> },
+    /// Force a memtable flush.
+    Flush,
+    /// Force a full compaction.
+    FullCompaction,
+    /// A sync-point marker for the parent harness to detect.
+    SyncPoint,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchEntry {
+    pub kind: BatchOpKind,
+    pub key: String,
+    /// Value bytes as a string (None for deletes; Phase 1 values are printable ASCII).
+    pub value: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum BatchOpKind {
+    Put,
+    Delete,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum Checkpoint {
+    /// The operation was started (intent). May or may not be durable.
+    IntentStarted,
+    /// The operation crossed the external durability boundary.
+    DurabilityBoundaryPassed,
+}
+
+/// Writer for the control log.
+///
+/// Appends JSON-lines records to a file. Only `write_durability_boundary()` calls
+/// `sync_all()` — intents are written without fsync so they may be lost on crash,
+/// faithfully reflecting the durability contract.
+pub struct ControlLogWriter {
+    file: std::fs::File,
+    path: std::path::PathBuf,
+    next_op_id: u64,
+}
+
+impl ControlLogWriter {
+    /// Open (or create) the control log at `path`.
+    pub fn new(path: impl Into<std::path::PathBuf>) -> std::io::Result<Self> {
+        let path = path.into();
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .read(true)
+            .open(&path)?;
+        Ok(Self {
+            file,
+            path,
+            next_op_id: 0,
+        })
+    }
+
+    /// Allocate the next operation id.
+    pub fn next_op_id(&mut self) -> u64 {
+        let id = self.next_op_id;
+        self.next_op_id += 1;
+        id
+    }
+
+    /// Write an intent record (not fsynced).
+    pub fn write_intent(&mut self, op_id: u64, kind: OperationKind) -> std::io::Result<()> {
+        let record = ControlLogRecord {
+            op_id,
+            kind,
+            checkpoint: Checkpoint::IntentStarted,
+            ts_ns: now_ns(),
+        };
+        let line = serde_json::to_string(&record)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        writeln!(self.file, "{line}")
+    }
+
+    /// Write a durability-boundary record and fsync.
+    pub fn write_durability_boundary(
+        &mut self,
+        op_id: u64,
+        kind: OperationKind,
+    ) -> std::io::Result<()> {
+        let record = ControlLogRecord {
+            op_id,
+            kind,
+            checkpoint: Checkpoint::DurabilityBoundaryPassed,
+            ts_ns: now_ns(),
+        };
+        let line = serde_json::to_string(&record)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        writeln!(self.file, "{line}")?;
+        self.file.sync_all()?;
+        Ok(())
+    }
+
+    /// Write a sync-point marker and fsync.
+    /// The parent harness detects this to know when to send SIGKILL.
+    pub fn write_sync_point(&mut self) -> std::io::Result<()> {
+        let id = self.next_op_id();
+        self.write_durability_boundary(id, OperationKind::SyncPoint)
+    }
+
+    /// Consume the writer and return the path to the log file.
+    pub fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+}
+
+/// Read and classify operations from a control log.
+pub struct ControlLogReader {
+    records: Vec<ControlLogRecord>,
+}
+
+impl ControlLogReader {
+    /// Parse the control log file at `path`.
+    pub fn open(path: &std::path::Path) -> std::io::Result<Self> {
+        let content = std::fs::read_to_string(path).unwrap_or_default();
+        let records: Vec<ControlLogRecord> = content
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .filter_map(|line| serde_json::from_str(line).ok())
+            .collect();
+        Ok(Self { records })
+    }
+
+    /// Return all parsed records.
+    pub fn records(&self) -> &[ControlLogRecord] {
+        &self.records
+    }
+
+    /// Classify operations: returns `(committed_op_ids, possibly_visible_op_ids)`.
+    ///
+    /// - An operation is **committed** if it has at least one DurabilityBoundaryPassed marker.
+    /// - An operation is **possibly visible** if it has only IntentStarted markers (it may or
+    ///   may not have been durable before the crash, due to the durable-before-ack window).
+    pub fn classify_visibility(&self) -> (Vec<u64>, Vec<u64>) {
+        let mut committed = Vec::new();
+        let mut possibly_visible = Vec::new();
+
+        // Track per-op_id the highest checkpoint seen
+        use std::collections::BTreeMap;
+        let mut ops: BTreeMap<u64, bool> = BTreeMap::new();
+        for rec in &self.records {
+            match rec.checkpoint {
+                Checkpoint::DurabilityBoundaryPassed => {
+                    ops.insert(rec.op_id, true);
+                }
+                Checkpoint::IntentStarted => {
+                    ops.entry(rec.op_id).or_insert(false);
+                }
+            }
+        }
+        for (op_id, durable) in ops {
+            if durable {
+                committed.push(op_id);
+            } else {
+                possibly_visible.push(op_id);
+            }
+        }
+        (committed, possibly_visible)
+    }
+
+    /// Return committed and possibly-visible records grouped by op_id.
+    pub fn committed_records(&self, committed_ids: &[u64]) -> Vec<&ControlLogRecord> {
+        let set: std::collections::BTreeSet<u64> = committed_ids.iter().copied().collect();
+        self.records
+            .iter()
+            .filter(|r| set.contains(&r.op_id))
+            .collect()
+    }
+}
+
+fn now_ns() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_control_log_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("control.log");
+
+        let mut writer = ControlLogWriter::new(&path).unwrap();
+        let op1 = writer.next_op_id();
+        writer
+            .write_intent(op1, OperationKind::Put {
+                key: "k1".into(),
+                value: "test".into(),
+            })
+            .unwrap();
+        writer
+            .write_durability_boundary(
+                op1,
+                OperationKind::Put {
+                    key: "k1".into(),
+                    value: "test".into(),
+                },
+            )
+            .unwrap();
+        let op2 = writer.next_op_id();
+        writer
+            .write_intent(op2, OperationKind::Delete { key: "k2".into() })
+            .unwrap();
+        writer.write_sync_point().unwrap();
+        drop(writer);
+
+        let reader = ControlLogReader::open(&path).unwrap();
+        assert_eq!(reader.records().len(), 4);
+
+        let (committed, possibly_visible) = reader.classify_visibility();
+        assert_eq!(committed.len(), 2); // op1 + sync point
+        assert_eq!(possibly_visible.len(), 1); // op2 (intent only)
+    }
+
+    #[test]
+    fn test_control_log_truncated_last_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("control.log");
+
+        // Write a valid record, then append a truncated line
+        let mut writer = ControlLogWriter::new(&path).unwrap();
+        let op1 = writer.next_op_id();
+        writer
+            .write_durability_boundary(
+                op1,
+                OperationKind::Put {
+                    key: "k1".into(),
+                    value: "test".into(),
+                },
+            )
+            .unwrap();
+        drop(writer);
+
+        // Append a partial JSON line
+        use std::io::Write;
+        let mut f = std::fs::OpenOptions::new().append(true).open(&path).unwrap();
+        writeln!(f, "{{\"partial\"").unwrap();
+        drop(f);
+
+        let reader = ControlLogReader::open(&path).unwrap();
+        assert_eq!(reader.records().len(), 1);
+        assert_eq!(reader.records()[0].op_id, op1);
+    }
+
+    #[test]
+    fn test_control_log_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("control.log");
+        std::fs::write(&path, b"").unwrap();
+        let reader = ControlLogReader::open(&path).unwrap();
+        assert_eq!(reader.records().len(), 0);
+        let (committed, possibly_visible) = reader.classify_visibility();
+        assert!(committed.is_empty());
+        assert!(possibly_visible.is_empty());
+    }
+
+    #[test]
+    fn test_control_log_no_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nonexistent.log");
+        let reader = ControlLogReader::open(&path).unwrap();
+        assert_eq!(reader.records().len(), 0);
+    }
+}

--- a/kv-engine/src/chaos/control_log.rs
+++ b/kv-engine/src/chaos/control_log.rs
@@ -105,7 +105,10 @@ impl ControlLogWriter {
             ts_ns: now_ns(),
         };
         let line = serde_json::to_string(&record).map_err(std::io::Error::other)?;
-        writeln!(self.file, "{line}")
+        let mut line_bytes = line.into_bytes();
+        line_bytes.push(b'\n');
+        self.file.write_all(&line_bytes)?;
+        Ok(())
     }
 
     /// Write a durability-boundary record and fsync.
@@ -121,7 +124,9 @@ impl ControlLogWriter {
             ts_ns: now_ns(),
         };
         let line = serde_json::to_string(&record).map_err(std::io::Error::other)?;
-        writeln!(self.file, "{line}")?;
+        let mut line_bytes = line.into_bytes();
+        line_bytes.push(b'\n');
+        self.file.write_all(&line_bytes)?;
         self.file.sync_all()?;
         Ok(())
     }

--- a/kv-engine/src/chaos/control_log.rs
+++ b/kv-engine/src/chaos/control_log.rs
@@ -151,17 +151,36 @@ pub struct ControlLogReader {
 
 impl ControlLogReader {
     /// Parse the control log file at `path`.
+    ///
+    /// Tolerates a torn final line (incomplete JSON on the last line when the file
+    /// does not end with `\n`) since the child process may be killed between `write`
+    /// and the implicit newline. All other parse failures are surfaced as errors.
     pub fn open(path: &std::path::Path) -> std::io::Result<Self> {
         let content = match std::fs::read_to_string(path) {
             Ok(c) => c,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
             Err(e) => return Err(e),
         };
-        let records: Vec<ControlLogRecord> = content
-            .lines()
-            .filter(|l| !l.trim().is_empty())
-            .filter_map(|line| serde_json::from_str(line).ok())
-            .collect();
+        let mut records = Vec::new();
+        let ends_with_newline = content.ends_with('\n');
+        let mut lines = content.lines().peekable();
+        while let Some(line) = lines.next() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<ControlLogRecord>(line) {
+                Ok(record) => records.push(record),
+                // Tolerate a torn final line: the child may have been killed between
+                // write() and the newline. Only the LAST line gets this leniency.
+                Err(_) if lines.peek().is_none() && !ends_with_newline => break,
+                Err(e) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("corrupt control log at line {}: {e}", records.len() + 1),
+                    ));
+                }
+            }
+        }
         Ok(Self { records })
     }
 
@@ -288,7 +307,7 @@ mod tests {
             .append(true)
             .open(&path)
             .unwrap();
-        writeln!(f, "{{\"partial\"").unwrap();
+        write!(f, "{{\"partial\"").unwrap();
         drop(f);
 
         let reader = ControlLogReader::open(&path).unwrap();

--- a/kv-engine/src/chaos/control_log.rs
+++ b/kv-engine/src/chaos/control_log.rs
@@ -147,7 +147,11 @@ pub struct ControlLogReader {
 impl ControlLogReader {
     /// Parse the control log file at `path`.
     pub fn open(path: &std::path::Path) -> std::io::Result<Self> {
-        let content = std::fs::read_to_string(path).unwrap_or_default();
+        let content = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+            Err(e) => return Err(e),
+        };
         let records: Vec<ControlLogRecord> = content
             .lines()
             .filter(|l| !l.trim().is_empty())

--- a/kv-engine/src/chaos/control_log.rs
+++ b/kv-engine/src/chaos/control_log.rs
@@ -177,7 +177,10 @@ impl ControlLogReader {
                 Err(e) => {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidData,
-                        format!("invalid UTF-8 in control log at line {}: {e}", records.len() + 1),
+                        format!(
+                            "invalid UTF-8 in control log at line {}: {e}",
+                            records.len() + 1
+                        ),
                     ));
                 }
             };

--- a/kv-engine/src/chaos/control_log.rs
+++ b/kv-engine/src/chaos/control_log.rs
@@ -104,8 +104,7 @@ impl ControlLogWriter {
             checkpoint: Checkpoint::IntentStarted,
             ts_ns: now_ns(),
         };
-        let line = serde_json::to_string(&record)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        let line = serde_json::to_string(&record).map_err(std::io::Error::other)?;
         writeln!(self.file, "{line}")
     }
 
@@ -121,8 +120,7 @@ impl ControlLogWriter {
             checkpoint: Checkpoint::DurabilityBoundaryPassed,
             ts_ns: now_ns(),
         };
-        let line = serde_json::to_string(&record)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        let line = serde_json::to_string(&record).map_err(std::io::Error::other)?;
         writeln!(self.file, "{line}")?;
         self.file.sync_all()?;
         Ok(())
@@ -166,8 +164,8 @@ impl ControlLogReader {
     /// Classify operations: returns `(committed_op_ids, possibly_visible_op_ids)`.
     ///
     /// - An operation is **committed** if it has at least one DurabilityBoundaryPassed marker.
-    /// - An operation is **possibly visible** if it has only IntentStarted markers (it may or
-    ///   may not have been durable before the crash, due to the durable-before-ack window).
+    /// - An operation is **possibly visible** if it has only IntentStarted markers (it may or may
+    ///   not have been durable before the crash, due to the durable-before-ack window).
     pub fn classify_visibility(&self) -> (Vec<u64>, Vec<u64>) {
         let mut committed = Vec::new();
         let mut possibly_visible = Vec::new();
@@ -224,10 +222,13 @@ mod tests {
         let mut writer = ControlLogWriter::new(&path).unwrap();
         let op1 = writer.next_op_id();
         writer
-            .write_intent(op1, OperationKind::Put {
-                key: "k1".into(),
-                value: "test".into(),
-            })
+            .write_intent(
+                op1,
+                OperationKind::Put {
+                    key: "k1".into(),
+                    value: "test".into(),
+                },
+            )
             .unwrap();
         writer
             .write_durability_boundary(
@@ -274,7 +275,10 @@ mod tests {
 
         // Append a partial JSON line
         use std::io::Write;
-        let mut f = std::fs::OpenOptions::new().append(true).open(&path).unwrap();
+        let mut f = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap();
         writeln!(f, "{{\"partial\"").unwrap();
         drop(f);
 

--- a/kv-engine/src/chaos/control_log.rs
+++ b/kv-engine/src/chaos/control_log.rs
@@ -156,18 +156,31 @@ impl ControlLogReader {
     /// does not end with `\n`) since the child process may be killed between `write`
     /// and the implicit newline. All other parse failures are surfaced as errors.
     pub fn open(path: &std::path::Path) -> std::io::Result<Self> {
-        let content = match std::fs::read_to_string(path) {
-            Ok(c) => c,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        // Read raw bytes to tolerate a torn multi-byte UTF-8 character if the
+        // child was SIGKILL'd mid-write. We validate UTF-8 per line instead.
+        let bytes = match std::fs::read(path) {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Vec::new(),
             Err(e) => return Err(e),
         };
         let mut records = Vec::new();
-        let ends_with_newline = content.ends_with('\n');
-        let mut lines = content.lines().peekable();
-        while let Some(line) = lines.next() {
-            if line.trim().is_empty() {
+        let ends_with_newline = bytes.last().copied() == Some(b'\n');
+        let mut lines = bytes.split(|&b| b == b'\n').peekable();
+        while let Some(line_bytes) = lines.next() {
+            if line_bytes.iter().all(|&b| b.is_ascii_whitespace()) {
                 continue;
             }
+            let line = match std::str::from_utf8(line_bytes) {
+                Ok(s) => s,
+                // Tolerate torn multi-byte UTF-8 on the final line.
+                Err(_) if lines.peek().is_none() && !ends_with_newline => break,
+                Err(e) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("invalid UTF-8 in control log at line {}: {e}", records.len() + 1),
+                    ));
+                }
+            };
             match serde_json::from_str::<ControlLogRecord>(line) {
                 Ok(record) => records.push(record),
                 // Tolerate a torn final line: the child may have been killed between

--- a/kv-engine/src/chaos/mod.rs
+++ b/kv-engine/src/chaos/mod.rs
@@ -1,0 +1,15 @@
+//! Chaos-testing harness for kv-engine (RFC 013).
+//!
+//! This module provides the building blocks for process-level crash/chaos tests:
+//! a control log for external operation tracking, an oracle for post-crash state
+//! reconciliation, and deterministic scenario generators.
+//!
+//! All code here is gated behind `#[cfg(feature = "chaos-testing")]` and is never
+//! compiled into production builds.
+
+pub mod control_log;
+pub mod oracle;
+pub mod scenarios;
+
+/// File name for the test control log written by the child process.
+pub const CONTROL_LOG_FILENAME: &str = "chaos_control.log";

--- a/kv-engine/src/chaos/oracle.rs
+++ b/kv-engine/src/chaos/oracle.rs
@@ -344,14 +344,6 @@ pub fn reconcile(
             continue;
         }
 
-        // If the key's latest operation is uncommitted, the post-crash state
-        // is inherently non-deterministic — the uncommitted op may or may not
-        // have been applied. Be conservative and skip the violation check
-        // even when the actual value falls outside allowed_values.
-        if reference.possibly_visible.contains(key_bytes) {
-            continue;
-        }
-
         let expected = reference.expected.get(key_bytes);
         match (expected, actual) {
             (Some(Some(expected_val)), Some(actual_val)) => {

--- a/kv-engine/src/chaos/oracle.rs
+++ b/kv-engine/src/chaos/oracle.rs
@@ -82,10 +82,15 @@ impl ReferenceState {
         for rec in reader.records() {
             if rec.checkpoint == Checkpoint::IntentStarted && !committed_set.contains(&rec.op_id) {
                 match &rec.kind {
-                    OperationKind::Put { key, .. }
-                    | OperationKind::Delete { key }
-                    | OperationKind::DeleteRange { start: key, .. } => {
+                    OperationKind::Put { key, .. } => {
                         possibly_visible.insert(key.as_bytes().to_vec());
+                    }
+                    OperationKind::Delete { key } => {
+                        possibly_visible.insert(key.as_bytes().to_vec());
+                    }
+                    OperationKind::DeleteRange { start, end } => {
+                        possibly_visible.insert(start.as_bytes().to_vec());
+                        possibly_visible.insert(end.as_bytes().to_vec());
                     }
                     OperationKind::WriteBatch { entries } => {
                         for e in entries {

--- a/kv-engine/src/chaos/oracle.rs
+++ b/kv-engine/src/chaos/oracle.rs
@@ -344,6 +344,14 @@ pub fn reconcile(
             continue;
         }
 
+        // If the key's latest operation is uncommitted, the post-crash state
+        // is inherently non-deterministic — the uncommitted op may or may not
+        // have been applied. Be conservative and skip the violation check
+        // even when the actual value falls outside allowed_values.
+        if reference.possibly_visible.contains(key_bytes) {
+            continue;
+        }
+
         let expected = reference.expected.get(key_bytes);
         match (expected, actual) {
             (Some(Some(expected_val)), Some(actual_val)) => {
@@ -394,27 +402,25 @@ pub fn reconcile(
 /// 1. Repeated reopen succeeds
 /// 2. close() after reopen succeeds
 /// 3. A follow-up write after reopen succeeds
+///
+/// Does NOT close the borrowed `engine` handle — callers that need a fresh
+/// handle after this function should close and reopen explicitly.
 pub fn structural_checks(
-    engine: &KvEngine,
+    _engine: &KvEngine,
     db_path: &std::path::Path,
     options: &LsmStorageOptions,
 ) -> Result<(), String> {
-    // 1. Close the current instance
-    engine
-        .close()
-        .map_err(|e| format!("close after reopen failed: {e}"))?;
-
-    // 2. Reopen - second open
+    // Open a fresh instance for the reopen test (don't touch the borrowed handle).
     let re2 = KvEngine::open(db_path, options.clone())
-        .map_err(|e| format!("second reopen failed: {e}"))?;
+        .map_err(|e| format!("first reopen failed: {e}"))?;
 
-    // 3. Close again
+    // Close and reopen again
     re2.close()
-        .map_err(|e| format!("close after second reopen failed: {e}"))?;
+        .map_err(|e| format!("close after first reopen failed: {e}"))?;
 
-    // 4. Final reopen + follow-up write
+    // Final reopen + follow-up write
     let re3 = KvEngine::open(db_path, options.clone())
-        .map_err(|e| format!("third reopen failed: {e}"))?;
+        .map_err(|e| format!("second reopen failed: {e}"))?;
 
     re3.put(b"__chaos_probe__", b"__chaos_probe__")
         .map_err(|e| format!("follow-up write failed: {e}"))?;
@@ -437,7 +443,7 @@ pub fn structural_checks(
     }
 
     re3.close()
-        .map_err(|e| format!("close after third reopen failed: {e}"))?;
+        .map_err(|e| format!("close after final reopen failed: {e}"))?;
 
     Ok(())
 }

--- a/kv-engine/src/chaos/oracle.rs
+++ b/kv-engine/src/chaos/oracle.rs
@@ -76,29 +76,41 @@ impl ReferenceState {
             }
         }
 
-        // Track possibly-visible keys — only for uncommitted (intent-only) op_ids
+        // Track the latest operation per key.
+        // A key is only possibly_visible if its LATEST operation is uncommitted.
+        // If the latest operation on a key is committed, the expected state is deterministic.
         let committed_set: std::collections::BTreeSet<u64> =
             committed_ids.iter().copied().collect();
+        let mut latest_ops: std::collections::HashMap<Vec<u8>, (u64, bool)> =
+            std::collections::HashMap::new();
         for rec in reader.records() {
-            if rec.checkpoint == Checkpoint::IntentStarted && !committed_set.contains(&rec.op_id) {
-                match &rec.kind {
-                    OperationKind::Put { key, .. } => {
-                        possibly_visible.insert(key.as_bytes().to_vec());
-                    }
-                    OperationKind::Delete { key } => {
-                        possibly_visible.insert(key.as_bytes().to_vec());
-                    }
-                    OperationKind::DeleteRange { start, end } => {
-                        possibly_visible.insert(start.as_bytes().to_vec());
-                        possibly_visible.insert(end.as_bytes().to_vec());
-                    }
-                    OperationKind::WriteBatch { entries } => {
-                        for e in entries {
-                            possibly_visible.insert(e.key.as_bytes().to_vec());
-                        }
-                    }
-                    _ => {}
+            let is_committed = committed_set.contains(&rec.op_id);
+            let mut update_key = |k: &[u8]| {
+                let entry = latest_ops
+                    .entry(k.to_vec())
+                    .or_insert((rec.op_id, is_committed));
+                if rec.op_id > entry.0 {
+                    *entry = (rec.op_id, is_committed);
                 }
+            };
+            match &rec.kind {
+                OperationKind::Put { key, .. } => update_key(key.as_bytes()),
+                OperationKind::Delete { key } => update_key(key.as_bytes()),
+                OperationKind::DeleteRange { start, end } => {
+                    update_key(start.as_bytes());
+                    update_key(end.as_bytes());
+                }
+                OperationKind::WriteBatch { entries } => {
+                    for e in entries {
+                        update_key(e.key.as_bytes());
+                    }
+                }
+                _ => {}
+            }
+        }
+        for (key, (_op_id, is_committed)) in latest_ops {
+            if !is_committed {
+                possibly_visible.insert(key);
             }
         }
 

--- a/kv-engine/src/chaos/oracle.rs
+++ b/kv-engine/src/chaos/oracle.rs
@@ -156,18 +156,55 @@ impl ReferenceState {
                 values.insert(value.clone());
             }
         }
+        let mut latest_committed_op_by_key: HashMap<Vec<u8>, u64> = HashMap::new();
+        for rec in reader.records() {
+            if !committed_set.contains(&rec.op_id) {
+                continue;
+            }
+            let mut record_committed = |k: &[u8]| {
+                latest_committed_op_by_key.insert(k.to_vec(), rec.op_id);
+            };
+            match &rec.kind {
+                OperationKind::Put { key, .. } => record_committed(key.as_bytes()),
+                OperationKind::Delete { key } => record_committed(key.as_bytes()),
+                OperationKind::DeleteRange { start, end } => {
+                    let start_bytes = start.as_bytes();
+                    let end_bytes = end.as_bytes();
+                    for key in &all_keys {
+                        if key.as_slice() >= start_bytes && key.as_slice() < end_bytes {
+                            record_committed(key);
+                        }
+                    }
+                }
+                OperationKind::WriteBatch { entries } => {
+                    for entry in entries {
+                        record_committed(entry.key.as_bytes());
+                    }
+                }
+                OperationKind::Flush | OperationKind::FullCompaction | OperationKind::SyncPoint => {
+                }
+            }
+        }
         for rec in reader.records() {
             if committed_set.contains(&rec.op_id) {
                 continue;
             }
             match &rec.kind {
                 OperationKind::Put { key, value } => {
-                    if let Some(values) = allowed_values.get_mut(key.as_bytes()) {
+                    if latest_committed_op_by_key
+                        .get(key.as_bytes())
+                        .is_none_or(|latest| rec.op_id > *latest)
+                        && let Some(values) = allowed_values.get_mut(key.as_bytes())
+                    {
                         values.insert(Some(Bytes::copy_from_slice(value.as_bytes())));
                     }
                 }
                 OperationKind::Delete { key } => {
-                    if let Some(values) = allowed_values.get_mut(key.as_bytes()) {
+                    if latest_committed_op_by_key
+                        .get(key.as_bytes())
+                        .is_none_or(|latest| rec.op_id > *latest)
+                        && let Some(values) = allowed_values.get_mut(key.as_bytes())
+                    {
                         values.insert(None);
                     }
                 }
@@ -177,6 +214,9 @@ impl ReferenceState {
                     for key in &all_keys {
                         if key.as_slice() >= start_bytes
                             && key.as_slice() < end_bytes
+                            && latest_committed_op_by_key
+                                .get(key)
+                                .is_none_or(|latest| rec.op_id > *latest)
                             && let Some(values) = allowed_values.get_mut(key)
                         {
                             values.insert(None);
@@ -185,7 +225,11 @@ impl ReferenceState {
                 }
                 OperationKind::WriteBatch { entries } => {
                     for entry in entries {
-                        if let Some(values) = allowed_values.get_mut(entry.key.as_bytes()) {
+                        if latest_committed_op_by_key
+                            .get(entry.key.as_bytes())
+                            .is_none_or(|latest| rec.op_id > *latest)
+                            && let Some(values) = allowed_values.get_mut(entry.key.as_bytes())
+                        {
                             let value = entry
                                 .value
                                 .as_deref()

--- a/kv-engine/src/chaos/oracle.rs
+++ b/kv-engine/src/chaos/oracle.rs
@@ -403,10 +403,9 @@ pub fn reconcile(
 /// 2. close() after reopen succeeds
 /// 3. A follow-up write after reopen succeeds
 ///
-/// Does NOT close the borrowed `engine` handle — callers that need a fresh
-/// handle after this function should close and reopen explicitly.
+/// Opens fresh instances directly — callers should close any existing
+/// engine handle on the same `db_path` before calling this function.
 pub fn structural_checks(
-    _engine: &KvEngine,
     db_path: &std::path::Path,
     options: &LsmStorageOptions,
 ) -> Result<(), String> {

--- a/kv-engine/src/chaos/oracle.rs
+++ b/kv-engine/src/chaos/oracle.rs
@@ -408,6 +408,7 @@ pub fn structural_checks(
     // Close and reopen again
     re2.close()
         .map_err(|e| format!("close after first reopen failed: {e}"))?;
+    drop(re2);
 
     // Final reopen + follow-up write
     let re3 = KvEngine::open(db_path, options.clone())

--- a/kv-engine/src/chaos/oracle.rs
+++ b/kv-engine/src/chaos/oracle.rs
@@ -43,6 +43,8 @@ pub struct ReferenceState {
     pub expected: HashMap<Vec<u8>, Option<Bytes>>,
     /// Keys that may legitimately appear even if not in `expected` (durable-before-ack window).
     pub possibly_visible: BTreeSet<Vec<u8>>,
+    /// Allowed post-crash values for each key, including committed and intent-only outcomes.
+    pub allowed_values: HashMap<Vec<u8>, BTreeSet<Option<Bytes>>>,
     /// Committed operation ids used to build this state.
     pub committed_op_ids: Vec<u64>,
     /// Possibly-visible (intent-only) operation ids.
@@ -76,6 +78,29 @@ impl ReferenceState {
             }
         }
 
+        let mut all_keys: BTreeSet<Vec<u8>> = BTreeSet::new();
+        for rec in reader.records() {
+            match &rec.kind {
+                OperationKind::Put { key, .. } => {
+                    all_keys.insert(key.as_bytes().to_vec());
+                }
+                OperationKind::Delete { key } => {
+                    all_keys.insert(key.as_bytes().to_vec());
+                }
+                OperationKind::DeleteRange { start, end } => {
+                    all_keys.insert(start.as_bytes().to_vec());
+                    all_keys.insert(end.as_bytes().to_vec());
+                }
+                OperationKind::WriteBatch { entries } => {
+                    for e in entries {
+                        all_keys.insert(e.key.as_bytes().to_vec());
+                    }
+                }
+                OperationKind::Flush | OperationKind::FullCompaction | OperationKind::SyncPoint => {
+                }
+            }
+        }
+
         // Track the latest operation per key.
         // A key is only possibly_visible if its LATEST operation is uncommitted.
         // If the latest operation on a key is committed, the expected state is deterministic.
@@ -97,8 +122,13 @@ impl ReferenceState {
                 OperationKind::Put { key, .. } => update_key(key.as_bytes()),
                 OperationKind::Delete { key } => update_key(key.as_bytes()),
                 OperationKind::DeleteRange { start, end } => {
-                    update_key(start.as_bytes());
-                    update_key(end.as_bytes());
+                    let start_bytes = start.as_bytes();
+                    let end_bytes = end.as_bytes();
+                    for key in &all_keys {
+                        if key.as_slice() >= start_bytes && key.as_slice() < end_bytes {
+                            update_key(key);
+                        }
+                    }
                 }
                 OperationKind::WriteBatch { entries } => {
                     for e in entries {
@@ -114,9 +144,65 @@ impl ReferenceState {
             }
         }
 
+        let mut allowed_values: HashMap<Vec<u8>, BTreeSet<Option<Bytes>>> = HashMap::new();
+        for key in &all_keys {
+            let mut values = BTreeSet::new();
+            values.insert(None);
+            allowed_values.insert(key.clone(), values);
+        }
+        for (key, value) in &expected {
+            if let Some(values) = allowed_values.get_mut(key) {
+                values.clear();
+                values.insert(value.clone());
+            }
+        }
+        for rec in reader.records() {
+            if committed_set.contains(&rec.op_id) {
+                continue;
+            }
+            match &rec.kind {
+                OperationKind::Put { key, value } => {
+                    if let Some(values) = allowed_values.get_mut(key.as_bytes()) {
+                        values.insert(Some(Bytes::copy_from_slice(value.as_bytes())));
+                    }
+                }
+                OperationKind::Delete { key } => {
+                    if let Some(values) = allowed_values.get_mut(key.as_bytes()) {
+                        values.insert(None);
+                    }
+                }
+                OperationKind::DeleteRange { start, end } => {
+                    let start_bytes = start.as_bytes();
+                    let end_bytes = end.as_bytes();
+                    for key in &all_keys {
+                        if key.as_slice() >= start_bytes
+                            && key.as_slice() < end_bytes
+                            && let Some(values) = allowed_values.get_mut(key)
+                        {
+                            values.insert(None);
+                        }
+                    }
+                }
+                OperationKind::WriteBatch { entries } => {
+                    for entry in entries {
+                        if let Some(values) = allowed_values.get_mut(entry.key.as_bytes()) {
+                            let value = entry
+                                .value
+                                .as_deref()
+                                .map(|v| Bytes::copy_from_slice(v.as_bytes()));
+                            values.insert(value);
+                        }
+                    }
+                }
+                OperationKind::Flush | OperationKind::FullCompaction | OperationKind::SyncPoint => {
+                }
+            }
+        }
+
         Self {
             expected,
             possibly_visible,
+            allowed_values,
             committed_op_ids: committed_ids,
             possibly_visible_op_ids: possibly_visible_ids,
         }
@@ -208,59 +294,47 @@ pub fn reconcile(
     for key_bytes in &universe.keys {
         result.total_keys_checked += 1;
         let actual = engine.get(key_bytes)?;
+        let allowed = reference.allowed_values.get(key_bytes);
+        let is_allowed = allowed.is_some_and(|values| values.contains(&actual));
+        if is_allowed {
+            continue;
+        }
 
         let expected = reference.expected.get(key_bytes);
-
         match (expected, actual) {
             (Some(Some(expected_val)), Some(actual_val)) => {
-                if expected_val != &*actual_val && !reference.possibly_visible.contains(key_bytes) {
-                    result.violations.push(Violation {
-                        key: key_bytes.clone(),
-                        kind: ViolationKind::WrongValue {
-                            expected: expected_val.clone(),
-                            actual: actual_val,
-                        },
-                    });
-                }
+                result.violations.push(Violation {
+                    key: key_bytes.clone(),
+                    kind: ViolationKind::WrongValue {
+                        expected: expected_val.clone(),
+                        actual: actual_val,
+                    },
+                });
             }
             (Some(Some(expected_val)), None) => {
-                // Key should have a value but was not found - lost durable write
-                if !reference.possibly_visible.contains(key_bytes) {
-                    result.violations.push(Violation {
-                        key: key_bytes.clone(),
-                        kind: ViolationKind::LostDurableWrite {
-                            expected_value: expected_val.clone(),
-                        },
-                    });
-                }
+                result.violations.push(Violation {
+                    key: key_bytes.clone(),
+                    kind: ViolationKind::LostDurableWrite {
+                        expected_value: expected_val.clone(),
+                    },
+                });
             }
             (Some(None), Some(_actual_val)) => {
-                // Key should be deleted but has a value
-                // Check if it's in the possibly-visible window
-                if !reference.possibly_visible.contains(key_bytes) {
-                    result.violations.push(Violation {
-                        key: key_bytes.clone(),
-                        kind: ViolationKind::ResurrectedDelete,
-                    });
-                }
+                result.violations.push(Violation {
+                    key: key_bytes.clone(),
+                    kind: ViolationKind::ResurrectedDelete,
+                });
             }
-            (Some(None), None) => {
-                // Key correctly deleted - OK
-            }
+            (Some(None), None) => continue,
             (None, Some(actual_val)) => {
-                // Key not in expected state - may be in possibly-visible window
-                if !reference.possibly_visible.contains(key_bytes) {
-                    result.violations.push(Violation {
-                        key: key_bytes.clone(),
-                        kind: ViolationKind::UnexpectedKey {
-                            actual_value: actual_val,
-                        },
-                    });
-                }
+                result.violations.push(Violation {
+                    key: key_bytes.clone(),
+                    kind: ViolationKind::UnexpectedKey {
+                        actual_value: actual_val,
+                    },
+                });
             }
-            (None, None) => {
-                // Key not touched by any operation - OK
-            }
+            (None, None) => continue,
         }
     }
 
@@ -370,6 +444,9 @@ mod tests {
         let state = ReferenceState::from_control_log(&reader);
         assert_eq!(state.expected.len(), 1);
         assert!(state.expected.contains_key(b"hello".as_slice()));
+        let allowed = state.allowed_values.get(b"hello".as_slice()).unwrap();
+        assert!(allowed.contains(&Some(Bytes::from("hello"))));
+        assert!(!allowed.contains(&None));
     }
 
     #[test]
@@ -393,6 +470,9 @@ mod tests {
         let state = ReferenceState::from_control_log(&reader);
         assert!(state.expected.is_empty());
         assert!(state.possibly_visible.contains(b"partial_key".as_slice()));
+        let allowed = state.allowed_values.get(b"partial_key".as_slice()).unwrap();
+        assert!(allowed.contains(&None));
+        assert!(allowed.contains(&Some(Bytes::from("partial_val"))));
     }
 
     #[test]
@@ -402,6 +482,7 @@ mod tests {
         let reference = ReferenceState {
             expected: HashMap::new(),
             possibly_visible: BTreeSet::new(),
+            allowed_values: HashMap::new(),
             committed_op_ids: vec![],
             possibly_visible_op_ids: vec![],
         };

--- a/kv-engine/src/chaos/oracle.rs
+++ b/kv-engine/src/chaos/oracle.rs
@@ -1,0 +1,401 @@
+//! Oracle for chaos-testing.
+//!
+//! Provides a bounded-key-universe reconciliation that compares the post-crash
+//! database state against the expected state derived from the control log.
+//! Also provides structural checks (double-reopen, close-after-reopen, etc.).
+
+use crate::chaos::control_log::{self, Checkpoint, OperationKind};
+use crate::lsm_storage::{KvEngine, LsmStorageOptions};
+use bytes::Bytes;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+/// Generate the bounded key universe used in a scenario.
+///
+/// Keys are deterministically generated: `f"{prefix}_{i:010}"` for i in 0..count.
+pub struct BoundedKeyUniverse {
+    keys: Vec<Vec<u8>>,
+    pub prefix: String,
+}
+
+impl BoundedKeyUniverse {
+    pub fn new(prefix: &str, count: usize) -> Self {
+        let keys: Vec<Vec<u8>> = (0..count)
+            .map(|i| format!("{prefix}_{i:010}").into_bytes())
+            .collect();
+        Self {
+            keys,
+            prefix: prefix.to_string(),
+        }
+    }
+
+    pub fn keys(&self) -> &[Vec<u8>] {
+        &self.keys
+    }
+
+    pub fn num_keys(&self) -> usize {
+        self.keys.len()
+    }
+}
+
+/// Expected state derived from replaying committed control-log operations.
+pub struct ReferenceState {
+    /// For each key, the expected post-crash value (None = key should be absent/deleted).
+    pub expected: HashMap<Vec<u8>, Option<Bytes>>,
+    /// Keys that may legitimately appear even if not in `expected` (durable-before-ack window).
+    pub possibly_visible: BTreeSet<Vec<u8>>,
+    /// Committed operation ids used to build this state.
+    pub committed_op_ids: Vec<u64>,
+    /// Possibly-visible (intent-only) operation ids.
+    pub possibly_visible_op_ids: Vec<u64>,
+}
+
+impl ReferenceState {
+    /// Build a reference state from the control log and the bounded key universe.
+    ///
+    /// Committed operations are applied to the reference map. Possibly-visible operations
+    /// are tracked in `possibly_visible` so the oracle can distinguish "lost durable write"
+    /// from "non-durable write that happened to survive."
+    pub fn from_control_log(
+        reader: &control_log::ControlLogReader,
+    ) -> Self {
+        let (committed_ids, possibly_visible_ids) = reader.classify_visibility();
+
+        // Collect committed records in op_id order for deterministic replay
+        let mut records_by_op: BTreeMap<u64, Vec<&control_log::ControlLogRecord>> =
+            BTreeMap::new();
+        for rec in reader.records() {
+            if rec.checkpoint == Checkpoint::DurabilityBoundaryPassed {
+                records_by_op.entry(rec.op_id).or_default().push(rec);
+            }
+        }
+
+        let mut expected: HashMap<Vec<u8>, Option<Bytes>> = HashMap::new();
+        let mut possibly_visible: BTreeSet<Vec<u8>> = BTreeSet::new();
+
+        // Apply committed operations
+        for (_op_id, records) in &records_by_op {
+            for rec in records {
+                apply_operation(&mut expected, &rec.kind);
+            }
+        }
+
+        // Track possibly-visible keys
+        for rec in reader.records() {
+            if rec.checkpoint == Checkpoint::IntentStarted {
+                match &rec.kind {
+                    OperationKind::Put { key, .. }
+                    | OperationKind::Delete { key }
+                    | OperationKind::DeleteRange { start: key, .. } => {
+                        possibly_visible.insert(key.as_bytes().to_vec());
+                    }
+                    OperationKind::WriteBatch { entries } => {
+                        for e in entries {
+                            possibly_visible.insert(e.key.as_bytes().to_vec());
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        Self {
+            expected,
+            possibly_visible,
+            committed_op_ids: committed_ids,
+            possibly_visible_op_ids: possibly_visible_ids,
+        }
+    }
+}
+
+fn apply_operation(
+    state: &mut HashMap<Vec<u8>, Option<Bytes>>,
+    kind: &OperationKind,
+) {
+    match kind {
+        OperationKind::Put { key, value } => {
+            state.insert(key.as_bytes().to_vec(), Some(Bytes::copy_from_slice(value.as_bytes())));
+        }
+        OperationKind::Delete { key } => {
+            state.insert(key.as_bytes().to_vec(), None);
+        }
+        OperationKind::DeleteRange { start, end } => {
+            // Mark all keys in the speculative range as deleted
+            // (the concrete key range is scenario-specific)
+            let start_bytes = start.as_bytes();
+            let end_bytes = end.as_bytes();
+            state
+                .keys()
+                .filter(|k| k.as_slice() >= start_bytes && k.as_slice() < end_bytes)
+                .cloned()
+                .collect::<Vec<_>>()
+                .into_iter()
+                .for_each(|k| {
+                    state.insert(k, None);
+                });
+        }
+        OperationKind::WriteBatch { entries } => {
+            for entry in entries {
+                match entry.kind {
+                    control_log::BatchOpKind::Put => {
+                        let val = entry.value.as_deref().unwrap_or("");
+                        state.insert(entry.key.as_bytes().to_vec(), Some(Bytes::copy_from_slice(val.as_bytes())));
+                    }
+                    control_log::BatchOpKind::Delete => {
+                        state.insert(entry.key.as_bytes().to_vec(), None);
+                    }
+                }
+            }
+        }
+        OperationKind::Flush | OperationKind::FullCompaction | OperationKind::SyncPoint => {
+            // No-ops for state reconciliation
+        }
+    }
+}
+
+/// The result of reconciling the actual post-crash state against the reference.
+#[derive(Debug, Default)]
+pub struct ReconciliationResult {
+    pub violations: Vec<Violation>,
+    pub total_keys_checked: usize,
+    pub committed_op_count: usize,
+    pub possibly_visible_op_count: usize,
+}
+
+#[derive(Debug)]
+pub struct Violation {
+    pub key: Vec<u8>,
+    pub kind: ViolationKind,
+}
+
+#[derive(Debug)]
+pub enum ViolationKind {
+    LostDurableWrite {
+        expected_value: Bytes,
+    },
+    ResurrectedDelete,
+    WrongValue {
+        expected: Bytes,
+        actual: Bytes,
+    },
+    UnexpectedKey {
+        actual_value: Bytes,
+    },
+}
+
+/// Reconcile the post-crash database state against the reference.
+///
+/// Scans all keys in the bounded universe, checks each against the expected state,
+/// and reports any violations.
+pub fn reconcile(
+    engine: &KvEngine,
+    universe: &BoundedKeyUniverse,
+    reference: &ReferenceState,
+) -> anyhow::Result<ReconciliationResult> {
+    let mut result = ReconciliationResult::default();
+
+    for key_bytes in &universe.keys {
+        result.total_keys_checked += 1;
+        let actual = engine.get(key_bytes)?;
+
+        let expected = reference.expected.get(key_bytes);
+
+        match (expected, actual) {
+            (Some(Some(expected_val)), Some(actual_val)) => {
+                if &*expected_val != &*actual_val {
+                    result.violations.push(Violation {
+                        key: key_bytes.clone(),
+                        kind: ViolationKind::WrongValue {
+                            expected: expected_val.clone(),
+                            actual: actual_val,
+                        },
+                    });
+                }
+            }
+            (Some(Some(expected_val)), None) => {
+                // Key should have a value but was not found - lost durable write
+                result.violations.push(Violation {
+                    key: key_bytes.clone(),
+                    kind: ViolationKind::LostDurableWrite {
+                        expected_value: expected_val.clone(),
+                    },
+                });
+            }
+            (Some(None), Some(_actual_val)) => {
+                // Key should be deleted but has a value
+                // Check if it's in the possibly-visible window
+                if !reference.possibly_visible.contains(key_bytes) {
+                    result.violations.push(Violation {
+                        key: key_bytes.clone(),
+                        kind: ViolationKind::ResurrectedDelete,
+                    });
+                }
+            }
+            (Some(None), None) => {
+                // Key correctly deleted - OK
+            }
+            (None, Some(actual_val)) => {
+                // Key not in expected state - may be in possibly-visible window
+                if !reference.possibly_visible.contains(key_bytes) {
+                    result.violations.push(Violation {
+                        key: key_bytes.clone(),
+                        kind: ViolationKind::UnexpectedKey {
+                            actual_value: actual_val,
+                        },
+                    });
+                }
+            }
+            (None, None) => {
+                // Key not touched by any operation - OK
+            }
+        }
+    }
+
+    result.committed_op_count = reference.committed_op_ids.len();
+    result.possibly_visible_op_count = reference.possibly_visible_op_ids.len();
+
+    Ok(result)
+}
+
+/// Run structural checks on a reopened database.
+///
+/// Verifies:
+/// 1. Repeated reopen succeeds
+/// 2. close() after reopen succeeds
+/// 3. A follow-up write after reopen succeeds
+pub fn structural_checks(
+    engine: &KvEngine,
+    db_path: &std::path::Path,
+    options: &LsmStorageOptions,
+) -> Result<(), String> {
+    // 1. Close the current instance
+    engine.close().map_err(|e| format!("close after reopen failed: {e}"))?;
+
+    // 2. Reopen - second open
+    let re2 = KvEngine::open(db_path, options.clone())
+        .map_err(|e| format!("second reopen failed: {e}"))?;
+
+    // 3. Close again
+    re2.close().map_err(|e| format!("close after second reopen failed: {e}"))?;
+
+    // 4. Final reopen + follow-up write
+    let re3 = KvEngine::open(db_path, options.clone())
+        .map_err(|e| format!("third reopen failed: {e}"))?;
+
+    re3.put(b"__chaos_probe__", b"__chaos_probe__")
+        .map_err(|e| format!("follow-up write failed: {e}"))?;
+
+    let val = re3
+        .get(b"__chaos_probe__")
+        .map_err(|e| format!("follow-up read failed: {e}"))?;
+
+    match val {
+        Some(v) if &*v == b"__chaos_probe__" => {}
+        Some(v) => {
+            return Err(format!(
+                "follow-up read got wrong value: expected __chaos_probe__, got {:?}",
+                v
+            ));
+        }
+        None => {
+            return Err("follow-up read returned None".to_string());
+        }
+    }
+
+    re3.close().map_err(|e| format!("close after third reopen failed: {e}"))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chaos::control_log::ControlLogWriter;
+
+    #[test]
+    fn test_reference_state_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.log");
+        std::fs::write(&path, b"").unwrap();
+        let reader = control_log::ControlLogReader::open(&path).unwrap();
+        let state = ReferenceState::from_control_log(&reader);
+        assert!(state.expected.is_empty());
+        assert!(state.possibly_visible.is_empty());
+    }
+
+    #[test]
+    fn test_reference_state_committed_put() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("log.json");
+        let mut writer = ControlLogWriter::new(&path).unwrap();
+        let op1 = writer.next_op_id();
+        writer
+            .write_intent(op1, OperationKind::Put {
+                key: "hello".into(),
+                value: "hello".into(),
+            })
+            .unwrap();
+        writer
+            .write_durability_boundary(
+                op1,
+                OperationKind::Put {
+                    key: "hello".into(),
+                    value: "hello".into(),
+                },
+            )
+            .unwrap();
+        drop(writer);
+
+        let reader = control_log::ControlLogReader::open(&path).unwrap();
+        let state = ReferenceState::from_control_log(&reader);
+        assert_eq!(state.expected.len(), 1);
+        assert!(state.expected.contains_key(b"hello".as_slice()));
+    }
+
+    #[test]
+    fn test_reference_state_intent_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("log.json");
+        let mut writer = ControlLogWriter::new(&path).unwrap();
+        let op1 = writer.next_op_id();
+        writer
+            .write_intent(op1, OperationKind::Put {
+                key: "partial_key".into(),
+                value: "partial_val".into(),
+            })
+            .unwrap();
+        drop(writer);
+
+        let reader = control_log::ControlLogReader::open(&path).unwrap();
+        let state = ReferenceState::from_control_log(&reader);
+        assert!(state.expected.is_empty());
+        assert!(state.possibly_visible.contains(b"partial_key".as_slice()));
+    }
+
+    #[test]
+    fn test_reconcile_no_violations() {
+        // This is a structural test: with an empty engine and empty reference, reconcile passes.
+        let universe = BoundedKeyUniverse::new("k", 5);
+        let reference = ReferenceState {
+            expected: HashMap::new(),
+            possibly_visible: BTreeSet::new(),
+            committed_op_ids: vec![],
+            possibly_visible_op_ids: vec![],
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let engine = KvEngine::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap();
+        let result = reconcile(&engine, &universe, &reference).unwrap();
+        assert_eq!(result.violations.len(), 0);
+        assert_eq!(result.total_keys_checked, 5);
+        drop(engine);
+    }
+
+    #[test]
+    fn test_bounded_key_universe_generation() {
+        let universe = BoundedKeyUniverse::new("k", 3);
+        let keys = universe.keys();
+        assert_eq!(keys.len(), 3);
+        assert_eq!(keys[0], b"k_0000000000");
+        assert_eq!(keys[1], b"k_0000000001");
+        assert_eq!(keys[2], b"k_0000000002");
+    }
+}

--- a/kv-engine/src/chaos/oracle.rs
+++ b/kv-engine/src/chaos/oracle.rs
@@ -55,14 +55,11 @@ impl ReferenceState {
     /// Committed operations are applied to the reference map. Possibly-visible operations
     /// are tracked in `possibly_visible` so the oracle can distinguish "lost durable write"
     /// from "non-durable write that happened to survive."
-    pub fn from_control_log(
-        reader: &control_log::ControlLogReader,
-    ) -> Self {
+    pub fn from_control_log(reader: &control_log::ControlLogReader) -> Self {
         let (committed_ids, possibly_visible_ids) = reader.classify_visibility();
 
         // Collect committed records in op_id order for deterministic replay
-        let mut records_by_op: BTreeMap<u64, Vec<&control_log::ControlLogRecord>> =
-            BTreeMap::new();
+        let mut records_by_op: BTreeMap<u64, Vec<&control_log::ControlLogRecord>> = BTreeMap::new();
         for rec in reader.records() {
             if rec.checkpoint == Checkpoint::DurabilityBoundaryPassed {
                 records_by_op.entry(rec.op_id).or_default().push(rec);
@@ -73,7 +70,7 @@ impl ReferenceState {
         let mut possibly_visible: BTreeSet<Vec<u8>> = BTreeSet::new();
 
         // Apply committed operations
-        for (_op_id, records) in &records_by_op {
+        for records in records_by_op.values() {
             for rec in records {
                 apply_operation(&mut expected, &rec.kind);
             }
@@ -107,13 +104,13 @@ impl ReferenceState {
     }
 }
 
-fn apply_operation(
-    state: &mut HashMap<Vec<u8>, Option<Bytes>>,
-    kind: &OperationKind,
-) {
+fn apply_operation(state: &mut HashMap<Vec<u8>, Option<Bytes>>, kind: &OperationKind) {
     match kind {
         OperationKind::Put { key, value } => {
-            state.insert(key.as_bytes().to_vec(), Some(Bytes::copy_from_slice(value.as_bytes())));
+            state.insert(
+                key.as_bytes().to_vec(),
+                Some(Bytes::copy_from_slice(value.as_bytes())),
+            );
         }
         OperationKind::Delete { key } => {
             state.insert(key.as_bytes().to_vec(), None);
@@ -138,7 +135,10 @@ fn apply_operation(
                 match entry.kind {
                     control_log::BatchOpKind::Put => {
                         let val = entry.value.as_deref().unwrap_or("");
-                        state.insert(entry.key.as_bytes().to_vec(), Some(Bytes::copy_from_slice(val.as_bytes())));
+                        state.insert(
+                            entry.key.as_bytes().to_vec(),
+                            Some(Bytes::copy_from_slice(val.as_bytes())),
+                        );
                     }
                     control_log::BatchOpKind::Delete => {
                         state.insert(entry.key.as_bytes().to_vec(), None);
@@ -169,17 +169,10 @@ pub struct Violation {
 
 #[derive(Debug)]
 pub enum ViolationKind {
-    LostDurableWrite {
-        expected_value: Bytes,
-    },
+    LostDurableWrite { expected_value: Bytes },
     ResurrectedDelete,
-    WrongValue {
-        expected: Bytes,
-        actual: Bytes,
-    },
-    UnexpectedKey {
-        actual_value: Bytes,
-    },
+    WrongValue { expected: Bytes, actual: Bytes },
+    UnexpectedKey { actual_value: Bytes },
 }
 
 /// Reconcile the post-crash database state against the reference.
@@ -201,7 +194,7 @@ pub fn reconcile(
 
         match (expected, actual) {
             (Some(Some(expected_val)), Some(actual_val)) => {
-                if &*expected_val != &*actual_val {
+                if expected_val != &*actual_val {
                     result.violations.push(Violation {
                         key: key_bytes.clone(),
                         kind: ViolationKind::WrongValue {
@@ -268,14 +261,17 @@ pub fn structural_checks(
     options: &LsmStorageOptions,
 ) -> Result<(), String> {
     // 1. Close the current instance
-    engine.close().map_err(|e| format!("close after reopen failed: {e}"))?;
+    engine
+        .close()
+        .map_err(|e| format!("close after reopen failed: {e}"))?;
 
     // 2. Reopen - second open
     let re2 = KvEngine::open(db_path, options.clone())
         .map_err(|e| format!("second reopen failed: {e}"))?;
 
     // 3. Close again
-    re2.close().map_err(|e| format!("close after second reopen failed: {e}"))?;
+    re2.close()
+        .map_err(|e| format!("close after second reopen failed: {e}"))?;
 
     // 4. Final reopen + follow-up write
     let re3 = KvEngine::open(db_path, options.clone())
@@ -301,7 +297,8 @@ pub fn structural_checks(
         }
     }
 
-    re3.close().map_err(|e| format!("close after third reopen failed: {e}"))?;
+    re3.close()
+        .map_err(|e| format!("close after third reopen failed: {e}"))?;
 
     Ok(())
 }
@@ -329,10 +326,13 @@ mod tests {
         let mut writer = ControlLogWriter::new(&path).unwrap();
         let op1 = writer.next_op_id();
         writer
-            .write_intent(op1, OperationKind::Put {
-                key: "hello".into(),
-                value: "hello".into(),
-            })
+            .write_intent(
+                op1,
+                OperationKind::Put {
+                    key: "hello".into(),
+                    value: "hello".into(),
+                },
+            )
             .unwrap();
         writer
             .write_durability_boundary(
@@ -358,10 +358,13 @@ mod tests {
         let mut writer = ControlLogWriter::new(&path).unwrap();
         let op1 = writer.next_op_id();
         writer
-            .write_intent(op1, OperationKind::Put {
-                key: "partial_key".into(),
-                value: "partial_val".into(),
-            })
+            .write_intent(
+                op1,
+                OperationKind::Put {
+                    key: "partial_key".into(),
+                    value: "partial_val".into(),
+                },
+            )
             .unwrap();
         drop(writer);
 

--- a/kv-engine/src/chaos/oracle.rs
+++ b/kv-engine/src/chaos/oracle.rs
@@ -76,9 +76,11 @@ impl ReferenceState {
             }
         }
 
-        // Track possibly-visible keys
+        // Track possibly-visible keys — only for uncommitted (intent-only) op_ids
+        let committed_set: std::collections::BTreeSet<u64> =
+            committed_ids.iter().copied().collect();
         for rec in reader.records() {
-            if rec.checkpoint == Checkpoint::IntentStarted {
+            if rec.checkpoint == Checkpoint::IntentStarted && !committed_set.contains(&rec.op_id) {
                 match &rec.kind {
                     OperationKind::Put { key, .. }
                     | OperationKind::Delete { key }
@@ -194,7 +196,7 @@ pub fn reconcile(
 
         match (expected, actual) {
             (Some(Some(expected_val)), Some(actual_val)) => {
-                if expected_val != &*actual_val {
+                if expected_val != &*actual_val && !reference.possibly_visible.contains(key_bytes) {
                     result.violations.push(Violation {
                         key: key_bytes.clone(),
                         kind: ViolationKind::WrongValue {
@@ -206,12 +208,14 @@ pub fn reconcile(
             }
             (Some(Some(expected_val)), None) => {
                 // Key should have a value but was not found - lost durable write
-                result.violations.push(Violation {
-                    key: key_bytes.clone(),
-                    kind: ViolationKind::LostDurableWrite {
-                        expected_value: expected_val.clone(),
-                    },
-                });
+                if !reference.possibly_visible.contains(key_bytes) {
+                    result.violations.push(Violation {
+                        key: key_bytes.clone(),
+                        kind: ViolationKind::LostDurableWrite {
+                            expected_value: expected_val.clone(),
+                        },
+                    });
+                }
             }
             (Some(None), Some(_actual_val)) => {
                 // Key should be deleted but has a value

--- a/kv-engine/src/chaos/scenarios.rs
+++ b/kv-engine/src/chaos/scenarios.rs
@@ -255,3 +255,99 @@ pub fn manifest_snapshot_churn(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chaos::control_log::ControlLogReader;
+
+    #[test]
+    fn test_scenario_config_wal_only() {
+        let cfg = ScenarioConfig::wal_only();
+        assert!(cfg.storage_options.enable_wal);
+        assert_eq!(cfg.num_keys, 200);
+        assert_eq!(cfg.name, "wal-only");
+    }
+
+    #[test]
+    fn test_scenario_config_flush_boundary() {
+        let cfg = ScenarioConfig::flush_boundary();
+        assert!(cfg.storage_options.enable_wal);
+        assert_eq!(cfg.num_keys, 100);
+        assert_eq!(cfg.name, "flush-boundary");
+    }
+
+    #[test]
+    fn test_scenario_config_manifest_snapshot() {
+        let cfg = ScenarioConfig::manifest_snapshot();
+        assert!(cfg.storage_options.enable_wal);
+        assert_eq!(cfg.storage_options.manifest_snapshot_threshold_bytes, 1024);
+        assert_eq!(cfg.name, "manifest-snapshot");
+    }
+
+    #[test]
+    fn test_wal_only_scenario_control_log() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("db");
+        let log_path = dir.path().join("control.log");
+        let cfg = ScenarioConfig::wal_only();
+        let engine =
+            crate::lsm_storage::KvEngine::open(&db_path, cfg.storage_options.clone()).unwrap();
+        let mut log = ControlLogWriter::new(&log_path).unwrap();
+        wal_only_restart(&engine, &mut log, &cfg, 42).unwrap();
+        engine.close().unwrap();
+        let reader = ControlLogReader::open(&log_path).unwrap();
+        let (committed, _) = reader.classify_visibility();
+        // 150 puts + 20 deletes + 1 sync point = 171 committed ops
+        assert_eq!(
+            committed.len(),
+            171,
+            "expected 171 committed ops, got {}",
+            committed.len()
+        );
+    }
+
+    #[test]
+    fn test_flush_boundary_scenario_control_log() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("db");
+        let log_path = dir.path().join("control.log");
+        let cfg = ScenarioConfig::flush_boundary();
+        let engine =
+            crate::lsm_storage::KvEngine::open(&db_path, cfg.storage_options.clone()).unwrap();
+        let mut log = ControlLogWriter::new(&log_path).unwrap();
+        flush_boundary(&engine, &mut log, &cfg, 42).unwrap();
+        engine.close().unwrap();
+        let reader = ControlLogReader::open(&log_path).unwrap();
+        let (committed, _) = reader.classify_visibility();
+        // 80 puts + 1 sync point = 81 committed ops
+        assert_eq!(
+            committed.len(),
+            81,
+            "expected 81 committed ops, got {}",
+            committed.len()
+        );
+    }
+
+    #[test]
+    fn test_manifest_snapshot_scenario_control_log() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("db");
+        let log_path = dir.path().join("control.log");
+        let cfg = ScenarioConfig::manifest_snapshot();
+        let engine =
+            crate::lsm_storage::KvEngine::open(&db_path, cfg.storage_options.clone()).unwrap();
+        let mut log = ControlLogWriter::new(&log_path).unwrap();
+        manifest_snapshot_churn(&engine, &mut log, &cfg, 42).unwrap();
+        engine.close().unwrap();
+        let reader = ControlLogReader::open(&log_path).unwrap();
+        let (committed, _) = reader.classify_visibility();
+        // 100 puts + 1 sync point = 101 committed ops
+        assert_eq!(
+            committed.len(),
+            101,
+            "expected 101 committed ops, got {}",
+            committed.len()
+        );
+    }
+}

--- a/kv-engine/src/chaos/scenarios.rs
+++ b/kv-engine/src/chaos/scenarios.rs
@@ -44,7 +44,7 @@ impl ScenarioConfig {
     pub fn manifest_snapshot() -> Self {
         let mut opts = LsmStorageOptions::default_for_test();
         opts.enable_wal = true;
-        opts.manifest_snapshot_threshold_bytes = 1024;
+        opts.manifest_snapshot_threshold_bytes = 256;
         Self {
             name: "manifest-snapshot",
             num_keys: 100,
@@ -127,6 +127,12 @@ pub fn wal_only_restart(
         log.write_durability_boundary(op_id, OperationKind::Delete { key: key.clone() })
             .map_err(|e| format!("write_durability_boundary failed: {e}"))?;
     }
+
+    // Drive a real flush boundary before the crash point so recovery validates
+    // flushed SST state instead of only WAL replay.
+    engine
+        .force_flush()
+        .map_err(|e| format!("force_flush failed: {e}"))?;
 
     // Sync point — parent will kill here
     log.write_sync_point()
@@ -247,6 +253,13 @@ pub fn manifest_snapshot_churn(
             },
         )
         .map_err(|e| format!("write_durability_boundary failed: {e}"))?;
+
+        if i % 10 == 9 {
+            // Flush periodically so the manifest grows and crosses the snapshot threshold.
+            engine
+                .force_flush()
+                .map_err(|e| format!("force_flush failed: {e}"))?;
+        }
     }
 
     // Sync point
@@ -281,7 +294,7 @@ mod tests {
     fn test_scenario_config_manifest_snapshot() {
         let cfg = ScenarioConfig::manifest_snapshot();
         assert!(cfg.storage_options.enable_wal);
-        assert_eq!(cfg.storage_options.manifest_snapshot_threshold_bytes, 1024);
+        assert_eq!(cfg.storage_options.manifest_snapshot_threshold_bytes, 256);
         assert_eq!(cfg.name, "manifest-snapshot");
     }
 

--- a/kv-engine/src/chaos/scenarios.rs
+++ b/kv-engine/src/chaos/scenarios.rs
@@ -145,7 +145,7 @@ pub fn flush_boundary(
     _seed: u64,
 ) -> Result<(), String> {
     let large_value = vec![b'x'; 2000];
-    let large_value_str = String::from_utf8_lossy(&large_value).to_string();
+    let large_value_str = "x".repeat(2000);
 
     // Phase 1: Write 50 small keys
     for i in 0..50 {
@@ -153,7 +153,7 @@ pub fn flush_boundary(
         let value = if i % 2 == 0 {
             format!("v_{i}")
         } else {
-            String::from_utf8_lossy(&[b'y'; 1000]).to_string()
+            "y".repeat(1000)
         };
         let op_id = log.next_op_id();
         log.write_intent(
@@ -225,7 +225,7 @@ pub fn manifest_snapshot_churn(
         let value = if i % 2 == 0 {
             format!("v_{i}")
         } else {
-            String::from_utf8_lossy(&[b'y'; 1000]).to_string()
+            "y".repeat(1000)
         };
         let op_id = log.next_op_id();
         log.write_intent(

--- a/kv-engine/src/chaos/scenarios.rs
+++ b/kv-engine/src/chaos/scenarios.rs
@@ -45,8 +45,6 @@ impl ScenarioConfig {
         let mut opts = LsmStorageOptions::default_for_test();
         opts.enable_wal = true;
         opts.manifest_snapshot_threshold_bytes = 1024;
-        opts.target_sst_size = 4096;
-        opts.num_memtable_limit = 2;
         Self {
             name: "manifest-snapshot",
             num_keys: 100,
@@ -152,7 +150,11 @@ pub fn flush_boundary(
     // Phase 1: Write 50 small keys
     for i in 0..50 {
         let key = format!("{}_{:010}", config.key_prefix, i);
-        let value = format!("v_{i}");
+        let value = if i % 2 == 0 {
+            format!("v_{i}")
+        } else {
+            String::from_utf8_lossy(&[b'y'; 1000]).to_string()
+        };
         let op_id = log.next_op_id();
         log.write_intent(
             op_id,
@@ -220,7 +222,11 @@ pub fn manifest_snapshot_churn(
     // Write all 100 keys sequentially
     for i in 0..config.num_keys {
         let key = format!("{}_{:010}", config.key_prefix, i);
-        let value = format!("v_{i}");
+        let value = if i % 2 == 0 {
+            format!("v_{i}")
+        } else {
+            String::from_utf8_lossy(&[b'y'; 1000]).to_string()
+        };
         let op_id = log.next_op_id();
         log.write_intent(
             op_id,

--- a/kv-engine/src/chaos/scenarios.rs
+++ b/kv-engine/src/chaos/scenarios.rs
@@ -1,0 +1,219 @@
+//! Deterministic crash-test scenarios (RFC 013 Phase 1).
+//!
+//! Each scenario function executes a scripted workload against the engine while
+//! recording operation intents and durability boundaries to the control log.
+//! The parent harness kills the child process and uses the control log to validate
+//! post-crash state.
+
+use crate::chaos::control_log::{ControlLogWriter, OperationKind};
+use crate::lsm_storage::{KvEngine, LsmStorageOptions};
+
+/// Options for a scenario.
+pub struct ScenarioConfig {
+    pub name: &'static str,
+    pub num_keys: usize,
+    pub key_prefix: &'static str,
+    pub storage_options: LsmStorageOptions,
+}
+
+impl ScenarioConfig {
+    pub fn wal_only() -> Self {
+        let mut opts = LsmStorageOptions::default_for_test();
+        opts.enable_wal = true;
+        opts.manifest_snapshot_threshold_bytes = 0;
+        Self {
+            name: "wal-only",
+            num_keys: 200,
+            key_prefix: "k",
+            storage_options: opts,
+        }
+    }
+
+    pub fn flush_boundary() -> Self {
+        let mut opts = LsmStorageOptions::default_for_test();
+        opts.enable_wal = true;
+        opts.manifest_snapshot_threshold_bytes = 0;
+        Self {
+            name: "flush-boundary",
+            num_keys: 100,
+            key_prefix: "k",
+            storage_options: opts,
+        }
+    }
+
+    pub fn manifest_snapshot() -> Self {
+        let mut opts = LsmStorageOptions::default_for_test();
+        opts.enable_wal = true;
+        opts.manifest_snapshot_threshold_bytes = 1024;
+        Self {
+            name: "manifest-snapshot",
+            num_keys: 100,
+            key_prefix: "k",
+            storage_options: opts,
+        }
+    }
+}
+
+/// Run the WAL-only restart scenario.
+///
+/// 1. Write 100 keys (op_id 1-100)
+/// 2. Write 50 more keys (101-150) + delete 20 keys (151-170)
+/// 3. Write sync point marker
+pub fn wal_only_restart(
+    engine: &KvEngine,
+    log: &mut ControlLogWriter,
+    config: &ScenarioConfig,
+    _seed: u64,
+) -> Result<(), String> {
+    // Phase 1: Write 100 keys
+    for i in 0..100 {
+        let key = format!("{}_{:010}", config.key_prefix, i);
+        let value = format!("v_{}", i);
+        let op_id = log.next_op_id();
+        log.write_intent(op_id, OperationKind::Put {
+            key: key.clone(),
+            value: value.clone(),
+        })
+        .map_err(|e| format!("write_intent failed: {e}"))?;
+        engine
+            .put(key.as_bytes(), value.as_bytes())
+            .map_err(|e| format!("put failed: {e}"))?;
+        log.write_durability_boundary(op_id, OperationKind::Put {
+            key: key.clone(),
+            value,
+        })
+        .map_err(|e| format!("write_durability_boundary failed: {e}"))?;
+    }
+
+    // Phase 2: Write 50 more + delete 20
+    for i in 100..150 {
+        let key = format!("{}_{:010}", config.key_prefix, i);
+        let value = format!("v_{}", i);
+        let op_id = log.next_op_id();
+        log.write_intent(op_id, OperationKind::Put {
+            key: key.clone(),
+            value: value.clone(),
+        })
+        .map_err(|e| format!("write_intent failed: {e}"))?;
+        engine
+            .put(key.as_bytes(), value.as_bytes())
+            .map_err(|e| format!("put failed: {e}"))?;
+        log.write_durability_boundary(op_id, OperationKind::Put {
+            key: key.clone(),
+            value,
+        })
+        .map_err(|e| format!("write_durability_boundary failed: {e}"))?;
+    }
+    for i in 0..20 {
+        let key = format!("{}_{:010}", config.key_prefix, i);
+        let op_id = log.next_op_id();
+        log.write_intent(op_id, OperationKind::Delete { key: key.clone() })
+            .map_err(|e| format!("write_intent failed: {e}"))?;
+        engine
+            .delete(key.as_bytes())
+            .map_err(|e| format!("delete failed: {e}"))?;
+        log.write_durability_boundary(op_id, OperationKind::Delete { key: key.clone() })
+            .map_err(|e| format!("write_durability_boundary failed: {e}"))?;
+    }
+
+    // Sync point — parent will kill here
+    log.write_sync_point()
+        .map_err(|e| format!("write_sync_point failed: {e}"))?;
+
+    Ok(())
+}
+
+/// Run the flush boundary scenario (WAL-heavy recovery, mixed value sizes).
+///
+/// Mixes small and large values — all WAL-backed, no explicit flushes.
+pub fn flush_boundary(
+    engine: &KvEngine,
+    log: &mut ControlLogWriter,
+    config: &ScenarioConfig,
+    _seed: u64,
+) -> Result<(), String> {
+    let large_value = vec![b'x'; 2000];
+    let large_value_str = String::from_utf8_lossy(&large_value).to_string();
+
+    // Phase 1: Write 50 small keys
+    for i in 0..50 {
+        let key = format!("{}_{:010}", config.key_prefix, i);
+        let value = format!("v_{i}");
+        let op_id = log.next_op_id();
+        log.write_intent(op_id, OperationKind::Put {
+            key: key.clone(),
+            value: value.clone(),
+        })
+        .map_err(|e| format!("write_intent failed: {e}"))?;
+        engine
+            .put(key.as_bytes(), value.as_bytes())
+            .map_err(|e| format!("put failed: {e}"))?;
+        log.write_durability_boundary(op_id, OperationKind::Put {
+            key: key.clone(),
+            value,
+        })
+        .map_err(|e| format!("write_durability_boundary failed: {e}"))?;
+    }
+
+    // Phase 2: Write 30 keys with large values
+    for i in 50..80 {
+        let key = format!("{}_{:010}", config.key_prefix, i);
+        let op_id = log.next_op_id();
+        log.write_intent(op_id, OperationKind::Put {
+            key: key.clone(),
+            value: large_value_str.clone(),
+        })
+        .map_err(|e| format!("write_intent failed: {e}"))?;
+        engine
+            .put(key.as_bytes(), &large_value)
+            .map_err(|e| format!("put failed: {e}"))?;
+        log.write_durability_boundary(op_id, OperationKind::Put {
+            key: key.clone(),
+            value: large_value_str.clone(),
+        })
+        .map_err(|e| format!("write_durability_boundary failed: {e}"))?;
+    }
+
+    // Sync point
+    log.write_sync_point()
+        .map_err(|e| format!("write_sync_point failed: {e}"))?;
+
+    Ok(())
+}
+
+/// Run the manifest snapshot churn scenario.
+///
+/// Writes 100 keys sequentially with manifest snapshot threshold of 1024 bytes
+/// to exercise the crash-safe snapshot handoff. No explicit flushes.
+pub fn manifest_snapshot_churn(
+    engine: &KvEngine,
+    log: &mut ControlLogWriter,
+    config: &ScenarioConfig,
+    _seed: u64,
+) -> Result<(), String> {
+    // Write all 100 keys sequentially
+    for i in 0..config.num_keys {
+        let key = format!("{}_{:010}", config.key_prefix, i);
+        let value = format!("v_{i}");
+        let op_id = log.next_op_id();
+        log.write_intent(op_id, OperationKind::Put {
+            key: key.clone(),
+            value: value.clone(),
+        })
+        .map_err(|e| format!("write_intent failed: {e}"))?;
+        engine
+            .put(key.as_bytes(), value.as_bytes())
+            .map_err(|e| format!("put failed: {e}"))?;
+        log.write_durability_boundary(op_id, OperationKind::Put {
+            key: key.clone(),
+            value,
+        })
+        .map_err(|e| format!("write_durability_boundary failed: {e}"))?;
+    }
+
+    // Sync point
+    log.write_sync_point()
+        .map_err(|e| format!("write_sync_point failed: {e}"))?;
+
+    Ok(())
+}

--- a/kv-engine/src/chaos/scenarios.rs
+++ b/kv-engine/src/chaos/scenarios.rs
@@ -45,6 +45,8 @@ impl ScenarioConfig {
         let mut opts = LsmStorageOptions::default_for_test();
         opts.enable_wal = true;
         opts.manifest_snapshot_threshold_bytes = 1024;
+        opts.target_sst_size = 4096;
+        opts.num_memtable_limit = 2;
         Self {
             name: "manifest-snapshot",
             num_keys: 100,

--- a/kv-engine/src/chaos/scenarios.rs
+++ b/kv-engine/src/chaos/scenarios.rs
@@ -70,18 +70,24 @@ pub fn wal_only_restart(
         let key = format!("{}_{:010}", config.key_prefix, i);
         let value = format!("v_{}", i);
         let op_id = log.next_op_id();
-        log.write_intent(op_id, OperationKind::Put {
-            key: key.clone(),
-            value: value.clone(),
-        })
+        log.write_intent(
+            op_id,
+            OperationKind::Put {
+                key: key.clone(),
+                value: value.clone(),
+            },
+        )
         .map_err(|e| format!("write_intent failed: {e}"))?;
         engine
             .put(key.as_bytes(), value.as_bytes())
             .map_err(|e| format!("put failed: {e}"))?;
-        log.write_durability_boundary(op_id, OperationKind::Put {
-            key: key.clone(),
-            value,
-        })
+        log.write_durability_boundary(
+            op_id,
+            OperationKind::Put {
+                key: key.clone(),
+                value,
+            },
+        )
         .map_err(|e| format!("write_durability_boundary failed: {e}"))?;
     }
 
@@ -90,18 +96,24 @@ pub fn wal_only_restart(
         let key = format!("{}_{:010}", config.key_prefix, i);
         let value = format!("v_{}", i);
         let op_id = log.next_op_id();
-        log.write_intent(op_id, OperationKind::Put {
-            key: key.clone(),
-            value: value.clone(),
-        })
+        log.write_intent(
+            op_id,
+            OperationKind::Put {
+                key: key.clone(),
+                value: value.clone(),
+            },
+        )
         .map_err(|e| format!("write_intent failed: {e}"))?;
         engine
             .put(key.as_bytes(), value.as_bytes())
             .map_err(|e| format!("put failed: {e}"))?;
-        log.write_durability_boundary(op_id, OperationKind::Put {
-            key: key.clone(),
-            value,
-        })
+        log.write_durability_boundary(
+            op_id,
+            OperationKind::Put {
+                key: key.clone(),
+                value,
+            },
+        )
         .map_err(|e| format!("write_durability_boundary failed: {e}"))?;
     }
     for i in 0..20 {
@@ -140,18 +152,24 @@ pub fn flush_boundary(
         let key = format!("{}_{:010}", config.key_prefix, i);
         let value = format!("v_{i}");
         let op_id = log.next_op_id();
-        log.write_intent(op_id, OperationKind::Put {
-            key: key.clone(),
-            value: value.clone(),
-        })
+        log.write_intent(
+            op_id,
+            OperationKind::Put {
+                key: key.clone(),
+                value: value.clone(),
+            },
+        )
         .map_err(|e| format!("write_intent failed: {e}"))?;
         engine
             .put(key.as_bytes(), value.as_bytes())
             .map_err(|e| format!("put failed: {e}"))?;
-        log.write_durability_boundary(op_id, OperationKind::Put {
-            key: key.clone(),
-            value,
-        })
+        log.write_durability_boundary(
+            op_id,
+            OperationKind::Put {
+                key: key.clone(),
+                value,
+            },
+        )
         .map_err(|e| format!("write_durability_boundary failed: {e}"))?;
     }
 
@@ -159,18 +177,24 @@ pub fn flush_boundary(
     for i in 50..80 {
         let key = format!("{}_{:010}", config.key_prefix, i);
         let op_id = log.next_op_id();
-        log.write_intent(op_id, OperationKind::Put {
-            key: key.clone(),
-            value: large_value_str.clone(),
-        })
+        log.write_intent(
+            op_id,
+            OperationKind::Put {
+                key: key.clone(),
+                value: large_value_str.clone(),
+            },
+        )
         .map_err(|e| format!("write_intent failed: {e}"))?;
         engine
             .put(key.as_bytes(), &large_value)
             .map_err(|e| format!("put failed: {e}"))?;
-        log.write_durability_boundary(op_id, OperationKind::Put {
-            key: key.clone(),
-            value: large_value_str.clone(),
-        })
+        log.write_durability_boundary(
+            op_id,
+            OperationKind::Put {
+                key: key.clone(),
+                value: large_value_str.clone(),
+            },
+        )
         .map_err(|e| format!("write_durability_boundary failed: {e}"))?;
     }
 
@@ -196,18 +220,24 @@ pub fn manifest_snapshot_churn(
         let key = format!("{}_{:010}", config.key_prefix, i);
         let value = format!("v_{i}");
         let op_id = log.next_op_id();
-        log.write_intent(op_id, OperationKind::Put {
-            key: key.clone(),
-            value: value.clone(),
-        })
+        log.write_intent(
+            op_id,
+            OperationKind::Put {
+                key: key.clone(),
+                value: value.clone(),
+            },
+        )
         .map_err(|e| format!("write_intent failed: {e}"))?;
         engine
             .put(key.as_bytes(), value.as_bytes())
             .map_err(|e| format!("put failed: {e}"))?;
-        log.write_durability_boundary(op_id, OperationKind::Put {
-            key: key.clone(),
-            value,
-        })
+        log.write_durability_boundary(
+            op_id,
+            OperationKind::Put {
+                key: key.clone(),
+                value,
+            },
+        )
         .map_err(|e| format!("write_durability_boundary failed: {e}"))?;
     }
 

--- a/kv-engine/src/chaos/scenarios.rs
+++ b/kv-engine/src/chaos/scenarios.rs
@@ -23,7 +23,7 @@ impl ScenarioConfig {
         opts.manifest_snapshot_threshold_bytes = 0;
         Self {
             name: "wal-only",
-            num_keys: 200,
+            num_keys: 150,
             key_prefix: "k",
             storage_options: opts,
         }
@@ -35,7 +35,7 @@ impl ScenarioConfig {
         opts.manifest_snapshot_threshold_bytes = 0;
         Self {
             name: "flush-boundary",
-            num_keys: 100,
+            num_keys: 80,
             key_prefix: "k",
             storage_options: opts,
         }
@@ -205,6 +205,12 @@ pub fn flush_boundary(
         .map_err(|e| format!("write_durability_boundary failed: {e}"))?;
     }
 
+    // Force a flush so at least one SST is created, exercising
+    // the crash-recovery path through flushed (not just WAL) data.
+    engine
+        .force_flush()
+        .map_err(|e| format!("force_flush failed: {e}"))?;
+
     // Sync point
     log.write_sync_point()
         .map_err(|e| format!("write_sync_point failed: {e}"))?;
@@ -275,7 +281,7 @@ mod tests {
     fn test_scenario_config_wal_only() {
         let cfg = ScenarioConfig::wal_only();
         assert!(cfg.storage_options.enable_wal);
-        assert_eq!(cfg.num_keys, 200);
+        assert_eq!(cfg.num_keys, 150);
         assert_eq!(cfg.name, "wal-only");
     }
 
@@ -283,7 +289,7 @@ mod tests {
     fn test_scenario_config_flush_boundary() {
         let cfg = ScenarioConfig::flush_boundary();
         assert!(cfg.storage_options.enable_wal);
-        assert_eq!(cfg.num_keys, 100);
+        assert_eq!(cfg.num_keys, 80);
         assert_eq!(cfg.name, "flush-boundary");
     }
 

--- a/kv-engine/src/chaos/scenarios.rs
+++ b/kv-engine/src/chaos/scenarios.rs
@@ -59,6 +59,9 @@ impl ScenarioConfig {
 /// 1. Write 100 keys (op_id 1-100)
 /// 2. Write 50 more keys (101-150) + delete 20 keys (151-170)
 /// 3. Write sync point marker
+///
+/// Intentionally avoids `force_flush()` so this scenario isolates pure WAL
+/// recovery instead of exercising flushed-SST crash behavior.
 pub fn wal_only_restart(
     engine: &KvEngine,
     log: &mut ControlLogWriter,
@@ -127,12 +130,6 @@ pub fn wal_only_restart(
         log.write_durability_boundary(op_id, OperationKind::Delete { key: key.clone() })
             .map_err(|e| format!("write_durability_boundary failed: {e}"))?;
     }
-
-    // Drive a real flush boundary before the crash point so recovery validates
-    // flushed SST state instead of only WAL replay.
-    engine
-        .force_flush()
-        .map_err(|e| format!("force_flush failed: {e}"))?;
 
     // Sync point — parent will kill here
     log.write_sync_point()

--- a/kv-engine/src/lib.rs
+++ b/kv-engine/src/lib.rs
@@ -14,6 +14,9 @@ pub mod table;
 pub mod vlog;
 pub mod wal;
 
+#[cfg(feature = "chaos-testing")]
+pub mod chaos;
+
 /// Initialize structured logging via logforth.
 ///
 /// Reads `RUST_LOG` for level filtering (defaults to `info`).

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -4196,20 +4196,11 @@ impl LsmStorageInner {
                 state.imm_memtables.pop();
                 self.state.store(Arc::new(state));
             }
-            // Write a Flush record so recovery knows this memtable was handled.
-            // Without this, the NewMemtable record written at freeze time would
-            // cause recovery to try to recover from the WAL we're about to delete.
-            self.manifest
-                .as_ref()
-                .expect("manifest initialized")
-                .add_record(&state_lock, ManifestRecord::Flush(sst_id))?;
-            self.maybe_snapshot_manifest(&state_lock)?;
-            // Clean up the WAL for this empty immutable to prevent orphaned
-            // .wal files and manifest recovery failures on restart.
-            if self.options.enable_wal {
-                let wal_path = self.path_of_wal(sst_id);
-                let _ = std::fs::remove_file(&wal_path);
-            }
+            // Keep the WAL file (do NOT delete it). When WAL is enabled,
+            // recovery will replay it and find nothing; when WAL is disabled,
+            // recovery is skipped entirely. Deleting the WAL without a
+            // corresponding Flush manifest record would cause recovery to
+            // fail with NotFound if WAL is enabled.
             drop(memtable_to_flush);
             return Ok(());
         }

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -4190,6 +4190,23 @@ impl LsmStorageInner {
         };
 
         let sst_id = memtable_to_flush.id();
+        if memtable_to_flush.is_empty() {
+            {
+                let mut state = self.state.load().as_ref().clone();
+                state.imm_memtables.pop();
+                self.state.store(Arc::new(state));
+            }
+            drop(memtable_to_flush);
+            if self.options.enable_wal {
+                let wal_path = self.path_of_wal(sst_id);
+                if let Err(e) = std::fs::remove_file(&wal_path)
+                    && e.kind() != std::io::ErrorKind::NotFound
+                {
+                    log::warn!("failed to remove empty WAL {}: {}", wal_path.display(), e);
+                }
+            }
+            return Ok(());
+        }
 
         // Build SST with optional vLog support
         let (sst, vlog_ids) = if let Some(ref vlog) = self.vlog {

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -4196,15 +4196,13 @@ impl LsmStorageInner {
                 state.imm_memtables.pop();
                 self.state.store(Arc::new(state));
             }
-            // Drop the memtable before removing the WAL file so that
-            // any open file handle is closed first (required on Windows).
-            drop(memtable_to_flush);
             // Clean up the WAL for this empty immutable to prevent orphaned
             // .wal files and manifest recovery failures on restart.
             if self.options.enable_wal {
                 let wal_path = self.path_of_wal(sst_id);
                 let _ = std::fs::remove_file(&wal_path);
             }
+            drop(memtable_to_flush);
             return Ok(());
         }
 

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -4196,13 +4196,15 @@ impl LsmStorageInner {
                 state.imm_memtables.pop();
                 self.state.store(Arc::new(state));
             }
+            // Drop the memtable before removing the WAL file so that
+            // any open file handle is closed first (required on Windows).
+            drop(memtable_to_flush);
             // Clean up the WAL for this empty immutable to prevent orphaned
             // .wal files and manifest recovery failures on restart.
             if self.options.enable_wal {
                 let wal_path = self.path_of_wal(sst_id);
                 let _ = std::fs::remove_file(&wal_path);
             }
-            drop(memtable_to_flush);
             return Ok(());
         }
 

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -4196,6 +4196,14 @@ impl LsmStorageInner {
                 state.imm_memtables.pop();
                 self.state.store(Arc::new(state));
             }
+            // Write a Flush record so recovery knows this memtable was handled.
+            // Without this, the NewMemtable record written at freeze time would
+            // cause recovery to try to recover from the WAL we're about to delete.
+            self.manifest
+                .as_ref()
+                .expect("manifest initialized")
+                .add_record(&state_lock, ManifestRecord::Flush(sst_id))?;
+            self.maybe_snapshot_manifest(&state_lock)?;
             // Clean up the WAL for this empty immutable to prevent orphaned
             // .wal files and manifest recovery failures on restart.
             if self.options.enable_wal {

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -4196,6 +4196,12 @@ impl LsmStorageInner {
                 state.imm_memtables.pop();
                 self.state.store(Arc::new(state));
             }
+            // Clean up the WAL for this empty immutable to prevent orphaned
+            // .wal files and manifest recovery failures on restart.
+            if self.options.enable_wal {
+                let wal_path = self.path_of_wal(sst_id);
+                let _ = std::fs::remove_file(&wal_path);
+            }
             drop(memtable_to_flush);
             return Ok(());
         }

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -4197,14 +4197,6 @@ impl LsmStorageInner {
                 self.state.store(Arc::new(state));
             }
             drop(memtable_to_flush);
-            if self.options.enable_wal {
-                let wal_path = self.path_of_wal(sst_id);
-                if let Err(e) = std::fs::remove_file(&wal_path)
-                    && e.kind() != std::io::ErrorKind::NotFound
-                {
-                    log::warn!("failed to remove empty WAL {}: {}", wal_path.display(), e);
-                }
-            }
             return Ok(());
         }
 

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -11,7 +11,7 @@ pub use iterator::SsTableIterator;
 
 use self::bloom::Bloom;
 use crate::{
-    block::{Block, SIZE_OF_U16},
+    block::Block,
     key::{Key, KeyBytes, KeySlice, TS_ENABLED},
     lsm_storage::BlockCache,
 };
@@ -384,7 +384,7 @@ impl SsTable {
             Vec::new()
         } else {
             anyhow::ensure!(
-                meta_len >= SIZE_OF_U16 as u64,
+                meta_len >= SIZE_OF_U32 as u64,
                 "SST meta block too small: meta_offset={}, bloom_offset={}",
                 meta_offset,
                 bloom_offset

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -27,6 +27,12 @@ const SST_FOOTER_VERSION_V2: u8 = 2;
 const SST_FOOTER_VERSION_V3: u8 = 3;
 /// Footer version for SSTs with range-tombstone blocks.
 const SST_FOOTER_VERSION_V4: u8 = 4;
+/// Footer version for MVCC-format SSTs with stable persisted whole-key bloom hashing.
+const SST_FOOTER_VERSION_V5: u8 = 5;
+/// Footer version for SSTs with stable whole-key + prefix bloom hashing.
+const SST_FOOTER_VERSION_V6: u8 = 6;
+/// Footer version for SSTs with stable whole-key + prefix bloom hashing and range tombstones.
+const SST_FOOTER_VERSION_V7: u8 = 7;
 /// Size of the MVCC footer extension: max_ts (8) + magic (4) + version (1) = 13 bytes.
 const MVCC_FOOTER_EXTRA: u64 = (SIZE_OF_U64 + SIZE_OF_U32 + 1) as u64;
 
@@ -138,6 +144,17 @@ impl BlockMeta {
             })?;
         let mut datas = &data[0..offset];
 
+        // Guard against corrupt SST headers: each block meta entry is at
+        // minimum 8 bytes (two u16 key lengths + one u32 offset), so the
+        // entry count cannot exceed the payload divided by 8.
+        const MIN_ENTRY_SIZE: usize = 2 + 2 + SIZE_OF_U32; // SIZE_OF_U16 + SIZE_OF_U16 + SIZE_OF_U32
+        anyhow::ensure!(
+            num_of_elements <= offset / MIN_ENTRY_SIZE,
+            "SST block metadata count {} exceeds maximum possible entries for payload size {}",
+            num_of_elements,
+            offset
+        );
+
         let mut ret = vec![];
         for _ in 0..num_of_elements {
             anyhow::ensure!(
@@ -232,11 +249,14 @@ pub struct SsTable {
     /// Last point key. `None` for range-only SSTs.
     last_key: Option<KeyBytes>,
     pub(crate) bloom: Option<Bloom>,
+    /// Whether persisted whole-key/prefix bloom hashes are the stable
+    /// cross-process variant introduced in footer versions v5+.
+    stable_bloom_hash: bool,
     /// The maximum timestamp stored in this SST, implemented in MVCC.
     max_ts: u64,
-    /// Prefix bloom filters for prefix scan pruning. Present only in v3+ SSTs.
+    /// Prefix bloom filters for prefix scan pruning. Present in v3, v4, v6, and v7 SSTs.
     pub(crate) prefix_blooms: Option<PrefixBloomSet>,
-    /// Cached range-tombstone fragments. Present in v4 SSTs with range tombstones.
+    /// Cached range-tombstone fragments. Present in v4 and v7 SSTs with range tombstones.
     range_tombstones: Option<Arc<[crate::range_tombstone::RangeTombstoneFragment]>>,
     /// Last block index hint for sorted batch lookups. When consecutive
     /// sorted keys land in the same block, this avoids a full binary search.
@@ -257,17 +277,17 @@ impl SsTable {
             "SST file too small: {} bytes",
             file.size()
         );
-        // Read the tail region in a single I/O call.  v3 footer needs 21 bytes
+        // Read the tail region in a single I/O call. v3/v6 footers need 21 bytes
         // (bloom_offset:4 + prefix_bloom_offset:4 + max_ts:8 + magic:4 + version:1),
-        // v2 needs 17 bytes (bloom_offset:4 + max_ts:8 + magic:4 + version:1).
-        // Read 21 to cover both cases.
+        // v2/v5 need 17 bytes (bloom_offset:4 + max_ts:8 + magic:4 + version:1).
+        // Read 21 to cover both cases; v4/v7 (25 bytes) get a re-read below.
         let v3_tail_size = MVCC_FOOTER_EXTRA as usize + SIZE_OF_U32 + SIZE_OF_U32;
         let tail_start = file.size().saturating_sub(v3_tail_size as u64);
         let tail = file.read(tail_start, file.size() - tail_start)?;
 
         // Detect MVCC footer by checking magic AND version at their expected
-        // positions. Version can be 2 (no prefix bloom), 3 (with prefix bloom),
-        // or 4 (with range-tombstone block).
+        // positions. Versions 2-4 use the legacy persisted bloom hash;
+        // versions 5-7 use the stable cross-process persisted bloom hash.
         let version = tail[tail.len() - 1];
         let has_mvcc_magic = tail.len() >= (MVCC_FOOTER_EXTRA as usize + SIZE_OF_U32)
             && (&tail[tail.len() - 5..tail.len() - 1]).get_u32() == SST_MVCC_MAGIC;
@@ -275,25 +295,38 @@ impl SsTable {
             && version != SST_FOOTER_VERSION_V2
             && version != SST_FOOTER_VERSION_V3
             && version != SST_FOOTER_VERSION_V4
+            && version != SST_FOOTER_VERSION_V5
+            && version != SST_FOOTER_VERSION_V6
+            && version != SST_FOOTER_VERSION_V7
         {
             anyhow::bail!(
-                "unsupported MVCC footer version: {} (expected {}, {} or {})",
+                "unsupported MVCC footer version: {} (expected {}, {}, {}, {}, {} or {})",
                 version,
                 SST_FOOTER_VERSION_V2,
                 SST_FOOTER_VERSION_V3,
-                SST_FOOTER_VERSION_V4
+                SST_FOOTER_VERSION_V4,
+                SST_FOOTER_VERSION_V5,
+                SST_FOOTER_VERSION_V6,
+                SST_FOOTER_VERSION_V7
             );
         }
         let is_mvcc = has_mvcc_magic
             && (version == SST_FOOTER_VERSION_V2
                 || version == SST_FOOTER_VERSION_V3
-                || version == SST_FOOTER_VERSION_V4);
+                || version == SST_FOOTER_VERSION_V4
+                || version == SST_FOOTER_VERSION_V5
+                || version == SST_FOOTER_VERSION_V6
+                || version == SST_FOOTER_VERSION_V7);
+        let stable_bloom_hash = matches!(
+            version,
+            SST_FOOTER_VERSION_V5 | SST_FOOTER_VERSION_V6 | SST_FOOTER_VERSION_V7
+        );
 
-        // v4 footer is 25 bytes: [bloom_offset:4][prefix_bloom_offset:4]
+        // v4/v7 footer is 25 bytes: [bloom_offset:4][prefix_bloom_offset:4]
         // [range_tombstone_offset:4][max_ts:8][magic:4][version:1].
-        // Need to re-read with a larger tail if v4 detected.
+        // Need to re-read with a larger tail if v4 or v7 detected.
         let (bloom_offset_base, mut max_ts, bloom_offset, prefix_bloom_set, v4_rt_off) = if is_mvcc
-            && version == SST_FOOTER_VERSION_V4
+            && matches!(version, SST_FOOTER_VERSION_V4 | SST_FOOTER_VERSION_V7)
         {
             let v4_tail_size = SIZE_OF_U32 + SIZE_OF_U32 + SIZE_OF_U32 + MVCC_FOOTER_EXTRA as usize;
             let v4_tail = file.read(
@@ -333,8 +366,8 @@ impl SsTable {
                 footer_start
             };
             (base, max_ts_val, bloom_off, prefix_set, Some(rt_off))
-        } else if is_mvcc && version == SST_FOOTER_VERSION_V3 {
-            // v3 file layout (from end of file):
+        } else if is_mvcc && matches!(version, SST_FOOTER_VERSION_V3 | SST_FOOTER_VERSION_V6) {
+            // v3/v6 file layout (from end of file):
             //   [version:1][magic:4][max_ts:8][prefix_bloom_offset:4]
             //   [prefix_bloom_section (variable size)]
             //   [bloom_offset:4]
@@ -503,6 +536,7 @@ impl SsTable {
             first_key,
             last_key,
             bloom: Some(bloom),
+            stable_bloom_hash,
             max_ts,
             prefix_blooms: prefix_bloom_set,
             range_tombstones,
@@ -548,10 +582,13 @@ impl SsTable {
         })?;
         let section = file.read(prefix_bloom_offset, section_size)?;
         let filter_count = (&section[0..2]).get_u16() as usize;
-        anyhow::ensure!(
-            filter_count > 0,
-            "SST v3 prefix bloom section has filter_count=0"
-        );
+        if filter_count == 0 {
+            // Empty prefix bloom section: no prefix-bloom pruning available.
+            // This is the normal representation for "no filters" and also
+            // tolerates legacy SSTs whose prefix bloom section may have been
+            // zeroed out after a hash-function migration.
+            return Ok(None);
+        }
         let table_len = 2 + filter_count * (2 + 4 + 4); // u16 + u32 + u32 per entry
         anyhow::ensure!(
             section_size_usize >= table_len,
@@ -658,6 +695,7 @@ impl SsTable {
             first_key: Some(first_key),
             last_key: Some(last_key),
             bloom: None,
+            stable_bloom_hash: false,
             max_ts: 0,
             prefix_blooms: None,
             range_tombstones: None,
@@ -837,10 +875,11 @@ impl SsTable {
             return false;
         }
 
-        // Whole-key bloom pruning is safe once the persisted hash function is
-        // stable across processes. The SST bloom is built from the decoded user
-        // key in MVCC mode, and the read path probes it with the same user-key hash.
-        if let Some(ref bloom) = self.bloom
+        // Legacy SSTs (v2-v4) used the old persisted bloom hash and must
+        // bypass bloom pruning after reopen. New SSTs (v5+) use the stable
+        // cross-process hash and can safely prune here.
+        if self.stable_bloom_hash
+            && let Some(ref bloom) = self.bloom
             && !bloom.may_contain(bloom_hash)
         {
             return false;
@@ -1079,6 +1118,9 @@ impl SsTable {
     /// prefix bloom disabled). Returns `false` only when the prefix bloom
     /// filter proves the SST cannot contain matching keys.
     pub(crate) fn may_contain_prefix(&self, prefix: &[u8]) -> bool {
+        if !self.stable_bloom_hash {
+            return true;
+        }
         let Some(ref prefix_blooms) = self.prefix_blooms else {
             return true;
         };

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -837,11 +837,10 @@ impl SsTable {
             return false;
         }
 
-        // Whole-key bloom pruning: safe for non-MVCC (user keys match directly).
-        // In MVCC mode the lookup key uses a sentinel timestamp that differs from
-        // stored version timestamps, so skip bloom pruning to avoid false negatives.
-        if !TS_ENABLED
-            && let Some(ref bloom) = self.bloom
+        // Whole-key bloom pruning is safe once the persisted hash function is
+        // stable across processes. The SST bloom is built from the decoded user
+        // key in MVCC mode, and the read path probes it with the same user-key hash.
+        if let Some(ref bloom) = self.bloom
             && !bloom.may_contain(bloom_hash)
         {
             return false;

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -791,12 +791,9 @@ impl SsTable {
             return false;
         }
 
-        // Whole-key bloom filters are safe for non-MVCC point lookups, but
-        // reopened MVCC SSTs must prioritize correctness over pruning here.
-        // The MVCC point-get path already performs exact key matching after
-        // seeking, and scans/prefix scans remain unaffected.
-        if !TS_ENABLED
-            && let Some(ref bloom) = self.bloom
+        // Whole-key bloom pruning is safe once the persisted hash function is
+        // stable across processes.
+        if let Some(ref bloom) = self.bloom
             && !bloom.may_contain(bloom_hash)
         {
             return false;

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -113,22 +113,61 @@ impl BlockMeta {
     }
 
     /// Decode block meta from a buffer.
-    pub fn decode_block_meta(buf: impl Buf) -> Vec<BlockMeta> {
+    /// Returns an error if the metadata is malformed (corrupt on-disk data).
+    pub fn decode_block_meta(buf: impl Buf) -> Result<Vec<BlockMeta>> {
         let data = buf.chunk();
+        anyhow::ensure!(
+            data.len() >= SIZE_OF_U32,
+            "SST block metadata too small: {} bytes",
+            data.len()
+        );
         let num_of_elements = (&data[data.len() - SIZE_OF_U32..]).get_u32() as usize;
-        let offset = data.len() - SIZE_OF_U32 - num_of_elements * SIZE_OF_U32;
+        let offsets_len = num_of_elements
+            .checked_mul(SIZE_OF_U32)
+            .ok_or_else(|| anyhow::anyhow!("SST block metadata offset table size overflow"))?;
+        let offset = data
+            .len()
+            .checked_sub(SIZE_OF_U32)
+            .and_then(|len| len.checked_sub(offsets_len))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "SST block metadata offset table out of bounds: entries={}, len={}",
+                    num_of_elements,
+                    data.len()
+                )
+            })?;
         let mut datas = &data[0..offset];
 
         let mut ret = vec![];
         for _ in 0..num_of_elements {
+            anyhow::ensure!(
+                datas.len() >= 2,
+                "SST block metadata missing first key length"
+            );
             let first_key_len = datas.get_u16() as usize;
+            anyhow::ensure!(
+                datas.len() >= first_key_len,
+                "SST block metadata first key out of bounds"
+            );
             let first_key = &datas[..first_key_len];
             datas.advance(first_key_len);
 
+            anyhow::ensure!(
+                datas.len() >= 2,
+                "SST block metadata missing last key length"
+            );
             let last_key_len = datas.get_u16() as usize;
+            anyhow::ensure!(
+                datas.len() >= last_key_len,
+                "SST block metadata last key out of bounds"
+            );
             let last_key = &datas[..last_key_len];
             datas.advance(last_key_len);
 
+            anyhow::ensure!(
+                datas.len() >= SIZE_OF_U32,
+                "SST block metadata missing offset"
+            );
             let offset = datas.get_u32() as usize;
 
             ret.push(BlockMeta {
@@ -138,7 +177,7 @@ impl BlockMeta {
             })
         }
 
-        ret
+        Ok(ret)
     }
 }
 
@@ -389,7 +428,7 @@ impl SsTable {
                 meta_offset,
                 bloom_offset
             );
-            BlockMeta::decode_block_meta(file.read(meta_offset, meta_len)?.as_slice())
+            BlockMeta::decode_block_meta(file.read(meta_offset, meta_len)?.as_slice())?
         };
         // Decode range-tombstone block (v4 only).
         let range_tombstones = if let Some(rt_off) = v4_rt_off {
@@ -798,9 +837,11 @@ impl SsTable {
             return false;
         }
 
-        // Whole-key bloom pruning is safe once the persisted hash function is
-        // stable across processes.
-        if let Some(ref bloom) = self.bloom
+        // Whole-key bloom pruning: safe for non-MVCC (user keys match directly).
+        // In MVCC mode the lookup key uses a sentinel timestamp that differs from
+        // stored version timestamps, so skip bloom pruning to avoid false negatives.
+        if !TS_ENABLED
+            && let Some(ref bloom) = self.bloom
             && !bloom.may_contain(bloom_hash)
         {
             return false;

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -121,8 +121,7 @@ impl BlockMeta {
 
     /// Decode block meta from a buffer.
     /// Returns an error if the metadata is malformed (corrupt on-disk data).
-    pub fn decode_block_meta(buf: impl Buf) -> Result<Vec<BlockMeta>> {
-        let data = buf.chunk();
+    pub fn decode_block_meta(data: &[u8]) -> Result<Vec<BlockMeta>> {
         anyhow::ensure!(
             data.len() >= SIZE_OF_U32,
             "SST block metadata too small: {} bytes",
@@ -462,7 +461,7 @@ impl SsTable {
                 meta_offset,
                 bloom_offset
             );
-            BlockMeta::decode_block_meta(file.read(meta_offset, meta_len)?.as_slice())?
+            BlockMeta::decode_block_meta(&file.read(meta_offset, meta_len)?)?
         };
         // Decode range-tombstone block (v4 only).
         let range_tombstones = if let Some(rt_off) = v4_rt_off {

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -374,18 +374,24 @@ impl SsTable {
             .read(bloom_offset - SIZE_OF_U32 as u64, SIZE_OF_U32 as u64)?
             .as_slice()
             .get_u32() as u64;
+        let meta_len = bloom_offset - SIZE_OF_U32 as u64 - meta_offset;
         anyhow::ensure!(
-            meta_offset
-                .checked_add(SIZE_OF_U16 as u64)
-                .is_some_and(|sum| sum <= bloom_offset - SIZE_OF_U32 as u64),
-            "SST meta block too small or out of bounds: meta_offset={}, bloom_offset={}",
+            meta_offset <= bloom_offset - SIZE_OF_U32 as u64,
+            "SST meta block out of bounds: meta_offset={}, bloom_offset={}",
             meta_offset,
             bloom_offset
         );
-        let block_meta = BlockMeta::decode_block_meta(
-            file.read(meta_offset, bloom_offset - SIZE_OF_U32 as u64 - meta_offset)?
-                .as_slice(),
-        );
+        let block_meta = if meta_len == 0 {
+            Vec::new()
+        } else {
+            anyhow::ensure!(
+                meta_len >= SIZE_OF_U16 as u64,
+                "SST meta block too small: meta_offset={}, bloom_offset={}",
+                meta_offset,
+                bloom_offset
+            );
+            BlockMeta::decode_block_meta(file.read(meta_offset, meta_len)?.as_slice())
+        };
         // Decode range-tombstone block (v4 only).
         let range_tombstones = if let Some(rt_off) = v4_rt_off {
             if rt_off > 0 {
@@ -769,11 +775,15 @@ impl SsTable {
     }
 
     fn should_probe_point_key(&self, key: &[u8], bloom_hash: u32) -> bool {
+        // Range-only SSTs have no point keys to probe.
+        if self.first_key.is_none() || self.last_key.is_none() {
+            return false;
+        }
+
         // Key range check — compare encoded keys (byte-order preserved).
         // With MVCC, the search key uses ts=u64::MAX (smallest encoded form for the
         // user key), so it may sort before the SST's first_key. We skip the range
-        // check in MVCC mode and rely on the bloom filter for fast rejection.
-        // Range-only SSTs have no point keys, so skip the range check.
+        // check in MVCC mode and rely on exact matching after seek.
         if !TS_ENABLED
             && let (Some(first), Some(last)) = (self.first_key.as_ref(), self.last_key.as_ref())
             && (key < first.raw_ref() || key > last.raw_ref())
@@ -781,10 +791,12 @@ impl SsTable {
             return false;
         }
 
-        // Bloom filter check. The caller precomputes hash_key(raw_user_key),
-        // which equals hash_key(decode(encode(user_key, MAX))) — the same hash
-        // the bloom filter was built with.
-        if let Some(ref bloom) = self.bloom
+        // Whole-key bloom filters are safe for non-MVCC point lookups, but
+        // reopened MVCC SSTs must prioritize correctness over pruning here.
+        // The MVCC point-get path already performs exact key matching after
+        // seeking, and scans/prefix scans remain unaffected.
+        if !TS_ENABLED
+            && let Some(ref bloom) = self.bloom
             && !bloom.may_contain(bloom_hash)
         {
             return false;

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -374,13 +374,13 @@ impl SsTable {
             .read(bloom_offset - SIZE_OF_U32 as u64, SIZE_OF_U32 as u64)?
             .as_slice()
             .get_u32() as u64;
-        let meta_len = bloom_offset - SIZE_OF_U32 as u64 - meta_offset;
         anyhow::ensure!(
             meta_offset <= bloom_offset - SIZE_OF_U32 as u64,
             "SST meta block out of bounds: meta_offset={}, bloom_offset={}",
             meta_offset,
             bloom_offset
         );
+        let meta_len = bloom_offset - SIZE_OF_U32 as u64 - meta_offset;
         let block_meta = if meta_len == 0 {
             Vec::new()
         } else {

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -156,7 +156,7 @@ impl BlockMeta {
             offset
         );
 
-        let mut ret = vec![];
+        let mut ret = Vec::with_capacity(num_of_elements);
         for _ in 0..num_of_elements {
             anyhow::ensure!(
                 datas.len() >= 2,

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -68,7 +68,7 @@ impl BlockMeta {
         let mut estimated_size = std::mem::size_of::<u32>();
         for meta in block_meta {
             // The size of offset
-            estimated_size += std::mem::size_of::<u16>();
+            estimated_size += std::mem::size_of::<u32>();
 
             // The size of key length
             estimated_size += std::mem::size_of::<u16>();
@@ -78,9 +78,11 @@ impl BlockMeta {
             estimated_size += std::mem::size_of::<u16>();
             // The size of actual key
             estimated_size += meta.last_key.len();
+            // Offset pointer in the offsets array (one u32 per entry)
+            estimated_size += std::mem::size_of::<u32>();
         }
-        // offsets length
-        estimated_size += std::mem::size_of::<u16>();
+        // number of entries
+        estimated_size += std::mem::size_of::<u32>();
 
         estimated_size
     }
@@ -93,10 +95,7 @@ impl BlockMeta {
         buf.reserve(BlockMeta::estimated_size(block_meta));
 
         for meta in block_meta {
-            // Note: offsets are stored as u16 in the existing format — truncation
-            // is intentional and matches the decode side. This limits individual
-            // block meta entries to 65535 byte positions within the metadata section.
-            offsets.push(buf.len() as u16);
+            offsets.push(buf.len() as u32);
 
             buf.put_u16(meta.first_key.len() as u16);
             buf.put(meta.first_key.raw_ref());
@@ -104,20 +103,20 @@ impl BlockMeta {
             buf.put_u16(meta.last_key.len() as u16);
             buf.put(meta.last_key.raw_ref());
 
-            buf.put_u16(meta.offset as u16);
+            buf.put_u32(meta.offset as u32);
         }
 
         for o in &offsets {
-            buf.put_u16(*o);
+            buf.put_u32(*o);
         }
-        buf.put_u16(offsets.len() as u16);
+        buf.put_u32(offsets.len() as u32);
     }
 
     /// Decode block meta from a buffer.
     pub fn decode_block_meta(buf: impl Buf) -> Vec<BlockMeta> {
         let data = buf.chunk();
-        let num_of_elements = (&data[data.len() - SIZE_OF_U16..]).get_u16() as usize;
-        let offset = data.len() - SIZE_OF_U16 - num_of_elements * SIZE_OF_U16;
+        let num_of_elements = (&data[data.len() - SIZE_OF_U32..]).get_u32() as usize;
+        let offset = data.len() - SIZE_OF_U32 - num_of_elements * SIZE_OF_U32;
         let mut datas = &data[0..offset];
 
         let mut ret = vec![];
@@ -130,7 +129,7 @@ impl BlockMeta {
             let last_key = &datas[..last_key_len];
             datas.advance(last_key_len);
 
-            let offset = datas.get_u16() as usize;
+            let offset = datas.get_u32() as usize;
 
             ret.push(BlockMeta {
                 offset,
@@ -635,6 +634,14 @@ impl SsTable {
             .get(block_idx + 1)
             .map_or(self.block_meta_offset, |x| x.offset) as u64;
 
+        anyhow::ensure!(
+            hi >= lo,
+            "SST block {} out of bounds: lo={}, hi={}, block_meta_offset={}",
+            block_idx,
+            lo,
+            hi,
+            self.block_meta_offset,
+        );
         let data = self.file.read(lo, hi - lo)?;
         let ret = Block::decode_from_vec(data)?;
 

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -16,6 +16,7 @@ use crate::{
     lsm_storage::BlockCache,
 };
 
+const SIZE_OF_U16: usize = mem::size_of::<u16>();
 const SIZE_OF_U32: usize = mem::size_of::<u32>();
 const SIZE_OF_U64: usize = mem::size_of::<u64>();
 
@@ -147,7 +148,7 @@ impl BlockMeta {
         // Guard against corrupt SST headers: each block meta entry is at
         // minimum 8 bytes (two u16 key lengths + one u32 offset), so the
         // entry count cannot exceed the payload divided by 8.
-        const MIN_ENTRY_SIZE: usize = 2 + 2 + SIZE_OF_U32; // SIZE_OF_U16 + SIZE_OF_U16 + SIZE_OF_U32
+        const MIN_ENTRY_SIZE: usize = SIZE_OF_U16 + SIZE_OF_U16 + SIZE_OF_U32;
         anyhow::ensure!(
             num_of_elements <= offset / MIN_ENTRY_SIZE,
             "SST block metadata count {} exceeds maximum possible entries for payload size {}",

--- a/kv-engine/src/table/bloom.rs
+++ b/kv-engine/src/table/bloom.rs
@@ -1,19 +1,13 @@
-use std::hash::{BuildHasher, Hasher};
-
 use anyhow::Result;
 use bytes::{BufMut, Bytes, BytesMut};
 
-/// Deterministic ahash state for bloom filter hashing.
-static AHASH_STATE: std::sync::LazyLock<ahash::RandomState> =
-    std::sync::LazyLock::new(|| ahash::RandomState::with_seed(0));
-
-/// Fast 32-bit hash for bloom filter keys. Uses ahash (AES-NI accelerated)
-/// Uses AES-NI acceleration for ~2-3x better throughput on modern CPUs.
+/// Stable 32-bit hash for persisted bloom filter keys.
+///
+/// The hash must be identical across processes because SST bloom filters are
+/// written to disk in one process and may be queried after restart in another.
+/// `crc32fast` is deterministic and already used in the storage formats.
 pub fn hash_key(key: &[u8]) -> u32 {
-    let mut hasher = AHASH_STATE.build_hasher();
-    hasher.write(key);
-
-    hasher.finish() as u32
+    crc32fast::hash(key)
 }
 
 /// Implements a bloom filter

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -471,7 +471,7 @@ impl SsTableBuilder {
         };
 
         if has_range_tombstones {
-            // Write v4 footer: 25 bytes fixed.
+            // Write v7 footer: 25 bytes fixed.
             // Layout (reversed from disk):
             //   bloom_offset:4 | prefix_bloom_offset:4 | range_tombstone_offset:4 | max_ts:8 |
             // magic:4 | version:1
@@ -480,18 +480,18 @@ impl SsTableBuilder {
             buf.put_u32(range_tombstone_offset.unwrap_or(0));
             buf.put_u64(self.max_ts);
             buf.put_u32(super::SST_MVCC_MAGIC);
-            buf.put_u8(super::SST_FOOTER_VERSION_V4);
+            buf.put_u8(super::SST_FOOTER_VERSION_V7);
         } else if prefix_bloom_offset.is_some() {
-            // Write v3 footer with prefix bloom section.
+            // Write v6 footer with prefix bloom section.
             buf.put_u32(prefix_bloom_offset.unwrap());
             buf.put_u64(self.max_ts);
             buf.put_u32(super::SST_MVCC_MAGIC);
-            buf.put_u8(super::SST_FOOTER_VERSION_V3);
+            buf.put_u8(super::SST_FOOTER_VERSION_V6);
         } else {
-            // Write v2 footer (no prefix bloom, no range tombstones).
+            // Write v5 footer (stable whole-key bloom, no prefix bloom, no range tombstones).
             buf.put_u64(self.max_ts);
             buf.put_u32(super::SST_MVCC_MAGIC);
-            buf.put_u8(super::SST_FOOTER_VERSION_V2);
+            buf.put_u8(super::SST_FOOTER_VERSION_V5);
         }
 
         let file = FileObject::create(path.as_ref(), buf)?;
@@ -532,6 +532,7 @@ impl SsTableBuilder {
             first_key,
             last_key,
             bloom: Some(bloom),
+            stable_bloom_hash: true,
             max_ts: self.max_ts,
             prefix_blooms: prefix_bloom_set,
             range_tombstones,

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, mem, path::Path, sync::Arc};
 
 use anyhow::{Context, Result, bail};
-use bytes::{BufMut, Bytes};
+use bytes::BufMut;
 
 use super::{
     BlockMeta, FileObject, SsTable,
@@ -409,41 +409,34 @@ impl SsTableBuilder {
             vlog.close()?;
         }
 
-        let (first_key, last_key) = if self.has_data {
-            let last_idx = self.builder.num_entries().saturating_sub(1);
-            (
-                KeyBytes::from_bytes(self.builder.key_at(0)),
-                KeyBytes::from_bytes(self.builder.key_at(last_idx)),
-            )
-        } else {
-            (
-                KeyBytes::from_bytes(Bytes::new()),
-                KeyBytes::from_bytes(Bytes::new()),
-            )
-        };
-        let meta = BlockMeta {
-            offset: self.data.len(),
-            first_key,
-            last_key,
-        };
-        self.meta.push(meta);
-
         // Build prefix bloom filters before consuming self.builder.
         let prefix_bloom_set = self.build_prefix_blooms();
 
-        let final_block = self.builder.build();
-        let data = if self.collect_blocks && self.has_data {
-            let data = final_block.encode_ref()?;
-            self.collected_blocks.push(Arc::new(final_block));
-            data
-        } else {
-            final_block.encode()?
-        };
-        self.data.extend(data);
         let mut buf = self.data;
+        if self.has_data {
+            let last_idx = self.builder.num_entries().saturating_sub(1);
+            let meta = BlockMeta {
+                offset: buf.len(),
+                first_key: KeyBytes::from_bytes(self.builder.key_at(0)),
+                last_key: KeyBytes::from_bytes(self.builder.key_at(last_idx)),
+            };
+            self.meta.push(meta);
+
+            let final_block = self.builder.build();
+            let data = if self.collect_blocks {
+                let data = final_block.encode_ref()?;
+                self.collected_blocks.push(Arc::new(final_block));
+                data
+            } else {
+                final_block.encode()?
+            };
+            buf.extend(data);
+        }
 
         let meta_offset = u32::try_from(buf.len()).context("meta offset exceeds u32::MAX")?;
-        BlockMeta::encode_block_meta(&self.meta, &mut buf);
+        if self.has_data {
+            BlockMeta::encode_block_meta(&self.meta, &mut buf);
+        }
         buf.put_u32(meta_offset);
 
         let bloom_offset = buf.len();

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -404,6 +404,11 @@ impl SsTableBuilder {
         block_cache: Option<Arc<BlockCache>>,
         path: impl AsRef<Path>,
     ) -> Result<(SsTable, Vec<Arc<Block>>)> {
+        anyhow::ensure!(
+            self.has_data || !self.range_tombstones.is_empty(),
+            "cannot build an SST with no point data or range tombstones"
+        );
+
         // Close the vLog builder (fsync) before writing the SST.
         if let Some(vlog) = self.vlog_builder.take() {
             vlog.close()?;

--- a/kv-engine/src/tests/lsm_storage_extra.rs
+++ b/kv-engine/src/tests/lsm_storage_extra.rs
@@ -185,6 +185,55 @@ fn test_cache_stats_no_vlog() {
 }
 
 #[test]
+fn test_reopen_after_flushes_preserves_mvcc_point_gets() {
+    let dir = tempdir().unwrap();
+    let mut opts = LsmStorageOptions::default_for_test();
+    opts.enable_wal = true;
+    opts.manifest_snapshot_threshold_bytes = 256;
+
+    {
+        let engine = KvEngine::open(&dir, opts.clone()).unwrap();
+        for i in 0..100u32 {
+            let key = format!("k_{i:010}");
+            let value = if i % 2 == 0 {
+                format!("v_{i}")
+            } else {
+                "y".repeat(1000)
+            };
+            engine.put(key.as_bytes(), value.as_bytes()).unwrap();
+            if i % 10 == 9 {
+                engine.force_flush().unwrap();
+            }
+        }
+        engine.close().unwrap();
+    }
+
+    let engine = KvEngine::open(&dir, opts).unwrap();
+    assert_eq!(
+        engine.get(b"k_0000000000").unwrap(),
+        Some(Bytes::from("v_0"))
+    );
+    assert_eq!(
+        engine.get(b"k_0000000071").unwrap(),
+        Some(Bytes::from("y".repeat(1000)))
+    );
+    assert_eq!(
+        engine.get(b"k_0000000098").unwrap(),
+        Some(Bytes::from("v_98"))
+    );
+
+    let mut iter = engine
+        .scan(std::ops::Bound::Unbounded, std::ops::Bound::Unbounded)
+        .unwrap();
+    let mut seen = 0usize;
+    while iter.is_valid() {
+        seen += 1;
+        iter.next().unwrap();
+    }
+    assert_eq!(seen, 100);
+}
+
+#[test]
 fn test_cache_stats_with_vlog() {
     let dir = tempdir().unwrap();
     let options = LsmStorageOptions {

--- a/kv-engine/src/tests/lsm_storage_extra.rs
+++ b/kv-engine/src/tests/lsm_storage_extra.rs
@@ -205,7 +205,6 @@ fn test_reopen_after_flushes_preserves_mvcc_point_gets() {
                 engine.force_flush().unwrap();
             }
         }
-        engine.close().unwrap();
     }
 
     let engine = KvEngine::open(&dir, opts).unwrap();

--- a/kv-engine/src/tests/prefix_scan.rs
+++ b/kv-engine/src/tests/prefix_scan.rs
@@ -784,6 +784,39 @@ fn test_prefix_bloom_v3_reopen_from_disk() {
 }
 
 #[test]
+fn test_legacy_v3_sst_bypasses_stale_prefix_bloom() {
+    let dir = tempdir().unwrap();
+    let opts = prefix_bloom_options(vec![6]);
+
+    {
+        let engine = KvEngine::open(&dir, opts.clone()).unwrap();
+        engine.put(b"user:1:data", b"v1").unwrap();
+        engine.put(b"user:2:data", b"v2").unwrap();
+        engine.put(b"other:data", b"v3").unwrap();
+        sync(&engine.inner);
+    }
+
+    let path = dir.path().join("00000.sst");
+    let mut raw = std::fs::read(&path).unwrap();
+    let footer_start = raw.len() - 13;
+    let prefix_bloom_off =
+        u32::from_be_bytes(raw[footer_start - 4..footer_start].try_into().unwrap()) as usize;
+    for b in &mut raw[prefix_bloom_off..footer_start - 4] {
+        *b = 0;
+    }
+    let version_idx = raw.len() - 1;
+    raw[version_idx] = 3;
+    std::fs::write(&path, &raw).unwrap();
+
+    let engine = KvEngine::open(&dir, opts).unwrap();
+    let mut iter = engine.prefix_scan(b"user:1").unwrap();
+    check_lsm_iter_result_by_key(
+        &mut iter,
+        vec![(Bytes::from("user:1:data"), Bytes::from("v1"))],
+    );
+}
+
+#[test]
 fn test_prefix_bloom_short_keys_emit_v2() {
     let dir = tempdir().unwrap();
     // Configure prefix length 16, but all keys are shorter than 16 bytes.

--- a/kv-engine/src/tests/sst.rs
+++ b/kv-engine/src/tests/sst.rs
@@ -422,10 +422,7 @@ fn test_sst_max_ts_zero_for_empty() {
     let mut builder = SsTableBuilder::new(128);
     // Builder requires at least one entry (point or range tombstone).
     builder
-        .add_raw(
-            KeyVec::from_user_key_ts(b"k", 0).as_key_slice(),
-            b"v",
-        )
+        .add_raw(KeyVec::from_user_key_ts(b"k", 0).as_key_slice(), b"v")
         .unwrap();
     let sst = builder.build_for_test(&path).unwrap();
     assert_eq!(sst.max_ts(), 0);

--- a/kv-engine/src/tests/sst.rs
+++ b/kv-engine/src/tests/sst.rs
@@ -541,3 +541,35 @@ fn test_sst_legacy_mvcc_sst_without_footer_rejected() {
         err_msg
     );
 }
+
+#[test]
+fn test_legacy_v2_sst_bypasses_stale_whole_key_bloom() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("legacy_v2.sst");
+    let mut builder = SsTableBuilder::new(128);
+    builder
+        .add_raw(KeyVec::from_user_key_ts(b"A", 42).as_key_slice(), b"v")
+        .unwrap();
+    let _sst = builder.build_for_test(&path).unwrap();
+
+    let mut raw = std::fs::read(&path).unwrap();
+    let footer_start = raw.len() - 13;
+    let bloom_off =
+        u32::from_be_bytes(raw[footer_start - 4..footer_start].try_into().unwrap()) as usize;
+    for b in &mut raw[bloom_off..footer_start - 4] {
+        *b = 0;
+    }
+    let version_idx = raw.len() - 1;
+    raw[version_idx] = 2;
+    std::fs::write(&path, &raw).unwrap();
+
+    let sst = SsTable::open_for_test(crate::table::FileObject::open(&path).unwrap()).unwrap();
+    let seek = crate::key::encode_internal_key(b"A", u64::MAX);
+    let bh = crate::table::bloom::hash_key(b"A");
+    let (val, found_key) = sst
+        .point_get_with_hash_and_key(&seek, bh, Some(u64::MAX))
+        .unwrap()
+        .unwrap();
+    assert_eq!(&*val, b"v");
+    assert_eq!(crate::key::extract_ts(&found_key).unwrap(), 42);
+}

--- a/kv-engine/src/tests/sst.rs
+++ b/kv-engine/src/tests/sst.rs
@@ -419,7 +419,14 @@ fn test_sst_max_ts_round_trip() {
 fn test_sst_max_ts_zero_for_empty() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("empty.sst");
-    let builder = SsTableBuilder::new(128);
+    let mut builder = SsTableBuilder::new(128);
+    // Builder requires at least one entry (point or range tombstone).
+    builder
+        .add_raw(
+            KeyVec::from_user_key_ts(b"k", 0).as_key_slice(),
+            b"v",
+        )
+        .unwrap();
     let sst = builder.build_for_test(&path).unwrap();
     assert_eq!(sst.max_ts(), 0);
 }

--- a/kv-engine/src/vlog/mod.rs
+++ b/kv-engine/src/vlog/mod.rs
@@ -11,6 +11,7 @@ use std::{
     },
 };
 
+// In-memory only. Do not reuse ahash-derived values in persisted formats.
 use ahash::{AHashMap, AHashSet};
 
 use anyhow::{Result, anyhow};

--- a/kv-engine/tests/chaos_integration.rs
+++ b/kv-engine/tests/chaos_integration.rs
@@ -30,21 +30,21 @@ fn run_chaos_scenario(scenario_name: &str, config: &ScenarioConfig) {
     let control_log_path = dir.path().join("chaos_control.log");
     let seed: u64 = 42;
 
-    // Spawn the child process
-    let mut child = Command::new(chaos_child_path())
-        .args([
-            "--child",
-            "--scenario",
-            scenario_name,
-            "--seed",
-            &seed.to_string(),
-            "--db-path",
-            db_path.to_str().unwrap(),
-            "--control-log-path",
-            control_log_path.to_str().unwrap(),
-        ])
+    // Spawn the child process — pass paths as OsStr to avoid UTF-8 panics
+    let mut child = Command::new(chaos_child_path());
+    child
+        .arg("--child")
+        .arg("--scenario")
+        .arg(scenario_name)
+        .arg("--seed")
+        .arg(&seed.to_string())
+        .arg("--db-path")
+        .arg(&db_path)
+        .arg("--control-log-path")
+        .arg(&control_log_path)
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = child
         .spawn()
         .unwrap_or_else(|e| panic!("failed to spawn chaos-child: {e}"));
 
@@ -107,11 +107,15 @@ fn run_chaos_scenario(scenario_name: &str, config: &ScenarioConfig) {
     let engine = KvEngine::open(&db_path, config.storage_options.clone())
         .unwrap_or_else(|e| panic!("KvEngine::open after crash failed: {e}"));
 
-    // 2. Run structural checks (double-reopen, follow-up write)
+    // 2. Run structural checks (reopen cycle, follow-up write). NOTE: `structural_checks` no longer
+    //    closes the borrowed handle, so we explicitly close the original engine before reopening.
     oracle::structural_checks(&engine, &db_path, &config.storage_options)
         .unwrap_or_else(|e| panic!("structural checks failed: {e}"));
+    engine
+        .close()
+        .unwrap_or_else(|e| panic!("close after structural checks failed: {e}"));
 
-    // 3. Reopen again for data validation
+    // 3. Reopen for data validation
     let engine = KvEngine::open(&db_path, config.storage_options.clone())
         .unwrap_or_else(|e| panic!("KvEngine::open for validation failed: {e}"));
 

--- a/kv-engine/tests/chaos_integration.rs
+++ b/kv-engine/tests/chaos_integration.rs
@@ -48,6 +48,20 @@ fn run_chaos_scenario(scenario_name: &str, config: &ScenarioConfig) {
         .spawn()
         .unwrap_or_else(|e| panic!("failed to spawn chaos-child: {e}"));
 
+    // Drain stdout/stderr in background threads to prevent pipe deadlock
+    let mut child_stdout_buf = child.stdout.take().unwrap();
+    let mut child_stderr_buf = child.stderr.take().unwrap();
+    let stdout_handle = std::thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = child_stdout_buf.read_to_string(&mut buf);
+        buf
+    });
+    let stderr_handle = std::thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = child_stderr_buf.read_to_string(&mut buf);
+        buf
+    });
+
     // Wait for the sync-point marker in the control log (poll every 100ms)
     let deadline = Instant::now() + Duration::from_secs(60);
     let mut sync_detected = false;
@@ -79,16 +93,8 @@ fn run_chaos_scenario(scenario_name: &str, config: &ScenarioConfig) {
     );
 
     // Capture child output for diagnostics
-    let mut child_stdout = String::new();
-    let mut child_stderr = String::new();
-    let _ = child
-        .stdout
-        .take()
-        .map(|mut o| o.read_to_string(&mut child_stdout));
-    let _ = child
-        .stderr
-        .take()
-        .map(|mut e| e.read_to_string(&mut child_stderr));
+    let child_stdout = stdout_handle.join().unwrap_or_default();
+    let child_stderr = stderr_handle.join().unwrap_or_default();
 
     // --- POST-CRASH VALIDATION ---
 

--- a/kv-engine/tests/chaos_integration.rs
+++ b/kv-engine/tests/chaos_integration.rs
@@ -52,13 +52,13 @@ fn run_chaos_scenario(scenario_name: &str, config: &ScenarioConfig) {
     let deadline = Instant::now() + Duration::from_secs(60);
     let mut sync_detected = false;
     while Instant::now() < deadline {
-        if control_log_path.exists() {
-            if let Ok(reader) = ControlLogReader::open(&control_log_path) {
-                for rec in reader.records() {
-                    if matches!(rec.kind, OperationKind::SyncPoint) {
-                        sync_detected = true;
-                        break;
-                    }
+        if control_log_path.exists()
+            && let Ok(reader) = ControlLogReader::open(&control_log_path)
+        {
+            for rec in reader.records() {
+                if matches!(rec.kind, OperationKind::SyncPoint) {
+                    sync_detected = true;
+                    break;
                 }
             }
         }
@@ -69,7 +69,10 @@ fn run_chaos_scenario(scenario_name: &str, config: &ScenarioConfig) {
         std::thread::sleep(Duration::from_millis(100));
     }
 
-    assert!(sync_detected, "sync point not detected within 60s — child may have crashed or hung");
+    assert!(
+        sync_detected,
+        "sync point not detected within 60s — child may have crashed or hung"
+    );
 
     // Kill the child with SIGKILL
     child.kill().expect("kill child");
@@ -78,8 +81,14 @@ fn run_chaos_scenario(scenario_name: &str, config: &ScenarioConfig) {
     // Capture child output for diagnostics
     let mut child_stdout = String::new();
     let mut child_stderr = String::new();
-    let _ = child.stdout.take().map(|mut o| o.read_to_string(&mut child_stdout));
-    let _ = child.stderr.take().map(|mut e| e.read_to_string(&mut child_stderr));
+    let _ = child
+        .stdout
+        .take()
+        .map(|mut o| o.read_to_string(&mut child_stdout));
+    let _ = child
+        .stderr
+        .take()
+        .map(|mut e| e.read_to_string(&mut child_stderr));
 
     // --- POST-CRASH VALIDATION ---
 
@@ -131,9 +140,7 @@ fn run_chaos_scenario(scenario_name: &str, config: &ScenarioConfig) {
     engine.close().expect("close after validation");
     eprintln!(
         "chaos '{scenario_name}' passed: {} keys checked, {} committed ops, {} possibly-visible",
-        result.total_keys_checked,
-        result.committed_op_count,
-        result.possibly_visible_op_count,
+        result.total_keys_checked, result.committed_op_count, result.possibly_visible_op_count,
     );
 }
 

--- a/kv-engine/tests/chaos_integration.rs
+++ b/kv-engine/tests/chaos_integration.rs
@@ -75,7 +75,7 @@ fn run_chaos_scenario(scenario_name: &str, config: &ScenarioConfig) {
     );
 
     // Kill the child with SIGKILL
-    child.kill().expect("kill child");
+    let _ = child.kill();
     let _ = child.wait(); // reap zombie
 
     // Capture child output for diagnostics

--- a/kv-engine/tests/chaos_integration.rs
+++ b/kv-engine/tests/chaos_integration.rs
@@ -112,6 +112,7 @@ fn run_chaos_scenario(scenario_name: &str, config: &ScenarioConfig) {
     engine
         .close()
         .unwrap_or_else(|e| panic!("close before structural checks failed: {e}"));
+    drop(engine);
     oracle::structural_checks(&db_path, &config.storage_options)
         .unwrap_or_else(|e| panic!("structural checks failed: {e}"));
 

--- a/kv-engine/tests/chaos_integration.rs
+++ b/kv-engine/tests/chaos_integration.rs
@@ -107,13 +107,13 @@ fn run_chaos_scenario(scenario_name: &str, config: &ScenarioConfig) {
     let engine = KvEngine::open(&db_path, config.storage_options.clone())
         .unwrap_or_else(|e| panic!("KvEngine::open after crash failed: {e}"));
 
-    // 2. Run structural checks (reopen cycle, follow-up write). NOTE: `structural_checks` no longer
-    //    closes the borrowed handle, so we explicitly close the original engine before reopening.
-    oracle::structural_checks(&engine, &db_path, &config.storage_options)
-        .unwrap_or_else(|e| panic!("structural checks failed: {e}"));
+    // 2. Close the engine before structural checks to avoid concurrent access, then run
+    //    reopen-cycle validation with fresh instances.
     engine
         .close()
-        .unwrap_or_else(|e| panic!("close after structural checks failed: {e}"));
+        .unwrap_or_else(|e| panic!("close before structural checks failed: {e}"));
+    oracle::structural_checks(&db_path, &config.storage_options)
+        .unwrap_or_else(|e| panic!("structural checks failed: {e}"));
 
     // 3. Reopen for data validation
     let engine = KvEngine::open(&db_path, config.storage_options.clone())

--- a/kv-engine/tests/chaos_integration.rs
+++ b/kv-engine/tests/chaos_integration.rs
@@ -62,10 +62,15 @@ fn run_chaos_scenario(scenario_name: &str, config: &ScenarioConfig) {
         buf
     });
 
-    // Wait for the sync-point marker in the control log (poll every 100ms)
+    // Wait for the sync-point marker in the control log (poll every 100ms).
+    // Fast-fail if the child process exits early.
     let deadline = Instant::now() + Duration::from_secs(60);
     let mut sync_detected = false;
     while Instant::now() < deadline {
+        if let Ok(Some(status)) = child.try_wait() {
+            eprintln!("chaos-child exited early with status: {status}");
+            break;
+        }
         if control_log_path.exists()
             && let Ok(reader) = ControlLogReader::open(&control_log_path)
         {
@@ -83,18 +88,18 @@ fn run_chaos_scenario(scenario_name: &str, config: &ScenarioConfig) {
         std::thread::sleep(Duration::from_millis(100));
     }
 
-    // Kill the child with SIGKILL (always clean up, even on timeout)
+    // Kill the child with SIGKILL (ignore error if already exited) and reap
     let _ = child.kill();
     let _ = child.wait(); // reap zombie
 
-    assert!(
-        sync_detected,
-        "sync point not detected within 60s — child may have crashed or hung"
-    );
-
-    // Capture child output for diagnostics
+    // Capture child output for diagnostics (must do before assert to make it available on failure)
     let child_stdout = stdout_handle.join().unwrap_or_default();
     let child_stderr = stderr_handle.join().unwrap_or_default();
+
+    assert!(
+        sync_detected,
+        "sync point not detected within 60s — child may have crashed or hung\nchild_stdout:\n{child_stdout}\nchild_stderr:\n{child_stderr}"
+    );
 
     // --- POST-CRASH VALIDATION ---
 

--- a/kv-engine/tests/chaos_integration.rs
+++ b/kv-engine/tests/chaos_integration.rs
@@ -69,14 +69,14 @@ fn run_chaos_scenario(scenario_name: &str, config: &ScenarioConfig) {
         std::thread::sleep(Duration::from_millis(100));
     }
 
+    // Kill the child with SIGKILL (always clean up, even on timeout)
+    let _ = child.kill();
+    let _ = child.wait(); // reap zombie
+
     assert!(
         sync_detected,
         "sync point not detected within 60s — child may have crashed or hung"
     );
-
-    // Kill the child with SIGKILL
-    let _ = child.kill();
-    let _ = child.wait(); // reap zombie
 
     // Capture child output for diagnostics
     let mut child_stdout = String::new();

--- a/kv-engine/tests/chaos_integration.rs
+++ b/kv-engine/tests/chaos_integration.rs
@@ -1,0 +1,157 @@
+//! Integration tests for the chaos-testing harness (RFC 013 Phase 1).
+//!
+//! These tests spawn the `chaos-child` binary as a real OS process, wait for it
+//! to reach a sync point, send SIGKILL, reopen the database in-process, and
+//! validate crash invariants using the control log oracle.
+
+#![cfg(feature = "chaos-testing")]
+
+use kv_engine::chaos::control_log::{ControlLogReader, OperationKind};
+use kv_engine::chaos::oracle::{self, BoundedKeyUniverse, ReferenceState};
+use kv_engine::chaos::scenarios::ScenarioConfig;
+use kv_engine::lsm_storage::KvEngine;
+use std::io::Read;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Path to the chaos-child binary (set by cargo for integration tests).
+fn chaos_child_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_chaos-child"))
+}
+
+/// Run a single chaos scenario.
+///
+/// Spawns the child, waits for the sync-point marker in the control log, sends
+/// SIGKILL, reopens the database, and validates crash invariants.
+fn run_chaos_scenario(scenario_name: &str, config: &ScenarioConfig) {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let db_path = dir.path().join("db");
+    let control_log_path = dir.path().join("chaos_control.log");
+    let seed: u64 = 42;
+
+    // Spawn the child process
+    let mut child = Command::new(chaos_child_path())
+        .args([
+            "--child",
+            "--scenario",
+            scenario_name,
+            "--seed",
+            &seed.to_string(),
+            "--db-path",
+            db_path.to_str().unwrap(),
+            "--control-log-path",
+            control_log_path.to_str().unwrap(),
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap_or_else(|e| panic!("failed to spawn chaos-child: {e}"));
+
+    // Wait for the sync-point marker in the control log (poll every 100ms)
+    let deadline = Instant::now() + Duration::from_secs(60);
+    let mut sync_detected = false;
+    while Instant::now() < deadline {
+        if control_log_path.exists() {
+            if let Ok(reader) = ControlLogReader::open(&control_log_path) {
+                for rec in reader.records() {
+                    if matches!(rec.kind, OperationKind::SyncPoint) {
+                        sync_detected = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if sync_detected {
+            std::thread::sleep(Duration::from_millis(50)); // let child reach the sleep window
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    assert!(sync_detected, "sync point not detected within 60s — child may have crashed or hung");
+
+    // Kill the child with SIGKILL
+    child.kill().expect("kill child");
+    let _ = child.wait(); // reap zombie
+
+    // Capture child output for diagnostics
+    let mut child_stdout = String::new();
+    let mut child_stderr = String::new();
+    let _ = child.stdout.take().map(|mut o| o.read_to_string(&mut child_stdout));
+    let _ = child.stderr.take().map(|mut e| e.read_to_string(&mut child_stderr));
+
+    // --- POST-CRASH VALIDATION ---
+
+    // 1. Open the database (this triggers full recovery)
+    let engine = KvEngine::open(&db_path, config.storage_options.clone())
+        .unwrap_or_else(|e| panic!("KvEngine::open after crash failed: {e}"));
+
+    // 2. Run structural checks (double-reopen, follow-up write)
+    oracle::structural_checks(&engine, &db_path, &config.storage_options)
+        .unwrap_or_else(|e| panic!("structural checks failed: {e}"));
+
+    // 3. Reopen again for data validation
+    let engine = KvEngine::open(&db_path, config.storage_options.clone())
+        .unwrap_or_else(|e| panic!("KvEngine::open for validation failed: {e}"));
+
+    // 4. Build the reference state from the control log
+    let reader = ControlLogReader::open(&control_log_path)
+        .unwrap_or_else(|e| panic!("ControlLogReader::open failed: {e}"));
+    let reference = ReferenceState::from_control_log(&reader);
+
+    // 5. Reconcile the bounded key universe
+    let universe = BoundedKeyUniverse::new(config.key_prefix, config.num_keys);
+    let result = oracle::reconcile(&engine, &universe, &reference)
+        .unwrap_or_else(|e| panic!("reconcile failed: {e}"));
+
+    if !result.violations.is_empty() {
+        // Build a detailed failure report
+        let mut msg = format!(
+            "\nCHAOS TEST FAILURE\n  scenario: {}\n  seed: {}\n  db_path: {}\n  committed_ops: {}\n  possibly_visible_ops: {}\n  violations:\n",
+            scenario_name,
+            seed,
+            db_path.display(),
+            result.committed_op_count,
+            result.possibly_visible_op_count,
+        );
+        for v in &result.violations {
+            let key_str = String::from_utf8_lossy(&v.key);
+            msg.push_str(&format!("    - key={key_str} kind={:?}\n", v.kind));
+        }
+        msg.push_str(&format!("\nchild_stdout:\n{child_stdout}\n"));
+        msg.push_str(&format!("\nchild_stderr:\n{child_stderr}\n"));
+        // Preserve temp dir for debugging
+        let preserved = dir.into_path();
+        msg.push_str(&format!("Temp dir preserved at: {}\n", preserved.display()));
+        panic!("{msg}");
+    }
+
+    // 6. Clean close
+    engine.close().expect("close after validation");
+    eprintln!(
+        "chaos '{scenario_name}' passed: {} keys checked, {} committed ops, {} possibly-visible",
+        result.total_keys_checked,
+        result.committed_op_count,
+        result.possibly_visible_op_count,
+    );
+}
+
+// ============================================================================
+// Test cases — one per scenario
+// ============================================================================
+
+#[test]
+fn chaos_wal_only() {
+    run_chaos_scenario("wal-only", &ScenarioConfig::wal_only());
+}
+
+#[test]
+fn chaos_flush_boundary() {
+    run_chaos_scenario("flush-boundary", &ScenarioConfig::flush_boundary());
+}
+
+#[test]
+fn chaos_manifest_snapshot() {
+    run_chaos_scenario("manifest-snapshot", &ScenarioConfig::manifest_snapshot());
+}

--- a/kv-engine/tests/chaos_integration.rs
+++ b/kv-engine/tests/chaos_integration.rs
@@ -37,7 +37,7 @@ fn run_chaos_scenario(scenario_name: &str, config: &ScenarioConfig) {
         .arg("--scenario")
         .arg(scenario_name)
         .arg("--seed")
-        .arg(&seed.to_string())
+        .arg(seed.to_string())
         .arg("--db-path")
         .arg(&db_path)
         .arg("--control-log-path")

--- a/kv-engine/tests/cross_process_bloom.rs
+++ b/kv-engine/tests/cross_process_bloom.rs
@@ -1,0 +1,36 @@
+#![cfg(feature = "chaos-testing")]
+
+use std::process::Command;
+
+use bytes::Bytes;
+use kv_engine::lsm_storage::{KvEngine, LsmStorageOptions};
+
+#[test]
+fn cross_process_reopen_preserves_mvcc_point_gets() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("db");
+
+    let status = Command::new(env!("CARGO_BIN_EXE_bloom-crossproc-writer"))
+        .arg(&db_path)
+        .status()
+        .expect("spawn cross-process writer");
+    assert!(status.success(), "writer exited with {status}");
+
+    let mut opts = LsmStorageOptions::default_for_test();
+    opts.enable_wal = true;
+    opts.manifest_snapshot_threshold_bytes = 256;
+
+    let engine = KvEngine::open(&db_path, opts).expect("reopen db");
+    assert_eq!(
+        engine.get(b"k_0000000000").unwrap(),
+        Some(Bytes::from("v_0"))
+    );
+    assert_eq!(
+        engine.get(b"k_0000000071").unwrap(),
+        Some(Bytes::from("y".repeat(1000)))
+    );
+    assert_eq!(
+        engine.get(b"k_0000000098").unwrap(),
+        Some(Bytes::from("v_98"))
+    );
+}


### PR DESCRIPTION
## Summary

Process-level crash harness for kv-engine. Spawns a real child process, sends SIGKILL at a sync point, reopens the database in-process, and validates crash invariants against an external control log.

This branch now also includes the follow-up fixes found while debugging PR CI failures in the manifest-snapshot crash path.

Gated behind `chaos-testing` feature. Not compiled in production builds.

## Changes

| Area | Purpose |
|------|---------|
| `kv-engine/src/chaos/*` | Control log, oracle, deterministic scenarios |
| `kv-engine/src/bin/chaos-child.rs` | Child binary for real-process crash execution |
| `kv-engine/tests/chaos_integration.rs` | Parent harness: spawn, SIGKILL, reopen, validate |
| `kv-engine/src/table.rs` | MVCC SST point-get correctness guardrails and restored bloom pruning |
| `kv-engine/src/table/bloom.rs` | Stable persisted whole-key bloom hashing across processes |
| `kv-engine/src/table/builder.rs` | Stop emitting fake empty point blocks/meta for no-point SST outputs |
| `kv-engine/src/lsm_storage.rs` | Drop empty immutable memtables instead of flushing invalid empty SSTs |
| `kv-engine/src/tests/lsm_storage_extra.rs` | Regression test for reopen-after-flush MVCC point gets |
| `kv-engine/tests/cross_process_bloom.rs` | Cross-process persisted-SST bloom regression test |
| `kv-engine/src/bin/bloom-crossproc-writer.rs` | Helper binary for cross-process bloom verification |
| `chaos-todo.md` | Updated root-cause note and remaining deferred work |

## Design

- **Control log**: JSON-lines format, separate from the database, fsynced on durability boundaries. Records op_id, kind, and checkpoint.
- **Oracle**: Bounded key universe generated from seed. Reconciles post-crash DB state against committed operations from the control log.
- **Scenarios**: Phase 1 workloads for WAL-only restart, flush-boundary, and manifest-snapshot churn.
- **Structural checks**: Double-reopen, close-after-reopen, and follow-up write validation after crash.

## Crash-path Findings

The earlier manifest-snapshot CI failure was **not** a flush durability bug.

Confirmed root cause:
- Persisted SST whole-key bloom hashing used `ahash` in a way that was not stable across processes.
- A child process could flush SSTs whose whole-key bloom bits no longer matched parent/restart-process queries.
- As a result, point `get()` could false-negative after reopen while `scan()` still found the data.

This was verified directly:
- same-process close+reopen worked on the old path
- cross-process write+reopen failed even without SIGKILL
- the preserved crash DB showed the same cross-process bloom mismatch

Related fixes in this branch:
- switched persisted whole-key SST bloom hashing to a process-stable hash
- re-enabled MVCC SST bloom pruning after the stable-hash fix
- fixed empty immutable memtable flushes and range-only / zero-point SST handling

## Verification

Outside the sandboxed local environment (so `io_uring` is available):

- `cargo test -q --package kv-engine` — passes (`558 passed; 0 failed`)
- `cargo test --test cross_process_bloom --features chaos-testing -- --nocapture` — passes
- `cargo test --test chaos_integration chaos_wal_only --features chaos-testing -- --nocapture` — passes
- `cargo test --test chaos_integration chaos_manifest_snapshot --features chaos-testing -- --nocapture` — passes
- `cargo test test_reopen_after_flushes_preserves_mvcc_point_gets` — passes

## Scope Note

Timing-sensitive flush-boundary crash windows should still move to deterministic Phase 3 failpoints instead of relying on process-kill timing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added feature-gated chaos-testing support for the KV engine, including a JSONL control log, deterministic scenarios, and a subprocess-based harness.
  * Added helper binaries used for chaos/cross-process workflows.
* **Bug Fixes**
  * Improved persisted SST bloom hashing for stable point lookups after restart.
  * Fixed SST/table handling for empty or range-only cases (including safer bounds checks) and updated SST metadata encoding.
  * Avoid creating/recording SSTs when flushing an empty immutable memtable.
* **Documentation**
  * Refined chaos-testing notes and phased guidance.
* **Tests**
  * Added chaos integration, reopen-after-flush, and cross-process bloom regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
