### PR TITLE
docs(chaos): Phase 4 RocksDB-style stress testing roadmap

### DIFF
--- a/chaos-todo.md
+++ b/chaos-todo.md
@@ -59,7 +59,7 @@ RocksDB's `db_crashtest.py` operates in kill/reopen *loops* with randomized para
 ### Randomized Configuration
 - [ ] Random SST target size from a set: {4KB, 64KB, 256KB, 2MB}
 - [ ] Random compaction mode: {NoCompaction, Leveled, Tiered, Simple}
-- [ ] Random WAL setting: {on, off} (off = sanity-only, lower coverage)
+- [ ] Random WAL setting: {on, off} (off = sanity-only/clean-reopen, requires oracle adjustment to tolerate memtable data loss)
 - [ ] Random value separation: {on, off} with random min_value_size
 - [ ] Random manifest snapshot threshold: {0, 256, 1024, 65536}
 - [ ] Config sanitizer to exclude incompatible combos (delete_range + vlog, etc.)

--- a/chaos-todo.md
+++ b/chaos-todo.md
@@ -60,6 +60,7 @@ RocksDB's `db_crashtest.py` operates in kill/reopen *loops* with randomized para
 - [ ] Random SST target size from a set: {4KB, 64KB, 256KB, 2MB}
 - [ ] Random compaction mode: {NoCompaction, Leveled, Tiered, Simple}
 - [ ] Random WAL setting: {on, off} (off = sanity-only/clean-reopen, requires oracle adjustment to tolerate memtable data loss)
+- [ ] Random serializable mode: {on, off}
 - [ ] Random value separation: {on, off} with random min_value_size
 - [ ] Random manifest snapshot threshold: {0, 256, 1024, 65536}
 - [ ] Config sanitizer to exclude incompatible combos (delete_range + vlog, etc.)

--- a/chaos-todo.md
+++ b/chaos-todo.md
@@ -63,7 +63,7 @@ RocksDB's `db_crashtest.py` operates in kill/reopen *loops* with randomized para
 - [ ] Random serializable mode: {on, off}
 - [ ] Random value separation: {on, off} with random min_value_size
 - [ ] Random manifest snapshot threshold: {0, 256, 1024, 65536}
-- [ ] Config sanitizer to exclude incompatible combos (delete_range + vlog, etc.)
+- [ ] Config sanitizer to exclude incompatible combos (delete_range + vlog, delete_range + serializable)
 
 ### Stress/Verify Phase Alternation
 - [ ] Stress phase: kill-heavy, loose oracle (reopen must succeed, no crash)

--- a/chaos-todo.md
+++ b/chaos-todo.md
@@ -41,6 +41,48 @@
 - [x] Deterministic flush-boundary tests using failpoints instead of SIGKILL timing
 - [x] Deterministic manifest-snapshot tests using failpoints
 
+## Phase 4: RocksDB-Style Stress Testing (not started)
+
+RocksDB's `db_crashtest.py` operates in kill/reopen *loops* with randomized parameters and alternating stress/verify phases. Our current harness does one-shot kill+validate. Phase 4 closes the gap.
+
+### Kill/Reopen Loops
+- [ ] Multi-cycle crash loop: `open → write → kill → reopen → verify → write → kill → ...` (N cycles)
+- [ ] Configurable cycle count (seed-driven, default 10-100 cycles)
+- [ ] Per-cycle operation count randomization within bounds
+
+### Randomized Workloads
+- [ ] Random operation sequence generator (put/delete/delete_range/flush/compact) driven by seed
+- [ ] Random key selection from a bounded universe (not sequential)
+- [ ] Random value sizes (small/large/mixed, triggers value separation)
+- [ ] Random inter-operation timing (flush after N ops, compact after M flushes)
+
+### Randomized Configuration
+- [ ] Random SST target size from a set: {4KB, 64KB, 256KB, 2MB}
+- [ ] Random compaction mode: {NoCompaction, Leveled, Tiered, Simple}
+- [ ] Random WAL setting: {on, off} (off = sanity-only, lower coverage)
+- [ ] Random value separation: {on, off} with random min_value_size
+- [ ] Random manifest snapshot threshold: {0, 256, 1024, 65536}
+- [ ] Config sanitizer to exclude incompatible combos (delete_range + vlog, etc.)
+
+### Stress/Verify Phase Alternation
+- [ ] Stress phase: kill-heavy, loose oracle (reopen must succeed, no crash)
+- [ ] Verify phase: kill-light, strict oracle (full key-universe reconciliation)
+- [ ] Alternation driven by cycle parity or explicit phase transitions
+
+### Extended Runtime
+- [ ] Time-bounded mode: "run for 60 seconds, kill/reopen as fast as possible"
+- [ ] Cycle-bounded mode: "100 kill/reopen cycles"
+- [ ] Progress reporting: ops/sec, cycles completed, violations found
+
+### Reproducibility
+- [ ] Single seed deterministically generates workload, config, and kill points
+- [ ] Failure report includes: seed, cycle number, op sequence, config, control log path
+- [ ] Replay mode: `--seed 42` reproduces the exact same failure
+
+### CI Integration
+- [ ] `cargo make test-chaos-stress` task (long-running, nightly only)
+- [ ] Short deterministic stress smoke test for PR CI (3-5 cycles, 10s limit)
+
 ## Minor Improvements
 
 - [ ] Pass file paths as `OsStr` instead of `to_str().unwrap()` in parent harness

--- a/chaos-todo.md
+++ b/chaos-todo.md
@@ -52,6 +52,7 @@ RocksDB's `db_crashtest.py` operates in kill/reopen *loops* with randomized para
 
 ### Randomized Workloads
 - [ ] Random operation sequence generator (put/delete/delete_range/flush/compact) driven by seed, constrained by active config
