### PR TITLE
feat(chaos): Phase 3 failpoint injection at all 10 RFC durability boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
 
 [[package]]
+name = "fail"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5e43d0f78a42ad591453aedb1d7ae631ce7ee445c7643691055a9ed8d3b01c"
+dependencies = [
+ "log",
+ "once_cell",
+ "rand",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +628,7 @@ dependencies = [
  "crossbeam-queue",
  "crossbeam-skiplist",
  "dashmap",
+ "fail",
  "io-uring",
  "libc",
  "log",

--- a/chaos-todo.md
+++ b/chaos-todo.md
@@ -27,10 +27,10 @@
 - [x] Compaction scenarios — leveled + tiered compaction, kill mid-compaction, validate
 - [x] Second reopen pass — reopen, write more, reopen again to catch latent metadata issues
 
-## Phase 3: Whitebox Failpoints (not started)
+## Phase 3: Whitebox Failpoints (complete)
 
-- [ ] Feature-gated failpoint registry (`chaos::failpoint` module behind `chaos-testing`)
-- [ ] Instrumentation targets:
+- [x] Feature-gated failpoint registry (`chaos::failpoint` module behind `chaos-testing`)
+- [x] Instrumentation targets:
   - `wal.after_batch_encode`
   - `wal.after_submit_before_wait`
   - `wal.after_fsync_before_publish`
@@ -38,8 +38,8 @@
   - `manifest.after_snapshot_tmp_sync`
   - `flush.after_sst_sync_before_manifest`
   - `compaction.after_output_sync_before_manifest`
-- [ ] Deterministic flush-boundary tests using failpoints instead of SIGKILL timing
-- [ ] Deterministic manifest-snapshot tests using failpoints
+- [x] Deterministic flush-boundary tests using failpoints instead of SIGKILL timing
+- [x] Deterministic manifest-snapshot tests using failpoints
 
 ## Minor Improvements
 

--- a/kv-engine/Cargo.toml
+++ b/kv-engine/Cargo.toml
@@ -9,13 +9,14 @@ ignored = ["arc-swap", "crossbeam-epoch"]
 
 [features]
 bench = []
-chaos-testing = []
+chaos-testing = ["fail/failpoints"]
 
 [dependencies]
 TinyUFO = "0.8"
 ahash = "0.8"
 anyhow = "1"
 arc-swap = "1"
+fail = "0.5"
 bytes = "1"
 clap = { version = "4.4.17", features = ["derive"] }
 crc32fast = "1.3.2"
@@ -65,4 +66,9 @@ harness = false
 [[bin]]
 name = "chaos-child"
 path = "src/bin/chaos-child.rs"
+required-features = ["chaos-testing"]
+
+[[test]]
+name = "chaos_failpoint"
+path = "tests/chaos_failpoint.rs"
 required-features = ["chaos-testing"]

--- a/kv-engine/src/chaos/failpoint.rs
+++ b/kv-engine/src/chaos/failpoint.rs
@@ -1,0 +1,31 @@
+//! Deterministic failpoint injection for chaos testing (RFC 013 Phase 3).
+//!
+//! Powered by the `fail` crate (tikv/fail-rs v0.5). All injection sites use
+//! the `fail_point!` macro so that when failpoints are disabled the macro
+//! expands to a no-op — zero runtime cost in production builds.
+//!
+//! ## Usage at injection sites
+//!
+//! ```ignore
+//! #[cfg(feature = "chaos-testing")]
+//! {
+//!     crate::chaos::failpoint::fail_point!("wal.after_batch_encode");
+//! }
+//! ```
+//!
+//! ## Usage in tests
+//!
+//! ```ignore
+//! use kv_engine::chaos::failpoint::{cfg, FailScenario};
+//! let scenario = FailScenario::setup();
+//! cfg("wal.after_batch_encode", "panic").unwrap();
+//! // ... run code that triggers the failpoint ...
+//! scenario.teardown();
+//! ```
+
+/// The core failpoint macro. Re-exported from the `fail` crate so injection
+/// sites within this crate can use it via `crate::chaos::failpoint::fail_point!`.
+pub(crate) use fail::fail_point;
+
+/// Re-export failpoint configuration primitives for tests.
+pub use fail::{FailScenario, cfg};

--- a/kv-engine/src/chaos/mod.rs
+++ b/kv-engine/src/chaos/mod.rs
@@ -8,6 +8,7 @@
 //! compiled into production builds.
 
 pub mod control_log;
+pub mod failpoint;
 pub mod oracle;
 pub mod scenarios;
 

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -1285,6 +1285,12 @@ impl LsmStorageInner {
         self.state.store(Arc::new(snapshot));
 
         self.sync_dir()?;
+
+        #[cfg(feature = "chaos-testing")]
+        {
+            crate::chaos::failpoint::fail_point!("compaction.after_output_sync_before_manifest");
+        }
+
         let manifest_record = ManifestRecord::CompactionV3(
             task,
             new_sst_ids,
@@ -1395,6 +1401,14 @@ impl LsmStorageInner {
             self.state.store(Arc::new(snapshot));
 
             self.sync_dir()?;
+
+            #[cfg(feature = "chaos-testing")]
+            {
+                crate::chaos::failpoint::fail_point!(
+                    "compaction.after_output_sync_before_manifest"
+                );
+            }
+
             let task = task.expect("task checked for Some above");
             let manifest_record = ManifestRecord::CompactionV3(
                 task,

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -4233,6 +4233,12 @@ impl LsmStorageInner {
                 self.path_of_sst(sst_id),
             )?;
             self.block_cache.backfill(sst_id, blocks);
+
+            #[cfg(feature = "chaos-testing")]
+            {
+                crate::chaos::failpoint::fail_point!("vlog.after_append_before_index_publish");
+            }
+
             // Register vLog references
             if !vlog_ids.is_empty() {
                 vlog.register_sst_references(sst_id, &vlog_ids);

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -4281,6 +4281,11 @@ impl LsmStorageInner {
 
         self.sync_dir()?;
 
+        #[cfg(feature = "chaos-testing")]
+        {
+            crate::chaos::failpoint::fail_point!("flush.after_sst_sync_before_manifest");
+        }
+
         let manifest_record = if vlog_ids.is_empty() {
             ManifestRecord::Flush(sst_id)
         } else {

--- a/kv-engine/src/manifest.rs
+++ b/kv-engine/src/manifest.rs
@@ -158,8 +158,18 @@ impl Manifest {
             file.sync_all()
                 .context("failed to sync truncated manifest")?;
 
+            #[cfg(feature = "chaos-testing")]
+            {
+                crate::chaos::failpoint::fail_point!("manifest.after_truncate_before_rename");
+            }
+
             // Step 3: Atomic rename over MANIFEST_SNAPSHOT
             fs::rename(&tmp_path, &snapshot_path).context("failed to rename MANIFEST_SNAPSHOT")?;
+
+            #[cfg(feature = "chaos-testing")]
+            {
+                crate::chaos::failpoint::fail_point!("manifest.after_rename_before_dir_sync");
+            }
 
             // Fsync parent directory to ensure rename is durable
             File::open(dir)

--- a/kv-engine/src/manifest.rs
+++ b/kv-engine/src/manifest.rs
@@ -143,6 +143,11 @@ impl Manifest {
                 .context("failed to sync MANIFEST_SNAPSHOT.tmp")?;
         }
 
+        #[cfg(feature = "chaos-testing")]
+        {
+            crate::chaos::failpoint::fail_point!("manifest.after_snapshot_tmp_sync");
+        }
+
         // Step 2+3: Truncate MANIFEST then rename snapshot, all under the
         // manifest lock to prevent new records from being written between them.
         let dir = self.path.parent().unwrap_or(Path::new("."));
@@ -311,6 +316,11 @@ impl Manifest {
         }
         let mut file = self.file.lock();
         file.write_all(&buf)?;
+
+        #[cfg(feature = "chaos-testing")]
+        {
+            crate::chaos::failpoint::fail_point!("manifest.after_append_before_sync");
+        }
 
         file.sync_all().context("failed to sync manifest")
     }

--- a/kv-engine/src/vlog/gc.rs
+++ b/kv-engine/src/vlog/gc.rs
@@ -259,7 +259,7 @@ impl<'a> GarbageCollector<'a> {
 
             #[cfg(feature = "chaos-testing")]
             {
-                crate::chaos::failpoint::fail_point!("vlog.after_append_before_index_publish");
+                crate::chaos::failpoint::fail_point!("vlog.gc.after_append_before_index_publish");
             }
 
             // Persist the vLog index for the new file

--- a/kv-engine/src/vlog/gc.rs
+++ b/kv-engine/src/vlog/gc.rs
@@ -257,6 +257,11 @@ impl<'a> GarbageCollector<'a> {
             let total_bytes = writer.offset();
             writer.close()?;
 
+            #[cfg(feature = "chaos-testing")]
+            {
+                crate::chaos::failpoint::fail_point!("vlog.after_append_before_index_publish");
+            }
+
             // Persist the vLog index for the new file
             if let Err(e) = self.vlog.save_index(new_file_id, index_entries) {
                 log::warn!("failed to save vLog index for {}: {}", new_file_id, e);

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -537,6 +537,7 @@ impl Wal {
         let mut pending = self.pending.lock();
         let ticket = self.next_ticket.fetch_add(1, Ordering::Release);
         pending.push(TicketedBuf { ticket, buf });
+        drop(pending);
 
         #[cfg(feature = "chaos-testing")]
         {
@@ -622,6 +623,7 @@ impl Wal {
         let mut pending = self.pending.lock();
         let ticket = self.next_ticket.fetch_add(1, Ordering::Release);
         pending.push(TicketedBuf { ticket, buf });
+        drop(pending);
 
         #[cfg(feature = "chaos-testing")]
         {

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -537,6 +537,12 @@ impl Wal {
         let mut pending = self.pending.lock();
         let ticket = self.next_ticket.fetch_add(1, Ordering::Release);
         pending.push(TicketedBuf { ticket, buf });
+
+        #[cfg(feature = "chaos-testing")]
+        {
+            crate::chaos::failpoint::fail_point!("wal.after_batch_encode");
+        }
+
         Ok(ticket)
     }
 
@@ -616,6 +622,12 @@ impl Wal {
         let mut pending = self.pending.lock();
         let ticket = self.next_ticket.fetch_add(1, Ordering::Release);
         pending.push(TicketedBuf { ticket, buf });
+
+        #[cfg(feature = "chaos-testing")]
+        {
+            crate::chaos::failpoint::fail_point!("wal.after_batch_encode");
+        }
+
         Ok(ticket)
     }
 
@@ -1463,6 +1475,12 @@ impl Wal {
 
         let max_ticket = ticketed_bufs.last().unwrap().ticket;
         let result = self.submit_sqes_and_poll(ticketed_bufs);
+
+        #[cfg(feature = "chaos-testing")]
+        {
+            crate::chaos::failpoint::fail_point!("wal.after_fsync_before_publish");
+        }
+
         self.publish_submit_result(max_ticket, &result);
         result
     }
@@ -1592,6 +1610,12 @@ impl Wal {
                 // Submit all write SQEs in one syscall and wait for completions.
                 // Retry on EINTR to prevent spurious failures from signals
                 // (profilers, thread suspension, etc.), matching fdatasync below.
+
+                #[cfg(feature = "chaos-testing")]
+                {
+                    crate::chaos::failpoint::fail_point!("wal.after_submit_before_wait");
+                }
+
                 loop {
                     match ring.submit_and_wait(chunk_len) {
                         Ok(_) => break,

--- a/kv-engine/tests/chaos_failpoint.rs
+++ b/kv-engine/tests/chaos_failpoint.rs
@@ -265,3 +265,111 @@ fn failpoint_compaction_after_output_sync_before_manifest() {
         },
     );
 }
+
+// ---------------------------------------------------------------------------
+// Manifest sub-step failpoints
+// ---------------------------------------------------------------------------
+
+/// `manifest.after_truncate_before_rename`: crash after the old manifest is
+/// truncated and synced but before the snapshot tmp file is renamed over it.
+/// On recovery, the manifest is empty and the snapshot tmp file still exists
+/// — recovery must rebuild from the tmp file.
+#[test]
+fn failpoint_manifest_after_truncate_before_rename() {
+    let mut opts = LsmStorageOptions::default_for_test();
+    opts.enable_wal = true;
+    opts.manifest_snapshot_threshold_bytes = 256;
+
+    run_failpoint_test(
+        "manifest.after_truncate_before_rename",
+        opts,
+        |engine| {
+            for i in 0..20 {
+                let key = format!("mt_{i:010}");
+                let val = format!("mv_{i}");
+                engine.put(key.as_bytes(), val.as_bytes()).unwrap();
+                engine.force_flush().unwrap();
+            }
+        },
+        |engine| {
+            let v = engine.get(b"mt_0000000000").expect("get mt_0");
+            assert!(
+                v.is_some(),
+                "data must survive manifest truncate-before-rename crash"
+            );
+        },
+    );
+}
+
+/// `manifest.after_rename_before_dir_sync`: crash after the snapshot is renamed
+/// over the manifest but before the parent directory is fsynced. The rename is
+/// not durable — on recovery the old manifest may still be visible.
+#[test]
+fn failpoint_manifest_after_rename_before_dir_sync() {
+    let mut opts = LsmStorageOptions::default_for_test();
+    opts.enable_wal = true;
+    opts.manifest_snapshot_threshold_bytes = 256;
+
+    run_failpoint_test(
+        "manifest.after_rename_before_dir_sync",
+        opts,
+        |engine| {
+            for i in 0..20 {
+                let key = format!("mr_{i:010}");
+                let val = format!("mv_{i}");
+                engine.put(key.as_bytes(), val.as_bytes()).unwrap();
+                engine.force_flush().unwrap();
+            }
+        },
+        |engine| {
+            let v = engine.get(b"mr_0000000000").expect("get mr_0");
+            assert!(
+                v.is_some(),
+                "data must survive manifest rename-before-dir-sync crash"
+            );
+        },
+    );
+}
+
+// ---------------------------------------------------------------------------
+// vLog failpoint
+// ---------------------------------------------------------------------------
+
+/// `vlog.after_append_before_index_publish`: crash after values are written and
+/// fsynced to the vlog file but before the `.vidx` index is published. On
+/// recovery, the vlog file contains valid data but has no index — the engine
+/// must recover gracefully without dangling references.
+#[test]
+fn failpoint_vlog_after_append_before_index_publish() {
+    let mut opts = LsmStorageOptions::default_for_test();
+    opts.enable_wal = true;
+    opts.value_separation = Some(kv_engine::vlog::ValueSeparationOptions {
+        enabled: true,
+        min_value_size: 512,
+        max_value_size: 128 << 20,
+        max_vlog_file_size: 64 << 20,
+        gc_threshold_ratio: 0.5,
+        max_open_vlog_files: 64,
+        value_cache_capacity_bytes: 0,
+    });
+
+    run_failpoint_test(
+        "vlog.after_append_before_index_publish",
+        opts,
+        |engine| {
+            let large_val = vec![b'X'; 2000];
+            for i in 0..10 {
+                let key = format!("vk_{i:010}");
+                engine.put(key.as_bytes(), &large_val).unwrap();
+            }
+            engine.force_flush().unwrap();
+        },
+        |engine| {
+            let v = engine.get(b"vk_0000000000").expect("get vk_0");
+            assert!(
+                v.is_some(),
+                "vlog data must survive index crash via WAL replay"
+            );
+        },
+    );
+}

--- a/kv-engine/tests/chaos_failpoint.rs
+++ b/kv-engine/tests/chaos_failpoint.rs
@@ -1,0 +1,267 @@
+//! Deterministic failpoint tests for chaos testing (RFC 013 Phase 3).
+//!
+//! Each test configures a named failpoint to `"panic"`, performs the triggering
+//! operation inside `catch_unwind`, then reopens the database and verifies that
+//! crash recovery produces a consistent state.
+//!
+//! These tests complement the SIGKILL-based chaos_integration tests by injecting
+//! failures at precise durability boundaries that are difficult to hit with
+//! timing-based process killing alone.
+
+#![cfg(feature = "chaos-testing")]
+
+use kv_engine::chaos::failpoint::{self, FailScenario};
+use kv_engine::compact::{CompactionOptions, LeveledCompactionOptions};
+use kv_engine::lsm_storage::{KvEngine, LsmStorageOptions};
+
+/// Helper: open a fresh engine, run a body that may panic due to a configured
+/// failpoint, then reopen and run verification. Both the body and the reopen
+/// are wrapped in `catch_unwind` because some failpoints leave the database in
+/// a state that triggers a panic during recovery (which is itself a finding).
+fn run_failpoint_test(
+    fp_name: &str,
+    opts: LsmStorageOptions,
+    body: impl FnOnce(&KvEngine) + std::panic::UnwindSafe,
+    verify: impl FnOnce(&KvEngine) + std::panic::UnwindSafe,
+) {
+    let scenario = FailScenario::setup();
+    failpoint::cfg(fp_name, "panic").expect("failpoint cfg");
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("db");
+
+    // Phase 1: run the body — the failpoint may panic here.
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let engine = KvEngine::open(&db_path, opts.clone()).expect("open");
+        body(&engine);
+        engine.close().expect("close");
+    }));
+
+    // Phase 2: reopen and verify. Some failpoints leave the on-disk state
+    // inconsistent (e.g. torn manifest), which may cause reopen to panic.
+    // We catch that too — the test passes as long as it doesn't deadlock
+    // or segfault. Panics during reopen are findings, not test failures.
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let engine = KvEngine::open(&db_path, opts.clone()).expect("reopen after failpoint");
+        verify(&engine);
+        engine.close().expect("close after verify");
+    }));
+
+    scenario.teardown();
+}
+
+// ---------------------------------------------------------------------------
+// WAL failpoints
+// ---------------------------------------------------------------------------
+
+/// `wal.after_batch_encode`: crash after batch is queued in `pending` but
+/// before submission to io_uring. The unsubmitted batch is lost on recovery.
+/// Verifies reopen succeeds without panic.
+#[test]
+fn failpoint_wal_after_batch_encode() {
+    let mut opts = LsmStorageOptions::default_for_test();
+    opts.enable_wal = true;
+
+    run_failpoint_test(
+        "wal.after_batch_encode",
+        opts,
+        |engine| {
+            // Every put goes through encode_and_push_direct_buf, so the
+            // failpoint fires on the first put. The batch is lost.
+            engine.put(b"lost_key", b"lost_val").expect("put lost_key");
+        },
+        |engine| {
+            // Verify reopen succeeded — the database is not corrupted.
+            // The unsubmitted batch is legitimately lost; that's correct
+            // crash semantics.
+            let _ = engine.get(b"lost_key");
+        },
+    );
+}
+
+/// `wal.after_submit_before_wait`: crash after SQEs are pushed to the
+/// submission queue but before `submit_and_wait` processes them. Recovery
+/// must not panic.
+#[test]
+fn failpoint_wal_after_submit_before_wait() {
+    let mut opts = LsmStorageOptions::default_for_test();
+    opts.enable_wal = true;
+
+    run_failpoint_test(
+        "wal.after_submit_before_wait",
+        opts,
+        |engine| {
+            engine.put(b"lost_key", b"lost_val").expect("put lost_key");
+        },
+        |engine| {
+            let _ = engine.get(b"lost_key");
+        },
+    );
+}
+
+/// `wal.after_fsync_before_publish`: crash after data is fsynced to disk but
+/// before the completion is published to waiting callers. The data IS durable
+/// and MUST survive recovery.
+#[test]
+fn failpoint_wal_after_fsync_before_publish() {
+    let mut opts = LsmStorageOptions::default_for_test();
+    opts.enable_wal = true;
+
+    run_failpoint_test(
+        "wal.after_fsync_before_publish",
+        opts,
+        |engine| {
+            engine
+                .put(b"must_survive", b"durable")
+                .expect("put must_survive");
+            // This triggers the failpoint AFTER the write+fdatasync complete
+            // but BEFORE publish_submit_result. Data is on disk.
+            // (The failpoint fires inside submit_as_leader.)
+        },
+        |engine| {
+            let v = engine.get(b"must_survive").expect("get must_survive");
+            assert_eq!(
+                v.as_deref(),
+                Some(b"durable".as_slice()),
+                "fsynced data must survive recovery"
+            );
+        },
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Manifest failpoints
+// ---------------------------------------------------------------------------
+
+/// `manifest.after_append_before_sync`: crash after a manifest record is
+/// written to the kernel buffer but before it is fsynced. The torn manifest
+/// may cause recovery to detect an inconsistent state. Verification catches
+/// the reopen panic — the test passes as long as the process doesn't hang
+/// or segfault.
+#[test]
+fn failpoint_manifest_after_append_before_sync() {
+    let mut opts = LsmStorageOptions::default_for_test();
+    opts.enable_wal = true;
+
+    run_failpoint_test(
+        "manifest.after_append_before_sync",
+        opts,
+        |engine| {
+            engine
+                .put(b"flushed_key", b"flushed_val")
+                .expect("put flushed_key");
+            engine.force_flush().expect("force_flush");
+        },
+        |engine| {
+            let _ = engine.get(b"flushed_key");
+        },
+    );
+}
+
+/// `manifest.after_snapshot_tmp_sync`: crash after the manifest snapshot
+/// temp file is synced but before the old manifest is truncated and the
+/// snapshot is renamed. Recovery must rebuild from the snapshot.
+#[test]
+fn failpoint_manifest_after_snapshot_tmp_sync() {
+    let mut opts = LsmStorageOptions::default_for_test();
+    opts.enable_wal = true;
+    opts.manifest_snapshot_threshold_bytes = 256;
+
+    run_failpoint_test(
+        "manifest.after_snapshot_tmp_sync",
+        opts,
+        |engine| {
+            // Generate enough manifest churn to trigger a snapshot.
+            for i in 0..20 {
+                let key = format!("mk_{i:010}");
+                let val = format!("mv_{i}");
+                engine.put(key.as_bytes(), val.as_bytes()).unwrap();
+                engine.force_flush().unwrap();
+            }
+        },
+        |engine| {
+            // Verify the engine reopens cleanly and committed data survives.
+            let v = engine.get(b"mk_0000000000").expect("get mk_0");
+            assert!(v.is_some(), "data must survive manifest snapshot crash");
+        },
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Flush failpoint
+// ---------------------------------------------------------------------------
+
+/// `flush.after_sst_sync_before_manifest`: crash after the SST file is synced
+/// to disk but before the manifest `Flush` record is written. The SST becomes
+/// an orphan; recovery must fall back to WAL replay for the memtable data.
+#[test]
+fn failpoint_flush_after_sst_sync_before_manifest() {
+    let mut opts = LsmStorageOptions::default_for_test();
+    opts.enable_wal = true;
+
+    run_failpoint_test(
+        "flush.after_sst_sync_before_manifest",
+        opts,
+        |engine| {
+            engine
+                .put(b"flush_target", b"before_crash")
+                .expect("put flush_target");
+            // force_flush writes the SST, syncs it, syncs the dir, then
+            // the failpoint fires before the manifest record is written.
+            engine.force_flush().expect("force_flush");
+        },
+        |engine| {
+            let v = engine.get(b"flush_target").expect("get flush_target");
+            assert!(
+                v.is_some(),
+                "flushed data must survive via WAL replay when manifest record is lost"
+            );
+        },
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Compaction failpoint
+// ---------------------------------------------------------------------------
+
+/// `compaction.after_output_sync_before_manifest`: crash after compaction
+/// output SSTs are synced but before the manifest `CompactionV3` record is
+/// written. Recovery must succeed and original data must be intact.
+#[test]
+fn failpoint_compaction_after_output_sync_before_manifest() {
+    let mut opts = LsmStorageOptions::default_for_test();
+    opts.enable_wal = true;
+    opts.target_sst_size = 4096;
+    opts.compaction_options = CompactionOptions::Leveled(LeveledCompactionOptions {
+        level_size_multiplier: 10,
+        level0_file_num_compaction_trigger: 2,
+        max_levels: 3,
+        base_level_size_mb: 1,
+    });
+
+    run_failpoint_test(
+        "compaction.after_output_sync_before_manifest",
+        opts,
+        |engine| {
+            // Write keys in 2 batches with interleaved flushes to create
+            // multiple SSTs at L0 and trigger compaction.
+            for batch in 0..2 {
+                for i in (batch * 20)..(batch * 20 + 20) {
+                    let key = format!("ck_{i:010}");
+                    let val = format!("cv_{i}");
+                    engine.put(key.as_bytes(), val.as_bytes()).unwrap();
+                }
+                engine.force_flush().unwrap();
+            }
+            // Trigger compaction — the failpoint fires after output SSTs are
+            // synced but before the manifest record is written.
+            engine.force_full_compaction().unwrap();
+        },
+        |engine| {
+            // Original data must survive — compaction data is not lost, just
+            // the manifest record for the compaction result may be missing.
+            let v = engine.get(b"ck_0000000000").expect("get ck_0");
+            assert!(v.is_some(), "original data must survive compaction crash");
+        },
+    );
+}

--- a/kv-engine/tests/chaos_failpoint.rs
+++ b/kv-engine/tests/chaos_failpoint.rs
@@ -14,11 +14,11 @@ use kv_engine::chaos::failpoint::{self, FailScenario};
 use kv_engine::compact::{CompactionOptions, LeveledCompactionOptions};
 use kv_engine::lsm_storage::{KvEngine, LsmStorageOptions};
 
-/// Helper: open a fresh engine, run a body that may panic due to a configured
-/// failpoint, then reopen and run verification. Both the body and the reopen
-/// are wrapped in `catch_unwind` because some failpoints leave the database in
-/// a state that triggers a panic during recovery (which is itself a finding).
-fn run_failpoint_test(
+/// Helper for **lossy** failpoints: the failpoint may leave the database in an
+/// inconsistent state, so both the body and the reopen+verify are wrapped in
+/// `catch_unwind`. The test passes as long as the process doesn't hang or
+/// segfault.
+fn run_failpoint_test_lossy(
     fp_name: &str,
     opts: LsmStorageOptions,
     body: impl FnOnce(&KvEngine) + std::panic::UnwindSafe,
@@ -39,13 +39,42 @@ fn run_failpoint_test(
 
     // Phase 2: reopen and verify. Some failpoints leave the on-disk state
     // inconsistent (e.g. torn manifest), which may cause reopen to panic.
-    // We catch that too — the test passes as long as it doesn't deadlock
-    // or segfault. Panics during reopen are findings, not test failures.
     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let engine = KvEngine::open(&db_path, opts.clone()).expect("reopen after failpoint");
         verify(&engine);
         engine.close().expect("close after verify");
     }));
+
+    scenario.teardown();
+}
+
+/// Helper for **durable** failpoints: data MUST survive recovery, so Phase 2
+/// is NOT wrapped in `catch_unwind`. Assertion failures propagate to the test
+/// runner and are reported as test failures.
+fn run_failpoint_test_durable(
+    fp_name: &str,
+    opts: LsmStorageOptions,
+    body: impl FnOnce(&KvEngine) + std::panic::UnwindSafe,
+    verify: impl FnOnce(&KvEngine) + std::panic::UnwindSafe,
+) {
+    let scenario = FailScenario::setup();
+    failpoint::cfg(fp_name, "panic").expect("failpoint cfg");
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("db");
+
+    // Phase 1: run the body — the failpoint may panic here.
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let engine = KvEngine::open(&db_path, opts.clone()).expect("open");
+        body(&engine);
+        engine.close().expect("close");
+    }));
+
+    // Phase 2: reopen and verify. NOT wrapped in catch_unwind —
+    // assertion failures propagate and are reported as test failures.
+    let engine = KvEngine::open(&db_path, opts.clone()).expect("reopen after failpoint");
+    verify(&engine);
+    engine.close().expect("close after verify");
 
     scenario.teardown();
 }
@@ -62,7 +91,7 @@ fn failpoint_wal_after_batch_encode() {
     let mut opts = LsmStorageOptions::default_for_test();
     opts.enable_wal = true;
 
-    run_failpoint_test(
+    run_failpoint_test_lossy(
         "wal.after_batch_encode",
         opts,
         |engine| {
@@ -93,7 +122,7 @@ fn failpoint_wal_after_submit_before_wait() {
     let mut opts = LsmStorageOptions::default_for_test();
     opts.enable_wal = true;
 
-    run_failpoint_test(
+    run_failpoint_test_lossy(
         "wal.after_submit_before_wait",
         opts,
         |engine| {
@@ -122,7 +151,7 @@ fn failpoint_wal_after_fsync_before_publish() {
     let mut opts = LsmStorageOptions::default_for_test();
     opts.enable_wal = true;
 
-    run_failpoint_test(
+    run_failpoint_test_durable(
         "wal.after_fsync_before_publish",
         opts,
         |engine| {
@@ -158,7 +187,7 @@ fn failpoint_manifest_after_append_before_sync() {
     let mut opts = LsmStorageOptions::default_for_test();
     opts.enable_wal = true;
 
-    run_failpoint_test(
+    run_failpoint_test_lossy(
         "manifest.after_append_before_sync",
         opts,
         |engine| {
@@ -192,7 +221,7 @@ fn failpoint_manifest_after_snapshot_tmp_sync() {
     opts.enable_wal = true;
     opts.manifest_snapshot_threshold_bytes = 256;
 
-    run_failpoint_test(
+    run_failpoint_test_durable(
         "manifest.after_snapshot_tmp_sync",
         opts,
         |engine| {
@@ -224,7 +253,7 @@ fn failpoint_flush_after_sst_sync_before_manifest() {
     let mut opts = LsmStorageOptions::default_for_test();
     opts.enable_wal = true;
 
-    run_failpoint_test(
+    run_failpoint_test_durable(
         "flush.after_sst_sync_before_manifest",
         opts,
         |engine| {
@@ -264,7 +293,7 @@ fn failpoint_compaction_after_output_sync_before_manifest() {
         base_level_size_mb: 1,
     });
 
-    run_failpoint_test(
+    run_failpoint_test_durable(
         "compaction.after_output_sync_before_manifest",
         opts,
         |engine| {
@@ -305,7 +334,7 @@ fn failpoint_manifest_after_truncate_before_rename() {
     opts.enable_wal = true;
     opts.manifest_snapshot_threshold_bytes = 256;
 
-    run_failpoint_test(
+    run_failpoint_test_durable(
         "manifest.after_truncate_before_rename",
         opts,
         |engine| {
@@ -335,7 +364,7 @@ fn failpoint_manifest_after_rename_before_dir_sync() {
     opts.enable_wal = true;
     opts.manifest_snapshot_threshold_bytes = 256;
 
-    run_failpoint_test(
+    run_failpoint_test_durable(
         "manifest.after_rename_before_dir_sync",
         opts,
         |engine| {
@@ -383,7 +412,7 @@ fn failpoint_vlog_after_append_before_index_publish() {
         value_cache_capacity_bytes: 0,
     });
 
-    run_failpoint_test(
+    run_failpoint_test_durable(
         "vlog.after_append_before_index_publish",
         opts,
         |engine| {

--- a/kv-engine/tests/chaos_failpoint.rs
+++ b/kv-engine/tests/chaos_failpoint.rs
@@ -30,12 +30,16 @@ fn run_failpoint_test_lossy(
     let dir = tempfile::tempdir().expect("tempdir");
     let db_path = dir.path().join("db");
 
-    // Phase 1: run the body — the failpoint may panic here.
-    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    // Phase 1: run the body — the failpoint must panic here.
+    let phase1 = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let engine = KvEngine::open(&db_path, opts.clone()).expect("open");
         body(&engine);
         engine.close().expect("close");
     }));
+    assert!(
+        phase1.is_err(),
+        "failpoint '{fp_name}' did not fire — body completed without panic"
+    );
 
     // Disable the failpoint before Phase 2 so recovery doesn't re-trigger it.
     failpoint::cfg(fp_name, "off").expect("failpoint off");
@@ -66,12 +70,16 @@ fn run_failpoint_test_durable(
     let dir = tempfile::tempdir().expect("tempdir");
     let db_path = dir.path().join("db");
 
-    // Phase 1: run the body — the failpoint may panic here.
-    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    // Phase 1: run the body — the failpoint must panic here.
+    let phase1 = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let engine = KvEngine::open(&db_path, opts.clone()).expect("open");
         body(&engine);
         engine.close().expect("close");
     }));
+    assert!(
+        phase1.is_err(),
+        "failpoint '{fp_name}' did not fire — body completed without panic"
+    );
 
     // Disable the failpoint before Phase 2 so recovery doesn't re-trigger it.
     failpoint::cfg(fp_name, "off").expect("failpoint off");

--- a/kv-engine/tests/chaos_failpoint.rs
+++ b/kv-engine/tests/chaos_failpoint.rs
@@ -160,7 +160,8 @@ fn failpoint_manifest_after_append_before_sync() {
 
 /// `manifest.after_snapshot_tmp_sync`: crash after the manifest snapshot
 /// temp file is synced but before the old manifest is truncated and the
-/// snapshot is renamed. Recovery must rebuild from the snapshot.
+/// snapshot is renamed. The old manifest is still intact — recovery
+/// replays from the existing manifest, not the snapshot tmp file.
 #[test]
 fn failpoint_manifest_after_snapshot_tmp_sync() {
     let mut opts = LsmStorageOptions::default_for_test();
@@ -339,6 +340,11 @@ fn failpoint_manifest_after_rename_before_dir_sync() {
 /// fsynced to the vlog file but before the `.vidx` index is published. On
 /// recovery, the vlog file contains valid data but has no index — the engine
 /// must recover gracefully without dangling references.
+///
+/// Note: this test exercises the flush-path injection site (lsm_storage.rs).
+/// The GC-path injection site (vlog/gc.rs) is not covered by this test —
+/// triggering GC with a configured failpoint requires a separate test that
+/// explicitly calls `trigger_gc()` after writing enough stale data.
 #[test]
 fn failpoint_vlog_after_append_before_index_publish() {
     let mut opts = LsmStorageOptions::default_for_test();

--- a/kv-engine/tests/chaos_failpoint.rs
+++ b/kv-engine/tests/chaos_failpoint.rs
@@ -37,6 +37,9 @@ fn run_failpoint_test_lossy(
         engine.close().expect("close");
     }));
 
+    // Disable the failpoint before Phase 2 so recovery doesn't re-trigger it.
+    failpoint::cfg(fp_name, "off").expect("failpoint off");
+
     // Phase 2: reopen and verify. Some failpoints leave the on-disk state
     // inconsistent (e.g. torn manifest), which may cause reopen to panic.
     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -69,6 +72,9 @@ fn run_failpoint_test_durable(
         body(&engine);
         engine.close().expect("close");
     }));
+
+    // Disable the failpoint before Phase 2 so recovery doesn't re-trigger it.
+    failpoint::cfg(fp_name, "off").expect("failpoint off");
 
     // Phase 2: reopen and verify. NOT wrapped in catch_unwind —
     // assertion failures propagate and are reported as test failures.

--- a/kv-engine/tests/chaos_failpoint.rs
+++ b/kv-engine/tests/chaos_failpoint.rs
@@ -71,10 +71,16 @@ fn failpoint_wal_after_batch_encode() {
             engine.put(b"lost_key", b"lost_val").expect("put lost_key");
         },
         |engine| {
-            // Verify reopen succeeded — the database is not corrupted.
-            // The unsubmitted batch is legitimately lost; that's correct
-            // crash semantics.
-            let _ = engine.get(b"lost_key");
+            // Verify the database is fully operational after recovery.
+            engine
+                .put(b"__probe__", b"ok")
+                .expect("probe put after batch_encode crash");
+            let v = engine.get(b"__probe__").expect("probe get");
+            assert_eq!(
+                v.as_deref(),
+                Some(b"ok".as_slice()),
+                "database must be usable after recovery"
+            );
         },
     );
 }
@@ -94,7 +100,16 @@ fn failpoint_wal_after_submit_before_wait() {
             engine.put(b"lost_key", b"lost_val").expect("put lost_key");
         },
         |engine| {
-            let _ = engine.get(b"lost_key");
+            // Verify the database is fully operational after recovery.
+            engine
+                .put(b"__probe__", b"ok")
+                .expect("probe put after submit_before_wait crash");
+            let v = engine.get(b"__probe__").expect("probe get");
+            assert_eq!(
+                v.as_deref(),
+                Some(b"ok".as_slice()),
+                "database must be usable after recovery"
+            );
         },
     );
 }
@@ -153,7 +168,16 @@ fn failpoint_manifest_after_append_before_sync() {
             engine.force_flush().expect("force_flush");
         },
         |engine| {
-            let _ = engine.get(b"flushed_key");
+            // Verify the database is fully operational after recovery.
+            engine
+                .put(b"__probe__", b"ok")
+                .expect("probe put after manifest crash");
+            let v = engine.get(b"__probe__").expect("probe get");
+            assert_eq!(
+                v.as_deref(),
+                Some(b"ok".as_slice()),
+                "database must be usable after recovery"
+            );
         },
     );
 }


### PR DESCRIPTION
## Summary
Implement RFC 013 Phase 3 — deterministic failpoint injection at all 10 durability boundaries from the RFC. Uses the fail crate (tikv/fail-rs v0.5) behind #[cfg(feature = "chaos-testing")].

## Changes
### Infrastructure
- Add fail = 0.5 dependency, chaos-testing = [fail/failpoints]
- New chaos::failpoint module (fail_point! pub(crate), cfg/FailScenario pub)
- New [[test]] chaos_failpoint with required-features

### Injection sites — all 10 RFC §9.3 targets
1. wal.after_batch_encode — After pending.push, before Ok(ticket)
2. wal.after_submit_before_wait — Before submit_and_wait
3. wal.after_fsync_before_publish — After fsync, before publish
4. manifest.after_append_before_sync — After write_all, before sync_all
5. manifest.after_snapshot_tmp_sync — After tmp sync, before truncate
6. manifest.after_truncate_before_rename — After truncate sync, before rename
7. manifest.after_rename_before_dir_sync — After rename, before dir sync
8. flush.after_sst_sync_before_manifest — After SST sync, before Flush record
9. compaction.after_output_sync_before_manifest — force_full + trigger paths
10. vlog.after_append_before_index_publish — Flush + GC paths

### Tests — 10 deterministic failpoint tests
New tests/chaos_failpoint.rs: FailScenario::setup() + catch_unwind pattern, serialized via global lock.

### Files (7 modified, 2 new)
kv-engine/Cargo.toml (+5/-1), chaos/failpoint.rs (+31), wal.rs (+12), manifest.rs (+20), lsm_storage.rs (+10), compact.rs (+12), vlog/gc.rs (+5), tests/chaos_failpoint.rs (+364)

## Verification
- [x] 560 production tests pass (failpoints disabled — zero overhead)
- [x] 30 chaos tests pass (23 unit + 7 integration)
- [x] 10 failpoint tests pass
- [x] clippy + fmt clean
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic chaos-testing coverage for storage recovery scenarios.
  * Expanded support for controlled failure injection during key write, flush, compaction, and manifest operations.

* **Bug Fixes**
  * Improved validation of recovery behavior after crashes and interruptions.
  * Clarified and hardened handling of previously flaky durability-related scenarios.

* **Tests**
  * Added a broad suite of failure-recovery tests to verify data safety and reopen behavior across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->