### PR TITLE
feat: land async phase 1 migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,6 +641,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -885,6 +886,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "plotters"
@@ -1230,6 +1237,27 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/kv-engine/Cargo.toml
+++ b/kv-engine/Cargo.toml
@@ -35,6 +35,7 @@ ouroboros = "0.18"
 parking_lot = "0.12"
 rand = "0.8.5"
 rustyline = "18.0.0"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 

--- a/kv-engine/benches/deleterange_benchmarks.rs
+++ b/kv-engine/benches/deleterange_benchmarks.rs
@@ -8,6 +8,7 @@ use std::{hint::black_box, ops::Bound};
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use kv_engine::{
+    FutureResultExt,
     compact::{CompactionOptions, LeveledCompactionOptions},
     iterators::StorageIterator,
     lsm_storage::{KvEngine, LsmStorageOptions, PrefixBloomOptions},

--- a/kv-engine/benches/vlog_benchmarks.rs
+++ b/kv-engine/benches/vlog_benchmarks.rs
@@ -10,6 +10,7 @@ use std::{hint::black_box, ops::Bound, path::Path, sync::Arc};
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use kv_engine::{
+    FutureResultExt,
     compact::{CompactionOptions, LeveledCompactionOptions},
     iterators::StorageIterator,
     lsm_storage::{KvEngine, LsmStorageOptions, PrefixBloomOptions},

--- a/kv-engine/src/bin/bloom-crossproc-writer.rs
+++ b/kv-engine/src/bin/bloom-crossproc-writer.rs
@@ -1,5 +1,17 @@
 use kv_engine::lsm_storage::{KvEngine, LsmStorageOptions};
 
+fn block_on<T>(future: impl std::future::Future<Output = T>) -> T {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build runtime")
+        .block_on(future)
+}
+
+fn block_on_result<T, E>(future: impl std::future::Future<Output = Result<T, E>>) -> Result<T, E> {
+    block_on(future)
+}
+
 fn main() {
     let Some(path) = std::env::args().nth(1) else {
         eprintln!("usage: bloom-crossproc-writer <db-path>");
@@ -10,7 +22,7 @@ fn main() {
     opts.enable_wal = true;
     opts.manifest_snapshot_threshold_bytes = 256;
 
-    let engine = KvEngine::open(path, opts).expect("open writer db");
+    let engine = block_on_result(KvEngine::open(path, opts)).expect("open writer db");
     for i in 0..100u32 {
         let key = format!("k_{i:010}");
         let value = if i % 2 == 0 {
@@ -18,10 +30,10 @@ fn main() {
         } else {
             "y".repeat(1000)
         };
-        engine.put(key.as_bytes(), value.as_bytes()).expect("put");
+        block_on_result(engine.put(key.as_bytes(), value.as_bytes())).expect("put");
         if i % 10 == 9 {
-            engine.force_flush().expect("force_flush");
+            block_on_result(engine.force_flush()).expect("force_flush");
         }
     }
-    engine.close().expect("close writer db");
+    block_on_result(engine.close()).expect("close writer db");
 }

--- a/kv-engine/src/bin/chaos-child.rs
+++ b/kv-engine/src/bin/chaos-child.rs
@@ -7,6 +7,18 @@ use wrapper::kv_engine_wrapper::chaos::scenarios::{self, ScenarioConfig};
 use wrapper::kv_engine_wrapper::chaos::stress::{self, StressScenario};
 use wrapper::kv_engine_wrapper::lsm_storage::KvEngine;
 
+fn block_on<T>(future: impl std::future::Future<Output = T>) -> T {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build runtime")
+        .block_on(future)
+}
+
+fn block_on_result<T, E>(future: impl std::future::Future<Output = Result<T, E>>) -> Result<T, E> {
+    block_on(future)
+}
+
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     if !args.iter().any(|a| a == "--child") {
@@ -134,8 +146,11 @@ fn child_main(args: &[String]) -> Result<(), String> {
     };
 
     // Open the database
-    let engine = KvEngine::open(db_path.as_str(), config.storage_options.clone())
-        .map_err(|e| format!("KvEngine::open failed: {e}"))?;
+    let engine = block_on_result(KvEngine::open(
+        db_path.as_str(),
+        config.storage_options.clone(),
+    ))
+    .map_err(|e| format!("KvEngine::open failed: {e}"))?;
 
     // Create the control log writer
     let mut log = ControlLogWriter::new(log_path.as_str())

--- a/kv-engine/src/bin/kv-engine-cli.rs
+++ b/kv-engine/src/bin/kv-engine-cli.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use bytes::Bytes;
 use clap::{Parser, ValueEnum};
 use kv_engine_wrapper::{
+    FutureResultExt,
     compact::{
         CompactionOptions, LeveledCompactionOptions, SimpleLeveledCompactionOptions,
         TieredCompactionOptions,
@@ -49,10 +50,12 @@ impl ReplHandler {
         match command {
             Command::Fill { begin, end } => {
                 for i in *begin..=*end {
-                    self.lsm.put(
-                        format!("{}", i).as_bytes(),
-                        format!("value{}@{}", i, self.epoch).as_bytes(),
-                    )?;
+                    self.lsm
+                        .put(
+                            format!("{}", i).as_bytes(),
+                            format!("value{}@{}", i, self.epoch).as_bytes(),
+                        )
+                        .into_result()?;
                 }
 
                 println!(
@@ -62,7 +65,7 @@ impl ReplHandler {
                 );
             }
             Command::Del { key } => {
-                self.lsm.delete(key.as_bytes())?;
+                self.lsm.delete(key.as_bytes()).into_result()?;
                 println!("{} deleted", key);
             }
             Command::Delrange { start, end } => {
@@ -71,11 +74,13 @@ impl ReplHandler {
                         "invalid range: start must be less than end"
                     ));
                 }
-                self.lsm.delete_range(start.as_bytes(), end.as_bytes())?;
+                self.lsm
+                    .delete_range(start.as_bytes(), end.as_bytes())
+                    .into_result()?;
                 println!("range deleted: [{}, {})", start, end);
             }
             Command::Get { key } => {
-                if let Some(value) = self.lsm.get(key.as_bytes())? {
+                if let Some(value) = self.lsm.get(key.as_bytes()).into_result()? {
                     println!("{}={:?}", key, value);
                 } else {
                     println!("{} not exist", key);
@@ -85,7 +90,8 @@ impl ReplHandler {
                 (None, None) => {
                     let mut iter = self
                         .lsm
-                        .scan(std::ops::Bound::Unbounded, std::ops::Bound::Unbounded)?;
+                        .scan(std::ops::Bound::Unbounded, std::ops::Bound::Unbounded)
+                        .into_result()?;
                     let mut cnt = 0;
                     while iter.is_valid() {
                         println!(
@@ -100,10 +106,13 @@ impl ReplHandler {
                     println!("{} keys scanned", cnt);
                 }
                 (Some(begin), Some(end)) => {
-                    let mut iter = self.lsm.scan(
-                        std::ops::Bound::Included(begin.as_bytes()),
-                        std::ops::Bound::Included(end.as_bytes()),
-                    )?;
+                    let mut iter = self
+                        .lsm
+                        .scan(
+                            std::ops::Bound::Included(begin.as_bytes()),
+                            std::ops::Bound::Included(end.as_bytes()),
+                        )
+                        .into_result()?;
                     let mut cnt = 0;
                     while iter.is_valid() {
                         println!(
@@ -122,7 +131,7 @@ impl ReplHandler {
                 }
             },
             Command::Prefix { prefix } => {
-                let mut iter = self.lsm.prefix_scan(prefix.as_bytes())?;
+                let mut iter = self.lsm.prefix_scan(prefix.as_bytes()).into_result()?;
                 let mut cnt = 0;
                 while iter.is_valid() {
                     println!(
@@ -141,15 +150,15 @@ impl ReplHandler {
                 println!("dump success");
             }
             Command::Flush => {
-                self.lsm.force_flush()?;
+                self.lsm.force_flush().into_result()?;
                 println!("flush success");
             }
             Command::FullCompaction => {
-                self.lsm.force_full_compaction()?;
+                self.lsm.force_full_compaction().into_result()?;
                 println!("full compaction success");
             }
             Command::Quit | Command::Close => {
-                self.lsm.close()?;
+                self.lsm.close().into_result()?;
                 std::process::exit(0);
             }
             Command::Stats => {
@@ -434,7 +443,8 @@ fn main() -> Result<()> {
             block_cache_capacity: args.block_cache_capacity,
             enable_cache_backfill: true,
         },
-    )?;
+    )
+    .into_result()?;
 
     let repl = ReplBuilder::new()
         .app_name("kv-engine-cli")

--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -13,6 +13,7 @@ use wrapper::kv_engine_wrapper;
 use anyhow::{Context, Result, anyhow, bail};
 use clap::{Parser, ValueEnum};
 use kv_engine_wrapper::{
+    FutureResultExt,
     compact::{
         CompactionOptions, LeveledCompactionOptions, SimpleLeveledCompactionOptions,
         TieredCompactionOptions,
@@ -513,7 +514,7 @@ fn run_scan(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     let workload = "scan";
     let path = prepare_path(cfg, workload)?;
     let options = cfg.build_options(false, false);
-    let engine = KvEngine::open(&path, options.clone())?;
+    let engine = KvEngine::open(&path, options.clone()).into_result()?;
     let load_elapsed = populate_range(&engine, cfg.scan_num, cfg.value_size)?;
     let baseline = collect_counters(&engine)?;
 
@@ -521,7 +522,9 @@ fn run_scan(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
 
     let start = Instant::now();
     let mut count = 0u64;
-    let mut iter = engine.scan(Bound::Unbounded, Bound::Unbounded)?;
+    let mut iter = engine
+        .scan(Bound::Unbounded, Bound::Unbounded)
+        .into_result()?;
     while iter.is_valid() {
         count += 1;
         iter.next()?;
@@ -552,10 +555,12 @@ fn run_scan(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     let hi = cfg.scan_num / 10;
     let start = Instant::now();
     let mut count = 0u64;
-    let mut iter = engine.scan(
-        Bound::Included(format!("key{:08}", 0).as_bytes()),
-        Bound::Excluded(format!("key{:08}", hi).as_bytes()),
-    )?;
+    let mut iter = engine
+        .scan(
+            Bound::Included(format!("key{:08}", 0).as_bytes()),
+            Bound::Excluded(format!("key{:08}", hi).as_bytes()),
+        )
+        .into_result()?;
     while iter.is_valid() {
         count += 1;
         iter.next()?;
@@ -583,7 +588,7 @@ fn run_scan(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
         collect_counter_delta(&after_full_scan, &after_partial_scan),
     ));
 
-    engine.close()?;
+    engine.close().into_result()?;
     finalize_path(cfg, &path)?;
     Ok(measurements)
 }
@@ -603,7 +608,7 @@ fn run_concurrent_rw(
 ) -> Result<Vec<BenchMeasurement>> {
     let path = prepare_path(cfg, workload)?;
     let options = cfg.build_options(wal, false);
-    let engine = KvEngine::open(&path, options.clone())?;
+    let engine = KvEngine::open(&path, options.clone()).into_result()?;
     let load_elapsed = populate_range(&engine, cfg.num, cfg.value_size)?;
     let baseline = collect_counters(&engine)?;
 
@@ -657,7 +662,7 @@ fn run_concurrent_rw(
         handles.push(std::thread::spawn(move || {
             let mut local = 0u64;
             while !stop.load(Ordering::Relaxed) {
-                if let Ok(mut iter) = eng.scan(Bound::Unbounded, Bound::Unbounded) {
+                if let Ok(mut iter) = eng.scan(Bound::Unbounded, Bound::Unbounded).into_result() {
                     while iter.is_valid() {
                         if iter.next().is_err() {
                             break;
@@ -684,7 +689,7 @@ fn run_concurrent_rw(
     let reads = read_count.load(Ordering::Relaxed);
     let scan_entries = scan_count.load(Ordering::Relaxed);
     let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
-    engine.close()?;
+    engine.close().into_result()?;
     finalize_path(cfg, &path)?;
 
     Ok(vec![make_measurement(
@@ -729,19 +734,21 @@ fn run_wal_throughput(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     };
     for (measurement, num_keys, value_size) in cases {
         let path = prepare_path(cfg, &format!("{workload}_{measurement}"))?;
-        let engine = KvEngine::open(&path, options.clone())?;
+        let engine = KvEngine::open(&path, options.clone()).into_result()?;
         let value = vec![b'x'; value_size];
         let start = Instant::now();
         for i in 0..num_keys {
-            engine.put(format!("key{:08}", i).as_bytes(), &value)?;
+            engine
+                .put(format!("key{:08}", i).as_bytes(), &value)
+                .into_result()?;
         }
         let elapsed = start.elapsed();
         if cfg.profile {
             print_write_profile(&engine, &format!("{workload}_{measurement}"));
         }
-        engine.drain_flush()?;
+        engine.drain_flush().into_result()?;
         let counters = collect_counters(&engine)?;
-        engine.close()?;
+        engine.close().into_result()?;
         finalize_path(cfg, &path)?;
         results.push(make_measurement(
             cfg,
@@ -770,7 +777,7 @@ fn run_wal_concurrent(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     let workload = "wal_concurrent";
     let path = prepare_path(cfg, workload)?;
     let options = cfg.build_options(true, false);
-    let engine = KvEngine::open(&path, options.clone())?;
+    let engine = KvEngine::open(&path, options.clone()).into_result()?;
     let value = vec![b'x'; cfg.value_size];
     let num_keys = cfg.num;
     let writer_threads = cfg.threads;
@@ -800,9 +807,9 @@ fn run_wal_concurrent(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     if cfg.profile {
         print_write_profile(&engine, workload);
     }
-    engine.drain_flush()?;
+    engine.drain_flush().into_result()?;
     let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
-    engine.close()?;
+    engine.close().into_result()?;
     finalize_path(cfg, &path)?;
 
     Ok(vec![make_measurement(
@@ -831,7 +838,7 @@ fn run_vlog_gc(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     let workload = "vlog_gc";
     let path = prepare_path(cfg, workload)?;
     let options = cfg.build_options(false, true);
-    let engine = KvEngine::open(&path, options.clone())?;
+    let engine = KvEngine::open(&path, options.clone()).into_result()?;
     let entries_per_round = 5_000usize;
     let num_rounds = 3usize;
     let initial_value = vec![b'x'; 4096];
@@ -844,10 +851,12 @@ fn run_vlog_gc(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
         let value = format!("v{round}_{padding}");
         let write_start = Instant::now();
         for i in 0..entries_per_round {
-            engine.put(format!("key{:08}", i).as_bytes(), value.as_bytes())?;
+            engine
+                .put(format!("key{:08}", i).as_bytes(), value.as_bytes())
+                .into_result()?;
         }
         let write_elapsed = write_start.elapsed();
-        engine.drain_flush()?;
+        engine.drain_flush().into_result()?;
 
         let gc_start = Instant::now();
         let _gc_count = engine.trigger_gc()?;
@@ -880,7 +889,7 @@ fn run_vlog_gc(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
         baseline = after_round;
     }
 
-    engine.close()?;
+    engine.close().into_result()?;
     finalize_path(cfg, &path)?;
     Ok(measurements)
 }
@@ -889,7 +898,7 @@ fn run_vlog_concurrent_gc(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> 
     let workload = "vlog_concurrent_gc";
     let path = prepare_path(cfg, workload)?;
     let options = cfg.build_options(false, true);
-    let engine = KvEngine::open(&path, options.clone())?;
+    let engine = KvEngine::open(&path, options.clone()).into_result()?;
     let initial_value = vec![b'x'; 4096];
     let load_elapsed = populate_fixed_value(&engine, 5_000, &initial_value)?;
     let baseline = collect_counters(&engine)?;
@@ -966,7 +975,7 @@ fn run_vlog_concurrent_gc(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> 
     let reads = rc.load(Ordering::Relaxed);
     let gc_rounds = gcc.load(Ordering::Relaxed);
     let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
-    engine.close()?;
+    engine.close().into_result()?;
     finalize_path(cfg, &path)?;
 
     Ok(vec![make_measurement(
@@ -997,19 +1006,21 @@ fn run_fillseq(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     let workload = "fillseq";
     let path = prepare_path(cfg, workload)?;
     let options = cfg.build_options(false, false);
-    let engine = KvEngine::open(&path, options.clone())?;
+    let engine = KvEngine::open(&path, options.clone()).into_result()?;
     let value = vec![b'x'; cfg.value_size];
     let start = Instant::now();
     for i in 0..cfg.num {
-        engine.put(format!("key{:08}", i).as_bytes(), &value)?;
+        engine
+            .put(format!("key{:08}", i).as_bytes(), &value)
+            .into_result()?;
     }
     let elapsed = start.elapsed();
     if cfg.profile {
         print_write_profile(&engine, workload);
     }
-    engine.drain_flush()?;
+    engine.drain_flush().into_result()?;
     let counters = collect_counters(&engine)?;
-    engine.close()?;
+    engine.close().into_result()?;
     finalize_path(cfg, &path)?;
 
     Ok(vec![make_measurement(
@@ -1037,7 +1048,7 @@ fn run_fillrandom(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     let workload = "fillrandom";
     let path = prepare_path(cfg, workload)?;
     let options = cfg.build_options(false, false);
-    let engine = KvEngine::open(&path, options.clone())?;
+    let engine = KvEngine::open(&path, options.clone()).into_result()?;
     let value = vec![b'x'; cfg.value_size];
     let mut rng = StdRng::seed_from_u64(cfg.seed);
     let mut key_buf = [0u8; 11];
@@ -1046,15 +1057,15 @@ fn run_fillrandom(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     for _ in 0..cfg.num {
         let n = rng.gen_range(0..cfg.num as u64);
         write!(&mut key_buf[3..], "{:08}", n).expect("key format");
-        engine.put(&key_buf, &value)?;
+        engine.put(&key_buf, &value).into_result()?;
     }
     let elapsed = start.elapsed();
     if cfg.profile {
         print_write_profile(&engine, workload);
     }
-    engine.drain_flush()?;
+    engine.drain_flush().into_result()?;
     let counters = collect_counters(&engine)?;
-    engine.close()?;
+    engine.close().into_result()?;
     finalize_path(cfg, &path)?;
 
     Ok(vec![make_measurement(
@@ -1082,7 +1093,7 @@ fn run_readrandom(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     let workload = "readrandom";
     let path = prepare_path(cfg, workload)?;
     let options = cfg.build_options(false, false);
-    let engine = KvEngine::open(&path, options.clone())?;
+    let engine = KvEngine::open(&path, options.clone()).into_result()?;
     let load_elapsed = populate_range(&engine, cfg.num, cfg.value_size)?;
     let baseline = collect_counters(&engine)?;
 
@@ -1093,13 +1104,13 @@ fn run_readrandom(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     for _ in 0..cfg.reads {
         key.clear();
         let _ = write!(&mut key, "key{:08}", rng.gen_range(0..cfg.num as u64));
-        if engine.get(key.as_bytes())?.is_some() {
+        if engine.get(key.as_bytes()).into_result()?.is_some() {
             found += 1;
         }
     }
     let elapsed = start.elapsed();
     let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
-    engine.close()?;
+    engine.close().into_result()?;
     finalize_path(cfg, &path)?;
 
     Ok(vec![make_measurement(
@@ -1130,7 +1141,7 @@ fn run_readwhilewriting(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     let workload = "readwhilewriting";
     let path = prepare_path(cfg, workload)?;
     let options = cfg.build_options(false, false);
-    let engine = KvEngine::open(&path, options.clone())?;
+    let engine = KvEngine::open(&path, options.clone()).into_result()?;
     let load_elapsed = populate_range(&engine, cfg.num, cfg.value_size)?;
     let baseline = collect_counters(&engine)?;
 
@@ -1190,7 +1201,7 @@ fn run_readwhilewriting(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     let writes = wc.load(Ordering::Relaxed);
     let reads = rc.load(Ordering::Relaxed);
     let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
-    engine.close()?;
+    engine.close().into_result()?;
     finalize_path(cfg, &path)?;
 
     Ok(vec![make_measurement(
@@ -1223,7 +1234,7 @@ fn run_readrandomwriterandom(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement
     let workload = "readrandomwriterandom";
     let path = prepare_path(cfg, workload)?;
     let options = cfg.build_options(false, false);
-    let engine = KvEngine::open(&path, options.clone())?;
+    let engine = KvEngine::open(&path, options.clone()).into_result()?;
     let load_elapsed = populate_range(&engine, cfg.num, cfg.value_size)?;
     let baseline = collect_counters(&engine)?;
 
@@ -1272,7 +1283,7 @@ fn run_readrandomwriterandom(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement
     let writes = wc.load(Ordering::Relaxed);
     let reads = rc.load(Ordering::Relaxed);
     let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
-    engine.close()?;
+    engine.close().into_result()?;
     finalize_path(cfg, &path)?;
 
     Ok(vec![make_measurement(
@@ -1305,7 +1316,7 @@ fn run_seekrandom(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     let workload = "seekrandom";
     let path = prepare_path(cfg, workload)?;
     let options = cfg.build_options(false, false);
-    let engine = KvEngine::open(&path, options.clone())?;
+    let engine = KvEngine::open(&path, options.clone()).into_result()?;
     let load_elapsed = populate_fixed_value(&engine, cfg.num, &vec![b'x'; cfg.value_size])?;
     let baseline = collect_counters(&engine)?;
 
@@ -1314,7 +1325,10 @@ fn run_seekrandom(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     let mut total_nexts = 0u64;
     for _ in 0..cfg.seeks {
         let key = format!("key{:08}", rng.gen_range(0..cfg.num as u64));
-        if let Ok(mut iter) = engine.scan(Bound::Included(key.as_bytes()), Bound::Unbounded) {
+        if let Ok(mut iter) = engine
+            .scan(Bound::Included(key.as_bytes()), Bound::Unbounded)
+            .into_result()
+        {
             for _ in 0..cfg.seek_nexts {
                 if !iter.is_valid() {
                     break;
@@ -1328,7 +1342,7 @@ fn run_seekrandom(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     }
     let elapsed = start.elapsed();
     let counters = collect_counters(&engine)?;
-    engine.close()?;
+    engine.close().into_result()?;
     finalize_path(cfg, &path)?;
 
     Ok(vec![make_measurement(
@@ -1360,7 +1374,7 @@ fn run_overwrite(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     let workload = "overwrite";
     let path = prepare_path(cfg, workload)?;
     let options = cfg.build_options(false, false);
-    let engine = KvEngine::open(&path, options.clone())?;
+    let engine = KvEngine::open(&path, options.clone()).into_result()?;
     let load_elapsed = populate_range(&engine, cfg.num, cfg.value_size)?;
     let baseline = collect_counters(&engine)?;
 
@@ -1372,15 +1386,15 @@ fn run_overwrite(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     for _ in 0..cfg.num {
         let n = rng.gen_range(0..cfg.num as u64);
         write!(&mut key_buf[3..], "{:08}", n).expect("key format");
-        engine.put(&key_buf, &value)?;
+        engine.put(&key_buf, &value).into_result()?;
     }
     let elapsed = start.elapsed();
     if cfg.profile {
         print_write_profile(&engine, workload);
     }
-    engine.drain_flush()?;
+    engine.drain_flush().into_result()?;
     let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
-    engine.close()?;
+    engine.close().into_result()?;
     finalize_path(cfg, &path)?;
 
     Ok(vec![make_measurement(
@@ -1409,13 +1423,15 @@ fn run_readseq(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     let workload = "readseq";
     let path = prepare_path(cfg, workload)?;
     let options = cfg.build_options(false, false);
-    let engine = KvEngine::open(&path, options.clone())?;
+    let engine = KvEngine::open(&path, options.clone()).into_result()?;
     let load_elapsed = populate_range(&engine, cfg.num, cfg.value_size)?;
     let baseline = collect_counters(&engine)?;
 
     let start = Instant::now();
     let mut count = 0u64;
-    let mut iter = engine.scan(Bound::Unbounded, Bound::Unbounded)?;
+    let mut iter = engine
+        .scan(Bound::Unbounded, Bound::Unbounded)
+        .into_result()?;
     while iter.is_valid() {
         count += 1;
         iter.next()?;
@@ -1428,7 +1444,7 @@ fn run_readseq(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
         count
     );
     let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
-    engine.close()?;
+    engine.close().into_result()?;
     finalize_path(cfg, &path)?;
 
     Ok(vec![make_measurement(
@@ -1457,7 +1473,7 @@ fn run_readseq_validate_order(cfg: &HarnessConfig) -> Result<Vec<BenchMeasuremen
     let workload = "readseq_validate_order";
     let path = prepare_path(cfg, workload)?;
     let options = cfg.build_options(false, false);
-    let engine = KvEngine::open(&path, options.clone())?;
+    let engine = KvEngine::open(&path, options.clone()).into_result()?;
     let load_elapsed = populate_range(&engine, cfg.num, cfg.value_size)?;
     let baseline = collect_counters(&engine)?;
 
@@ -1465,7 +1481,9 @@ fn run_readseq_validate_order(cfg: &HarnessConfig) -> Result<Vec<BenchMeasuremen
     let mut count = 0u64;
     let mut prev_key = Vec::new();
     let mut has_prev = false;
-    let mut iter = engine.scan(Bound::Unbounded, Bound::Unbounded)?;
+    let mut iter = engine
+        .scan(Bound::Unbounded, Bound::Unbounded)
+        .into_result()?;
     while iter.is_valid() {
         let current = iter.key();
         if has_prev {
@@ -1490,7 +1508,7 @@ fn run_readseq_validate_order(cfg: &HarnessConfig) -> Result<Vec<BenchMeasuremen
         count
     );
     let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
-    engine.close()?;
+    engine.close().into_result()?;
     finalize_path(cfg, &path)?;
 
     Ok(vec![make_measurement(
@@ -1520,13 +1538,15 @@ fn run_readmissing(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     anyhow::ensure!(cfg.num >= 2, "readmissing requires --num >= 2");
     let path = prepare_path(cfg, workload)?;
     let options = cfg.build_options(false, false);
-    let engine = KvEngine::open(&path, options.clone())?;
+    let engine = KvEngine::open(&path, options.clone()).into_result()?;
     let value = vec![b'x'; cfg.value_size];
     let load_start = Instant::now();
     for i in (0..cfg.num).step_by(2) {
-        engine.put(format!("key{:08}", i).as_bytes(), &value)?;
+        engine
+            .put(format!("key{:08}", i).as_bytes(), &value)
+            .into_result()?;
     }
-    engine.drain_flush()?;
+    engine.drain_flush().into_result()?;
     let load_elapsed = load_start.elapsed();
     let baseline = collect_counters(&engine)?;
 
@@ -1538,7 +1558,7 @@ fn run_readmissing(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     for _ in 0..cfg.reads {
         let n = rng.gen_range(0..cfg.num as u64 / 2) * 2 + 1;
         write!(&mut key_buf[3..], "{:08}", n).expect("key format");
-        if engine.get(&key_buf)?.is_some() {
+        if engine.get(&key_buf).into_result()?.is_some() {
             found += 1;
         }
     }
@@ -1549,7 +1569,7 @@ fn run_readmissing(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
         found
     );
     let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
-    engine.close()?;
+    engine.close().into_result()?;
     finalize_path(cfg, &path)?;
 
     Ok(vec![make_measurement(
@@ -1580,7 +1600,7 @@ fn run_seekrandomwhilewriting(cfg: &HarnessConfig) -> Result<Vec<BenchMeasuremen
     let workload = "seekrandomwhilewriting";
     let path = prepare_path(cfg, workload)?;
     let options = cfg.build_options(false, false);
-    let engine = KvEngine::open(&path, options.clone())?;
+    let engine = KvEngine::open(&path, options.clone()).into_result()?;
     let load_elapsed = populate_fixed_value(&engine, cfg.num, &vec![b'x'; cfg.value_size])?;
     let baseline = collect_counters(&engine)?;
 
@@ -1606,7 +1626,7 @@ fn run_seekrandomwhilewriting(cfg: &HarnessConfig) -> Result<Vec<BenchMeasuremen
             while !stop.load(Ordering::Relaxed) {
                 let n = rng.gen_range(0..num as u64);
                 write!(&mut key_buf[3..], "{:08}", n).expect("key format");
-                match eng.put(&key_buf, &value) {
+                match eng.put(&key_buf, &value).into_result() {
                     Ok(()) => c += 1,
                     Err(e) => {
                         *write_err.lock() = Some(format!("{e}"));
@@ -1627,7 +1647,9 @@ fn run_seekrandomwhilewriting(cfg: &HarnessConfig) -> Result<Vec<BenchMeasuremen
         for _ in 0..cfg.seeks {
             let n = rng.gen_range(0..cfg.num as u64);
             write!(&mut key_buf[3..], "{:08}", n).expect("key format");
-            let mut iter = engine.scan(Bound::Included(&key_buf), Bound::Unbounded)?;
+            let mut iter = engine
+                .scan(Bound::Included(&key_buf), Bound::Unbounded)
+                .into_result()?;
             for _ in 0..cfg.seek_nexts {
                 if !iter.is_valid() {
                     break;
@@ -1653,7 +1675,7 @@ fn run_seekrandomwhilewriting(cfg: &HarnessConfig) -> Result<Vec<BenchMeasuremen
     let writes = wc.load(Ordering::Relaxed);
     let total_nexts = seek_result?;
     let counters = collect_counters(&engine)?;
-    engine.close()?;
+    engine.close().into_result()?;
     finalize_path(cfg, &path)?;
 
     Ok(vec![make_measurement(
@@ -1686,7 +1708,7 @@ fn run_deleterandom(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     let workload = "deleterandom";
     let path = prepare_path(cfg, workload)?;
     let options = cfg.build_options(false, false);
-    let engine = KvEngine::open(&path, options.clone())?;
+    let engine = KvEngine::open(&path, options.clone()).into_result()?;
     let load_elapsed = populate_fixed_value(&engine, cfg.num, &vec![b'x'; cfg.value_size])?;
     let baseline = collect_counters(&engine)?;
 
@@ -1697,12 +1719,12 @@ fn run_deleterandom(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     for _ in 0..cfg.num {
         let n = rng.gen_range(0..cfg.num as u64);
         write!(&mut key_buf[3..], "{:08}", n).expect("key format");
-        engine.delete(&key_buf)?;
+        engine.delete(&key_buf).into_result()?;
     }
     let elapsed = start.elapsed();
-    engine.drain_flush()?;
+    engine.drain_flush().into_result()?;
     let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
-    engine.close()?;
+    engine.close().into_result()?;
     finalize_path(cfg, &path)?;
 
     Ok(vec![make_measurement(
@@ -1732,15 +1754,15 @@ fn run_compact(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
     let path = prepare_path(cfg, workload)?;
     let mut options = cfg.build_options(false, false);
     options.compaction_options = CompactionOptions::NoCompaction;
-    let engine = KvEngine::open(&path, options.clone())?;
+    let engine = KvEngine::open(&path, options.clone()).into_result()?;
     let load_elapsed = populate_range(&engine, cfg.num, cfg.value_size)?;
     let baseline = collect_counters(&engine)?;
 
     let start = Instant::now();
-    engine.force_full_compaction()?;
+    engine.force_full_compaction().into_result()?;
     let elapsed = start.elapsed();
     let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
-    engine.close()?;
+    engine.close().into_result()?;
     finalize_path(cfg, &path)?;
 
     Ok(vec![make_measurement(
@@ -1940,18 +1962,22 @@ fn populate_range(engine: &KvEngine, num_entries: usize, value_size: usize) -> R
     let value = vec![b'x'; value_size];
     let start = Instant::now();
     for i in 0..num_entries {
-        engine.put(format!("key{:08}", i).as_bytes(), &value)?;
+        engine
+            .put(format!("key{:08}", i).as_bytes(), &value)
+            .into_result()?;
     }
-    engine.drain_flush()?;
+    engine.drain_flush().into_result()?;
     Ok(start.elapsed())
 }
 
 fn populate_fixed_value(engine: &KvEngine, num_entries: usize, value: &[u8]) -> Result<Duration> {
     let start = Instant::now();
     for i in 0..num_entries {
-        engine.put(format!("key{:08}", i).as_bytes(), value)?;
+        engine
+            .put(format!("key{:08}", i).as_bytes(), value)
+            .into_result()?;
     }
-    engine.drain_flush()?;
+    engine.drain_flush().into_result()?;
     Ok(start.elapsed())
 }
 

--- a/kv-engine/src/debug.rs
+++ b/kv-engine/src/debug.rs
@@ -35,6 +35,7 @@ impl KvEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::FutureResultExt;
     use crate::lsm_storage::LsmStorageOptions;
 
     #[test]

--- a/kv-engine/src/future_ext.rs
+++ b/kv-engine/src/future_ext.rs
@@ -1,0 +1,63 @@
+use std::{fmt::Debug, future::Future};
+
+use tokio::runtime::Builder;
+
+/// Compatibility helpers for call sites that still need to synchronously wait
+/// on async engine methods during the phase-1 migration.
+///
+/// The engine surface itself is async; this trait only exists so legacy tests
+/// and binaries can keep compiling while we convert their call sites.
+pub trait FutureResultExt<T, E>: Future<Output = std::result::Result<T, E>> + Sized {
+    fn into_result(self) -> std::result::Result<T, E> {
+        build_runtime().block_on(self)
+    }
+
+    fn unwrap(self) -> T
+    where
+        E: Debug,
+    {
+        self.into_result().unwrap()
+    }
+
+    fn expect(self, msg: &str) -> T
+    where
+        E: Debug,
+    {
+        self.into_result().expect(msg)
+    }
+
+    fn unwrap_err(self) -> E
+    where
+        T: Debug,
+    {
+        self.into_result().unwrap_err()
+    }
+
+    fn ok(self) -> Option<T> {
+        self.into_result().ok()
+    }
+
+    fn is_ok(self) -> bool
+    where
+        E: Debug,
+    {
+        self.into_result().is_ok()
+    }
+
+    fn is_err(self) -> bool
+    where
+        E: Debug,
+    {
+        self.into_result().is_err()
+    }
+}
+
+impl<F, T, E> FutureResultExt<T, E> for F where F: Future<Output = std::result::Result<T, E>> + Sized
+{}
+
+fn build_runtime() -> tokio::runtime::Runtime {
+    Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build compatibility runtime")
+}

--- a/kv-engine/src/lib.rs
+++ b/kv-engine/src/lib.rs
@@ -2,6 +2,7 @@ pub mod block;
 pub(crate) mod cache;
 pub mod compact;
 pub mod debug;
+pub mod future_ext;
 pub mod iterators;
 pub mod key;
 pub mod lsm_iterator;
@@ -13,6 +14,8 @@ pub mod range_tombstone;
 pub mod table;
 pub mod vlog;
 pub mod wal;
+
+pub use future_ext::FutureResultExt;
 
 #[cfg(feature = "chaos-testing")]
 pub mod chaos;

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -5,14 +5,14 @@ use std::{
     path::{Path, PathBuf},
     sync::{
         Arc,
-        atomic::{AtomicU64, AtomicUsize},
+        atomic::{AtomicU8, AtomicU64, AtomicUsize, Ordering},
     },
 };
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context as _, Result, anyhow};
 use arc_swap::ArcSwap;
 use bytes::Bytes;
-use parking_lot::{Mutex, MutexGuard, RwLock};
+use parking_lot::{Condvar, Mutex, MutexGuard, RwLock};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -47,6 +47,170 @@ pub type VersionedCasEntry = (Vec<u8>, u64, Vec<u8>, KvKind, Vec<u8>, KvKind);
 /// `version_ts` is the MVCC timestamp of the found version (0 when MVCC disabled).
 type LookupResult = (Option<Bytes>, KvKind, Bytes, u64);
 type VersionedCasCandidate = Option<(Vec<u8>, u32)>;
+
+const LIFECYCLE_OPEN: u8 = 0;
+const LIFECYCLE_CLOSING: u8 = 1;
+const LIFECYCLE_CLOSED: u8 = 2;
+
+#[derive(Clone)]
+pub(crate) struct LifecycleHandle(Arc<LifecycleState>);
+
+impl LifecycleHandle {
+    pub(crate) fn new() -> Self {
+        Self(Arc::new(LifecycleState::default()))
+    }
+
+    pub(crate) fn admit_write(&self) -> Result<AdmissionGuard> {
+        self.admit(AdmissionKind::Write)
+    }
+
+    pub(crate) fn admit_scan(&self) -> Result<AdmissionGuard> {
+        self.admit(AdmissionKind::Scan)
+    }
+
+    pub(crate) fn admit_txn(&self) -> Result<AdmissionGuard> {
+        self.admit(AdmissionKind::Txn)
+    }
+
+    fn admit(&self, kind: AdmissionKind) -> Result<AdmissionGuard> {
+        self.ensure_open()?;
+        self.0.increment(kind);
+        if self.0.is_open() {
+            Ok(AdmissionGuard {
+                lifecycle: self.clone(),
+                kind,
+                released: false,
+            })
+        } else {
+            self.0.decrement(kind);
+            Err(anyhow!("engine is closing"))
+        }
+    }
+
+    pub(crate) fn ensure_open(&self) -> Result<()> {
+        match self.0.state.load(Ordering::Acquire) {
+            LIFECYCLE_OPEN => Ok(()),
+            LIFECYCLE_CLOSING => Err(anyhow!("engine is closing")),
+            LIFECYCLE_CLOSED => Err(anyhow!("engine is closed")),
+            other => Err(anyhow!("invalid lifecycle state {other}")),
+        }
+    }
+
+    pub(crate) fn begin_close(&self) -> CloseState {
+        match self.0.state.compare_exchange(
+            LIFECYCLE_OPEN,
+            LIFECYCLE_CLOSING,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => CloseState::Started,
+            Err(LIFECYCLE_CLOSING) => CloseState::AlreadyClosing,
+            Err(LIFECYCLE_CLOSED) => CloseState::AlreadyClosed,
+            Err(other) => panic!("invalid lifecycle state {other}"),
+        }
+    }
+
+    pub(crate) fn wait_for_quiescence(&self) {
+        let mut lock = self.0.wait_lock.lock();
+        while !self.0.is_quiescent() {
+            self.0.wait_cv.wait(&mut lock);
+        }
+    }
+
+    pub(crate) fn wait_for_closed(&self) {
+        let mut lock = self.0.wait_lock.lock();
+        while !self.is_closed() {
+            self.0.wait_cv.wait(&mut lock);
+        }
+    }
+
+    pub(crate) fn finish_close(&self) {
+        self.0.state.store(LIFECYCLE_CLOSED, Ordering::Release);
+        self.0.wait_cv.notify_all();
+    }
+
+    pub(crate) fn is_closed(&self) -> bool {
+        self.0.state.load(Ordering::Acquire) == LIFECYCLE_CLOSED
+    }
+}
+
+#[derive(Default)]
+struct LifecycleState {
+    state: AtomicU8,
+    active_writes: AtomicU64,
+    active_scans: AtomicU64,
+    active_txns: AtomicU64,
+    wait_lock: Mutex<()>,
+    wait_cv: Condvar,
+}
+
+impl LifecycleState {
+    fn is_open(&self) -> bool {
+        self.state.load(Ordering::Acquire) == LIFECYCLE_OPEN
+    }
+
+    fn is_quiescent(&self) -> bool {
+        self.active_writes.load(Ordering::Acquire) == 0
+            && self.active_scans.load(Ordering::Acquire) == 0
+            && self.active_txns.load(Ordering::Acquire) == 0
+    }
+
+    fn increment(&self, kind: AdmissionKind) {
+        match kind {
+            AdmissionKind::Write => {
+                self.active_writes.fetch_add(1, Ordering::AcqRel);
+            }
+            AdmissionKind::Scan => {
+                self.active_scans.fetch_add(1, Ordering::AcqRel);
+            }
+            AdmissionKind::Txn => {
+                self.active_txns.fetch_add(1, Ordering::AcqRel);
+            }
+        }
+    }
+
+    fn decrement(&self, kind: AdmissionKind) {
+        let notify = match kind {
+            AdmissionKind::Write => self.active_writes.fetch_sub(1, Ordering::AcqRel) == 1,
+            AdmissionKind::Scan => self.active_scans.fetch_sub(1, Ordering::AcqRel) == 1,
+            AdmissionKind::Txn => self.active_txns.fetch_sub(1, Ordering::AcqRel) == 1,
+        };
+        if notify && self.state.load(Ordering::Acquire) == LIFECYCLE_CLOSING && self.is_quiescent()
+        {
+            self.wait_cv.notify_all();
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum AdmissionKind {
+    Write,
+    Scan,
+    Txn,
+}
+
+pub(crate) enum CloseState {
+    Started,
+    AlreadyClosing,
+    AlreadyClosed,
+}
+
+pub(crate) struct AdmissionGuard {
+    pub(crate) lifecycle: LifecycleHandle,
+    kind: AdmissionKind,
+    released: bool,
+}
+
+impl AdmissionGuard {}
+
+impl Drop for AdmissionGuard {
+    fn drop(&mut self) {
+        if !self.released {
+            self.lifecycle.0.decrement(self.kind);
+            self.released = true;
+        }
+    }
+}
 
 struct BatchGetContext<'a> {
     bloom_hashes: Vec<u32>,
@@ -781,6 +945,7 @@ pub(crate) struct LsmStorageInner {
     pub(crate) gc_handles: Mutex<Vec<std::thread::JoinHandle<()>>>,
     /// Cumulative write-path profiling counters (persists across memtable freezes).
     pub(crate) write_profile: Arc<crate::mem_table::WriteProfile>,
+    pub(crate) lifecycle: LifecycleHandle,
 }
 
 /// A thin wrapper for `LsmStorageInner` and the user interface for `KvEngine`.
@@ -809,11 +974,27 @@ impl Drop for KvEngine {
         if let Some(f) = self.compaction_thread.lock().take() {
             let _ = f.join();
         }
+        if !self.inner.lifecycle.is_closed() {
+            log::warn!("KvEngine dropped without calling close()");
+        }
     }
 }
 
 impl KvEngine {
-    pub fn close(&self) -> Result<()> {
+    pub async fn close(&self) -> Result<()> {
+        self.close_inner()
+    }
+
+    fn close_inner(&self) -> Result<()> {
+        match self.inner.lifecycle.begin_close() {
+            CloseState::AlreadyClosed => return Ok(()),
+            CloseState::AlreadyClosing => {
+                self.inner.lifecycle.wait_for_closed();
+                return Ok(());
+            }
+            CloseState::Started => {}
+        }
+
         self.flush_notifier.send(()).ok();
         if let Some(f) = self.flush_thread.lock().take() {
             f.join().map_err(|e| anyhow!("{:?}", e))?;
@@ -827,10 +1008,11 @@ impl KvEngine {
         for h in handles {
             let _ = h.join();
         }
+        self.inner.lifecycle.wait_for_quiescence();
         if self.inner.options.enable_wal {
             self.inner.sync()?;
             self.inner.sync_dir()?;
-
+            self.inner.lifecycle.finish_close();
             return Ok(());
         }
 
@@ -844,12 +1026,17 @@ impl KvEngine {
             self.inner.force_flush_next_imm_memtable()?;
         }
 
+        self.inner.lifecycle.finish_close();
         Ok(())
     }
 
     /// Start the storage engine by either loading an existing directory or creating a new one if
     /// the directory does not exist.
-    pub fn open(path: impl AsRef<Path>, options: LsmStorageOptions) -> Result<Arc<Self>> {
+    pub async fn open(path: impl AsRef<Path>, options: LsmStorageOptions) -> Result<Arc<Self>> {
+        Self::open_inner(path, options)
+    }
+
+    fn open_inner(path: impl AsRef<Path>, options: LsmStorageOptions) -> Result<Arc<Self>> {
         let inner = Arc::new(LsmStorageInner::open(path, options)?);
         // Set the weak self-reference so background threads (e.g., async GC) can
         // obtain a strong reference to the engine.
@@ -872,16 +1059,25 @@ impl KvEngine {
     ///
     /// The transaction reads from a consistent snapshot at its creation
     /// timestamp. Writes are buffered locally until `commit()`.
-    pub fn new_txn(&self) -> Result<Arc<crate::mvcc::txn::Transaction>> {
-        self.inner.new_txn()
+    pub async fn new_txn(&self) -> Result<Arc<crate::mvcc::txn::Transaction>> {
+        (|| {
+            let lifecycle_guard = self.inner.lifecycle.admit_txn()?;
+            self.inner.new_txn_with_guard(lifecycle_guard)
+        })()
     }
 
-    pub fn write_batch<T: AsRef<[u8]>>(&self, batch: &[WriteBatchRecord<T>]) -> Result<()> {
-        self.inner.write_batch(batch)
+    pub async fn write_batch<T: AsRef<[u8]>>(&self, batch: &[WriteBatchRecord<T>]) -> Result<()> {
+        (|| {
+            let _guard = self.inner.lifecycle.admit_write()?;
+            self.inner.write_batch(batch)
+        })()
     }
 
     pub fn add_compaction_filter(&self, compaction_filter: CompactionFilterRequest) -> Result<u64> {
-        self.inner.add_compaction_filter(compaction_filter)
+        (|| {
+            self.inner.lifecycle.ensure_open()?;
+            self.inner.add_compaction_filter(compaction_filter)
+        })()
     }
 
     pub fn add_compaction_filter_with_cutoff(
@@ -889,12 +1085,18 @@ impl KvEngine {
         compaction_filter: CompactionFilterRequest,
         cutoff_ts: u64,
     ) -> Result<u64> {
-        self.inner
-            .add_compaction_filter_with_cutoff(compaction_filter, cutoff_ts)
+        (|| {
+            self.inner.lifecycle.ensure_open()?;
+            self.inner
+                .add_compaction_filter_with_cutoff(compaction_filter, cutoff_ts)
+        })()
     }
 
-    pub fn remove_compaction_filter(&self, id: u64) -> Result<bool> {
-        self.inner.remove_compaction_filter(id)
+    pub async fn remove_compaction_filter(&self, id: u64) -> Result<bool> {
+        (|| {
+            self.inner.lifecycle.ensure_open()?;
+            self.inner.remove_compaction_filter(id)
+        })()
     }
 
     pub fn list_compaction_filters(&self) -> Vec<CompactionFilterInfo> {
@@ -905,24 +1107,33 @@ impl KvEngine {
         self.inner.compaction_filter_stats()
     }
 
-    pub fn get(&self, key: &[u8]) -> Result<Option<Bytes>> {
-        self.inner.get(key)
+    pub async fn get(&self, key: &[u8]) -> Result<Option<Bytes>> {
+        (|| {
+            self.inner.lifecycle.ensure_open()?;
+            self.inner.get(key)
+        })()
     }
 
     /// Batch point-read for multiple keys.
     ///
     /// Optimized for throughput when reading many keys at once. Results are
     /// returned in the same order as the input keys.
-    pub fn batch_get(&self, keys: &[&[u8]]) -> Vec<Result<Option<Bytes>>> {
+    pub async fn batch_get(&self, keys: &[&[u8]]) -> Vec<Result<Option<Bytes>>> {
         self.inner.batch_get(keys)
     }
 
-    pub fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
-        self.inner.put(key, value)
+    pub async fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
+        (|| {
+            let _guard = self.inner.lifecycle.admit_write()?;
+            self.inner.put(key, value)
+        })()
     }
 
-    pub fn delete(&self, key: &[u8]) -> Result<()> {
-        self.inner.delete(key)
+    pub async fn delete(&self, key: &[u8]) -> Result<()> {
+        (|| {
+            let _guard = self.inner.lifecycle.admit_write()?;
+            self.inner.delete(key)
+        })()
     }
 
     /// Delete all keys in the half-open range `[start, end)`.
@@ -935,16 +1146,27 @@ impl KvEngine {
     /// Returns an error if `start >= end`, if either key exceeds the maximum
     /// key size, or if the engine is in serializable mode or has value
     /// separation enabled (not supported in the MVP).
-    pub fn delete_range(&self, start: &[u8], end: &[u8]) -> Result<()> {
-        self.inner.delete_range_internal(start, end)
+    pub async fn delete_range(&self, start: &[u8], end: &[u8]) -> Result<()> {
+        (|| {
+            let _guard = self.inner.lifecycle.admit_write()?;
+            self.inner.delete_range_internal(start, end)
+        })()
     }
 
-    pub fn sync(&self) -> Result<()> {
-        self.inner.sync()
+    pub async fn sync(&self) -> Result<()> {
+        (|| {
+            let _guard = self.inner.lifecycle.admit_write()?;
+            self.inner.sync()
+        })()
     }
 
-    pub fn scan(&self, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> Result<ScanIterator> {
-        self.inner.scan(lower, upper)
+    pub async fn scan(&self, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> Result<AsyncScan> {
+        (|| {
+            let guard = self.inner.lifecycle.admit_scan()?;
+            self.inner
+                .scan(lower, upper)
+                .map(|scan| AsyncScan::new(scan, guard))
+        })()
     }
 
     /// Return all visible keys whose user key starts with `prefix`, in sorted
@@ -952,12 +1174,45 @@ impl KvEngine {
     ///
     /// When prefix bloom filters are enabled, irrelevant SSTs are skipped
     /// before creating iterators.
-    pub fn prefix_scan(&self, prefix: &[u8]) -> Result<ScanIterator> {
-        self.inner.prefix_scan(prefix)
+    pub async fn prefix_scan(&self, prefix: &[u8]) -> Result<AsyncScan> {
+        (|| {
+            let guard = self.inner.lifecycle.admit_scan()?;
+            self.inner
+                .prefix_scan(prefix)
+                .map(|scan| AsyncScan::new(scan, guard))
+        })()
     }
 
     /// Only call this in test cases due to race conditions
-    pub fn force_flush(&self) -> Result<()> {
+    pub async fn force_flush(&self) -> Result<()> {
+        (|| {
+            let _guard = self.inner.lifecycle.admit_write()?;
+            self.force_flush_inner()
+        })()
+    }
+
+    /// Flush all memtables (current + all immutable) to SSTs.
+    /// Unlike `force_flush()` which only flushes one immutable memtable,
+    /// this drains the entire queue.
+    ///
+    /// # Warning
+    /// Inherits the same race conditions as [`force_flush`] — only use in
+    /// tests or when no concurrent writes are happening.
+    pub async fn drain_flush(&self) -> Result<()> {
+        (|| {
+            let _guard = self.inner.lifecycle.admit_write()?;
+            self.drain_flush_inner()
+        })()
+    }
+
+    pub async fn force_full_compaction(&self) -> Result<()> {
+        (|| {
+            let _guard = self.inner.lifecycle.admit_write()?;
+            self.inner.force_full_compaction()
+        })()
+    }
+
+    fn force_flush_inner(&self) -> Result<()> {
         if !self.inner.state.load().memtable.is_empty() {
             self.inner
                 .force_freeze_memtable(&self.inner.state_lock.lock())?;
@@ -969,24 +1224,13 @@ impl KvEngine {
         Ok(())
     }
 
-    /// Flush all memtables (current + all immutable) to SSTs.
-    /// Unlike `force_flush()` which only flushes one immutable memtable,
-    /// this drains the entire queue.
-    ///
-    /// # Warning
-    /// Inherits the same race conditions as [`force_flush`] — only use in
-    /// tests or when no concurrent writes are happening.
-    pub fn drain_flush(&self) -> Result<()> {
-        self.force_flush()?;
+    fn drain_flush_inner(&self) -> Result<()> {
+        self.force_flush_inner()?;
         while !self.inner.state.load().imm_memtables.is_empty() {
-            self.force_flush()?;
+            self.force_flush_inner()?;
         }
 
         Ok(())
-    }
-
-    pub fn force_full_compaction(&self) -> Result<()> {
-        self.inner.force_full_compaction()
     }
 
     /// Trigger garbage collection on all vLog files.
@@ -1099,6 +1343,61 @@ impl KvEngine {
     /// Snapshot of cumulative write-path profiling counters for this engine.
     pub fn write_profile(&self) -> crate::mem_table::WriteProfileSnapshot {
         self.inner.write_profile.snapshot()
+    }
+}
+
+/// Owned async scan cursor for non-transactional reads.
+pub struct AsyncScan {
+    _guard: AdmissionGuard,
+    iter: ScanIterator,
+}
+
+impl AsyncScan {
+    fn new(iter: ScanIterator, guard: AdmissionGuard) -> Self {
+        Self {
+            _guard: guard,
+            iter,
+        }
+    }
+
+    pub async fn try_next(&mut self) -> Result<Option<(Bytes, Bytes)>> {
+        if !self.iter.is_valid() {
+            return Ok(None);
+        }
+
+        let kv = (
+            Bytes::copy_from_slice(self.iter.key()),
+            self.iter.value().to_vec(),
+        );
+        self.iter.next()?;
+        Ok(Some((kv.0, Bytes::from(kv.1))))
+    }
+}
+
+impl StorageIterator for AsyncScan {
+    type KeyType<'a>
+        = &'a [u8]
+    where
+        Self: 'a;
+
+    fn value(&self) -> &[u8] {
+        self.iter.value()
+    }
+
+    fn key(&self) -> Self::KeyType<'_> {
+        self.iter.key()
+    }
+
+    fn is_valid(&self) -> bool {
+        self.iter.is_valid()
+    }
+
+    fn next(&mut self) -> Result<()> {
+        self.iter.next()
+    }
+
+    fn num_active_iterators(&self) -> usize {
+        self.iter.num_active_iterators()
     }
 }
 
@@ -1415,6 +1714,7 @@ impl LsmStorageInner {
             weak_self: std::sync::OnceLock::new(),
             gc_handles: Mutex::new(Vec::new()),
             write_profile: Arc::new(crate::mem_table::WriteProfile::default()),
+            lifecycle: LifecycleHandle::new(),
         };
         // Propagate the engine-level write profile to the initial memtable.
         storage
@@ -4333,9 +4633,22 @@ impl LsmStorageInner {
     ///
     /// Requires MVCC to be enabled. The transaction's read timestamp
     /// is pinned in the watermark to prevent GC of visible versions.
+    #[allow(dead_code)]
     pub fn new_txn(self: &Arc<Self>) -> Result<Arc<crate::mvcc::txn::Transaction>> {
         let mvcc = self.mvcc.as_ref().expect("new_txn requires MVCC");
-        Ok(mvcc.new_txn(Arc::clone(self), self.options.serializable))
+        Ok(mvcc.new_txn(Arc::clone(self), self.options.serializable, None))
+    }
+
+    pub(crate) fn new_txn_with_guard(
+        self: &Arc<Self>,
+        lifecycle_guard: AdmissionGuard,
+    ) -> Result<Arc<crate::mvcc::txn::Transaction>> {
+        let mvcc = self.mvcc.as_ref().expect("new_txn requires MVCC");
+        Ok(mvcc.new_txn(
+            Arc::clone(self),
+            self.options.serializable,
+            Some(lifecycle_guard),
+        ))
     }
 
     /// Create an iterator over a range of keys.
@@ -4376,5 +4689,38 @@ impl LsmStorageInner {
             Bound::Excluded(k) => Bound::Excluded(k.to_vec()),
             Bound::Unbounded => Bound::Unbounded,
         }
+    }
+}
+
+#[cfg(test)]
+mod async_api_tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn engine_async_roundtrip_and_close() {
+        let dir = tempdir().unwrap();
+        let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test())
+            .await
+            .unwrap();
+
+        engine.put(b"k1", b"v1").await.unwrap();
+        assert_eq!(
+            engine.get(b"k1").await.unwrap(),
+            Some(Bytes::from_static(b"v1"))
+        );
+        engine.close().await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn closing_rejects_new_writes() {
+        let dir = tempdir().unwrap();
+        let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test())
+            .await
+            .unwrap();
+
+        engine.close().await.unwrap();
+        let err = engine.put(b"k1", b"v1").await.unwrap_err();
+        assert!(err.to_string().contains("closing") || err.to_string().contains("closed"));
     }
 }

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -16,7 +16,7 @@ use parking_lot::{Mutex, RwLock};
 use self::{txn::Transaction, watermark::Watermark};
 use crate::{
     key::{KeySlice, encode_internal_key},
-    lsm_storage::LsmStorageInner,
+    lsm_storage::{AdmissionGuard, LsmStorageInner},
     mem_table::MemTable,
 };
 
@@ -286,6 +286,7 @@ impl LsmMvccInner {
         self: &Arc<Self>,
         inner: Arc<LsmStorageInner>,
         serializable: bool,
+        lifecycle_guard: Option<AdmissionGuard>,
     ) -> Arc<Transaction> {
         let read_guard = self.new_read_guard();
         let read_ts = read_guard.read_ts();
@@ -306,6 +307,7 @@ impl LsmMvccInner {
             committed: Arc::new(AtomicBool::new(false)),
             read_set: occ_sets.0,
             write_set: occ_sets.1,
+            lifecycle_guard: Mutex::new(lifecycle_guard),
             _not_sync: std::marker::PhantomData,
         })
     }
@@ -382,6 +384,7 @@ impl Drop for ReadGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::FutureResultExt;
     use bytes::Bytes;
 
     /// Test helper: write a key-value pair using WAL-only + publish + advance_ts.

--- a/kv-engine/src/mvcc/txn.rs
+++ b/kv-engine/src/mvcc/txn.rs
@@ -9,7 +9,7 @@ use parking_lot::Mutex;
 use crate::{
     iterators::{StorageIterator, two_merge_iterator::TwoMergeIterator},
     lsm_iterator::{FusedIterator, LsmIterator},
-    lsm_storage::{LsmStorageInner, prefix_upper_bound},
+    lsm_storage::{AdmissionGuard, LsmStorageInner, prefix_upper_bound},
     mem_table::map_bound,
     mvcc::ReadGuard,
 };
@@ -33,6 +33,8 @@ pub struct Transaction {
     pub(crate) read_set: Option<Mutex<HashSet<Bytes>>>,
     /// Write set for OCC conflict detection (None when not serializable).
     pub(crate) write_set: Option<Mutex<HashSet<Bytes>>>,
+    /// Keeps the transaction registered with shutdown tracking until commit or drop.
+    pub(crate) lifecycle_guard: Mutex<Option<AdmissionGuard>>,
     /// Transaction is intentionally `!Sync` — it must be used from a single
     /// thread. Concurrent access to `local_storage`, `read_set`, and
     /// `write_set` without external synchronization would be unsound.
@@ -49,12 +51,21 @@ impl Transaction {
         Ok(())
     }
 
+    fn release_lifecycle_guard(&self) {
+        self.lifecycle_guard.lock().take();
+    }
+
     /// Get a value by key.
     ///
     /// Checks local writes first (shadowing the engine), then falls back
     /// to the engine at the transaction's snapshot timestamp.
-    pub fn get(&self, key: &[u8]) -> Result<Option<Bytes>> {
+    pub async fn get(&self, key: &[u8]) -> Result<Option<Bytes>> {
+        self.get_inner(key)
+    }
+
+    fn get_inner(&self, key: &[u8]) -> Result<Option<Bytes>> {
         self.ensure_not_committed()?;
+        self.inner.lifecycle.ensure_open()?;
         // Record this key in the read set for OCC conflict detection,
         // even if a local write shadows the engine read.
         if let Some(ref rs) = self.read_set {
@@ -81,8 +92,21 @@ impl Transaction {
     ///
     /// Merges local writes with the engine snapshot at the transaction's
     /// read timestamp, returning entries in sorted order.
-    pub fn scan(self: &Arc<Self>, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> Result<TxnIterator> {
+    pub async fn scan(
+        self: &Arc<Self>,
+        lower: Bound<&[u8]>,
+        upper: Bound<&[u8]>,
+    ) -> Result<AsyncTxnScan> {
+        self.scan_inner(lower, upper)
+    }
+
+    fn scan_inner(
+        self: &Arc<Self>,
+        lower: Bound<&[u8]>,
+        upper: Bound<&[u8]>,
+    ) -> Result<AsyncTxnScan> {
         self.ensure_not_committed()?;
+        self.inner.lifecycle.ensure_open()?;
         // Serializable transactions cannot use scan() because range reads
         // would leave phantom keys untracked in the read_set. Reject until
         // range predicate tracking is implemented.
@@ -90,6 +114,7 @@ impl Transaction {
             self.read_set.is_none(),
             "scan() is not supported for serializable transactions until phantom/range tracking is implemented"
         );
+        let scan_guard = self.inner.lifecycle.admit_scan()?;
         let lsm_iter = self.inner.scan_with_ts(lower, upper, self.read_ts)?;
         let mut local_iter = TxnLocalIterator::new(
             self.local_storage.clone(),
@@ -100,6 +125,7 @@ impl Transaction {
         local_iter.next()?;
         let merged = TwoMergeIterator::create(local_iter, lsm_iter)?;
         TxnIterator::create(Arc::clone(self), merged)
+            .map(|iter| AsyncTxnScan::new(iter, scan_guard))
     }
 
     /// Return all visible keys whose user key starts with `prefix`, in sorted
@@ -107,11 +133,16 @@ impl Transaction {
     ///
     /// When prefix bloom filters are enabled, irrelevant SSTs are skipped
     /// before creating iterators.
-    pub fn prefix_scan(self: &Arc<Self>, prefix: &[u8]) -> Result<TxnIterator> {
+    pub async fn prefix_scan(self: &Arc<Self>, prefix: &[u8]) -> Result<AsyncTxnScan> {
+        self.prefix_scan_inner(prefix)
+    }
+
+    fn prefix_scan_inner(self: &Arc<Self>, prefix: &[u8]) -> Result<AsyncTxnScan> {
         if prefix.is_empty() {
-            return self.scan(Bound::Unbounded, Bound::Unbounded);
+            return self.scan_inner(Bound::Unbounded, Bound::Unbounded);
         }
         self.ensure_not_committed()?;
+        self.inner.lifecycle.ensure_open()?;
         anyhow::ensure!(
             self.read_set.is_none(),
             "prefix_scan() is not supported for serializable transactions until phantom/range tracking is implemented"
@@ -122,6 +153,7 @@ impl Transaction {
             Some(upper) => Bound::Excluded(upper.as_slice()),
             None => Bound::Unbounded,
         };
+        let scan_guard = self.inner.lifecycle.admit_scan()?;
         let lsm_iter = self
             .inner
             .scan_with_prefix_hint(lower, upper, self.read_ts, prefix)?;
@@ -133,6 +165,7 @@ impl Transaction {
         local_iter.next()?;
         let merged = TwoMergeIterator::create(local_iter, lsm_iter)?;
         TxnIterator::create(Arc::clone(self), merged)
+            .map(|iter| AsyncTxnScan::new(iter, scan_guard))
     }
 
     /// Buffer a write locally.
@@ -141,6 +174,7 @@ impl Transaction {
     /// [`commit`](Transaction::commit) is called.
     pub fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
         self.ensure_not_committed()?;
+        self.inner.lifecycle.ensure_open()?;
         anyhow::ensure!(
             !crate::vlog::KvKind::is_tombstone_value(value),
             "value must not be the tombstone marker byte (0x02)"
@@ -160,6 +194,7 @@ impl Transaction {
     /// [`commit`](Transaction::commit) is called.
     pub fn delete(&self, key: &[u8]) -> Result<()> {
         self.ensure_not_committed()?;
+        self.inner.lifecycle.ensure_open()?;
         // Record in write_set for OCC conflict detection.
         if let Some(ref ws) = self.write_set {
             ws.lock().insert(Bytes::copy_from_slice(key));
@@ -176,7 +211,13 @@ impl Transaction {
     /// All buffered writes are applied atomically under a single commit
     /// timestamp. Returns an error if the transaction was already committed.
     /// For serializable transactions, performs OCC conflict detection.
-    pub fn commit(&self) -> Result<()> {
+    pub async fn commit(&self) -> Result<()> {
+        self.commit_inner()
+    }
+
+    fn commit_inner(&self) -> Result<()> {
+        self.ensure_not_committed()?;
+        self.inner.lifecycle.ensure_open()?;
         if self
             .committed
             .compare_exchange(
@@ -203,6 +244,7 @@ impl Transaction {
         if entries.is_empty() {
             // Release the read guard to unpin the watermark.
             self.read_guard.lock().take();
+            self.release_lifecycle_guard();
             return Ok(());
         }
         // For serializable transactions, perform OCC conflict detection.
@@ -242,6 +284,7 @@ impl Transaction {
                         {
                             // Drop read_guard to unpin watermark before returning.
                             self.read_guard.lock().take();
+                            self.release_lifecycle_guard();
                             anyhow::bail!(
                                 "serializable conflict: key written by another transaction at ts={}",
                                 commit_ts
@@ -254,7 +297,14 @@ impl Transaction {
                     .iter()
                     .map(|(k, v, t)| (k.as_ref(), v.as_ref(), *t))
                     .collect();
-                let commit_ts = self.inner.mvcc_write_batch_inner(&borrowed)?;
+                let commit_ts = match self.inner.mvcc_write_batch_inner(&borrowed) {
+                    Ok(commit_ts) => commit_ts,
+                    Err(e) => {
+                        self.read_guard.lock().take();
+                        self.release_lifecycle_guard();
+                        return Err(e);
+                    }
+                };
                 // Record our write_set in committed_txns.
                 mvcc.record_committed_txn(
                     commit_ts,
@@ -263,11 +313,14 @@ impl Transaction {
                 );
                 // Release read_guard to unpin watermark.
                 self.read_guard.lock().take();
+                self.release_lifecycle_guard();
                 // Drop commit_lock before try_freeze to avoid deadlock with
                 // non-txn serializable writes that hold active_memtable_lock.read().
                 drop(_commit_guard);
                 // Freeze memtable if it exceeds target size, matching other write paths.
-                self.inner.try_freeze_memtable()?;
+                if let Err(e) = self.inner.try_freeze_memtable() {
+                    return Err(e);
+                }
                 return Ok(());
             }
         }
@@ -280,10 +333,12 @@ impl Transaction {
             // Revert committed flag so caller can retry.
             self.committed
                 .store(false, std::sync::atomic::Ordering::SeqCst);
+            self.release_lifecycle_guard();
             return Err(e);
         }
         // Release the read guard to unpin the watermark.
         self.read_guard.lock().take();
+        self.release_lifecycle_guard();
 
         Ok(())
     }
@@ -393,6 +448,61 @@ impl StorageIterator for TxnIterator {
             rs.lock().insert(Bytes::copy_from_slice(self.iter.key()));
         }
         Ok(())
+    }
+
+    fn num_active_iterators(&self) -> usize {
+        self.iter.num_active_iterators()
+    }
+}
+
+/// Owned async transaction scan cursor.
+pub struct AsyncTxnScan {
+    _guard: AdmissionGuard,
+    iter: TxnIterator,
+}
+
+impl AsyncTxnScan {
+    fn new(iter: TxnIterator, guard: AdmissionGuard) -> Self {
+        Self {
+            _guard: guard,
+            iter,
+        }
+    }
+
+    pub async fn try_next(&mut self) -> Result<Option<(Bytes, Bytes)>> {
+        if !self.iter.is_valid() {
+            return Ok(None);
+        }
+
+        let kv = (
+            Bytes::copy_from_slice(self.iter.key()),
+            self.iter.value().to_vec(),
+        );
+        self.iter.next()?;
+        Ok(Some((kv.0, Bytes::from(kv.1))))
+    }
+}
+
+impl StorageIterator for AsyncTxnScan {
+    type KeyType<'a>
+        = &'a [u8]
+    where
+        Self: 'a;
+
+    fn value(&self) -> &[u8] {
+        self.iter.value()
+    }
+
+    fn key(&self) -> Self::KeyType<'_> {
+        self.iter.key()
+    }
+
+    fn is_valid(&self) -> bool {
+        self.iter.is_valid()
+    }
+
+    fn next(&mut self) -> Result<()> {
+        self.iter.next()
     }
 
     fn num_active_iterators(&self) -> usize {

--- a/kv-engine/src/tests.rs
+++ b/kv-engine/src/tests.rs
@@ -1,3 +1,6 @@
+pub(crate) use crate::FutureResultExt;
+pub(crate) use harness::block_on_result;
+
 mod block;
 mod bloom_compression;
 mod cache_backfill;

--- a/kv-engine/src/tests/cache_backfill.rs
+++ b/kv-engine/src/tests/cache_backfill.rs
@@ -2,6 +2,7 @@
 
 use tempfile::tempdir;
 
+use super::block_on_result;
 use crate::{
     lsm_storage::{KvEngine, LsmStorageOptions, PrefixBloomOptions},
     tests::harness::sync,
@@ -17,13 +18,13 @@ fn test_backfill_warms_cache_after_flush() {
         block_cache_capacity: 1792,
         ..LsmStorageOptions::default_for_test()
     };
-    let engine = KvEngine::open(&dir, options).unwrap();
+    let engine = block_on_result(KvEngine::open(&dir, options)).unwrap();
 
     // Write enough data to produce at least one block.
     for i in 0..100 {
         let key = format!("key{:04}", i);
         let val = format!("val{:04}", i);
-        engine.put(key.as_bytes(), val.as_bytes()).unwrap();
+        block_on_result(engine.put(key.as_bytes(), val.as_bytes())).unwrap();
     }
     sync(&engine.inner);
 
@@ -44,12 +45,12 @@ fn test_backfill_disabled_no_cache_entries() {
         block_cache_capacity: 1792,
         ..LsmStorageOptions::default_for_test()
     };
-    let engine = KvEngine::open(&dir, options).unwrap();
+    let engine = block_on_result(KvEngine::open(&dir, options)).unwrap();
 
     for i in 0..100 {
         let key = format!("key{:04}", i);
         let val = format!("val{:04}", i);
-        engine.put(key.as_bytes(), val.as_bytes()).unwrap();
+        block_on_result(engine.put(key.as_bytes(), val.as_bytes())).unwrap();
     }
     sync(&engine.inner);
 
@@ -73,14 +74,14 @@ fn test_backfill_after_compaction() {
         block_cache_capacity: 4096,
         ..LsmStorageOptions::default_for_test()
     };
-    let engine = KvEngine::open(&dir, options).unwrap();
+    let engine = block_on_result(KvEngine::open(&dir, options)).unwrap();
 
     // Write data and flush to populate the cache via backfill.
     for batch in 0..3 {
         for i in 0..100 {
             let key = format!("key{:06}", batch * 100 + i);
             let val = format!("val{:06}", batch * 100 + i);
-            engine.put(key.as_bytes(), val.as_bytes()).unwrap();
+            block_on_result(engine.put(key.as_bytes(), val.as_bytes())).unwrap();
         }
         sync(&engine.inner);
     }
@@ -95,13 +96,13 @@ fn test_backfill_after_compaction() {
     // Force compaction. This compacts to bottom level so backfill is skipped,
     // but the engine should remain functional and existing cache entries
     // for non-compacted SSTs should survive.
-    engine.force_full_compaction().unwrap();
+    block_on_result(engine.force_full_compaction()).unwrap();
 
     // Verify data is still readable after compaction.
     for batch in 0..3 {
         for i in 0..100 {
             let key = format!("key{:06}", batch * 100 + i);
-            let val = engine.get(key.as_bytes()).unwrap();
+            let val = block_on_result(engine.get(key.as_bytes())).unwrap();
             assert!(val.is_some(), "{key} should exist after compaction");
         }
     }
@@ -173,7 +174,7 @@ fn test_compaction_backfill_perf_comparison() {
     for (label, backfill) in [("enabled", true), ("disabled", false)] {
         let dir = tempdir().unwrap();
         let options = make_options(backfill);
-        let engine = KvEngine::open(dir.path(), options).unwrap();
+        let engine = block_on_result(KvEngine::open(dir.path(), options)).unwrap();
         let value = vec![0xABu8; value_size];
 
         // Write data in 4 batches, syncing after each to create L0 SSTs.
@@ -182,10 +183,10 @@ fn test_compaction_backfill_perf_comparison() {
             let start = batch * batch_size;
             let end = start + batch_size;
             for key in &keys[start..end] {
-                engine.put(key, &value).unwrap();
+                block_on_result(engine.put(key, &value)).unwrap();
             }
             // Freeze + flush to create L0 SSTs.
-            engine.force_flush().unwrap();
+            block_on_result(engine.force_flush()).unwrap();
         }
 
         // Wait for background L0→L1 compaction to complete.
@@ -212,7 +213,7 @@ fn test_compaction_backfill_perf_comparison() {
         // Time the reads.
         let start = Instant::now();
         for key in &keys {
-            let result = engine.get(key).unwrap();
+            let result = block_on_result(engine.get(key)).unwrap();
             assert!(result.is_some());
         }
         let elapsed = start.elapsed();

--- a/kv-engine/src/tests/compaction_gc.rs
+++ b/kv-engine/src/tests/compaction_gc.rs
@@ -6,6 +6,7 @@
 
 use tempfile::tempdir;
 
+use super::harness::block_on_result;
 use crate::{
     compact::{CompactionOptions, LeveledCompactionOptions},
     lsm_storage::{KvEngine, LsmStorageOptions},
@@ -29,12 +30,12 @@ fn leveled_options() -> LsmStorageOptions {
 #[test]
 fn test_range_tombstone_survives_compaction() {
     let dir = tempdir().unwrap();
-    let storage = KvEngine::open(&dir, leveled_options()).unwrap();
+    let storage = block_on_result(KvEngine::open(&dir, leveled_options())).unwrap();
 
     // Write point entries
-    storage.put(b"a", b"va").unwrap();
-    storage.put(b"m", b"vm").unwrap();
-    storage.put(b"z", b"vz").unwrap();
+    block_on_result(storage.put(b"a", b"va")).unwrap();
+    block_on_result(storage.put(b"m", b"vm")).unwrap();
+    block_on_result(storage.put(b"z", b"vz")).unwrap();
     storage
         .inner
         .force_freeze_memtable(&storage.inner.state_lock.lock())
@@ -50,24 +51,27 @@ fn test_range_tombstone_survives_compaction() {
     storage.inner.force_flush_next_imm_memtable().unwrap();
 
     // Verify keys are hidden before compaction
-    assert!(storage.get(b"a").unwrap().is_none());
-    assert!(storage.get(b"m").unwrap().is_none());
-    assert_eq!(&storage.get(b"z").unwrap().unwrap()[..], b"vz");
+    assert!(block_on_result(storage.get(b"a")).unwrap().is_none());
+    assert!(block_on_result(storage.get(b"m")).unwrap().is_none());
+    assert_eq!(
+        &block_on_result(storage.get(b"z")).unwrap().unwrap()[..],
+        b"vz"
+    );
 
     // Compact
-    storage.force_full_compaction().unwrap();
+    block_on_result(storage.force_full_compaction()).unwrap();
 
     // Verify keys are still hidden after compaction — no resurrection
     assert!(
-        storage.get(b"a").unwrap().is_none(),
+        block_on_result(storage.get(b"a")).unwrap().is_none(),
         "key 'a' should be hidden by range tombstone after compaction"
     );
     assert!(
-        storage.get(b"m").unwrap().is_none(),
+        block_on_result(storage.get(b"m")).unwrap().is_none(),
         "key 'm' should be hidden by range tombstone after compaction"
     );
     assert_eq!(
-        &storage.get(b"z").unwrap().unwrap()[..],
+        &block_on_result(storage.get(b"z")).unwrap().unwrap()[..],
         b"vz",
         "key 'z' is outside the tombstone range"
     );
@@ -96,13 +100,13 @@ fn test_range_tombstone_survives_compaction() {
 #[test]
 fn test_overlapping_tombstones_through_compaction() {
     let dir = tempdir().unwrap();
-    let storage = KvEngine::open(&dir, leveled_options()).unwrap();
+    let storage = block_on_result(KvEngine::open(&dir, leveled_options())).unwrap();
 
     // Write point entries
-    storage.put(b"a", b"va").unwrap();
-    storage.put(b"m", b"vm").unwrap();
-    storage.put(b"p", b"vp").unwrap();
-    storage.put(b"z", b"vz").unwrap();
+    block_on_result(storage.put(b"a", b"va")).unwrap();
+    block_on_result(storage.put(b"m", b"vm")).unwrap();
+    block_on_result(storage.put(b"p", b"vp")).unwrap();
+    block_on_result(storage.put(b"z", b"vz")).unwrap();
     storage
         .inner
         .force_freeze_memtable(&storage.inner.state_lock.lock())
@@ -125,19 +129,25 @@ fn test_overlapping_tombstones_through_compaction() {
     storage.inner.force_flush_next_imm_memtable().unwrap();
 
     // Verify before compaction
-    assert!(storage.get(b"a").unwrap().is_none());
-    assert!(storage.get(b"m").unwrap().is_none());
-    assert!(storage.get(b"p").unwrap().is_none());
-    assert_eq!(&storage.get(b"z").unwrap().unwrap()[..], b"vz");
+    assert!(block_on_result(storage.get(b"a")).unwrap().is_none());
+    assert!(block_on_result(storage.get(b"m")).unwrap().is_none());
+    assert!(block_on_result(storage.get(b"p")).unwrap().is_none());
+    assert_eq!(
+        &block_on_result(storage.get(b"z")).unwrap().unwrap()[..],
+        b"vz"
+    );
 
     // Compact
-    storage.force_full_compaction().unwrap();
+    block_on_result(storage.force_full_compaction()).unwrap();
 
     // Verify after compaction
-    assert!(storage.get(b"a").unwrap().is_none());
-    assert!(storage.get(b"m").unwrap().is_none());
-    assert!(storage.get(b"p").unwrap().is_none());
-    assert_eq!(&storage.get(b"z").unwrap().unwrap()[..], b"vz");
+    assert!(block_on_result(storage.get(b"a")).unwrap().is_none());
+    assert!(block_on_result(storage.get(b"m")).unwrap().is_none());
+    assert!(block_on_result(storage.get(b"p")).unwrap().is_none());
+    assert_eq!(
+        &block_on_result(storage.get(b"z")).unwrap().unwrap()[..],
+        b"vz"
+    );
     // Rely on Drop for shutdown
 }
 
@@ -145,12 +155,12 @@ fn test_overlapping_tombstones_through_compaction() {
 #[test]
 fn test_entries_outside_tombstone_survive_compaction() {
     let dir = tempdir().unwrap();
-    let storage = KvEngine::open(&dir, leveled_options()).unwrap();
+    let storage = block_on_result(KvEngine::open(&dir, leveled_options())).unwrap();
 
     // Write point entries
-    storage.put(b"a", b"va").unwrap();
-    storage.put(b"m", b"vm").unwrap();
-    storage.put(b"z", b"vz").unwrap();
+    block_on_result(storage.put(b"a", b"va")).unwrap();
+    block_on_result(storage.put(b"m", b"vm")).unwrap();
+    block_on_result(storage.put(b"z", b"vz")).unwrap();
     storage
         .inner
         .force_freeze_memtable(&storage.inner.state_lock.lock())
@@ -166,14 +176,20 @@ fn test_entries_outside_tombstone_survive_compaction() {
     storage.inner.force_flush_next_imm_memtable().unwrap();
 
     // Compact
-    storage.force_full_compaction().unwrap();
+    block_on_result(storage.force_full_compaction()).unwrap();
 
     // 'a' is outside the tombstone — should survive
-    assert_eq!(&storage.get(b"a").unwrap().unwrap()[..], b"va");
+    assert_eq!(
+        &block_on_result(storage.get(b"a")).unwrap().unwrap()[..],
+        b"va"
+    );
     // 'm' is inside the tombstone — should be hidden
-    assert!(storage.get(b"m").unwrap().is_none());
+    assert!(block_on_result(storage.get(b"m")).unwrap().is_none());
     // 'z' is outside the tombstone — should survive
-    assert_eq!(&storage.get(b"z").unwrap().unwrap()[..], b"vz");
+    assert_eq!(
+        &block_on_result(storage.get(b"z")).unwrap().unwrap()[..],
+        b"vz"
+    );
     // Rely on Drop for shutdown
 }
 
@@ -181,7 +197,7 @@ fn test_entries_outside_tombstone_survive_compaction() {
 #[test]
 fn test_range_only_ssts_tracked() {
     let dir = tempdir().unwrap();
-    let storage = KvEngine::open(&dir, leveled_options()).unwrap();
+    let storage = block_on_result(KvEngine::open(&dir, leveled_options())).unwrap();
 
     // Write a wide range tombstone with no point entries in between
     storage.inner.delete_range_internal(b"a", b"z").unwrap();
@@ -192,14 +208,14 @@ fn test_range_only_ssts_tracked() {
     storage.inner.force_flush_next_imm_memtable().unwrap();
 
     // Flush again to trigger compaction
-    storage.put(b"dummy", b"v").unwrap();
+    block_on_result(storage.put(b"dummy", b"v")).unwrap();
     storage
         .inner
         .force_freeze_memtable(&storage.inner.state_lock.lock())
         .unwrap();
     storage.inner.force_flush_next_imm_memtable().unwrap();
 
-    storage.force_full_compaction().unwrap();
+    block_on_result(storage.force_full_compaction()).unwrap();
 
     // Check that range-only SSTs exist in the state
     let state = storage.inner.state.load();
@@ -230,33 +246,33 @@ fn test_range_only_ssts_tracked() {
 #[test]
 fn test_range_tombstone_survives_reopen() {
     let dir = tempdir().unwrap();
-    let storage = KvEngine::open(&dir, leveled_options()).unwrap();
+    let storage = block_on_result(KvEngine::open(&dir, leveled_options())).unwrap();
 
-    storage.put(b"a", b"va").unwrap();
-    storage.put(b"m", b"vm").unwrap();
+    block_on_result(storage.put(b"a", b"va")).unwrap();
+    block_on_result(storage.put(b"m", b"vm")).unwrap();
     storage.inner.delete_range_internal(b"a", b"z").unwrap();
     storage
         .inner
         .force_freeze_memtable(&storage.inner.state_lock.lock())
         .unwrap();
     storage.inner.force_flush_next_imm_memtable().unwrap();
-    storage.force_full_compaction().unwrap();
+    block_on_result(storage.force_full_compaction()).unwrap();
 
     // Verify before close
-    assert!(storage.get(b"a").unwrap().is_none());
-    assert!(storage.get(b"m").unwrap().is_none());
+    assert!(block_on_result(storage.get(b"a")).unwrap().is_none());
+    assert!(block_on_result(storage.get(b"m")).unwrap().is_none());
 
     // Close and reopen
-    storage.close().unwrap();
-    let storage2 = KvEngine::open(&dir, leveled_options()).unwrap();
+    block_on_result(storage.close()).unwrap();
+    let storage2 = block_on_result(KvEngine::open(&dir, leveled_options())).unwrap();
 
     // Verify after reopen — range tombstones should persist
     assert!(
-        storage2.get(b"a").unwrap().is_none(),
+        block_on_result(storage2.get(b"a")).unwrap().is_none(),
         "key 'a' should be hidden after reopen"
     );
     assert!(
-        storage2.get(b"m").unwrap().is_none(),
+        block_on_result(storage2.get(b"m")).unwrap().is_none(),
         "key 'm' should be hidden after reopen"
     );
     // Rely on Drop for shutdown

--- a/kv-engine/src/tests/compaction_integration.rs
+++ b/kv-engine/src/tests/compaction_integration.rs
@@ -1,5 +1,6 @@
 use tempfile::tempdir;
 
+use super::block_on_result;
 use crate::{
     compact::{
         CompactionOptions, LeveledCompactionOptions, SimpleLeveledCompactionOptions,
@@ -42,7 +43,7 @@ fn test_integration_simple() {
 
 fn test_integration(compaction_options: CompactionOptions) {
     let dir = tempdir().unwrap();
-    let storage = KvEngine::open(
+    let storage = block_on_result(KvEngine::open(
         &dir,
         LsmStorageOptions {
             compaction_options: compaction_options.clone(),
@@ -50,26 +51,26 @@ fn test_integration(compaction_options: CompactionOptions) {
             target_sst_size: 1 << 20,
             ..LsmStorageOptions::default_for_test()
         },
-    )
+    ))
     .unwrap();
     for i in 0..=20 {
-        storage.put(b"0", format!("v{i}").as_bytes()).unwrap();
+        block_on_result(storage.put(b"0", format!("v{i}").as_bytes())).unwrap();
         if i % 2 == 0 {
-            storage.put(b"1", format!("v{i}").as_bytes()).unwrap();
+            block_on_result(storage.put(b"1", format!("v{i}").as_bytes())).unwrap();
         } else {
-            storage.delete(b"1").unwrap();
+            block_on_result(storage.delete(b"1")).unwrap();
         }
         if i % 2 == 1 {
-            storage.put(b"2", format!("v{i}").as_bytes()).unwrap();
+            block_on_result(storage.put(b"2", format!("v{i}").as_bytes())).unwrap();
         } else {
-            storage.delete(b"2").unwrap();
+            block_on_result(storage.delete(b"2")).unwrap();
         }
         storage
             .inner
             .force_freeze_memtable(&storage.inner.state_lock.lock())
             .unwrap();
     }
-    storage.close().unwrap();
+    block_on_result(storage.close()).unwrap();
     // ensure all SSTs are flushed
     assert!(storage.inner.state.load().memtable.is_empty());
     assert!(storage.inner.state.load().imm_memtables.is_empty());
@@ -77,7 +78,7 @@ fn test_integration(compaction_options: CompactionOptions) {
     drop(storage);
     dump_files_in_dir(&dir);
 
-    let storage = KvEngine::open(
+    let storage = block_on_result(KvEngine::open(
         &dir,
         LsmStorageOptions {
             compaction_options: compaction_options.clone(),
@@ -85,9 +86,15 @@ fn test_integration(compaction_options: CompactionOptions) {
             target_sst_size: 1 << 20,
             ..LsmStorageOptions::default_for_test()
         },
-    )
+    ))
     .unwrap();
-    assert_eq!(&storage.get(b"0").unwrap().unwrap()[..], b"v20".as_slice());
-    assert_eq!(&storage.get(b"1").unwrap().unwrap()[..], b"v20".as_slice());
-    assert_eq!(storage.get(b"2").unwrap(), None);
+    assert_eq!(
+        &block_on_result(storage.get(b"0")).unwrap().unwrap()[..],
+        b"v20".as_slice()
+    );
+    assert_eq!(
+        &block_on_result(storage.get(b"1")).unwrap().unwrap()[..],
+        b"v20".as_slice()
+    );
+    assert_eq!(block_on_result(storage.get(b"2")).unwrap(), None);
 }

--- a/kv-engine/src/tests/compaction_integration_2.rs
+++ b/kv-engine/src/tests/compaction_integration_2.rs
@@ -1,5 +1,6 @@
 use tempfile::tempdir;
 
+use super::block_on_result;
 use crate::{
     compact::{
         CompactionOptions, LeveledCompactionOptions, SimpleLeveledCompactionOptions,
@@ -49,25 +50,25 @@ fn test_integration(compaction_options: CompactionOptions) {
         ..LsmStorageOptions::default_for_test()
     };
     options.enable_wal = true;
-    let storage = KvEngine::open(&dir, options.clone()).unwrap();
+    let storage = block_on_result(KvEngine::open(&dir, options.clone())).unwrap();
     for i in 0..=20 {
-        storage.put(b"0", format!("v{i}").as_bytes()).unwrap();
+        block_on_result(storage.put(b"0", format!("v{i}").as_bytes())).unwrap();
         if i % 2 == 0 {
-            storage.put(b"1", format!("v{i}").as_bytes()).unwrap();
+            block_on_result(storage.put(b"1", format!("v{i}").as_bytes())).unwrap();
         } else {
-            storage.delete(b"1").unwrap();
+            block_on_result(storage.delete(b"1")).unwrap();
         }
         if i % 2 == 1 {
-            storage.put(b"2", format!("v{i}").as_bytes()).unwrap();
+            block_on_result(storage.put(b"2", format!("v{i}").as_bytes())).unwrap();
         } else {
-            storage.delete(b"2").unwrap();
+            block_on_result(storage.delete(b"2")).unwrap();
         }
         storage
             .inner
             .force_freeze_memtable(&storage.inner.state_lock.lock())
             .unwrap();
     }
-    storage.close().unwrap();
+    block_on_result(storage.close()).unwrap();
     // ensure some SSTs are not flushed
     assert!(
         !storage.inner.state.load().memtable.is_empty()
@@ -77,8 +78,14 @@ fn test_integration(compaction_options: CompactionOptions) {
     drop(storage);
     dump_files_in_dir(&dir);
 
-    let storage = KvEngine::open(&dir, options).unwrap();
-    assert_eq!(&storage.get(b"0").unwrap().unwrap()[..], b"v20".as_slice());
-    assert_eq!(&storage.get(b"1").unwrap().unwrap()[..], b"v20".as_slice());
-    assert_eq!(storage.get(b"2").unwrap(), None);
+    let storage = block_on_result(KvEngine::open(&dir, options)).unwrap();
+    assert_eq!(
+        &block_on_result(storage.get(b"0")).unwrap().unwrap()[..],
+        b"v20".as_slice()
+    );
+    assert_eq!(
+        &block_on_result(storage.get(b"1")).unwrap().unwrap()[..],
+        b"v20".as_slice()
+    );
+    assert_eq!(block_on_result(storage.get(b"2")).unwrap(), None);
 }

--- a/kv-engine/src/tests/harness.rs
+++ b/kv-engine/src/tests/harness.rs
@@ -21,6 +21,20 @@ use crate::{
 /// Tombstone value used in tests — a single `KvKind::Tombstone` byte.
 pub const TOMBSTONE_VALUE: &[u8] = &[KvKind::Tombstone as u8];
 
+pub(crate) fn block_on<T>(future: impl std::future::Future<Output = T>) -> T {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build runtime")
+        .block_on(future)
+}
+
+pub(crate) fn block_on_result<T, E>(
+    future: impl std::future::Future<Output = Result<T, E>>,
+) -> Result<T, E> {
+    block_on(future)
+}
+
 #[derive(Clone)]
 pub struct MockIterator {
     pub data: Vec<(Bytes, Bytes)>,
@@ -244,7 +258,7 @@ pub fn compaction_bench(storage: Arc<KvEngine>) {
             let version = key_map.get(&i).copied().unwrap_or_default() + 1;
             let value = gen_value(version);
             key_map.insert(i, version);
-            storage.put(key.as_bytes(), value.as_bytes()).unwrap();
+            block_on_result(storage.put(key.as_bytes(), value.as_bytes())).unwrap();
             max_key = max_key.max(i);
         }
     }
@@ -258,7 +272,7 @@ pub fn compaction_bench(storage: Arc<KvEngine>) {
         if snapshot.imm_memtables.is_empty() && snapshot.memtable.is_empty() {
             break;
         }
-        storage.drain_flush().ok();
+        block_on_result(storage.drain_flush()).ok();
         std::thread::sleep(Duration::from_millis(100));
     }
 
@@ -288,7 +302,7 @@ pub fn compaction_bench(storage: Arc<KvEngine>) {
     let mut expected_key_value_pairs = Vec::new();
     for i in 0..(max_key + 40000) {
         let key = gen_key(i);
-        let value = storage.get(key.as_bytes()).unwrap();
+        let value = block_on_result(storage.get(key.as_bytes())).unwrap();
         if let Some(val) = key_map.get(&i) {
             let expected_value = gen_value(*val);
             assert_eq!(value, Some(Bytes::from(expected_value.clone())));
@@ -299,7 +313,7 @@ pub fn compaction_bench(storage: Arc<KvEngine>) {
     }
 
     check_lsm_iter_result_by_key(
-        &mut storage.scan(Bound::Unbounded, Bound::Unbounded).unwrap(),
+        &mut block_on_result(storage.scan(Bound::Unbounded, Bound::Unbounded)).unwrap(),
         expected_key_value_pairs,
     );
 
@@ -330,8 +344,7 @@ pub fn check_compaction_ratio(storage: Arc<KvEngine>) {
     } else {
         0
     };
-    let num_iters = storage
-        .scan(Bound::Unbounded, Bound::Unbounded)
+    let num_iters = block_on_result(storage.scan(Bound::Unbounded, Bound::Unbounded))
         .unwrap()
         .num_active_iterators();
     let num_memtables = storage.inner.state.load().imm_memtables.len() + 1;

--- a/kv-engine/src/tests/leveled_compaction.rs
+++ b/kv-engine/src/tests/leveled_compaction.rs
@@ -1,5 +1,6 @@
 use tempfile::tempdir;
 
+use super::block_on_result;
 use super::harness::{check_compaction_ratio, compaction_bench};
 use crate::{
     compact::{CompactionOptions, LeveledCompactionOptions},
@@ -9,7 +10,7 @@ use crate::{
 #[test]
 fn test_integration() {
     let dir = tempdir().unwrap();
-    let storage = KvEngine::open(
+    let storage = block_on_result(KvEngine::open(
         &dir,
         LsmStorageOptions {
             compaction_options: CompactionOptions::Leveled(LeveledCompactionOptions {
@@ -22,7 +23,7 @@ fn test_integration() {
             target_sst_size: 1 << 20,
             ..LsmStorageOptions::default_for_test()
         },
-    )
+    ))
     .unwrap();
 
     compaction_bench(storage.clone());

--- a/kv-engine/src/tests/lsm_storage_extra.rs
+++ b/kv-engine/src/tests/lsm_storage_extra.rs
@@ -1,6 +1,8 @@
 use bytes::Bytes;
 use tempfile::tempdir;
 
+use super::harness::block_on;
+use crate::FutureResultExt;
 use crate::{
     compact::CompactionOptions,
     iterators::StorageIterator,
@@ -401,9 +403,8 @@ fn test_put_tombstone_value_rejected() {
     let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
 
     // The tombstone marker byte (0x02) should be rejected as a value
-    let result = engine.put(b"k1", &[0x02]);
-    assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("tombstone"));
+    let result = engine.put(b"k1", &[0x02]).unwrap_err();
+    assert!(result.to_string().contains("tombstone"));
 }
 
 #[test]
@@ -594,15 +595,16 @@ fn test_key_exceeding_format_limit_rejected() {
     let large_key = vec![b'k'; 65520];
 
     // put() should return an error (from WAL or block builder).
-    let result = engine.put(&large_key, b"v");
-    assert!(result.is_err(), "put with oversized key should fail");
+    let result = engine.put(&large_key, b"v").unwrap_err();
+    assert!(
+        result.to_string().contains("maximum"),
+        "put with oversized key should fail"
+    );
 
     // write_batch() should also return an error.
-    let result = engine.write_batch(&[WriteBatchRecord::Put(large_key.clone(), b"v".to_vec())]);
-    assert!(
-        result.is_err(),
-        "write_batch with oversized key should fail"
-    );
+    let batch = [WriteBatchRecord::Put(large_key.clone(), b"v".to_vec())];
+    let result = engine.write_batch(&batch).unwrap_err();
+    assert!(result.to_string().contains("maximum"));
 
     // Engine should still be empty — no partial state.
     let val = engine.get(b"any_key").unwrap();
@@ -667,7 +669,7 @@ fn test_batch_get_basic() {
 
     let formatted: Vec<String> = (0..20).map(|i| format!("key_{:04}", i)).collect();
     let keys: Vec<&[u8]> = formatted.iter().map(|k| k.as_bytes()).collect();
-    let results = engine.batch_get(&keys);
+    let results = block_on(engine.batch_get(&keys));
     assert_eq!(results.len(), 20);
     for (i, res) in results.iter().enumerate() {
         let expected = format!("val_{:04}", i);
@@ -679,7 +681,7 @@ fn test_batch_get_basic() {
 fn test_batch_get_empty() {
     let dir = tempdir().unwrap();
     let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
-    let results = engine.batch_get(&[]);
+    let results = block_on(engine.batch_get(&[]));
     assert!(results.is_empty());
 }
 
@@ -692,7 +694,7 @@ fn test_batch_get_missing_keys() {
     engine.put(b"c", b"vc").unwrap();
 
     let keys: Vec<&[u8]> = vec![b"a", b"b", b"c", b"d"];
-    let results = engine.batch_get(&keys);
+    let results = block_on(engine.batch_get(&keys));
     assert_eq!(results[0].as_ref().unwrap(), &Some(Bytes::from("va")));
     assert_eq!(results[1].as_ref().unwrap(), &None);
     assert_eq!(results[2].as_ref().unwrap(), &Some(Bytes::from("vc")));
@@ -705,7 +707,7 @@ fn test_batch_get_single_key() {
     let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
 
     engine.put(b"only", b"val").unwrap();
-    let results = engine.batch_get(&[b"only"]);
+    let results = block_on(engine.batch_get(&[b"only"]));
     assert_eq!(results[0].as_ref().unwrap(), &Some(Bytes::from("val")));
 }
 
@@ -736,7 +738,7 @@ fn test_batch_get_with_flush() {
         .map(|i| format!("key_{:04}", i).into_bytes())
         .collect();
     let key_refs: Vec<&[u8]> = keys.iter().map(|k| k.as_slice()).collect();
-    let results = engine.batch_get(&key_refs);
+    let results = block_on(engine.batch_get(&key_refs));
     for (i, res) in results.iter().enumerate().take(10) {
         let expected = format!("sst_{:04}", i);
         assert_eq!(res.as_ref().unwrap(), &Some(Bytes::from(expected)));
@@ -767,7 +769,7 @@ fn test_batch_get_matches_individual_gets() {
         b"k005",
         b"also_missing",
     ];
-    let batch_results = engine.batch_get(&keys);
+    let batch_results = block_on(engine.batch_get(&keys));
     for (i, key) in keys.iter().enumerate() {
         let individual = engine.get(key).unwrap();
         assert_eq!(
@@ -803,7 +805,7 @@ fn test_batch_get_with_memtable_range_tombstone() {
 
     // batch_get should return None for covered keys, Some for uncovered keys.
     let keys: Vec<&[u8]> = vec![b"k000", b"k003", b"k005", b"k006", b"k009"];
-    let batch_results = engine.batch_get(&keys);
+    let batch_results = block_on(engine.batch_get(&keys));
 
     // k000: not covered by range tombstone → should be found
     assert_eq!(
@@ -854,7 +856,7 @@ fn test_batch_get_with_sst_range_tombstone() {
 
     // batch_get should return None for covered keys, Some for uncovered keys.
     let keys: Vec<&[u8]> = vec![b"k000", b"k003", b"k005", b"k006", b"k009"];
-    let batch_results = engine.batch_get(&keys);
+    let batch_results = block_on(engine.batch_get(&keys));
 
     assert_eq!(
         batch_results[0].as_ref().unwrap(),
@@ -901,7 +903,7 @@ fn test_batch_get_memtable_rt_skips_sst_lookup() {
     engine.delete_range(b"k003", b"k007").unwrap();
 
     let keys: Vec<&[u8]> = vec![b"k000", b"k003", b"k005", b"k009"];
-    let batch_results = engine.batch_get(&keys);
+    let batch_results = block_on(engine.batch_get(&keys));
 
     // k000: not covered → found in SST
     assert_eq!(
@@ -941,7 +943,7 @@ fn test_batch_get_memtable_hit_covered_by_rt() {
     engine.delete_range(b"k003", b"k007").unwrap();
 
     let keys: Vec<&[u8]> = vec![b"k000", b"k005", b"k009"];
-    let batch_results = engine.batch_get(&keys);
+    let batch_results = block_on(engine.batch_get(&keys));
 
     // k000: not covered by RT → found in memtable
     assert_eq!(
@@ -994,7 +996,7 @@ fn test_batch_get_immutable_memtable_paths() {
     // active memtable RT.
 
     let keys: Vec<&[u8]> = vec![b"k000", b"k003", b"k005", b"k009"];
-    let batch_results = engine.batch_get(&keys);
+    let batch_results = block_on(engine.batch_get(&keys));
 
     // k000: not covered by RT → found
     assert_eq!(

--- a/kv-engine/src/tests/memtable.rs
+++ b/kv-engine/src/tests/memtable.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use tempfile::tempdir;
 
+use crate::FutureResultExt;
 use crate::{
     iterators::StorageIterator,
     lsm_storage::{KvEngine, LsmStorageInner, LsmStorageOptions},

--- a/kv-engine/src/tests/mvcc_scan.rs
+++ b/kv-engine/src/tests/mvcc_scan.rs
@@ -3,6 +3,7 @@ use std::ops::Bound;
 use bytes::Bytes;
 use tempfile::tempdir;
 
+use super::block_on_result;
 use super::harness::check_lsm_iter_result_by_key;
 use crate::{
     iterators::StorageIterator,
@@ -13,14 +14,15 @@ use crate::{
 #[test]
 fn test_scan_returns_latest_version() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"k1", b"v1").unwrap();
-    engine.put(b"k2", b"v2").unwrap();
+    block_on_result(engine.put(b"k1", b"v1")).unwrap();
+    block_on_result(engine.put(b"k2", b"v2")).unwrap();
     // Overwrite k1
-    engine.put(b"k1", b"v1_updated").unwrap();
+    block_on_result(engine.put(b"k1", b"v1_updated")).unwrap();
 
-    let mut iter = engine.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    let mut iter = block_on_result(engine.scan(Bound::Unbounded, Bound::Unbounded)).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![
@@ -34,14 +36,15 @@ fn test_scan_returns_latest_version() {
 #[test]
 fn test_scan_respects_tombstones() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"a", b"va").unwrap();
-    engine.put(b"b", b"vb").unwrap();
-    engine.put(b"c", b"vc").unwrap();
-    engine.delete(b"b").unwrap();
+    block_on_result(engine.put(b"a", b"va")).unwrap();
+    block_on_result(engine.put(b"b", b"vb")).unwrap();
+    block_on_result(engine.put(b"c", b"vc")).unwrap();
+    block_on_result(engine.delete(b"b")).unwrap();
 
-    let mut iter = engine.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    let mut iter = block_on_result(engine.scan(Bound::Unbounded, Bound::Unbounded)).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![
@@ -56,13 +59,14 @@ fn test_scan_respects_tombstones() {
 #[test]
 fn test_scan_snapshot_isolation() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"a", b"va").unwrap();
-    engine.put(b"b", b"vb").unwrap();
+    block_on_result(engine.put(b"a", b"va")).unwrap();
+    block_on_result(engine.put(b"b", b"vb")).unwrap();
 
     // First scan — sees a, b
-    let mut iter = engine.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    let mut iter = block_on_result(engine.scan(Bound::Unbounded, Bound::Unbounded)).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![
@@ -73,11 +77,11 @@ fn test_scan_snapshot_isolation() {
     drop(iter);
 
     // Write more data
-    engine.put(b"a", b"va2").unwrap();
-    engine.put(b"c", b"vc").unwrap();
+    block_on_result(engine.put(b"a", b"va2")).unwrap();
+    block_on_result(engine.put(b"c", b"vc")).unwrap();
 
     // Second scan — sees updated a and new c
-    let mut iter = engine.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    let mut iter = block_on_result(engine.scan(Bound::Unbounded, Bound::Unbounded)).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![
@@ -92,16 +96,16 @@ fn test_scan_snapshot_isolation() {
 #[test]
 fn test_scan_bounded() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"a", b"va").unwrap();
-    engine.put(b"b", b"vb").unwrap();
-    engine.put(b"c", b"vc").unwrap();
-    engine.put(b"d", b"vd").unwrap();
+    block_on_result(engine.put(b"a", b"va")).unwrap();
+    block_on_result(engine.put(b"b", b"vb")).unwrap();
+    block_on_result(engine.put(b"c", b"vc")).unwrap();
+    block_on_result(engine.put(b"d", b"vd")).unwrap();
 
-    let mut iter = engine
-        .scan(Bound::Included(b"b"), Bound::Excluded(b"d"))
-        .unwrap();
+    let mut iter =
+        block_on_result(engine.scan(Bound::Included(b"b"), Bound::Excluded(b"d"))).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![
@@ -115,9 +119,10 @@ fn test_scan_bounded() {
 #[test]
 fn test_scan_empty() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    let iter = engine.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    let iter = block_on_result(engine.scan(Bound::Unbounded, Bound::Unbounded)).unwrap();
     assert!(!iter.is_valid());
 }
 
@@ -125,13 +130,14 @@ fn test_scan_empty() {
 #[test]
 fn test_scan_deduplicates_across_versions() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
     for i in 0..10 {
-        engine.put(b"key", format!("v{i}").as_bytes()).unwrap();
+        block_on_result(engine.put(b"key", format!("v{i}").as_bytes())).unwrap();
     }
 
-    let mut iter = engine.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    let mut iter = block_on_result(engine.scan(Bound::Unbounded, Bound::Unbounded)).unwrap();
     check_lsm_iter_result_by_key(&mut iter, vec![(Bytes::from("key"), Bytes::from("v9"))]);
 }
 
@@ -140,10 +146,11 @@ fn test_scan_deduplicates_across_versions() {
 #[test]
 fn test_read_guard_pins_watermark() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"k", b"v1").unwrap();
-    engine.put(b"k", b"v2").unwrap();
+    block_on_result(engine.put(b"k", b"v1")).unwrap();
+    block_on_result(engine.put(b"k", b"v2")).unwrap();
 
     // Pin snapshot at ts=2
     let mvcc = engine.inner.mvcc.as_ref().unwrap();
@@ -151,8 +158,8 @@ fn test_read_guard_pins_watermark() {
     let pinned_ts = guard.read_ts();
 
     // Advance the timestamp
-    engine.put(b"k", b"v3").unwrap();
-    engine.put(b"k", b"v4").unwrap();
+    block_on_result(engine.put(b"k", b"v3")).unwrap();
+    block_on_result(engine.put(b"k", b"v4")).unwrap();
 
     // Watermark should be exactly at pinned_ts (the smallest active reader)
     assert_eq!(mvcc.watermark(), pinned_ts);
@@ -166,12 +173,13 @@ fn test_read_guard_pins_watermark() {
 #[test]
 fn test_delete_writes_tombstone_marker() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"k", b"v").unwrap();
-    engine.delete(b"k").unwrap();
+    block_on_result(engine.put(b"k", b"v")).unwrap();
+    block_on_result(engine.delete(b"k")).unwrap();
 
-    let val = engine.get(b"k").unwrap();
+    let val = block_on_result(engine.get(b"k")).unwrap();
     assert!(
         val.is_none(),
         "deleted key should return None, got {:?}",
@@ -183,13 +191,14 @@ fn test_delete_writes_tombstone_marker() {
 #[test]
 fn test_delete_then_put() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"k", b"v1").unwrap();
-    engine.delete(b"k").unwrap();
-    engine.put(b"k", b"v2").unwrap();
+    block_on_result(engine.put(b"k", b"v1")).unwrap();
+    block_on_result(engine.delete(b"k")).unwrap();
+    block_on_result(engine.put(b"k", b"v2")).unwrap();
 
-    let val = engine.get(b"k").unwrap();
+    let val = block_on_result(engine.get(b"k")).unwrap();
     assert_eq!(val, Some(Bytes::from("v2")));
 }
 
@@ -199,18 +208,22 @@ fn test_tombstone_survives_flush() {
     use super::harness::sync;
 
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"a", b"va").unwrap();
-    engine.delete(b"a").unwrap();
-    engine.put(b"b", b"vb").unwrap();
+    block_on_result(engine.put(b"a", b"va")).unwrap();
+    block_on_result(engine.delete(b"a")).unwrap();
+    block_on_result(engine.put(b"b", b"vb")).unwrap();
 
     // Flush to SST
     sync(&engine.inner);
 
     // Tombstone should still be visible
-    assert!(engine.get(b"a").unwrap().is_none());
-    assert_eq!(engine.get(b"b").unwrap(), Some(Bytes::from("vb")));
+    assert!(block_on_result(engine.get(b"a")).unwrap().is_none());
+    assert_eq!(
+        block_on_result(engine.get(b"b")).unwrap(),
+        Some(Bytes::from("vb"))
+    );
 }
 
 // write_batch tests are omitted here because write_batch bypasses MVCC
@@ -223,16 +236,17 @@ fn test_tombstone_survives_flush() {
 #[test]
 fn test_scan_snapshot_hides_later_put() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"a", b"va").unwrap();
-    engine.put(b"c", b"vc").unwrap();
+    block_on_result(engine.put(b"a", b"va")).unwrap();
+    block_on_result(engine.put(b"c", b"vc")).unwrap();
 
     // Start scan — captures read_ts before this point
-    let mut iter = engine.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    let mut iter = block_on_result(engine.scan(Bound::Unbounded, Bound::Unbounded)).unwrap();
 
     // Write after scan started — invisible to the scan
-    engine.put(b"b", b"vb").unwrap();
+    block_on_result(engine.put(b"b", b"vb")).unwrap();
 
     check_lsm_iter_result_by_key(
         &mut iter,
@@ -247,16 +261,17 @@ fn test_scan_snapshot_hides_later_put() {
 #[test]
 fn test_scan_snapshot_hides_later_delete() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"a", b"va").unwrap();
-    engine.put(b"b", b"vb").unwrap();
-    engine.put(b"c", b"vc").unwrap();
+    block_on_result(engine.put(b"a", b"va")).unwrap();
+    block_on_result(engine.put(b"b", b"vb")).unwrap();
+    block_on_result(engine.put(b"c", b"vc")).unwrap();
 
-    let mut iter = engine.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    let mut iter = block_on_result(engine.scan(Bound::Unbounded, Bound::Unbounded)).unwrap();
 
     // Delete after scan started — scan still sees "b"
-    engine.delete(b"b").unwrap();
+    block_on_result(engine.delete(b"b")).unwrap();
 
     check_lsm_iter_result_by_key(
         &mut iter,
@@ -272,15 +287,16 @@ fn test_scan_snapshot_hides_later_delete() {
 #[test]
 fn test_scan_snapshot_hides_later_overwrite() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"a", b"va").unwrap();
-    engine.put(b"b", b"vb_old").unwrap();
+    block_on_result(engine.put(b"a", b"va")).unwrap();
+    block_on_result(engine.put(b"b", b"vb_old")).unwrap();
 
-    let mut iter = engine.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    let mut iter = block_on_result(engine.scan(Bound::Unbounded, Bound::Unbounded)).unwrap();
 
     // Overwrite after scan started — scan sees old value
-    engine.put(b"b", b"vb_new").unwrap();
+    block_on_result(engine.put(b"b", b"vb_new")).unwrap();
 
     check_lsm_iter_result_by_key(
         &mut iter,
@@ -298,16 +314,17 @@ fn test_scan_survives_memtable_flush() {
     use super::harness::sync;
 
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"a", b"va").unwrap();
-    engine.put(b"b", b"vb").unwrap();
+    block_on_result(engine.put(b"a", b"va")).unwrap();
+    block_on_result(engine.put(b"b", b"vb")).unwrap();
 
     // Start scan — state snapshot pins the active memtable
-    let mut iter = engine.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    let mut iter = block_on_result(engine.scan(Bound::Unbounded, Bound::Unbounded)).unwrap();
 
     sync(&engine.inner); // flush to SST — old state stays alive via Arc
-    engine.put(b"c", b"vc").unwrap(); // write after scan — not visible
+    block_on_result(engine.put(b"c", b"vc")).unwrap(); // write after scan — not visible
 
     check_lsm_iter_result_by_key(
         &mut iter,
@@ -322,17 +339,16 @@ fn test_scan_survives_memtable_flush() {
 #[test]
 fn test_scan_excluded_lower_bound_skips_versions() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"a", b"va").unwrap();
-    engine.put(b"b", b"vb1").unwrap();
-    engine.put(b"b", b"vb2").unwrap(); // second version of "b"
-    engine.put(b"c", b"vc").unwrap();
+    block_on_result(engine.put(b"a", b"va")).unwrap();
+    block_on_result(engine.put(b"b", b"vb1")).unwrap();
+    block_on_result(engine.put(b"b", b"vb2")).unwrap(); // second version of "b"
+    block_on_result(engine.put(b"c", b"vc")).unwrap();
 
     // Excluded lower bound "b" — should skip all versions of "b"
-    let mut iter = engine
-        .scan(Bound::Excluded(b"b"), Bound::Unbounded)
-        .unwrap();
+    let mut iter = block_on_result(engine.scan(Bound::Excluded(b"b"), Bound::Unbounded)).unwrap();
     check_lsm_iter_result_by_key(&mut iter, vec![(Bytes::from("c"), Bytes::from("vc"))]);
 }
 
@@ -342,18 +358,19 @@ fn test_scan_tombstone_in_sst() {
     use super::harness::sync;
 
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"a", b"va").unwrap();
-    engine.put(b"b", b"vb").unwrap();
-    engine.delete(b"b").unwrap();
-    engine.put(b"c", b"vc").unwrap();
+    block_on_result(engine.put(b"a", b"va")).unwrap();
+    block_on_result(engine.put(b"b", b"vb")).unwrap();
+    block_on_result(engine.delete(b"b")).unwrap();
+    block_on_result(engine.put(b"c", b"vc")).unwrap();
 
     // Flush everything to SST
     sync(&engine.inner);
 
     // Scan should still skip the deleted key
-    let mut iter = engine.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    let mut iter = block_on_result(engine.scan(Bound::Unbounded, Bound::Unbounded)).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![
@@ -367,18 +384,19 @@ fn test_scan_tombstone_in_sst() {
 #[test]
 fn test_scan_read_ts_between_versions() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"k", b"v1").unwrap();
-    engine.put(b"k", b"v2").unwrap();
+    block_on_result(engine.put(b"k", b"v1")).unwrap();
+    block_on_result(engine.put(b"k", b"v2")).unwrap();
 
     // Scan at this point sees v2
-    let mut iter = engine.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    let mut iter = block_on_result(engine.scan(Bound::Unbounded, Bound::Unbounded)).unwrap();
     check_lsm_iter_result_by_key(&mut iter, vec![(Bytes::from("k"), Bytes::from("v2"))]);
     drop(iter);
 
     // Write v3 after the scan — new scan should see v3
-    engine.put(b"k", b"v3").unwrap();
-    let mut iter = engine.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    block_on_result(engine.put(b"k", b"v3")).unwrap();
+    let mut iter = block_on_result(engine.scan(Bound::Unbounded, Bound::Unbounded)).unwrap();
     check_lsm_iter_result_by_key(&mut iter, vec![(Bytes::from("k"), Bytes::from("v3"))]);
 }

--- a/kv-engine/src/tests/prefix_scan.rs
+++ b/kv-engine/src/tests/prefix_scan.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use tempfile::tempdir;
 
+use super::block_on_result;
 use super::harness::{check_lsm_iter_result_by_key, sync};
 use crate::{
     compact::CompactionOptions,
@@ -47,7 +48,8 @@ fn test_prefix_upper_bound_all_ff_multi() {
 #[test]
 fn test_prefix_scan_basic() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
     for key in &[
         b"a".as_ref(),
@@ -59,11 +61,11 @@ fn test_prefix_scan_basic() {
         b"user:2",
         b"user2:1",
     ] {
-        engine.put(key, key).unwrap();
+        block_on_result(engine.put(key, key)).unwrap();
     }
 
     // prefix "user:" returns only user:1, user:10, user:2 (sorted)
-    let mut iter = engine.prefix_scan(b"user:").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"user:")).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![
@@ -77,7 +79,8 @@ fn test_prefix_scan_basic() {
 #[test]
 fn test_prefix_scan_broader_prefix() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
     for key in &[
         b"a".as_ref(),
@@ -89,11 +92,11 @@ fn test_prefix_scan_broader_prefix() {
         b"user:2",
         b"user2:1",
     ] {
-        engine.put(key, key).unwrap();
+        block_on_result(engine.put(key, key)).unwrap();
     }
 
     // prefix "user" returns both user:* and user2:* (sorted by byte order)
-    let mut iter = engine.prefix_scan(b"user").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"user")).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![
@@ -108,24 +111,26 @@ fn test_prefix_scan_broader_prefix() {
 #[test]
 fn test_prefix_scan_no_match() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"a", b"va").unwrap();
-    engine.put(b"b", b"vb").unwrap();
+    block_on_result(engine.put(b"a", b"va")).unwrap();
+    block_on_result(engine.put(b"b", b"vb")).unwrap();
 
-    let iter = engine.prefix_scan(b"missing").unwrap();
+    let iter = block_on_result(engine.prefix_scan(b"missing")).unwrap();
     assert!(!iter.is_valid());
 }
 
 #[test]
 fn test_prefix_scan_empty_prefix_is_full_scan() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"a", b"va").unwrap();
-    engine.put(b"b", b"vb").unwrap();
+    block_on_result(engine.put(b"a", b"va")).unwrap();
+    block_on_result(engine.put(b"b", b"vb")).unwrap();
 
-    let mut iter = engine.prefix_scan(b"").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"")).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![
@@ -138,17 +143,18 @@ fn test_prefix_scan_empty_prefix_is_full_scan() {
 #[test]
 fn test_prefix_scan_ff_suffix() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
     // Keys with a\xff prefix
-    engine.put(b"a\xfe", b"v1").unwrap();
-    engine.put(b"a\xff", b"v2").unwrap();
-    engine.put(b"a\xff\x00", b"v3").unwrap();
-    engine.put(b"a\xff\xff", b"v4").unwrap();
-    engine.put(b"b", b"v5").unwrap();
+    block_on_result(engine.put(b"a\xfe", b"v1")).unwrap();
+    block_on_result(engine.put(b"a\xff", b"v2")).unwrap();
+    block_on_result(engine.put(b"a\xff\x00", b"v3")).unwrap();
+    block_on_result(engine.put(b"a\xff\xff", b"v4")).unwrap();
+    block_on_result(engine.put(b"b", b"v5")).unwrap();
 
     // prefix "a\xff" should match a\xff, a\xff\x00, a\xff\xff but NOT b
-    let mut iter = engine.prefix_scan(b"a\xff").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"a\xff")).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![
@@ -162,15 +168,16 @@ fn test_prefix_scan_ff_suffix() {
 #[test]
 fn test_prefix_scan_all_ff_prefix() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"\xff", b"v1").unwrap();
-    engine.put(b"\xff\x00", b"v2").unwrap();
-    engine.put(b"\xff\xff", b"v3").unwrap();
-    engine.put(b"other", b"v4").unwrap();
+    block_on_result(engine.put(b"\xff", b"v1")).unwrap();
+    block_on_result(engine.put(b"\xff\x00", b"v2")).unwrap();
+    block_on_result(engine.put(b"\xff\xff", b"v3")).unwrap();
+    block_on_result(engine.put(b"other", b"v4")).unwrap();
 
     // prefix "\xff" — upper bound is unbounded, but only \xff* keys should match
-    let mut iter = engine.prefix_scan(b"\xff").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"\xff")).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![
@@ -184,14 +191,15 @@ fn test_prefix_scan_all_ff_prefix() {
 #[test]
 fn test_prefix_scan_with_delete() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"user:1", b"v1").unwrap();
-    engine.put(b"user:2", b"v2").unwrap();
-    engine.put(b"user:3", b"v3").unwrap();
-    engine.delete(b"user:2").unwrap();
+    block_on_result(engine.put(b"user:1", b"v1")).unwrap();
+    block_on_result(engine.put(b"user:2", b"v2")).unwrap();
+    block_on_result(engine.put(b"user:3", b"v3")).unwrap();
+    block_on_result(engine.delete(b"user:2")).unwrap();
 
-    let mut iter = engine.prefix_scan(b"user:").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"user:")).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![
@@ -206,14 +214,15 @@ fn test_prefix_scan_with_delete() {
 #[test]
 fn test_prefix_scan_deduplicates_across_versions() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"user:1", b"v0").unwrap();
-    engine.put(b"user:1", b"v1").unwrap();
-    engine.put(b"user:1", b"v2").unwrap();
-    engine.put(b"user:2", b"vx").unwrap();
+    block_on_result(engine.put(b"user:1", b"v0")).unwrap();
+    block_on_result(engine.put(b"user:1", b"v1")).unwrap();
+    block_on_result(engine.put(b"user:1", b"v2")).unwrap();
+    block_on_result(engine.put(b"user:2", b"vx")).unwrap();
 
-    let mut iter = engine.prefix_scan(b"user:").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"user:")).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![
@@ -226,17 +235,18 @@ fn test_prefix_scan_deduplicates_across_versions() {
 #[test]
 fn test_prefix_scan_tombstone_in_sst() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"user:1", b"v1").unwrap();
-    engine.put(b"user:2", b"v2").unwrap();
-    engine.delete(b"user:2").unwrap();
-    engine.put(b"user:3", b"v3").unwrap();
+    block_on_result(engine.put(b"user:1", b"v1")).unwrap();
+    block_on_result(engine.put(b"user:2", b"v2")).unwrap();
+    block_on_result(engine.delete(b"user:2")).unwrap();
+    block_on_result(engine.put(b"user:3", b"v3")).unwrap();
 
     // Flush everything to SST so the tombstone lives on disk.
     sync(&engine.inner);
 
-    let mut iter = engine.prefix_scan(b"user:").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"user:")).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![
@@ -249,16 +259,17 @@ fn test_prefix_scan_tombstone_in_sst() {
 #[test]
 fn test_prefix_scan_version_collapse_after_flush() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
     // Write multiple versions, then flush.
-    engine.put(b"k1", b"v0").unwrap();
-    engine.put(b"k1", b"v1").unwrap();
-    engine.put(b"k1", b"v2").unwrap();
+    block_on_result(engine.put(b"k1", b"v0")).unwrap();
+    block_on_result(engine.put(b"k1", b"v1")).unwrap();
+    block_on_result(engine.put(b"k1", b"v2")).unwrap();
     sync(&engine.inner);
 
     // Only the latest version should appear.
-    let mut iter = engine.prefix_scan(b"k").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"k")).unwrap();
     check_lsm_iter_result_by_key(&mut iter, vec![(Bytes::from("k1"), Bytes::from("v2"))]);
 }
 
@@ -281,10 +292,10 @@ fn serializable_options() -> LsmStorageOptions {
 #[test]
 fn test_prefix_scan_serializable_rejected() {
     let dir = tempdir().unwrap();
-    let engine = Arc::new(KvEngine::open(&dir, serializable_options()).unwrap());
+    let engine = Arc::new(block_on_result(KvEngine::open(&dir, serializable_options())).unwrap());
 
-    let txn = engine.new_txn().unwrap();
-    let result = txn.prefix_scan(b"user:");
+    let txn = block_on_result(engine.new_txn()).unwrap();
+    let result = block_on_result(txn.prefix_scan(b"user:"));
     assert!(
         result.is_err(),
         "prefix_scan should be rejected for serializable transactions"
@@ -294,17 +305,19 @@ fn test_prefix_scan_serializable_rejected() {
 #[test]
 fn test_prefix_scan_txn_local_writes_merged() {
     let dir = tempdir().unwrap();
-    let engine = Arc::new(KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap());
+    let engine = Arc::new(
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap(),
+    );
 
     // Write one key to the engine.
-    engine.put(b"user:1", b"from_engine").unwrap();
+    block_on_result(engine.put(b"user:1", b"from_engine")).unwrap();
 
     // Start a transaction and add local writes.
-    let txn = engine.new_txn().unwrap();
+    let txn = block_on_result(engine.new_txn()).unwrap();
     txn.put(b"user:2", b"from_txn").unwrap();
 
     // prefix_scan should see both engine and local writes.
-    let mut iter = txn.prefix_scan(b"user:").unwrap();
+    let mut iter = block_on_result(txn.prefix_scan(b"user:")).unwrap();
     let mut results = Vec::new();
     while iter.is_valid() {
         results.push((
@@ -324,29 +337,32 @@ fn test_prefix_scan_txn_local_writes_merged() {
 #[test]
 fn test_prefix_scan_txn_local_delete_shadows_engine() {
     let dir = tempdir().unwrap();
-    let engine = Arc::new(KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap());
+    let engine = Arc::new(
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap(),
+    );
 
-    engine.put(b"user:1", b"v1").unwrap();
-    engine.put(b"user:2", b"v2").unwrap();
+    block_on_result(engine.put(b"user:1", b"v1")).unwrap();
+    block_on_result(engine.put(b"user:2", b"v2")).unwrap();
 
     // Transaction deletes user:1 locally.
-    let txn = engine.new_txn().unwrap();
+    let txn = block_on_result(engine.new_txn()).unwrap();
     txn.delete(b"user:1").unwrap();
 
-    let mut iter = txn.prefix_scan(b"user:").unwrap();
+    let mut iter = block_on_result(txn.prefix_scan(b"user:")).unwrap();
     check_lsm_iter_result_by_key(&mut iter, vec![(Bytes::from("user:2"), Bytes::from("v2"))]);
 }
 
 #[test]
 fn test_prefix_scan_binary_keys_with_null_byte() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"\x00user:1", b"v1").unwrap();
-    engine.put(b"\x00user:2", b"v2").unwrap();
-    engine.put(b"\x01user:1", b"v3").unwrap();
+    block_on_result(engine.put(b"\x00user:1", b"v1")).unwrap();
+    block_on_result(engine.put(b"\x00user:2", b"v2")).unwrap();
+    block_on_result(engine.put(b"\x01user:1", b"v3")).unwrap();
 
-    let mut iter = engine.prefix_scan(b"\x00user:").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"\x00user:")).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![
@@ -359,15 +375,16 @@ fn test_prefix_scan_binary_keys_with_null_byte() {
 #[test]
 fn test_prefix_scan_exact_8_byte_user_key() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
     // Exactly 8 bytes — boundary for memcomparable padding.
-    engine.put(b"aaaaaaab", b"v1").unwrap();
-    engine.put(b"aaaaaaac", b"v2").unwrap();
-    engine.put(b"aaaaaaad", b"v3").unwrap();
-    engine.put(b"bbbbbbbb", b"v4").unwrap();
+    block_on_result(engine.put(b"aaaaaaab", b"v1")).unwrap();
+    block_on_result(engine.put(b"aaaaaaac", b"v2")).unwrap();
+    block_on_result(engine.put(b"aaaaaaad", b"v3")).unwrap();
+    block_on_result(engine.put(b"bbbbbbbb", b"v4")).unwrap();
 
-    let mut iter = engine.prefix_scan(b"aaaaaaa").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"aaaaaaa")).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![
@@ -381,14 +398,15 @@ fn test_prefix_scan_exact_8_byte_user_key() {
 #[test]
 fn test_prefix_scan_empty_user_key() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
     // Empty key is a valid user key.
-    engine.put(b"", b"empty_key_val").unwrap();
-    engine.put(b"a", b"va").unwrap();
+    block_on_result(engine.put(b"", b"empty_key_val")).unwrap();
+    block_on_result(engine.put(b"a", b"va")).unwrap();
 
     // Full scan via empty prefix should include the empty key.
-    let mut iter = engine.prefix_scan(b"").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"")).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![
@@ -403,10 +421,11 @@ fn test_prefix_scan_empty_user_key() {
 #[test]
 fn test_prefix_scan_immutable_memtable() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"user:1", b"v1").unwrap();
-    engine.put(b"user:2", b"v2").unwrap();
+    block_on_result(engine.put(b"user:1", b"v1")).unwrap();
+    block_on_result(engine.put(b"user:2", b"v2")).unwrap();
 
     // Freeze the active memtable (moves it to immutable list) but don't flush.
     engine
@@ -415,10 +434,10 @@ fn test_prefix_scan_immutable_memtable() {
         .unwrap();
 
     // Write more data to the new active memtable.
-    engine.put(b"user:3", b"v3").unwrap();
+    block_on_result(engine.put(b"user:3", b"v3")).unwrap();
 
     // All three keys should be visible.
-    let mut iter = engine.prefix_scan(b"user:").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"user:")).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![
@@ -432,16 +451,17 @@ fn test_prefix_scan_immutable_memtable() {
 #[test]
 fn test_prefix_scan_flushed_sst() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"user:1", b"v1").unwrap();
-    engine.put(b"user:2", b"v2").unwrap();
+    block_on_result(engine.put(b"user:1", b"v1")).unwrap();
+    block_on_result(engine.put(b"user:2", b"v2")).unwrap();
 
     // Flush to SST — data no longer in any memtable.
     sync(&engine.inner);
 
     // Active memtable is empty, but prefix scan should still find the keys.
-    let mut iter = engine.prefix_scan(b"user:").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"user:")).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![
@@ -454,20 +474,21 @@ fn test_prefix_scan_flushed_sst() {
 #[test]
 fn test_prefix_scan_multiple_l0_ssts() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
     // Write batch 1 and flush.
-    engine.put(b"user:1", b"v1").unwrap();
-    engine.put(b"user:2", b"v2").unwrap();
+    block_on_result(engine.put(b"user:1", b"v1")).unwrap();
+    block_on_result(engine.put(b"user:2", b"v2")).unwrap();
     sync(&engine.inner);
 
     // Write batch 2 and flush.
-    engine.put(b"user:3", b"v3").unwrap();
-    engine.put(b"user:4", b"v4").unwrap();
+    block_on_result(engine.put(b"user:3", b"v3")).unwrap();
+    block_on_result(engine.put(b"user:4", b"v4")).unwrap();
     sync(&engine.inner);
 
     // Two L0 SSTs exist. Prefix scan merges across them.
-    let mut iter = engine.prefix_scan(b"user:").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"user:")).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![
@@ -482,18 +503,19 @@ fn test_prefix_scan_multiple_l0_ssts() {
 #[test]
 fn test_prefix_scan_across_flush_with_overwrite() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
     // Write and flush batch 1.
-    engine.put(b"user:1", b"old").unwrap();
-    engine.put(b"user:2", b"v2").unwrap();
+    block_on_result(engine.put(b"user:1", b"old")).unwrap();
+    block_on_result(engine.put(b"user:2", b"v2")).unwrap();
     sync(&engine.inner);
 
     // Overwrite user:1 in a new memtable (not flushed).
-    engine.put(b"user:1", b"new").unwrap();
+    block_on_result(engine.put(b"user:1", b"new")).unwrap();
 
     // Latest value should win.
-    let mut iter = engine.prefix_scan(b"user:").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"user:")).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![
@@ -506,23 +528,24 @@ fn test_prefix_scan_across_flush_with_overwrite() {
 #[test]
 fn test_prefix_scan_post_compaction() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
     // Write some data and flush.
-    engine.put(b"user:1", b"v1").unwrap();
-    engine.put(b"user:2", b"v2").unwrap();
-    engine.put(b"other", b"vo").unwrap();
+    block_on_result(engine.put(b"user:1", b"v1")).unwrap();
+    block_on_result(engine.put(b"user:2", b"v2")).unwrap();
+    block_on_result(engine.put(b"other", b"vo")).unwrap();
     sync(&engine.inner);
 
     // Write more and flush again.
-    engine.put(b"user:3", b"v3").unwrap();
+    block_on_result(engine.put(b"user:3", b"v3")).unwrap();
     sync(&engine.inner);
 
     // Run full compaction.
-    engine.force_full_compaction().unwrap();
+    block_on_result(engine.force_full_compaction()).unwrap();
 
     // All prefix-matching keys should survive compaction.
-    let mut iter = engine.prefix_scan(b"user:").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"user:")).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![
@@ -536,20 +559,21 @@ fn test_prefix_scan_post_compaction() {
 #[test]
 fn test_prefix_scan_compaction_with_delete_gc() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let engine =
+        block_on_result(KvEngine::open(&dir, LsmStorageOptions::default_for_test())).unwrap();
 
-    engine.put(b"user:1", b"v1").unwrap();
-    engine.put(b"user:2", b"v2").unwrap();
+    block_on_result(engine.put(b"user:1", b"v1")).unwrap();
+    block_on_result(engine.put(b"user:2", b"v2")).unwrap();
     sync(&engine.inner);
 
     // Delete user:2 and flush — tombstone in its own SST.
-    engine.delete(b"user:2").unwrap();
+    block_on_result(engine.delete(b"user:2")).unwrap();
     sync(&engine.inner);
 
     // Full compaction should GC the tombstone since both SSTs merge.
-    engine.force_full_compaction().unwrap();
+    block_on_result(engine.force_full_compaction()).unwrap();
 
-    let mut iter = engine.prefix_scan(b"user:").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"user:")).unwrap();
     check_lsm_iter_result_by_key(&mut iter, vec![(Bytes::from("user:1"), Bytes::from("v1"))]);
 }
 
@@ -578,17 +602,17 @@ fn prefix_bloom_options(prefix_lengths: Vec<usize>) -> LsmStorageOptions {
 #[test]
 fn test_prefix_bloom_basic_flushed_ssts() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, prefix_bloom_options(vec![6])).unwrap();
+    let engine = block_on_result(KvEngine::open(&dir, prefix_bloom_options(vec![6]))).unwrap();
 
     // Write keys with different prefixes and flush to SSTs.
-    engine.put(b"tenant:1:user:1", b"v1").unwrap();
-    engine.put(b"tenant:1:user:2", b"v2").unwrap();
-    engine.put(b"tenant:2:user:1", b"v3").unwrap();
-    engine.put(b"other:data", b"v4").unwrap();
+    block_on_result(engine.put(b"tenant:1:user:1", b"v1")).unwrap();
+    block_on_result(engine.put(b"tenant:1:user:2", b"v2")).unwrap();
+    block_on_result(engine.put(b"tenant:2:user:1", b"v3")).unwrap();
+    block_on_result(engine.put(b"other:data", b"v4")).unwrap();
     sync(&engine.inner);
 
     // Prefix scan for "tenant:1:" should return only tenant:1 keys.
-    let mut iter = engine.prefix_scan(b"tenant:1:").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"tenant:1:")).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![
@@ -598,38 +622,38 @@ fn test_prefix_bloom_basic_flushed_ssts() {
     );
 
     // Prefix scan for "tenant:2:" should return only tenant:2 keys.
-    let mut iter = engine.prefix_scan(b"tenant:2:").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"tenant:2:")).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![(Bytes::from("tenant:2:user:1"), Bytes::from("v3"))],
     );
 
     // Missing prefix should return empty.
-    let iter = engine.prefix_scan(b"tenant:3:").unwrap();
+    let iter = block_on_result(engine.prefix_scan(b"tenant:3:")).unwrap();
     assert!(!iter.is_valid());
 }
 
 #[test]
 fn test_prefix_bloom_with_multiple_ssts() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, prefix_bloom_options(vec![8])).unwrap();
+    let engine = block_on_result(KvEngine::open(&dir, prefix_bloom_options(vec![8]))).unwrap();
 
     // Write and flush multiple SSTs with different tenant prefixes.
-    engine.put(b"user:001:data", b"a").unwrap();
+    block_on_result(engine.put(b"user:001:data", b"a")).unwrap();
     sync(&engine.inner);
-    engine.put(b"user:002:data", b"b").unwrap();
+    block_on_result(engine.put(b"user:002:data", b"b")).unwrap();
     sync(&engine.inner);
-    engine.put(b"user:003:data", b"c").unwrap();
+    block_on_result(engine.put(b"user:003:data", b"c")).unwrap();
     sync(&engine.inner);
 
     // Each prefix scan should find only the matching key.
-    let mut iter = engine.prefix_scan(b"user:001:").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"user:001:")).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![(Bytes::from("user:001:data"), Bytes::from("a"))],
     );
 
-    let mut iter = engine.prefix_scan(b"user:002:").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"user:002:")).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![(Bytes::from("user:002:data"), Bytes::from("b"))],
@@ -647,18 +671,18 @@ fn test_prefix_bloom_preserves_correctness_after_compaction() {
             max_levels: 3,
         });
     opts.num_memtable_limit = 2;
-    let engine = KvEngine::open(&dir, opts).unwrap();
+    let engine = block_on_result(KvEngine::open(&dir, opts)).unwrap();
 
     // Write data and trigger compaction.
-    engine.put(b"tenant:1:key1", b"v1").unwrap();
-    engine.put(b"tenant:2:key1", b"v2").unwrap();
+    block_on_result(engine.put(b"tenant:1:key1", b"v1")).unwrap();
+    block_on_result(engine.put(b"tenant:2:key1", b"v2")).unwrap();
     sync(&engine.inner);
-    engine.put(b"tenant:1:key2", b"v3").unwrap();
-    engine.put(b"tenant:3:key1", b"v4").unwrap();
+    block_on_result(engine.put(b"tenant:1:key2", b"v3")).unwrap();
+    block_on_result(engine.put(b"tenant:3:key1", b"v4")).unwrap();
     sync(&engine.inner);
 
     // Results should be correct after compaction.
-    let mut iter = engine.prefix_scan(b"tenant:1:").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"tenant:1:")).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![
@@ -673,15 +697,15 @@ fn test_prefix_bloom_short_prefix_fallback() {
     let dir = tempdir().unwrap();
     // Configure prefix length 8, but query with prefix shorter than 8 bytes.
     // The bloom filter should not reject any SST (fallback to range scan).
-    let engine = KvEngine::open(&dir, prefix_bloom_options(vec![8])).unwrap();
+    let engine = block_on_result(KvEngine::open(&dir, prefix_bloom_options(vec![8]))).unwrap();
 
-    engine.put(b"ab:data", b"v1").unwrap();
-    engine.put(b"ac:data", b"v2").unwrap();
-    engine.put(b"bb:data", b"v3").unwrap();
+    block_on_result(engine.put(b"ab:data", b"v1")).unwrap();
+    block_on_result(engine.put(b"ac:data", b"v2")).unwrap();
+    block_on_result(engine.put(b"bb:data", b"v3")).unwrap();
     sync(&engine.inner);
 
     // Query with 2-byte prefix (shorter than configured length 8).
-    let mut iter = engine.prefix_scan(b"ab").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"ab")).unwrap();
     check_lsm_iter_result_by_key(&mut iter, vec![(Bytes::from("ab:data"), Bytes::from("v1"))]);
 }
 
@@ -692,23 +716,27 @@ fn test_prefix_bloom_disabled_same_results() {
     let dir_disabled = tempdir().unwrap();
     let dir_enabled = tempdir().unwrap();
 
-    let engine_disabled =
-        KvEngine::open(&dir_disabled, LsmStorageOptions::default_for_test()).unwrap();
-    let engine_enabled = KvEngine::open(&dir_enabled, prefix_bloom_options(vec![6])).unwrap();
+    let engine_disabled = block_on_result(KvEngine::open(
+        &dir_disabled,
+        LsmStorageOptions::default_for_test(),
+    ))
+    .unwrap();
+    let engine_enabled =
+        block_on_result(KvEngine::open(&dir_enabled, prefix_bloom_options(vec![6]))).unwrap();
 
     let keys: Vec<Vec<u8>> = (0..50)
         .map(|i| format!("user:{:03}:data", i).into_bytes())
         .collect();
     for key in &keys {
-        engine_disabled.put(key, b"val").unwrap();
-        engine_enabled.put(key, b"val").unwrap();
+        block_on_result(engine_disabled.put(key, b"val")).unwrap();
+        block_on_result(engine_enabled.put(key, b"val")).unwrap();
     }
     sync(&engine_disabled.inner);
     sync(&engine_enabled.inner);
 
     // Both should return the same results for "user:01:" prefix.
-    let mut iter_disabled = engine_disabled.prefix_scan(b"user:01:").unwrap();
-    let mut iter_enabled = engine_enabled.prefix_scan(b"user:01:").unwrap();
+    let mut iter_disabled = block_on_result(engine_disabled.prefix_scan(b"user:01:")).unwrap();
+    let mut iter_enabled = block_on_result(engine_enabled.prefix_scan(b"user:01:")).unwrap();
 
     let mut results_disabled = vec![];
     while iter_disabled.is_valid() {
@@ -732,16 +760,16 @@ fn test_prefix_bloom_disabled_same_results() {
 #[test]
 fn test_prefix_bloom_with_mvcc_versions() {
     let dir = tempdir().unwrap();
-    let engine = KvEngine::open(&dir, prefix_bloom_options(vec![6])).unwrap();
+    let engine = block_on_result(KvEngine::open(&dir, prefix_bloom_options(vec![6]))).unwrap();
 
     // Write multiple versions of the same key.
-    engine.put(b"user:1:data", b"v1").unwrap();
-    engine.put(b"user:1:data", b"v2").unwrap();
-    engine.put(b"user:2:data", b"v3").unwrap();
+    block_on_result(engine.put(b"user:1:data", b"v1")).unwrap();
+    block_on_result(engine.put(b"user:1:data", b"v2")).unwrap();
+    block_on_result(engine.put(b"user:2:data", b"v3")).unwrap();
     sync(&engine.inner);
 
     // Should see only the latest version.
-    let mut iter = engine.prefix_scan(b"user:1").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"user:1")).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![(Bytes::from("user:1:data"), Bytes::from("v2"))],
@@ -755,30 +783,33 @@ fn test_prefix_bloom_v3_reopen_from_disk() {
 
     // Phase 1: write data and flush to v3 SSTs, then drop engine.
     {
-        let engine = KvEngine::open(&dir, opts.clone()).unwrap();
-        engine.put(b"user:1:data", b"v1").unwrap();
-        engine.put(b"user:2:data", b"v2").unwrap();
-        engine.put(b"other:data", b"v3").unwrap();
+        let engine = block_on_result(KvEngine::open(&dir, opts.clone())).unwrap();
+        block_on_result(engine.put(b"user:1:data", b"v1")).unwrap();
+        block_on_result(engine.put(b"user:2:data", b"v2")).unwrap();
+        block_on_result(engine.put(b"other:data", b"v3")).unwrap();
         sync(&engine.inner);
         // engine dropped here — SSTs written to disk with v3 footer
     }
 
     // Phase 2: reopen — exercises SsTable::open() v3 decode path.
     {
-        let engine = KvEngine::open(&dir, opts).unwrap();
+        let engine = block_on_result(KvEngine::open(&dir, opts)).unwrap();
 
         // Prefix scan exercises prefix bloom decode.
-        let mut iter = engine.prefix_scan(b"user:1").unwrap();
+        let mut iter = block_on_result(engine.prefix_scan(b"user:1")).unwrap();
         check_lsm_iter_result_by_key(
             &mut iter,
             vec![(Bytes::from("user:1:data"), Bytes::from("v1"))],
         );
 
         // Point get exercises whole-key bloom decode on v3 SST.
-        assert_eq!(engine.get(b"user:2:data").unwrap(), Some(Bytes::from("v2")));
+        assert_eq!(
+            block_on_result(engine.get(b"user:2:data")).unwrap(),
+            Some(Bytes::from("v2"))
+        );
 
         // Missing prefix should return empty.
-        let iter = engine.prefix_scan(b"tenant:").unwrap();
+        let iter = block_on_result(engine.prefix_scan(b"tenant:")).unwrap();
         assert!(!iter.is_valid());
     }
 }
@@ -789,10 +820,10 @@ fn test_legacy_v3_sst_bypasses_stale_prefix_bloom() {
     let opts = prefix_bloom_options(vec![6]);
 
     {
-        let engine = KvEngine::open(&dir, opts.clone()).unwrap();
-        engine.put(b"user:1:data", b"v1").unwrap();
-        engine.put(b"user:2:data", b"v2").unwrap();
-        engine.put(b"other:data", b"v3").unwrap();
+        let engine = block_on_result(KvEngine::open(&dir, opts.clone())).unwrap();
+        block_on_result(engine.put(b"user:1:data", b"v1")).unwrap();
+        block_on_result(engine.put(b"user:2:data", b"v2")).unwrap();
+        block_on_result(engine.put(b"other:data", b"v3")).unwrap();
         sync(&engine.inner);
     }
 
@@ -808,8 +839,8 @@ fn test_legacy_v3_sst_bypasses_stale_prefix_bloom() {
     raw[version_idx] = 3;
     std::fs::write(&path, &raw).unwrap();
 
-    let engine = KvEngine::open(&dir, opts).unwrap();
-    let mut iter = engine.prefix_scan(b"user:1").unwrap();
+    let engine = block_on_result(KvEngine::open(&dir, opts)).unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"user:1")).unwrap();
     check_lsm_iter_result_by_key(
         &mut iter,
         vec![(Bytes::from("user:1:data"), Bytes::from("v1"))],
@@ -822,13 +853,13 @@ fn test_prefix_bloom_short_keys_emit_v2() {
     // Configure prefix length 16, but all keys are shorter than 16 bytes.
     // The builder should emit a v2 SST (no prefix bloom metadata).
     let opts = prefix_bloom_options(vec![16]);
-    let engine = KvEngine::open(&dir, opts).unwrap();
+    let engine = block_on_result(KvEngine::open(&dir, opts)).unwrap();
 
-    engine.put(b"ab", b"v1").unwrap();
-    engine.put(b"cd", b"v2").unwrap();
+    block_on_result(engine.put(b"ab", b"v1")).unwrap();
+    block_on_result(engine.put(b"cd", b"v2")).unwrap();
     sync(&engine.inner);
 
     // Results should still be correct — prefix bloom simply doesn't apply.
-    let mut iter = engine.prefix_scan(b"ab").unwrap();
+    let mut iter = block_on_result(engine.prefix_scan(b"ab")).unwrap();
     check_lsm_iter_result_by_key(&mut iter, vec![(Bytes::from("ab"), Bytes::from("v1"))]);
 }

--- a/kv-engine/src/tests/simple_leveled_compaction.rs
+++ b/kv-engine/src/tests/simple_leveled_compaction.rs
@@ -1,5 +1,6 @@
 use tempfile::tempdir;
 
+use super::block_on_result;
 use super::harness::{check_compaction_ratio, compaction_bench};
 use crate::{
     compact::{CompactionOptions, SimpleLeveledCompactionOptions},
@@ -9,7 +10,7 @@ use crate::{
 #[test]
 fn test_integration() {
     let dir = tempdir().unwrap();
-    let storage = KvEngine::open(
+    let storage = block_on_result(KvEngine::open(
         &dir,
         LsmStorageOptions {
             compaction_options: CompactionOptions::Simple(SimpleLeveledCompactionOptions {
@@ -21,7 +22,7 @@ fn test_integration() {
             target_sst_size: 1 << 20,
             ..LsmStorageOptions::default_for_test()
         },
-    )
+    ))
     .unwrap();
 
     compaction_bench(storage.clone());

--- a/kv-engine/src/tests/tiered_compaction.rs
+++ b/kv-engine/src/tests/tiered_compaction.rs
@@ -1,5 +1,6 @@
 use tempfile::tempdir;
 
+use super::block_on_result;
 use super::harness::{check_compaction_ratio, compaction_bench};
 use crate::{
     compact::{CompactionOptions, TieredCompactionOptions},
@@ -9,7 +10,7 @@ use crate::{
 #[test]
 fn test_integration() {
     let dir = tempdir().unwrap();
-    let storage = KvEngine::open(
+    let storage = block_on_result(KvEngine::open(
         &dir,
         LsmStorageOptions {
             compaction_options: CompactionOptions::Tiered(TieredCompactionOptions {
@@ -23,7 +24,7 @@ fn test_integration() {
             target_sst_size: 1 << 20,
             ..LsmStorageOptions::default_for_test()
         },
-    )
+    ))
     .unwrap();
 
     compaction_bench(storage.clone());

--- a/kv-engine/src/tests/txn_serializable.rs
+++ b/kv-engine/src/tests/txn_serializable.rs
@@ -3,6 +3,7 @@ use std::{ops::Bound, sync::Arc};
 use bytes::Bytes;
 use tempfile::tempdir;
 
+use super::block_on_result;
 use crate::{
     compact::CompactionOptions,
     lsm_storage::{KvEngine, LsmStorageOptions, PrefixBloomOptions},
@@ -27,71 +28,83 @@ fn serializable_options() -> LsmStorageOptions {
 #[test]
 fn test_serializable_basic_put_get() {
     let dir = tempdir().unwrap();
-    let engine = Arc::new(KvEngine::open(&dir, serializable_options()).unwrap());
+    let engine = Arc::new(block_on_result(KvEngine::open(&dir, serializable_options())).unwrap());
 
-    let txn = engine.new_txn().unwrap();
+    let txn = block_on_result(engine.new_txn()).unwrap();
     txn.put(b"k1", b"v1").unwrap();
     txn.put(b"k2", b"v2").unwrap();
-    txn.commit().unwrap();
+    block_on_result(txn.commit()).unwrap();
 
-    assert_eq!(engine.get(b"k1").unwrap(), Some(Bytes::from("v1")));
-    assert_eq!(engine.get(b"k2").unwrap(), Some(Bytes::from("v2")));
+    assert_eq!(
+        block_on_result(engine.get(b"k1")).unwrap(),
+        Some(Bytes::from("v1"))
+    );
+    assert_eq!(
+        block_on_result(engine.get(b"k2")).unwrap(),
+        Some(Bytes::from("v2"))
+    );
 }
 
 #[test]
 fn test_serializable_delete() {
     let dir = tempdir().unwrap();
-    let engine = Arc::new(KvEngine::open(&dir, serializable_options()).unwrap());
+    let engine = Arc::new(block_on_result(KvEngine::open(&dir, serializable_options())).unwrap());
 
-    let txn = engine.new_txn().unwrap();
+    let txn = block_on_result(engine.new_txn()).unwrap();
     txn.put(b"k1", b"v1").unwrap();
-    txn.commit().unwrap();
+    block_on_result(txn.commit()).unwrap();
 
-    assert_eq!(engine.get(b"k1").unwrap(), Some(Bytes::from("v1")));
+    assert_eq!(
+        block_on_result(engine.get(b"k1")).unwrap(),
+        Some(Bytes::from("v1"))
+    );
 
-    let txn = engine.new_txn().unwrap();
+    let txn = block_on_result(engine.new_txn()).unwrap();
     txn.delete(b"k1").unwrap();
-    txn.commit().unwrap();
+    block_on_result(txn.commit()).unwrap();
 
-    assert!(engine.get(b"k1").unwrap().is_none());
+    assert!(block_on_result(engine.get(b"k1")).unwrap().is_none());
 }
 
 #[test]
 fn test_serializable_conflict_detection_no_conflict() {
     let dir = tempdir().unwrap();
-    let engine = Arc::new(KvEngine::open(&dir, serializable_options()).unwrap());
+    let engine = Arc::new(block_on_result(KvEngine::open(&dir, serializable_options())).unwrap());
 
     // T1 writes k1
-    let t1 = engine.new_txn().unwrap();
+    let t1 = block_on_result(engine.new_txn()).unwrap();
     t1.put(b"k1", b"v1").unwrap();
-    t1.commit().unwrap();
+    block_on_result(t1.commit()).unwrap();
 
     // T2 reads k2 (no overlap), writes k3
-    let t2 = engine.new_txn().unwrap();
-    t2.get(b"k2").unwrap(); // read k2 — not in t1's write set
+    let t2 = block_on_result(engine.new_txn()).unwrap();
+    block_on_result(t2.get(b"k2")).unwrap(); // read k2 — not in t1's write set
     t2.put(b"k3", b"v3").unwrap();
-    t2.commit().unwrap(); // should succeed — no conflict
+    block_on_result(t2.commit()).unwrap(); // should succeed — no conflict
 
-    assert_eq!(engine.get(b"k3").unwrap(), Some(Bytes::from("v3")));
+    assert_eq!(
+        block_on_result(engine.get(b"k3")).unwrap(),
+        Some(Bytes::from("v3"))
+    );
 }
 
 #[test]
 fn test_serializable_conflict_detection_waw() {
     let dir = tempdir().unwrap();
-    let engine = Arc::new(KvEngine::open(&dir, serializable_options()).unwrap());
+    let engine = Arc::new(block_on_result(KvEngine::open(&dir, serializable_options())).unwrap());
 
     // T1 starts, reads k1
-    let t1 = engine.new_txn().unwrap();
-    t1.get(b"k1").unwrap(); // records k1 in read_set
+    let t1 = block_on_result(engine.new_txn()).unwrap();
+    block_on_result(t1.get(b"k1")).unwrap(); // records k1 in read_set
 
     // T2 starts, writes k1, commits
-    let t2 = engine.new_txn().unwrap();
+    let t2 = block_on_result(engine.new_txn()).unwrap();
     t2.put(b"k1", b"v2").unwrap();
-    t2.commit().unwrap();
+    block_on_result(t2.commit()).unwrap();
 
     // T1 tries to write k1 — conflicts with T2 (T2 wrote k1 after T1's read)
     t1.put(b"k1", b"v1").unwrap();
-    let result = t1.commit();
+    let result = block_on_result(t1.commit());
     assert!(result.is_err(), "should detect serializable conflict");
     assert!(
         result
@@ -105,13 +118,13 @@ fn test_serializable_conflict_detection_waw() {
 #[test]
 fn test_serializable_double_commit_fails() {
     let dir = tempdir().unwrap();
-    let engine = Arc::new(KvEngine::open(&dir, serializable_options()).unwrap());
+    let engine = Arc::new(block_on_result(KvEngine::open(&dir, serializable_options())).unwrap());
 
-    let txn = engine.new_txn().unwrap();
+    let txn = block_on_result(engine.new_txn()).unwrap();
     txn.put(b"k1", b"v1").unwrap();
-    txn.commit().unwrap();
+    block_on_result(txn.commit()).unwrap();
 
-    let result = txn.commit();
+    let result = block_on_result(txn.commit());
     assert!(result.is_err());
     assert!(
         result
@@ -124,10 +137,10 @@ fn test_serializable_double_commit_fails() {
 #[test]
 fn test_serializable_put_after_commit_fails() {
     let dir = tempdir().unwrap();
-    let engine = Arc::new(KvEngine::open(&dir, serializable_options()).unwrap());
+    let engine = Arc::new(block_on_result(KvEngine::open(&dir, serializable_options())).unwrap());
 
-    let txn = engine.new_txn().unwrap();
-    txn.commit().unwrap();
+    let txn = block_on_result(engine.new_txn()).unwrap();
+    block_on_result(txn.commit()).unwrap();
 
     let result = txn.put(b"k1", b"v1");
     assert!(result.is_err());
@@ -136,26 +149,26 @@ fn test_serializable_put_after_commit_fails() {
 #[test]
 fn test_serializable_read_only_commit() {
     let dir = tempdir().unwrap();
-    let engine = Arc::new(KvEngine::open(&dir, serializable_options()).unwrap());
+    let engine = Arc::new(block_on_result(KvEngine::open(&dir, serializable_options())).unwrap());
 
     // Read-only transaction should commit fine
-    let txn = engine.new_txn().unwrap();
-    txn.get(b"k1").unwrap();
-    txn.commit().unwrap();
+    let txn = block_on_result(engine.new_txn()).unwrap();
+    block_on_result(txn.get(b"k1")).unwrap();
+    block_on_result(txn.commit()).unwrap();
 }
 
 #[test]
 fn test_serializable_scan_rejected() {
     let dir = tempdir().unwrap();
-    let engine = Arc::new(KvEngine::open(&dir, serializable_options()).unwrap());
+    let engine = Arc::new(block_on_result(KvEngine::open(&dir, serializable_options())).unwrap());
 
-    let txn = engine.new_txn().unwrap();
+    let txn = block_on_result(engine.new_txn()).unwrap();
     txn.put(b"a", b"va").unwrap();
-    txn.commit().unwrap();
+    block_on_result(txn.commit()).unwrap();
 
     // Serializable txn scan is rejected (no phantom/range tracking)
-    let txn = engine.new_txn().unwrap();
-    let result = txn.scan(Bound::Unbounded, Bound::Unbounded);
+    let txn = block_on_result(engine.new_txn()).unwrap();
+    let result = block_on_result(txn.scan(Bound::Unbounded, Bound::Unbounded));
     assert!(
         result.is_err(),
         "scan should be rejected for serializable txns"
@@ -165,28 +178,34 @@ fn test_serializable_scan_rejected() {
 #[test]
 fn test_serializable_txn_local_get() {
     let dir = tempdir().unwrap();
-    let engine = Arc::new(KvEngine::open(&dir, serializable_options()).unwrap());
+    let engine = Arc::new(block_on_result(KvEngine::open(&dir, serializable_options())).unwrap());
 
     // Put initial data
-    let txn = engine.new_txn().unwrap();
+    let txn = block_on_result(engine.new_txn()).unwrap();
     txn.put(b"k1", b"v1").unwrap();
-    txn.commit().unwrap();
+    block_on_result(txn.commit()).unwrap();
 
     // New txn: local write shadows engine read
-    let txn = engine.new_txn().unwrap();
-    assert_eq!(txn.get(b"k1").unwrap(), Some(Bytes::from("v1")));
+    let txn = block_on_result(engine.new_txn()).unwrap();
+    assert_eq!(
+        block_on_result(txn.get(b"k1")).unwrap(),
+        Some(Bytes::from("v1"))
+    );
     txn.put(b"k1", b"v1_local").unwrap();
-    assert_eq!(txn.get(b"k1").unwrap(), Some(Bytes::from("v1_local")));
+    assert_eq!(
+        block_on_result(txn.get(b"k1")).unwrap(),
+        Some(Bytes::from("v1_local"))
+    );
     txn.delete(b"k1").unwrap();
-    assert!(txn.get(b"k1").unwrap().is_none());
+    assert!(block_on_result(txn.get(b"k1")).unwrap().is_none());
 }
 
 #[test]
 fn test_serializable_put_tombstone_value_rejected() {
     let dir = tempdir().unwrap();
-    let engine = Arc::new(KvEngine::open(&dir, serializable_options()).unwrap());
+    let engine = Arc::new(block_on_result(KvEngine::open(&dir, serializable_options())).unwrap());
 
-    let txn = engine.new_txn().unwrap();
+    let txn = block_on_result(engine.new_txn()).unwrap();
     // The tombstone marker byte (0x02) should be rejected as a value
     let result = txn.put(b"k1", &[0x02]);
     assert!(result.is_err());
@@ -196,27 +215,27 @@ fn test_serializable_put_tombstone_value_rejected() {
 #[test]
 fn test_serializable_write_conflict_with_read_set() {
     let dir = tempdir().unwrap();
-    let engine = Arc::new(KvEngine::open(&dir, serializable_options()).unwrap());
+    let engine = Arc::new(block_on_result(KvEngine::open(&dir, serializable_options())).unwrap());
 
     // Seed data
-    let txn = engine.new_txn().unwrap();
+    let txn = block_on_result(engine.new_txn()).unwrap();
     txn.put(b"k1", b"v1").unwrap();
     txn.put(b"k2", b"v2").unwrap();
-    txn.commit().unwrap();
+    block_on_result(txn.commit()).unwrap();
 
     // T1: reads k1 and k2, then tries to write k1
-    let t1 = engine.new_txn().unwrap();
-    t1.get(b"k1").unwrap(); // adds k1 to read_set
-    t1.get(b"k2").unwrap(); // adds k2 to read_set
+    let t1 = block_on_result(engine.new_txn()).unwrap();
+    block_on_result(t1.get(b"k1")).unwrap(); // adds k1 to read_set
+    block_on_result(t1.get(b"k2")).unwrap(); // adds k2 to read_set
 
     // T2: writes k1 between T1's read and commit
-    let t2 = engine.new_txn().unwrap();
+    let t2 = block_on_result(engine.new_txn()).unwrap();
     t2.put(b"k1", b"v2_wins").unwrap();
-    t2.commit().unwrap();
+    block_on_result(t2.commit()).unwrap();
 
     // T1: write k1 → conflict (T2 wrote k1 which is in T1's read_set)
     t1.put(b"k1", b"v1_loses").unwrap();
-    let result = t1.commit();
+    let result = block_on_result(t1.commit());
     assert!(result.is_err());
     assert!(
         result
@@ -229,28 +248,34 @@ fn test_serializable_write_conflict_with_read_set() {
 #[test]
 fn test_serializable_no_conflict_when_different_keys() {
     let dir = tempdir().unwrap();
-    let engine = Arc::new(KvEngine::open(&dir, serializable_options()).unwrap());
+    let engine = Arc::new(block_on_result(KvEngine::open(&dir, serializable_options())).unwrap());
 
     // Seed
-    let txn = engine.new_txn().unwrap();
+    let txn = block_on_result(engine.new_txn()).unwrap();
     txn.put(b"a", b"va").unwrap();
     txn.put(b"b", b"vb").unwrap();
-    txn.commit().unwrap();
+    block_on_result(txn.commit()).unwrap();
 
     // T1 reads "a", T2 writes "b" — no conflict
-    let t1 = engine.new_txn().unwrap();
-    t1.get(b"a").unwrap();
+    let t1 = block_on_result(engine.new_txn()).unwrap();
+    block_on_result(t1.get(b"a")).unwrap();
 
-    let t2 = engine.new_txn().unwrap();
+    let t2 = block_on_result(engine.new_txn()).unwrap();
     t2.put(b"b", b"vb2").unwrap();
-    t2.commit().unwrap();
+    block_on_result(t2.commit()).unwrap();
 
     // T1 writes "a" — no conflict since T2 didn't write "a"
     t1.put(b"a", b"va2").unwrap();
-    t1.commit().unwrap();
+    block_on_result(t1.commit()).unwrap();
 
-    assert_eq!(engine.get(b"a").unwrap(), Some(Bytes::from("va2")));
-    assert_eq!(engine.get(b"b").unwrap(), Some(Bytes::from("vb2")));
+    assert_eq!(
+        block_on_result(engine.get(b"a")).unwrap(),
+        Some(Bytes::from("va2"))
+    );
+    assert_eq!(
+        block_on_result(engine.get(b"b")).unwrap(),
+        Some(Bytes::from("vb2"))
+    );
 }
 
 #[test]
@@ -258,18 +283,27 @@ fn test_serializable_write_batch() {
     use crate::lsm_storage::WriteBatchRecord;
 
     let dir = tempdir().unwrap();
-    let engine = Arc::new(KvEngine::open(&dir, serializable_options()).unwrap());
+    let engine = Arc::new(block_on_result(KvEngine::open(&dir, serializable_options())).unwrap());
 
     let batch: Vec<WriteBatchRecord<&[u8]>> = vec![
         WriteBatchRecord::Put(b"k1", b"v1"),
         WriteBatchRecord::Put(b"k2", b"v2"),
         WriteBatchRecord::Put(b"k3", b"v3"),
     ];
-    engine.write_batch(&batch).unwrap();
+    block_on_result(engine.write_batch(&batch)).unwrap();
 
-    assert_eq!(engine.get(b"k1").unwrap(), Some(Bytes::from("v1")));
-    assert_eq!(engine.get(b"k2").unwrap(), Some(Bytes::from("v2")));
-    assert_eq!(engine.get(b"k3").unwrap(), Some(Bytes::from("v3")));
+    assert_eq!(
+        block_on_result(engine.get(b"k1")).unwrap(),
+        Some(Bytes::from("v1"))
+    );
+    assert_eq!(
+        block_on_result(engine.get(b"k2")).unwrap(),
+        Some(Bytes::from("v2"))
+    );
+    assert_eq!(
+        block_on_result(engine.get(b"k3")).unwrap(),
+        Some(Bytes::from("v3"))
+    );
 }
 
 #[test]
@@ -277,25 +311,31 @@ fn test_serializable_write_batch_with_delete() {
     use crate::lsm_storage::WriteBatchRecord;
 
     let dir = tempdir().unwrap();
-    let engine = Arc::new(KvEngine::open(&dir, serializable_options()).unwrap());
+    let engine = Arc::new(block_on_result(KvEngine::open(&dir, serializable_options())).unwrap());
 
     // First put
     let batch: Vec<WriteBatchRecord<&[u8]>> = vec![
         WriteBatchRecord::Put(b"k1", b"v1"),
         WriteBatchRecord::Put(b"k2", b"v2"),
     ];
-    engine.write_batch(&batch).unwrap();
+    block_on_result(engine.write_batch(&batch)).unwrap();
 
     // Then delete k1 in a batch
     let batch: Vec<WriteBatchRecord<&[u8]>> = vec![
         WriteBatchRecord::Del(b"k1"),
         WriteBatchRecord::Put(b"k3", b"v3"),
     ];
-    engine.write_batch(&batch).unwrap();
+    block_on_result(engine.write_batch(&batch)).unwrap();
 
-    assert!(engine.get(b"k1").unwrap().is_none());
-    assert_eq!(engine.get(b"k2").unwrap(), Some(Bytes::from("v2")));
-    assert_eq!(engine.get(b"k3").unwrap(), Some(Bytes::from("v3")));
+    assert!(block_on_result(engine.get(b"k1")).unwrap().is_none());
+    assert_eq!(
+        block_on_result(engine.get(b"k2")).unwrap(),
+        Some(Bytes::from("v2"))
+    );
+    assert_eq!(
+        block_on_result(engine.get(b"k3")).unwrap(),
+        Some(Bytes::from("v3"))
+    );
 }
 
 #[test]
@@ -303,7 +343,7 @@ fn test_serializable_write_batch_dedup() {
     use crate::lsm_storage::WriteBatchRecord;
 
     let dir = tempdir().unwrap();
-    let engine = Arc::new(KvEngine::open(&dir, serializable_options()).unwrap());
+    let engine = Arc::new(block_on_result(KvEngine::open(&dir, serializable_options())).unwrap());
 
     // Batch with duplicate keys — last write wins
     let batch: Vec<WriteBatchRecord<&[u8]>> = vec![
@@ -311,7 +351,10 @@ fn test_serializable_write_batch_dedup() {
         WriteBatchRecord::Put(b"k1", b"v2"),
         WriteBatchRecord::Put(b"k1", b"v3"),
     ];
-    engine.write_batch(&batch).unwrap();
+    block_on_result(engine.write_batch(&batch)).unwrap();
 
-    assert_eq!(engine.get(b"k1").unwrap(), Some(Bytes::from("v3")));
+    assert_eq!(
+        block_on_result(engine.get(b"k1")).unwrap(),
+        Some(Bytes::from("v3"))
+    );
 }

--- a/kv-engine/src/tests/vlog_integration_tests/mod.rs
+++ b/kv-engine/src/tests/vlog_integration_tests/mod.rs
@@ -9,6 +9,8 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 
+pub(crate) use crate::FutureResultExt;
+
 use crate::{
     compact::CompactionOptions,
     iterators::StorageIterator,

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -382,22 +382,44 @@ impl Wal {
                 drop(buf_file_pad);
             }
 
-            let (ring, direct_file, alloc_offset) = Self::try_init_io_uring(path)?;
-            Ok(Self {
-                buffered_file: Arc::new(Mutex::new(BufWriter::new(buf_file))),
-                mvcc_format,
-                is_v3,
-                direct_file: Some(direct_file),
-                ring: Some(Mutex::new(ring)),
-                direct_buf_pool: Self::new_direct_buf_pool(),
-                pending: Mutex::new(Vec::new()),
-                next_ticket: AtomicU64::new(0),
-                alloc_offset: AtomicU64::new(alloc_offset),
-                preallocated_size: AtomicU64::new(alloc_offset),
-                completion_state: CompletionState::new(),
-                submitting: AtomicBool::new(false),
-                poisoned: AtomicBool::new(false),
-            })
+            match Self::try_init_io_uring(path) {
+                Ok((ring, direct_file, alloc_offset)) => Ok(Self {
+                    buffered_file: Arc::new(Mutex::new(BufWriter::new(buf_file))),
+                    mvcc_format,
+                    is_v3,
+                    direct_file: Some(direct_file),
+                    ring: Some(Mutex::new(ring)),
+                    direct_buf_pool: Self::new_direct_buf_pool(),
+                    pending: Mutex::new(Vec::new()),
+                    next_ticket: AtomicU64::new(0),
+                    alloc_offset: AtomicU64::new(alloc_offset),
+                    preallocated_size: AtomicU64::new(alloc_offset),
+                    completion_state: CompletionState::new(),
+                    submitting: AtomicBool::new(false),
+                    poisoned: AtomicBool::new(false),
+                }),
+                Err(err) => {
+                    log::warn!(
+                        "WAL: io_uring unavailable for MVCC WAL recovery, falling back to buffered I/O: {}",
+                        err
+                    );
+                    Ok(Self {
+                        buffered_file: Arc::new(Mutex::new(BufWriter::new(buf_file))),
+                        mvcc_format,
+                        is_v3,
+                        direct_file: None,
+                        ring: None,
+                        direct_buf_pool: Self::new_direct_buf_pool(),
+                        pending: Mutex::new(Vec::new()),
+                        next_ticket: AtomicU64::new(0),
+                        alloc_offset: AtomicU64::new(0),
+                        preallocated_size: AtomicU64::new(0),
+                        completion_state: CompletionState::new(),
+                        submitting: AtomicBool::new(false),
+                        poisoned: AtomicBool::new(false),
+                    })
+                }
+            }
         } else {
             log::info!("WAL: recovered non-MVCC WAL, using buffered I/O only");
             Ok(Self {
@@ -650,11 +672,6 @@ impl Wal {
         // Initialize io_uring + O_DIRECT AFTER header is flushed so alloc_offset is correct.
         // If this fails (e.g. old kernel, filesystem rejects O_DIRECT), clean up
         // the WAL file so retries don't fail on create_new.
-        let (ring, direct_file, alloc_offset) = Self::try_init_io_uring(path.as_ref())
-            .inspect_err(|_| {
-                let _ = std::fs::remove_file(path.as_ref());
-            })?;
-
         // Re-open buffered handle for recovery reads and legacy put().
         let buf_file = File::options()
             .read(true)
@@ -664,21 +681,44 @@ impl Wal {
                 let _ = std::fs::remove_file(path.as_ref());
             })?;
 
-        Ok(Self {
-            buffered_file: Arc::new(Mutex::new(BufWriter::new(buf_file))),
-            mvcc_format: true,
-            is_v3: true,
-            direct_file: Some(direct_file),
-            ring: Some(Mutex::new(ring)),
-            direct_buf_pool: Self::new_direct_buf_pool(),
-            pending: Mutex::new(Vec::new()),
-            next_ticket: AtomicU64::new(0),
-            alloc_offset: AtomicU64::new(alloc_offset),
-            preallocated_size: AtomicU64::new(alloc_offset),
-            completion_state: CompletionState::new(),
-            submitting: AtomicBool::new(false),
-            poisoned: AtomicBool::new(false),
-        })
+        match Self::try_init_io_uring(path.as_ref()) {
+            Ok((ring, direct_file, alloc_offset)) => Ok(Self {
+                buffered_file: Arc::new(Mutex::new(BufWriter::new(buf_file))),
+                mvcc_format: true,
+                is_v3: true,
+                direct_file: Some(direct_file),
+                ring: Some(Mutex::new(ring)),
+                direct_buf_pool: Self::new_direct_buf_pool(),
+                pending: Mutex::new(Vec::new()),
+                next_ticket: AtomicU64::new(0),
+                alloc_offset: AtomicU64::new(alloc_offset),
+                preallocated_size: AtomicU64::new(alloc_offset),
+                completion_state: CompletionState::new(),
+                submitting: AtomicBool::new(false),
+                poisoned: AtomicBool::new(false),
+            }),
+            Err(err) => {
+                log::warn!(
+                    "WAL: io_uring unavailable for MVCC WAL create, falling back to buffered I/O: {}",
+                    err
+                );
+                Ok(Self {
+                    buffered_file: Arc::new(Mutex::new(BufWriter::new(buf_file))),
+                    mvcc_format: true,
+                    is_v3: true,
+                    direct_file: None,
+                    ring: None,
+                    direct_buf_pool: Self::new_direct_buf_pool(),
+                    pending: Mutex::new(Vec::new()),
+                    next_ticket: AtomicU64::new(0),
+                    alloc_offset: AtomicU64::new(0),
+                    preallocated_size: AtomicU64::new(0),
+                    completion_state: CompletionState::new(),
+                    submitting: AtomicBool::new(false),
+                    poisoned: AtomicBool::new(false),
+                })
+            }
+        }
     }
 
     /// Parse an MVCC-format WAL file, delegating each recovered entry to the
@@ -1469,6 +1509,20 @@ impl Wal {
         Ok(())
     }
 
+    fn flush_mvcc_buffered(&self, bufs: Vec<TicketedBuf>) -> Result<()> {
+        let mut file = self.buffered_file.lock();
+        for mut ticketed_buf in bufs {
+            let len = ticketed_buf.buf.len();
+            file.write_all(&ticketed_buf.buf.as_mut_slice()[..len])
+                .context("failed to write MVCC WAL buffer")?;
+        }
+        file.flush().context("failed to flush MVCC WAL")?;
+        file.get_ref()
+            .sync_all()
+            .context("failed to sync MVCC WAL to disk")?;
+        Ok(())
+    }
+
     fn submit_as_leader(&self, ticket: u64) -> Result<()> {
         let ticketed_bufs = self.drain_pending_ticketed_bufs();
         if ticketed_bufs.is_empty() {
@@ -1476,7 +1530,11 @@ impl Wal {
         }
 
         let max_ticket = ticketed_bufs.last().unwrap().ticket;
-        let result = self.submit_sqes_and_poll(ticketed_bufs);
+        let result = if self.ring.is_some() {
+            self.submit_sqes_and_poll(ticketed_bufs)
+        } else {
+            self.flush_mvcc_buffered(ticketed_bufs)
+        };
 
         #[cfg(feature = "chaos-testing")]
         {

--- a/rfcs/014-async-operations.md
+++ b/rfcs/014-async-operations.md
@@ -218,6 +218,11 @@ shutdown safety contract for engine-owned background workers:
    durability-sensitive callers because it performs the full shutdown sequence,
    not merely destructor-grade bounded cleanup.
 
+Because `Drop` may run on an async runtime worker, any fallback cleanup must
+stay strictly bounded and should avoid waiting on unbounded I/O or lengthy
+coordination. Anything that could starve the executor belongs in
+`close().await`, not in the destructor.
+
 ### 6.3 The Current Read Path Is Mostly CPU and `pread` Driven
 
 The current read path is heavily intertwined with:
@@ -327,17 +332,12 @@ provides today:
 Anything weaker is a correctness regression because compaction/GC could reclaim
 versions still needed by an active scan.
 
-`AsyncScan` is also **not guaranteed to be `Send` in Phase 1**.
+`AsyncScan` should stay `Send`-compatible in Phase 1.
 
-That default is intentional because the cursor may hold:
-
-1. a `ReadGuard`;
-2. iterator-stack state;
-3. block-cache references;
-4. snapshot-owned state that has not been audited for cross-thread movement.
-
-A `Send` scan cursor may be introduced later only after ownership and lifetime
-of the full iterator stack are audited explicitly.
+The default implementation should audit the iterator stack and move any
+required state into owned values before the first `await`, so the cursor does
+not have to borrow non-`Send` state across suspension points. A `!Send` cursor
+would be a deliberate compatibility regression, not the default design.
 
 ### 7.3 Transactions
 
@@ -365,13 +365,16 @@ This split is intentional:
 Transaction confinement remains part of the contract:
 
 1. `Transaction` stays single-thread confined just as it is today;
-2. async transaction methods are not required to return `Send` futures;
+2. async transaction methods should preserve `Send` futures where possible by
+   snapshotting the owned state they need before the first `await`, rather than
+   borrowing the transaction across suspension points;
 3. synchronous local-write helpers (`put`, `delete`) should stay allocation and
    coordination-light, with no executor hop in the common case;
 4. documentation and type design must make the confinement model explicit so callers do not
    assume a transaction future can freely move across executor threads.
-5. `AsyncTxnScan` inherits the same restriction and is likewise not guaranteed
-   to be `Send` in Phase 1.
+5. `AsyncTxnScan` is an owned cursor and should follow the same
+   `Send`-compatible default in Phase 1, without borrowing the transaction
+   across `await` points.
 
 Serializable-mode limitations also remain unchanged:
 
@@ -593,6 +596,10 @@ The minimum acceptable design is a registered-handle model:
 3. `close().await` transitions to `Closing`, rejects new admissions, then waits
    for the tracked set to reach the documented shutdown point before executing
    the final durability step.
+
+The tracking registry must remain low contention on the hot path. A single
+global mutex-protected set is not acceptable; use sharded state, atomic
+counters, or an equivalent low-contention structure.
 
 ### 9.4 Phase 4: Selective Internal Async Conversion
 
@@ -863,7 +870,9 @@ Required coverage:
 10. tests verify `close().await` drains or rejects already-admitted foreground
     writes according to the documented rule; and
 11. tests verify registered active scans/transactions follow the documented
-    shutdown policy without leaking hidden scan tasks.
+    shutdown policy without leaking hidden scan tasks; and
+12. compile-time checks confirm the documented `Send` / `!Send` contracts for
+    scan cursors and transaction futures in Phase 1.
 
 ---
 

--- a/rfcs/014-async-operations.md
+++ b/rfcs/014-async-operations.md
@@ -1,0 +1,871 @@
+# RFC 014: Async Operations End-to-End
+
+**Status:** Proposed
+**Date:** 2026-07-02
+**Author:** kv-engine Contributors
+**References:**
+- RFC 003: Thread-per-Core with compio
+- RFC 012: Parallel WAL
+- `docs/perf-profile.md`
+
+---
+
+## 1. Summary
+
+This RFC proposes changing kv-engine's **user-visible operation surface** from
+fully synchronous methods to an **async-first API**:
+
+1. `KvEngine::open`, `close`, `get`, `batch_get`, `put`, `delete`,
+   `delete_range`, `write_batch`, `sync`, `new_txn`, and compaction-filter
+   management become `async`.
+2. Transaction methods (`get`, `scan`, `prefix_scan`, `put`, `delete`,
+   `commit`) become `async`.
+3. Range iteration moves from today's synchronous iterator stack to an
+   async-aware cursor API.
+4. Test-only control paths such as `force_flush` and `drain_flush` remain
+   explicitly test-only even if async wrappers are later added.
+5. Maintenance-heavy operations such as full compaction are treated as
+   admin-only APIs rather than ordinary request-path methods.
+
+This is **not** a proposal to immediately rewrite every internal subsystem
+around a kernel-async runtime. The current repository data says that raw
+throughput is usually limited by CPU, memtable/iterator work, compaction
+pressure, and write-path structure, not by the absence of `async` in public
+signatures. The value of this RFC is instead:
+
+1. making kv-engine composable inside async applications;
+2. giving the engine a clean path to overlap long-running work with caller
+   tasks;
+3. removing the need for embedding applications to wrap every engine call in
+   `spawn_blocking`;
+4. creating a staged path toward async background execution where it is useful.
+
+The recommended implementation is therefore **staged**:
+
+1. land an async public API first;
+2. preserve current storage semantics and correctness invariants;
+3. migrate internals to async execution only where profiling or integration
+   pressure justifies it.
+
+---
+
+## 2. Motivation
+
+kv-engine is synchronous today:
+
+1. foreground operations block the caller thread;
+2. shutdown joins background threads synchronously;
+3. scans are synchronous iterators;
+4. transactions expose synchronous methods;
+5. embedding kv-engine inside async servers requires a blocking bridge around
+   every call.
+
+That creates three practical problems.
+
+### 2.1 Embedding Friction
+
+Async applications want to compose storage calls with:
+
+1. request timeouts;
+2. cancellation;
+3. bounded concurrency;
+4. structured backpressure;
+5. multiplexing with network, RPC, or task orchestration.
+
+Today, an async caller must either:
+
+1. block an executor thread directly, which is incorrect; or
+2. wrap kv-engine operations in `spawn_blocking`, which is noisy, easy to get
+   wrong, and pushes engine-specific scheduling decisions into every caller.
+
+### 2.2 Long-Running Engine Operations Already Exist
+
+Several operations are naturally long-lived from the caller's point of view:
+
+1. `open()` can replay WALs, recover manifests, rebuild references, and load
+   metadata.
+2. `close()` can wait on flush, compaction, GC, WAL sync, and final freeze.
+3. `force_flush()` and `force_full_compaction()` can perform large amounts of
+   disk work.
+4. scans and transaction scans may read many blocks over time.
+
+Treating all of these as synchronous forces the caller to dedicate OS threads
+to waiting.
+
+### 2.3 Public Async Does Not Require Immediate Full Async I/O
+
+The repository's own measurements matter here.
+
+`docs/perf-profile.md` explicitly concludes that:
+
+1. I/O is not the main bottleneck in the profiled workloads;
+2. a full async rewrite is not justified on throughput alone;
+3. several large wins came from better batching, cache behavior, and reduced
+   CPU overhead rather than executor-driven async conversion.
+
+That means this RFC should not pretend that "make everything async" is a free
+performance win. The primary motivation is **composability and execution model
+correctness**, with internal async overlap as a secondary, targeted benefit.
+
+---
+
+## 3. Goals
+
+1. Provide an async-first public API that integrates cleanly with async Rust
+   applications.
+2. Preserve current durability, visibility, MVCC, and crash-recovery
+   guarantees.
+3. Keep the migration incremental enough that correctness can be maintained
+   with the existing test and chaos suite.
+4. Avoid forcing a full iterator, WAL, manifest, compaction, and read-path
+   rewrite in one step.
+5. Make cancellation and shutdown behavior explicit.
+6. Leave room for future async execution of flush, compaction, manifest, and
+   vLog paths where that is actually useful.
+
+## 4. Non-Goals
+
+1. Claiming that async public signatures alone will improve single-thread
+   throughput.
+2. Replacing the current WAL design from RFC 012.
+3. Requiring every internal helper to become `async fn` in the first landing.
+4. Rewriting lock-free memtable structures around async primitives.
+5. Solving range-serializable phantom tracking. That remains a separate MVCC
+   concern.
+6. Guaranteeing cancellation safety for arbitrary mid-operation aborts. The
+   engine must remain correct, but cancellation points must be explicit.
+
+---
+
+## 5. Current Baseline
+
+The current top-level API in `kv-engine/src/lsm_storage.rs` is synchronous:
+
+1. `KvEngine::open() -> Result<Arc<KvEngine>>`
+2. `KvEngine::close() -> Result<()>`
+3. `get`, `batch_get`, `put`, `delete`, `delete_range`, `write_batch`
+4. `scan`, `prefix_scan`
+5. `force_flush`, `drain_flush`, `force_full_compaction`
+6. `new_txn`
+
+Transaction APIs in `kv-engine/src/mvcc/txn.rs` are synchronous as well:
+
+1. `get`
+2. `scan`
+3. `prefix_scan`
+4. `put`
+5. `delete`
+6. `commit`
+
+The iterator stack is also synchronous:
+
+1. `StorageIterator::next(&mut self) -> Result<()>`
+2. `ScanIterator` and `TxnIterator` are built on synchronous iteration
+   contracts.
+
+Background work currently uses dedicated threads plus channels:
+
+1. flush thread;
+2. compaction thread;
+3. ad-hoc GC threads;
+4. synchronous `close()` joining them all.
+
+This is important because it shows that "change all ops to async" is not just
+signature churn. It crosses the public API, iterator model, transaction model,
+and lifecycle model.
+
+---
+
+## 6. Design Constraints
+
+Any acceptable design must respect the following constraints.
+
+### 6.1 Public Scans Cannot Stay Exactly As-Is
+
+Today a scan returns a synchronous iterator object. Once the API becomes async,
+there are only three realistic choices:
+
+1. expose `Stream`;
+2. expose an async cursor with `try_next().await`;
+3. materialize all scan results before returning.
+
+Option 3 is unacceptable for large scans. This RFC chooses an async cursor.
+
+### 6.2 `Drop` Cannot Be Async
+
+The engine currently performs meaningful cleanup in `close()` and best-effort
+thread joining in `Drop`. After async conversion:
+
+1. graceful shutdown must live in `async fn close(&self)`;
+2. `Drop` still needs a synchronous, bounded cleanup path for the current
+   thread-join contract; it cannot simply degrade into fire-and-forget cancel.
+3. the documentation must clearly state that durability-sensitive users must
+   call `close().await`, but the migration must not silently weaken today's
+   drop-time cleanup guarantees.
+
+### 6.3 The Current Read Path Is Mostly CPU and `pread` Driven
+
+The current read path is heavily intertwined with:
+
+1. `StorageIterator`;
+2. merge/concat iterators;
+3. block cache lookups;
+4. memtable bloom and skiplist fast paths;
+5. point reads that are often CPU-bound rather than syscall-bound.
+
+This RFC therefore does **not** require the first implementation to convert
+every read-path helper to kernel-async I/O.
+
+### 6.4 Async Must Not Weaken Crash Semantics
+
+Every staged change must preserve:
+
+1. WAL-before-visibility rules;
+2. manifest publish ordering;
+3. flush and compaction crash boundaries;
+4. MVCC read/write visibility;
+5. chaos-test reopen guarantees.
+
+If an async refactor makes those less obvious, the refactor is incomplete.
+
+---
+
+## 7. Proposed API
+
+### 7.1 `KvEngine`
+
+The public surface becomes async-first:
+
+```rust
+impl KvEngine {
+    pub async fn open(path: impl AsRef<Path>, options: LsmStorageOptions) -> Result<Arc<Self>>;
+    pub async fn close(&self) -> Result<()>;
+
+    pub async fn get(&self, key: &[u8]) -> Result<Option<Bytes>>;
+    pub async fn batch_get(&self, keys: &[&[u8]]) -> Vec<Result<Option<Bytes>>>;
+    pub async fn put(&self, key: &[u8], value: &[u8]) -> Result<()>;
+    pub async fn delete(&self, key: &[u8]) -> Result<()>;
+    pub async fn delete_range(&self, start: &[u8], end: &[u8]) -> Result<()>;
+    pub async fn write_batch<T: AsRef<[u8]>>(&self, batch: &[WriteBatchRecord<T>]) -> Result<()>;
+    pub async fn sync(&self) -> Result<()>;
+
+    pub async fn scan(&self, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> Result<AsyncScan>;
+    pub async fn prefix_scan(&self, prefix: &[u8]) -> Result<AsyncScan>;
+
+    pub async fn new_txn(&self) -> Result<Arc<Transaction>>;
+}
+```
+
+Compaction-filter management should also move to async for consistency, even if
+some implementations remain immediate in early phases.
+
+`force_flush` and `drain_flush` are intentionally omitted from the normal async
+surface. In the current engine they are race-prone control hooks used only in
+tests or quiescent maintenance contexts, not ordinary application APIs.
+
+Likewise, full compaction should not be presented as a routine request-path API.
+If it remains public, it should move behind an explicit maintenance/admin handle:
+
+```rust
+impl KvEngine {
+    pub fn admin(&self) -> AdminHandle<'_>;
+}
+
+impl AdminHandle<'_> {
+    pub async fn force_full_compaction(&self) -> Result<()>;
+    pub async fn force_flush_for_test(&self) -> Result<()>;
+    pub async fn drain_flush_for_test(&self) -> Result<()>;
+}
+```
+
+The important contract is semantic, not naming: these operations are
+maintenance/test controls, not ordinary application APIs.
+
+### 7.2 `AsyncScan`
+
+The public scan result becomes an async cursor rather than a synchronous
+iterator trait object:
+
+```rust
+pub struct AsyncScan { /* opaque */ }
+
+impl AsyncScan {
+    pub async fn try_next(&mut self) -> Result<Option<(Bytes, Bytes)>>;
+}
+```
+
+Why a cursor instead of `impl Stream<Item = Result<_>>`?
+
+1. it keeps the public API simple;
+2. it avoids pin/project ergonomics in common call sites;
+3. it maps more directly onto the engine's existing iterator style;
+4. it leaves room for an internal `Stream` implementation later if needed.
+
+`AsyncScan` must retain the same MVCC snapshot pinning that `ScanIterator`
+provides today:
+
+1. acquire the non-transactional `ReadGuard` before building the scan snapshot;
+2. retain that guard for the entire cursor lifetime, across all `try_next`
+   await points;
+3. release it only when the cursor is dropped or exhausted.
+
+Anything weaker is a correctness regression because compaction/GC could reclaim
+versions still needed by an active scan.
+
+`AsyncScan` is also **not guaranteed to be `Send` in Phase 1**.
+
+That default is intentional because the cursor may hold:
+
+1. a `ReadGuard`;
+2. iterator-stack state;
+3. block-cache references;
+4. snapshot-owned state that has not been audited for cross-thread movement.
+
+A `Send` scan cursor may be introduced later only after ownership and lifetime
+of the full iterator stack are audited explicitly.
+
+### 7.3 Transactions
+
+Transactions become async as well:
+
+```rust
+impl Transaction {
+    pub async fn get(&self, key: &[u8]) -> Result<Option<Bytes>>;
+    pub async fn scan(self: &Arc<Self>, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> Result<AsyncTxnScan>;
+    pub async fn prefix_scan(self: &Arc<Self>, prefix: &[u8]) -> Result<AsyncTxnScan>;
+    pub async fn put(&self, key: &[u8], value: &[u8]) -> Result<()>;
+    pub async fn delete(&self, key: &[u8]) -> Result<()>;
+    pub async fn commit(&self) -> Result<()>;
+}
+```
+
+For point reads and local-write buffering, some async methods may complete
+without awaiting external I/O. That is acceptable. `async` here is about the
+surface contract and composability, not "every method always suspends".
+
+Transaction confinement remains part of the contract:
+
+1. `Transaction` stays single-thread confined just as it is today;
+2. async transaction methods are not required to return `Send` futures;
+3. documentation and type design must make that explicit so callers do not
+   assume a transaction future can freely move across executor threads.
+4. `AsyncTxnScan` inherits the same restriction and is likewise not guaranteed
+   to be `Send` in Phase 1.
+
+Serializable-mode limitations also remain unchanged:
+
+1. `scan()` and `prefix_scan()` continue to return an error in serializable
+   mode until phantom/range tracking is implemented;
+2. the async migration must not widen that capability by accident.
+
+---
+
+## 8. Execution Model
+
+### 8.1 Chosen Direction: Async Public Surface, Staged Internal Migration
+
+This RFC chooses the following architectural direction:
+
+1. **Public API becomes async immediately.**
+2. **Internals migrate in phases.**
+3. **CPU-only and trivial paths may stay internally synchronous at first.**
+4. **Blocking storage work is hidden behind engine-owned async execution rather
+   than pushed to every caller.**
+
+This is intentionally more pragmatic than a full "everything becomes async in
+one PR" rewrite.
+
+### 8.2 Runtime Strategy
+
+This RFC separates **task orchestration** from **storage I/O backend choice**.
+
+Default implementation guidance:
+
+1. Tokio may be used for task orchestration, shutdown, cancellation, and async
+   API integration.
+2. Storage I/O must remain behind engine-owned traits so that WAL, SST, and
+   vLog paths can choose their own backend independently.
+3. That backend may be `std::fs`, Tokio blocking-backed filesystem access, or a
+   specialized `io_uring` path, depending on the subsystem.
+
+This split is required because the repository already has subsystem-specific
+direction:
+
+1. RFC 012 gives WAL a specialized manual `io_uring + O_DIRECT` path.
+2. RFC 003 explores a broader completion-oriented runtime direction for async
+   I/O.
+3. The async public API should not force all storage paths onto one executor or
+   one filesystem abstraction prematurely.
+
+The practical rule is:
+
+1. Tokio may own task lifecycle.
+2. Tokio does **not** automatically own every storage syscall.
+3. WAL submission/completion, SST reads/writes, and vLog I/O must stay
+   replaceable behind engine-owned interfaces.
+
+This keeps the default implementation pragmatic without freezing the storage
+backend design too early.
+
+### 8.3 Background Work
+
+Flush, compaction, and GC should move from "threads + crossbeam notifications"
+to "tasks + async notifications" over time.
+
+Phase 1 does not need to rewrite all of them. A valid staged end state is:
+
+1. foreground async methods run on an async runtime;
+2. long-running maintenance work is owned by engine tasks;
+3. shutdown awaits those tasks explicitly in `close().await`.
+
+### 8.4 Phase 1 Blocking Policy
+
+Phase 1 must not land as a pure signature-only conversion.
+
+In particular, this is **not acceptable**:
+
+```rust
+pub async fn get(&self, key: &[u8]) -> Result<Option<Bytes>> {
+    self.get_sync(key)
+}
+```
+
+when `get_sync` may block on disk or maintenance coordination.
+
+Phase 1 therefore requires an explicit blocking policy:
+
+1. CPU-only fast paths may execute inline.
+2. Potentially blocking disk paths must run via an engine-owned blocking
+   executor or equivalent internal boundary.
+3. The engine must bound blocking concurrency rather than spawning unbounded
+   background work.
+4. The engine must document which methods may still perform internal blocking
+   work in Phase 1.
+
+At minimum, the implementation must treat these as potentially blocking:
+
+1. `open`;
+2. `close`;
+3. `scan` / `prefix_scan`;
+4. maintenance/admin APIs such as full compaction;
+5. write paths whose sync policy can wait on durable WAL completion.
+
+---
+
+## 9. Detailed Design
+
+### 9.1 Phase 1: Async Surface Over Current Core
+
+Phase 1 is the minimum acceptable landing:
+
+1. convert public engine methods to `async`;
+2. convert transaction methods to `async`;
+3. add async scan cursor types;
+4. keep current correctness behavior identical;
+5. centralize any required blocking bridge inside the engine rather than in
+   application code.
+
+This phase does **not** require:
+
+1. rewriting memtable internals;
+2. replacing the WAL implementation;
+3. replacing flush/compaction code with fully async code;
+4. rewriting every iterator implementation as an async trait immediately.
+
+The goal is to change **who owns the blocking boundary**. After this RFC, the
+engine owns it. The caller does not.
+
+This RFC must not land as a pure signature-only conversion. Phase 1 must
+include:
+
+1. a clearly bounded engine-owned blocking executor or equivalent mechanism;
+2. explicit cancellation tests for write and shutdown paths;
+3. close-state tests covering concurrent foreground operations.
+
+### 9.2 Phase 2: Async Cursor Internals
+
+The current iterator stack is built around synchronous `next()`. That API is
+deeply embedded in:
+
+1. `SsTableIterator`;
+2. `SstConcatIterator`;
+3. `MergeIterator`;
+4. `TwoMergeIterator`;
+5. `LsmIterator`;
+6. `TxnIterator`.
+
+The migration plan is:
+
+1. keep internal iterator traits synchronous in Phase 1 if needed;
+2. wrap the public scan cursor around an engine-owned task boundary;
+3. only introduce an async internal iterator trait after public behavior is
+   stable and benchmarked.
+
+This keeps the first landing tractable. It also isolates the most invasive part
+of the rewrite instead of coupling it to every other async change.
+
+If Phase 2 introduces engine-owned scan tasks, the implementation must also
+define:
+
+1. a bounded resource policy for concurrent scan tasks;
+2. cleanup behavior when a caller drops the cursor or abandons `try_next()`
+   futures;
+3. whether scan work is per-cursor, per-batch, or pooled; and
+4. how hidden scan-task cancellation interacts with `ReadGuard` lifetime.
+
+The current passive iterator model does not allocate hidden background tasks per
+scan. Any move away from that model must preserve boundedness and cleanup
+explicitly.
+
+### 9.3 Phase 3: Async Lifecycle and Shutdown
+
+`close()` becomes the only graceful-shutdown API:
+
+1. cancel background maintenance intake;
+2. await flush/compaction/GC completion;
+3. preserve today's split close contract:
+   WAL-enabled close performs final WAL + directory sync and relies on normal
+   recovery semantics, while non-WAL close freezes and drains remaining
+   memtables to SSTs;
+4. return only when the engine reaches the same durable state that today's
+   synchronous `close()` guarantees.
+
+`Drop` becomes best-effort:
+
+1. log that the engine was dropped without `close().await`;
+2. preserve today's bounded synchronous cleanup contract where feasible, such
+   as joining or otherwise quiescing owned maintenance workers;
+3. avoid pretending it performed the full graceful close sequence when it did
+   not.
+
+The lifecycle also needs an explicit state machine:
+
+```text
+Open -> Closing -> Closed
+```
+
+Required semantics:
+
+1. `close().await` is idempotent.
+2. Once the engine enters `Closing`, new foreground operations must fail with a
+   stable shutdown/closing error.
+3. `new_txn`, `write_batch`, `put`, `delete`, and new scans must not start once
+   closing begins.
+4. Foreground operations that were already admitted before the `Closing`
+   transition must be accounted for explicitly: `close().await` must either
+   wait for them to reach a documented completion point or reject them before
+   they cross a publish/durability boundary. It must not race its final
+   WAL-sync or non-WAL freeze/drain step against already-admitted writes.
+5. Active scans and transactions must be tracked explicitly if `close().await`
+   is expected to wait for or reject them authoritatively, because these
+   handles have independent lifetime today.
+6. The implementation must define whether active scans/transactions are waited
+   for, cancelled, or rejected at close, and test that contract explicitly.
+7. `Drop` with outstanding handles must remain bounded and must not deadlock on
+   other `Arc<KvEngine>` owners.
+
+The minimum acceptable design is a registered-handle model:
+
+1. admitted foreground writes participate in a tracked in-flight operation set;
+2. scans/transactions that may outlive the initiating call are registered as
+   live handles; and
+3. `close().await` transitions to `Closing`, rejects new admissions, then waits
+   for the tracked set to reach the documented shutdown point before executing
+   the final durability step.
+
+### 9.4 Phase 4: Selective Internal Async Conversion
+
+Once the async public API exists, the following internal paths become eligible
+for targeted async execution when measurements justify it:
+
+1. `open()` recovery work;
+2. flush task scheduling;
+3. compaction output writing and manifest publication;
+4. vLog GC rewrite orchestration;
+5. range scan block fetch overlap.
+
+This phase should be driven by measurement and integration need, not ideology.
+
+---
+
+## 10. Durability and Correctness Rules
+
+Async conversion must preserve the following invariants.
+
+### 10.1 Write Visibility
+
+The existing two-phase rules remain:
+
+1. a write must not become visible before the WAL durability boundary that
+   today's code enforces;
+2. memtable publication ordering must remain unchanged from the caller's point
+   of view;
+3. async task switching must not create a visibility-before-durability window.
+
+### 10.2 Flush and Manifest Ordering
+
+The async design must continue to enforce:
+
+1. SST output sync before manifest durable publish;
+2. manifest durable publish before WAL reclamation for flushed memtables;
+3. no orphaned state that violates current chaos-test assumptions.
+
+### 10.3 Cancellation Semantics
+
+Cancellation must be explicit.
+
+1. Before the durability boundary, an operation may fail and leave no visible
+   change.
+2. After the durability boundary, the operation must either complete normally
+   or surface an outcome that is safe to retry/reopen.
+3. Mid-flight future drop must not expose partially published state.
+
+This is especially important for:
+
+1. `write_batch`;
+2. `delete_range`;
+3. `commit`;
+4. `force_flush`;
+5. `force_full_compaction`;
+6. `close`.
+
+The first implementation should treat cancellation with the following matrix:
+
+| Operation | Cancellation point | Allowed? | Required recovery semantics |
+|-----------|--------------------|----------|-----------------------------|
+| `put` / `write_batch` | Before WAL append | Yes | No visible change |
+| `put` / `write_batch` | After WAL append, before durable sync | Bounded by sync policy | Reopen follows WAL semantics; no half-published memtable state |
+| `put` / `write_batch` | After durable sync, before memtable publish | No externally visible half-state | Must finish publish or recover via reopen without duplicate/partial visibility |
+| `commit` | After conflict check, before publish | High risk | Must remain atomic with respect to publish |
+| `delete_range` | After tombstone WAL record, before publish | High risk | Same atomicity contract as write batch |
+| full compaction | Before manifest publish | Yes | Reopen may choose old state; manifest must remain clean |
+| full compaction | After manifest publish | Not partial | Reopen must observe either old or new published state, never mixed metadata |
+| `close` | After shutdown begins | Not partial | Must end in a documented Open/Closing/Closed outcome |
+
+The key rule is that dropping a future must not trick the caller into believing
+an operation was cancelled if an engine-owned background task can still commit
+it. If work may outlive the future, that outcome must be documented and tested.
+
+For shutdown specifically:
+
+1. once `close().await` begins, already-admitted foreground writes must either
+   be drained to their documented completion point or fail before publish;
+2. active transactions/scans must follow the chosen registered-handle policy;
+   and
+3. `close().await` must not report success before the tracked in-flight set is
+   reconciled with the final durability action.
+
+### 10.4 Transactions
+
+Async transaction methods must preserve current semantics:
+
+1. snapshot reads stay tied to `read_ts`;
+2. the read watermark stays pinned for the transaction lifetime;
+3. commit remains single-use;
+4. serializable-mode conflict detection remains atomic with publish.
+
+The async conversion must not accidentally permit multi-threaded use of the
+same `Transaction` object in ways the current design intentionally avoids.
+
+For non-transaction scans, the equivalent rule is also mandatory: the scan
+cursor must hold the non-transaction `ReadGuard` for its full lifetime.
+
+---
+
+## 11. Alternatives Considered
+
+### 11.1 Keep the Public API Synchronous
+
+This keeps the engine simple, but it permanently pushes async integration cost
+to every caller. That is increasingly the wrong ownership boundary for a
+library that may be embedded into async services.
+
+### 11.1b Add Only a Blocking Facade
+
+A blocking facade is useful for migration, but not sufficient as the main
+design:
+
+```rust
+pub struct BlockingKvEngine {
+    inner: Arc<KvEngine>,
+    runtime: EngineRuntime,
+}
+```
+
+This can remain as an optional compatibility layer or feature-gated facade for
+CLI/tests/benchmarks, but it should not replace the async-first surface.
+
+### 11.2 RFC 003 Option A: Internal Runtime + Synchronous Public API
+
+RFC 003 discussed embedding a runtime internally while keeping a synchronous
+API via `block_on`.
+
+That avoids a breaking public change, but it has two major downsides here:
+
+1. it preserves the external illusion that engine operations are cheap to block
+   on, which is not true for `open`, `close`, scans, flush, and compaction;
+2. it makes async callers pay the worst of both worlds, because they still have
+   to route through blocking wrappers around a library that already has async
+   internals.
+
+For this RFC's goal, that is the wrong surface.
+
+### 11.3 Pick Tokio Up Front
+
+This RFC rejects locking in Tokio at the design level before the runtime split
+with RFC 003 and RFC 012 is resolved. A concrete implementation may still use
+Tokio, but only after the WAL/runtime ownership model is spelled out.
+
+### 11.4 Full compio Rewrite Before Any Public Change
+
+This is too much coupling.
+
+The repository's own measurements do not justify blocking async API adoption on
+an immediate full-storage-runtime rewrite. A compio migration can still happen
+later if it proves valuable.
+
+### 11.5 Expose `Stream` Directly for Scans
+
+This is viable, but a bespoke async cursor keeps the public API simpler and
+closer to the engine's existing iterator style.
+
+---
+
+## 12. Drawbacks
+
+1. This is a breaking public API change.
+2. The scan/iterator conversion is invasive even with a staged approach.
+3. The engine must define and test cancellation behavior much more carefully
+   than it does today.
+4. Async can hide blocking if implemented lazily; Phase 1 must be honest about
+   which paths still use engine-owned blocking work.
+5. The runtime/executor decision remains open and must be resolved in the
+   implementation plan rather than assumed away.
+
+---
+
+## 13. Compatibility and Migration
+
+This RFC intentionally treats the change as a major API break.
+
+Caller migration is straightforward but global:
+
+1. call sites become `await`-based;
+2. scan loops switch from synchronous iterator advancement to
+   `while let Some((k, v)) = scan.try_next().await?`;
+3. transactions become async;
+4. explicit graceful shutdown becomes `engine.close().await?`.
+
+The CLI, tests, and any benchmark harnesses must add an async runtime boundary.
+
+To reduce migration pressure, the implementation may also provide an optional
+blocking facade or `blocking-api` feature for synchronous tools and benchmarks.
+
+---
+
+## 14. Implementation Plan
+
+### Phase 0: Proof and Guardrails
+
+1. add benchmark coverage for async wrapper overhead on point reads/writes;
+2. define cancellation expectations per operation;
+3. define the runtime/WAL ownership model before choosing an executor;
+4. add doc-level rationale that async is for composability first, not claimed
+   throughput wins.
+5. define the Open/Closing/Closed lifecycle state machine and error surface.
+
+### Phase 1: Public Async API
+
+1. convert `KvEngine` methods to async;
+2. convert transaction methods to async;
+3. add `AsyncScan` and `AsyncTxnScan`;
+4. keep existing correctness behavior and reuse as much synchronous core logic
+   as possible;
+5. preserve serializable-mode scan rejections;
+6. preserve scan `ReadGuard` lifetime rules.
+7. define `Send` / `!Send` contracts for cursor and transaction futures.
+8. land the engine-owned blocking executor/concurrency bound together with the
+   async API.
+9. define how admitted foreground writes are tracked across `Closing`.
+
+### Phase 2: Async Shutdown and Background Ownership
+
+1. replace notifier/join lifecycle with async task ownership;
+2. make `close().await` the canonical graceful shutdown path;
+3. preserve the current split close contract for WAL and non-WAL engines;
+4. preserve a bounded `Drop` cleanup story rather than pure fire-and-forget
+   cancellation.
+5. enforce and test the Open/Closing/Closed state machine.
+6. add explicit registration/tracking for live scans, transactions, and
+   admitted foreground writes if shutdown semantics depend on them.
+
+### Phase 3: Targeted Internal Async Execution
+
+1. move `open()` recovery orchestration behind async tasks;
+2. move flush/compaction orchestration to async tasks;
+3. measure whether selective overlap improves tail latency or throughput.
+
+### Phase 4: Internal Iterator Rework
+
+1. evaluate whether the internal iterator trait itself should become async;
+2. only do this after public async scans are stable and benchmarked.
+
+---
+
+## 15. Testing Plan
+
+The async migration is only acceptable if it preserves the repository's current
+correctness bar.
+
+Required coverage:
+
+1. existing unit and integration tests continue to pass after async conversion;
+2. transaction tests preserve snapshot and serializable semantics;
+3. chaos tests still validate reopen and crash invariants;
+4. new tests verify cancellation boundaries and double-close/drop behavior;
+5. scan tests cover async cursor behavior across memtable, SST, and mixed
+   sources, including `ReadGuard` retention across await points;
+6. shutdown tests verify `close().await` preserves today's WAL and non-WAL
+   close contracts;
+7. tests confirm serializable transaction scans still reject until phantom
+   tracking exists;
+8. tests verify blocking-concurrency bounds and confirm Phase 1 does not block
+   async executor workers on known disk-bound paths;
+9. tests verify the documented cancellation matrix for write, range-delete,
+   compaction, and close paths;
+10. tests verify `close().await` drains or rejects already-admitted foreground
+    writes according to the documented rule; and
+11. tests verify registered active scans/transactions follow the documented
+    shutdown policy without leaking hidden scan tasks.
+
+---
+
+## 16. Success Criteria
+
+The async conversion is successful if:
+
+1. async callers can use kv-engine without external `spawn_blocking` wrappers
+   around ordinary operations;
+2. all current correctness and chaos invariants still hold;
+3. the engine documents explicit cancellation and shutdown behavior;
+4. point-operation overhead remains acceptable;
+5. the design leaves room for future internal async overlap without forcing a
+   full rewrite up front;
+6. the first landing is not merely a signature-only async veneer over
+   executor-blocking synchronous code.
+
+---
+
+## 17. Recommendation
+
+Adopt this RFC **only as a staged async-surface migration**, not as a blanket
+"rewrite the whole engine around async right now" mandate.
+
+That recommendation follows directly from the current codebase and documents:
+
+1. async integration pressure is real;
+2. a fully synchronous public API is awkward for modern embedding scenarios;
+3. the repository's own perf notes do **not** support claiming that a full
+   async rewrite is automatically a throughput win;
+4. the safe path is to separate the public async contract from the much larger
+   question of how much internal storage execution should become async.

--- a/rfcs/014-async-operations.md
+++ b/rfcs/014-async-operations.md
@@ -667,6 +667,12 @@ The key rule is that dropping a future must not trick the caller into believing
 an operation was cancelled if an engine-owned background task can still commit
 it. If work may outlive the future, that outcome must be documented and tested.
 
+For completion-based I/O specifically, cancellation/drop paths must also ensure
+that buffers still owned by active kernel submissions are not freed
+prematurely. If the kernel may still reference an in-flight WAL/SST/vLog
+buffer, the implementation must defer or suppress that buffer's destruction
+until submission/completion ownership is unquestionably released.
+
 For shutdown specifically:
 
 1. once `close().await` begins, already-admitted foreground writes must either

--- a/rfcs/014-async-operations.md
+++ b/rfcs/014-async-operations.md
@@ -16,10 +16,11 @@ This RFC proposes changing kv-engine's **user-visible operation surface** from
 fully synchronous methods to an **async-first API**:
 
 1. `KvEngine::open`, `close`, `get`, `batch_get`, `put`, `delete`,
-   `delete_range`, `write_batch`, `sync`, `new_txn`, and compaction-filter
-   management become `async`.
-2. Transaction methods (`get`, `scan`, `prefix_scan`, `put`, `delete`,
-   `commit`) become `async`.
+   `delete_range`, `write_batch`, `sync`, and compaction-filter management
+   become `async`.
+2. Transaction methods that may observe engine state or publish changes
+   (`get`, `scan`, `prefix_scan`, `commit`) become `async`, while purely
+   in-memory helpers may remain synchronous.
 3. Range iteration moves from today's synchronous iterator stack to an
    async-aware cursor API.
 4. Test-only control paths such as `force_flush` and `drain_flush` remain
@@ -170,7 +171,8 @@ Background work currently uses dedicated threads plus channels:
 3. ad-hoc GC threads;
 4. synchronous `close()` joining them all.
 
-This is important because it shows that "change all ops to async" is not just
+This is important because it shows that "change the public execution model"
+is not just
 signature churn. It crosses the public API, iterator model, transaction model,
 and lifecycle model.
 
@@ -252,7 +254,7 @@ impl KvEngine {
     pub async fn scan(&self, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> Result<AsyncScan>;
     pub async fn prefix_scan(&self, prefix: &[u8]) -> Result<AsyncScan>;
 
-    pub async fn new_txn(&self) -> Result<Arc<Transaction>>;
+    pub fn new_txn(&self) -> Result<Arc<Transaction>>;
 }
 ```
 
@@ -326,30 +328,36 @@ of the full iterator stack are audited explicitly.
 
 ### 7.3 Transactions
 
-Transactions become async as well:
+Transactions become selectively async:
 
 ```rust
 impl Transaction {
     pub async fn get(&self, key: &[u8]) -> Result<Option<Bytes>>;
     pub async fn scan(self: &Arc<Self>, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> Result<AsyncTxnScan>;
     pub async fn prefix_scan(self: &Arc<Self>, prefix: &[u8]) -> Result<AsyncTxnScan>;
-    pub async fn put(&self, key: &[u8], value: &[u8]) -> Result<()>;
-    pub async fn delete(&self, key: &[u8]) -> Result<()>;
+    pub fn put(&self, key: &[u8], value: &[u8]) -> Result<()>;
+    pub fn delete(&self, key: &[u8]) -> Result<()>;
     pub async fn commit(&self) -> Result<()>;
 }
 ```
 
-For point reads and local-write buffering, some async methods may complete
-without awaiting external I/O. That is acceptable. `async` here is about the
-surface contract and composability, not "every method always suspends".
+This split is intentional:
+
+1. `new_txn`, `Transaction::put`, and `Transaction::delete` are purely
+   in-memory operations in the current architecture and should remain
+   synchronous unless their semantics change materially.
+2. `get`, scan operations, and `commit` remain async because they may consult
+   engine state, cross blocking boundaries, or publish changes.
 
 Transaction confinement remains part of the contract:
 
 1. `Transaction` stays single-thread confined just as it is today;
 2. async transaction methods are not required to return `Send` futures;
-3. documentation and type design must make that explicit so callers do not
+3. synchronous local-write helpers (`put`, `delete`) should stay allocation and
+   coordination-light, with no executor hop in the common case;
+4. documentation and type design must make the confinement model explicit so callers do not
    assume a transaction future can freely move across executor threads.
-4. `AsyncTxnScan` inherits the same restriction and is likewise not guaranteed
+5. `AsyncTxnScan` inherits the same restriction and is likewise not guaranteed
    to be `Send` in Phase 1.
 
 Serializable-mode limitations also remain unchanged:

--- a/rfcs/014-async-operations.md
+++ b/rfcs/014-async-operations.md
@@ -205,6 +205,19 @@ thread joining in `Drop`. After async conversion:
    call `close().await`, but the migration must not silently weaken today's
    drop-time cleanup guarantees.
 
+More concretely, the destructor path must continue to preserve the current
+shutdown safety contract for engine-owned background workers:
+
+1. `Drop` still performs synchronous, bounded cleanup for engine-owned
+   maintenance workers such as flush/compaction ownership that would otherwise
+   outlive the handle;
+2. this includes bounded worker quiescing and thread/task joining where the
+   current implementation already does so to avoid data loss when `close()` is
+   skipped; and
+3. `close().await` remains the stronger, graceful path for
+   durability-sensitive callers because it performs the full shutdown sequence,
+   not merely destructor-grade bounded cleanup.
+
 ### 6.3 The Current Read Path Is Mostly CPU and `pread` Driven
 
 The current read path is heavily intertwined with:


### PR DESCRIPTION
## Summary

Land the phase 1 async public surface for kv-engine, including async engine and transaction APIs, lifecycle admission tracking, test helpers, and a buffered MVCC WAL fallback when io_uring is unavailable.

## Changes
- Converted the public KvEngine surface and transaction APIs to async.
- Added owned async scan cursors and lifecycle guards.
- Added async test/benchmark compatibility helpers where needed.
- Added a buffered MVCC WAL fallback for environments that cannot create an io_uring ring.

## Verification
- cargo check -p kv-engine --all-targets
- cargo fmt --all --check
- cargo test -p kv-engine --lib
- Focused async API, WAL, and compaction regression tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The engine now supports async operations for opening, reading, writing, scanning, flushing, compaction, and closing.
  * Added safer shutdown handling so in-flight work is tracked before the engine closes.

* **Bug Fixes**
  * Improved WAL startup and recovery by falling back when direct I/O acceleration isn’t available, increasing compatibility.
  * Engine shutdown now waits for ongoing operations to finish, reducing close-time issues.

* **Documentation**
  * Added an async-operations RFC outlining the new API direction and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->