+- [ ] Serializable mode uses transaction blocks and retries on serialization conflicts
 - [ ] Random key selection from a bounded universe (not sequential)
 - [ ] Random value sizes (small/large/mixed, triggers value separation)
 - [ ] Random inter-operation timing (flush after N ops, compact after M flushes)
@@ -59,7 +60,7 @@ RocksDB's `db_crashtest.py` operates in kill/reopen *loops* with randomized para
 ### Randomized Configuration
 - [ ] Random SST target size from a set: {4KB, 64KB, 256KB, 2MB}
 - [ ] Random compaction mode: {NoCompaction, Leveled, Tiered, Simple}
-- [ ] Random WAL setting: {on, off} (off = sanity-only/clean-reopen, requires oracle adjustment to tolerate memtable data loss)
+- [ ] Random WAL setting: {on, off} (off = sanity-only/clean-reopen, or requires oracle adjustment to tolerate memtable data loss)
 - [ ] Random serializable mode: {on, off}
 - [ ] Random value separation: {on, off} with random min_value_size from {128B, 512B, 1KB, 4KB}
 - [ ] Random manifest snapshot threshold: {0, 256, 1024, 65536}
@@ -78,11 +79,12 @@ RocksDB's `db_crashtest.py` operates in kill/reopen *loops* with randomized para
 ### Reproducibility
 - [ ] Single seed deterministically generates workload, config, and kill points
 - [ ] Failure report includes: seed, cycle number, op sequence, config, LSM structure dump, control log path
-- [ ] Replay mode: `--seed 42` reproduces the exact same failure
+- [ ] Replay mode: `--seed 42` reproduces the same failure
 
 ### CI Integration
 - [ ] `cargo make test-chaos-stress` task (long-running, nightly only)
 - [ ] Short deterministic stress smoke test for PR CI (3-5 cycles, 10s limit)
+- [ ] Archive full DB directory as a CI artifact on failure
 
 ## Minor Improvements
 

--- a/chaos-todo.md
+++ b/chaos-todo.md
@@ -51,7 +51,7 @@ RocksDB's `db_crashtest.py` operates in kill/reopen *loops* with randomized para
 - [ ] Per-cycle operation count randomization within bounds
 
 ### Randomized Workloads
-- [ ] Random operation sequence generator (put/delete/delete_range/flush/compact) driven by seed
+- [ ] Random operation sequence generator (put/delete/delete_range/flush/compact) driven by seed, constrained by active config
 - [ ] Random key selection from a bounded universe (not sequential)
 - [ ] Random value sizes (small/large/mixed, triggers value separation)
 - [ ] Random inter-operation timing (flush after N ops, compact after M flushes)
@@ -61,7 +61,7 @@ RocksDB's `db_crashtest.py` operates in kill/reopen *loops* with randomized para
 - [ ] Random compaction mode: {NoCompaction, Leveled, Tiered, Simple}
 - [ ] Random WAL setting: {on, off} (off = sanity-only/clean-reopen, requires oracle adjustment to tolerate memtable data loss)
 - [ ] Random serializable mode: {on, off}
-- [ ] Random value separation: {on, off} with random min_value_size
+- [ ] Random value separation: {on, off} with random min_value_size from {128B, 512B, 1KB, 4KB}
 - [ ] Random manifest snapshot threshold: {0, 256, 1024, 65536}
 - [ ] Config sanitizer to exclude incompatible combos (delete_range + vlog, delete_range + serializable)
 
@@ -77,7 +77,7 @@ RocksDB's `db_crashtest.py` operates in kill/reopen *loops* with randomized para
 
 ### Reproducibility
 - [ ] Single seed deterministically generates workload, config, and kill points
-- [ ] Failure report includes: seed, cycle number, op sequence, config, control log path
+- [ ] Failure report includes: seed, cycle number, op sequence, config, LSM structure dump, control log path
 - [ ] Replay mode: `--seed 42` reproduces the exact same failure
 
 ### CI Integration


### PR DESCRIPTION
## Summary

Document the Phase 4 plan for extending the chaos harness from one-shot kill/validate into RocksDB-style stress testing with kill/reopen loops, randomized parameters, and alternating stress/verify phases.

## Changes

Add Phase 4 section to `chaos-todo.md` covering 6 workstreams:

### Kill/Reopen Loops
- Multi-cycle crash loop (N cycles, configurable)
- Per-cycle randomized operation count

### Randomized Workloads
- Seed-driven random op sequence generator (put/delete/delete_range/flush/compact)
- Random key selection, value sizes, inter-op timing

### Randomized Configuration
- Random SST target size, compaction mode, WAL, value separation, manifest threshold
- Config sanitizer for incompatible combos

### Stress/Verify Phase Alternation
- Stress phase: kill-heavy, loose oracle
- Verify phase: kill-light, strict key-universe reconciliation

### Reproducibility
- Single seed deterministically generates workload + config + kill points
- Failure report includes: seed, cycle, op sequence, config, control log

### CI Integration
- `cargo make test-chaos-stress` for nightly
- Short smoke test (3-5 cycles, 10s) for PR CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Phase 4 plan for upcoming RocksDB-style chaos stress testing improvements (not yet started).
  * Outlines transitioning to multi-cycle kill/reopen loops with randomized per-cycle workloads and timing.
  * Specifies new seed-driven reproducibility and richer failure reporting (including cycle/op details and LSM state snapshots).
  * Describes planned CI coverage, including nightly long-running stress and a shorter deterministic PR smoke test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->