### PR TITLE
feat: add async transaction scan cursors

### DIFF
--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -292,8 +292,8 @@ impl LsmMvccInner {
         let read_ts = read_guard.read_ts();
         let occ_sets = if serializable {
             (
-                Some(Mutex::new(HashSet::new())),
-                Some(Mutex::new(HashSet::new())),
+                Some(Arc::new(Mutex::new(HashSet::new()))),
+                Some(Arc::new(Mutex::new(HashSet::new()))),
             )
         } else {
             (None, None)
@@ -307,7 +307,7 @@ impl LsmMvccInner {
             committed: Arc::new(AtomicBool::new(false)),
             read_set: occ_sets.0,
             write_set: occ_sets.1,
-            lifecycle_guard: Mutex::new(None),
+            lifecycle_guard: Arc::new(Mutex::new(None)),
             blocking,
             _not_sync: std::marker::PhantomData,
         })

--- a/kv-engine/src/mvcc/txn.rs
+++ b/kv-engine/src/mvcc/txn.rs
@@ -31,11 +31,11 @@ pub struct Transaction {
     pub(crate) local_storage: Arc<SkipMap<Bytes, Bytes>>,
     pub(crate) committed: Arc<AtomicBool>,
     /// Read set for OCC conflict detection (None when not serializable).
-    pub(crate) read_set: Option<Mutex<HashSet<Bytes>>>,
+    pub(crate) read_set: Option<Arc<Mutex<HashSet<Bytes>>>>,
     /// Write set for OCC conflict detection (None when not serializable).
-    pub(crate) write_set: Option<Mutex<HashSet<Bytes>>>,
+    pub(crate) write_set: Option<Arc<Mutex<HashSet<Bytes>>>>,
     /// Keeps the transaction registered with shutdown tracking until commit or drop.
-    pub(crate) lifecycle_guard: Mutex<Option<AdmissionGuard>>,
+    pub(crate) lifecycle_guard: Arc<Mutex<Option<AdmissionGuard>>>,
     /// Bounded blocking executor for offloading sync I/O in async txn methods.
     pub(crate) blocking: BlockingExecutor,
     /// Transaction is intentionally `!Sync` — it must be used from a single
@@ -148,7 +148,12 @@ impl Transaction {
         // Position at first entry (same as MemTableIterator::scan).
         local_iter.next()?;
         let merged = TwoMergeIterator::create(local_iter, lsm_iter)?;
-        TxnIterator::create(Arc::clone(self), merged)
+        TxnIterator::create(
+            self.read_set.clone(),
+            Arc::clone(&self.read_guard),
+            Arc::clone(&self.lifecycle_guard),
+            merged,
+        )
     }
 
     /// Return all visible keys whose user key starts with `prefix`, in sorted
@@ -181,7 +186,111 @@ impl Transaction {
         );
         local_iter.next()?;
         let merged = TwoMergeIterator::create(local_iter, lsm_iter)?;
-        TxnIterator::create(Arc::clone(self), merged)
+        TxnIterator::create(
+            self.read_set.clone(),
+            Arc::clone(&self.read_guard),
+            Arc::clone(&self.lifecycle_guard),
+            merged,
+        )
+    }
+
+    /// Scan a range of keys, asynchronously.
+    ///
+    /// Returns an owned async cursor over the transaction snapshot.
+    pub fn scan_async(
+        self: &Arc<Self>,
+        lower: Bound<&[u8]>,
+        upper: Bound<&[u8]>,
+    ) -> impl std::future::Future<Output = Result<AsyncTxnScan>> + Send {
+        let read_guard = Arc::clone(&self.read_guard);
+        let lifecycle_guard = Arc::clone(&self.lifecycle_guard);
+        let read_set = self.read_set.clone();
+        let local_storage = Arc::clone(&self.local_storage);
+        let inner = Arc::clone(&self.inner);
+        let committed = Arc::clone(&self.committed);
+        let read_ts = self.read_ts;
+        let lower_owned = lower.map(Bytes::copy_from_slice);
+        let upper_owned = upper.map(Bytes::copy_from_slice);
+        let blocking = self.blocking.clone();
+        async move {
+            anyhow::ensure!(
+                !committed.load(std::sync::atomic::Ordering::SeqCst),
+                "transaction already committed"
+            );
+            anyhow::ensure!(
+                read_set.is_none(),
+                "scan() is not supported for serializable transactions until phantom/range tracking is implemented"
+            );
+            use std::ops::Bound::*;
+            let lower: Bound<&[u8]> = match &lower_owned {
+                Included(b) => Included(b.as_ref()),
+                Excluded(b) => Excluded(b.as_ref()),
+                Unbounded => Unbounded,
+            };
+            let upper: Bound<&[u8]> = match &upper_owned {
+                Included(b) => Included(b.as_ref()),
+                Excluded(b) => Excluded(b.as_ref()),
+                Unbounded => Unbounded,
+            };
+            let lsm_iter = inner.scan_with_ts(lower, upper, read_ts)?;
+            let mut local_iter = TxnLocalIterator::new(
+                local_storage,
+                |map| map.range::<Bytes, _>((map_bound(lower), map_bound(upper))),
+                (Bytes::new(), Bytes::new()),
+            );
+            local_iter.next()?;
+            let merged = TwoMergeIterator::create(local_iter, lsm_iter)?;
+            Ok(AsyncTxnScan {
+                inner: TxnIterator::create(read_set, read_guard, lifecycle_guard, merged)?,
+                blocking,
+            })
+        }
+    }
+
+    /// Prefix scan, asynchronously.
+    ///
+    /// Returns an owned async cursor over the transaction snapshot.
+    pub fn prefix_scan_async(
+        self: &Arc<Self>,
+        prefix: &[u8],
+    ) -> impl std::future::Future<Output = Result<AsyncTxnScan>> + Send {
+        let read_guard = Arc::clone(&self.read_guard);
+        let lifecycle_guard = Arc::clone(&self.lifecycle_guard);
+        let read_set = self.read_set.clone();
+        let local_storage = Arc::clone(&self.local_storage);
+        let inner = Arc::clone(&self.inner);
+        let committed = Arc::clone(&self.committed);
+        let read_ts = self.read_ts;
+        let prefix = Bytes::copy_from_slice(prefix);
+        let blocking = self.blocking.clone();
+        async move {
+            anyhow::ensure!(
+                !committed.load(std::sync::atomic::Ordering::SeqCst),
+                "transaction already committed"
+            );
+            anyhow::ensure!(
+                read_set.is_none(),
+                "prefix_scan() is not supported for serializable transactions until phantom/range tracking is implemented"
+            );
+            let upper_bound = prefix_upper_bound(&prefix);
+            let lower = Bound::Included(prefix.as_ref());
+            let upper = match &upper_bound {
+                Some(upper) => Bound::Excluded(upper.as_slice()),
+                None => Bound::Unbounded,
+            };
+            let lsm_iter = inner.scan_with_prefix_hint(lower, upper, read_ts, &prefix)?;
+            let mut local_iter = TxnLocalIterator::new(
+                local_storage,
+                |map| map.range::<Bytes, _>((map_bound(lower), map_bound(upper))),
+                (Bytes::new(), Bytes::new()),
+            );
+            local_iter.next()?;
+            let merged = TwoMergeIterator::create(local_iter, lsm_iter)?;
+            Ok(AsyncTxnScan {
+                inner: TxnIterator::create(read_set, read_guard, lifecycle_guard, merged)?,
+                blocking,
+            })
+        }
     }
 
     /// Buffer a write locally.
@@ -568,23 +677,32 @@ impl StorageIterator for TxnLocalIterator {
 /// Local writes shadow engine entries with the same key. Tombstones
 /// (both local and from the engine) are skipped automatically.
 pub struct TxnIterator {
-    _txn: Arc<Transaction>,
+    _read_guard: Arc<Mutex<Option<ReadGuard>>>,
+    _lifecycle_guard: Arc<Mutex<Option<AdmissionGuard>>>,
+    read_set: Option<Arc<Mutex<HashSet<Bytes>>>>,
     iter: TwoMergeIterator<TxnLocalIterator, FusedIterator<LsmIterator>>,
 }
 
 impl TxnIterator {
-    pub fn create(
-        txn: Arc<Transaction>,
+    pub(crate) fn create(
+        read_set: Option<Arc<Mutex<HashSet<Bytes>>>>,
+        read_guard: Arc<Mutex<Option<ReadGuard>>>,
+        lifecycle_guard: Arc<Mutex<Option<AdmissionGuard>>>,
         iter: TwoMergeIterator<TxnLocalIterator, FusedIterator<LsmIterator>>,
     ) -> Result<Self> {
-        let mut s = Self { _txn: txn, iter };
+        let mut s = Self {
+            _read_guard: read_guard,
+            _lifecycle_guard: lifecycle_guard,
+            read_set,
+            iter,
+        };
         // Position at first valid entry, skipping tombstones.
         while s.iter.is_valid() && crate::vlog::KvKind::is_tombstone_value(s.iter.value()) {
             s.iter.next()?;
         }
         // Record the first key in read_set for OCC.
         if s.iter.is_valid()
-            && let Some(ref rs) = s._txn.read_set
+            && let Some(ref rs) = s.read_set
         {
             rs.lock().insert(Bytes::copy_from_slice(s.iter.key()));
         }
@@ -618,7 +736,7 @@ impl StorageIterator for TxnIterator {
         }
         // Record the current key in read_set for OCC.
         if self.iter.is_valid()
-            && let Some(ref rs) = self._txn.read_set
+            && let Some(ref rs) = self.read_set
         {
             rs.lock().insert(Bytes::copy_from_slice(self.iter.key()));
         }
@@ -627,5 +745,53 @@ impl StorageIterator for TxnIterator {
 
     fn num_active_iterators(&self) -> usize {
         self.iter.num_active_iterators()
+    }
+}
+
+/// Owned async cursor over a transaction snapshot.
+pub struct AsyncTxnScan {
+    inner: TxnIterator,
+    #[allow(dead_code)]
+    blocking: BlockingExecutor,
+}
+
+impl AsyncTxnScan {
+    pub async fn try_next(&mut self) -> Result<Option<(Bytes, Bytes)>> {
+        if !self.inner.is_valid() {
+            return Ok(None);
+        }
+        let kv = (
+            Bytes::copy_from_slice(self.inner.key()),
+            Bytes::from(self.inner.value().to_vec()),
+        );
+        self.inner.next()?;
+        Ok(Some(kv))
+    }
+}
+
+impl StorageIterator for AsyncTxnScan {
+    type KeyType<'a>
+        = &'a [u8]
+    where
+        Self: 'a;
+
+    fn value(&self) -> &[u8] {
+        self.inner.value()
+    }
+
+    fn key(&self) -> Self::KeyType<'_> {
+        self.inner.key()
+    }
+
+    fn is_valid(&self) -> bool {
+        self.inner.is_valid()
+    }
+
+    fn next(&mut self) -> Result<()> {
+        self.inner.next()
+    }
+
+    fn num_active_iterators(&self) -> usize {
+        self.inner.num_active_iterators()
     }
 }

--- a/kv-engine/src/mvcc/txn.rs
+++ b/kv-engine/src/mvcc/txn.rs
@@ -221,29 +221,39 @@ impl Transaction {
                 read_set.is_none(),
                 "scan() is not supported for serializable transactions until phantom/range tracking is implemented"
             );
-            use std::ops::Bound::*;
-            let lower: Bound<&[u8]> = match &lower_owned {
-                Included(b) => Included(b.as_ref()),
-                Excluded(b) => Excluded(b.as_ref()),
-                Unbounded => Unbounded,
-            };
-            let upper: Bound<&[u8]> = match &upper_owned {
-                Included(b) => Included(b.as_ref()),
-                Excluded(b) => Excluded(b.as_ref()),
-                Unbounded => Unbounded,
-            };
-            let lsm_iter = inner.scan_with_ts(lower, upper, read_ts)?;
-            let mut local_iter = TxnLocalIterator::new(
-                local_storage,
-                |map| map.range::<Bytes, _>((map_bound(lower), map_bound(upper))),
-                (Bytes::new(), Bytes::new()),
-            );
-            local_iter.next()?;
-            let merged = TwoMergeIterator::create(local_iter, lsm_iter)?;
-            Ok(AsyncTxnScan {
-                inner: TxnIterator::create(read_set, read_guard, lifecycle_guard, merged)?,
-                blocking,
-            })
+            let cursor_blocking = blocking.clone();
+            blocking
+                .run_result(move || {
+                    use std::ops::Bound::*;
+                    let lower: Bound<&[u8]> = match &lower_owned {
+                        Included(b) => Included(b.as_ref()),
+                        Excluded(b) => Excluded(b.as_ref()),
+                        Unbounded => Unbounded,
+                    };
+                    let upper: Bound<&[u8]> = match &upper_owned {
+                        Included(b) => Included(b.as_ref()),
+                        Excluded(b) => Excluded(b.as_ref()),
+                        Unbounded => Unbounded,
+                    };
+                    let lsm_iter = inner.scan_with_ts(lower, upper, read_ts)?;
+                    let mut local_iter = TxnLocalIterator::new(
+                        local_storage,
+                        |map| map.range::<Bytes, _>((map_bound(lower), map_bound(upper))),
+                        (Bytes::new(), Bytes::new()),
+                    );
+                    local_iter.next()?;
+                    let merged = TwoMergeIterator::create(local_iter, lsm_iter)?;
+                    Ok(AsyncTxnScan {
+                        inner: Arc::new(Mutex::new(TxnIterator::create(
+                            read_set,
+                            read_guard,
+                            lifecycle_guard,
+                            merged,
+                        )?)),
+                        blocking: cursor_blocking,
+                    })
+                })
+                .await
         }
     }
 
@@ -272,24 +282,34 @@ impl Transaction {
                 read_set.is_none(),
                 "prefix_scan() is not supported for serializable transactions until phantom/range tracking is implemented"
             );
-            let upper_bound = prefix_upper_bound(&prefix);
-            let lower = Bound::Included(prefix.as_ref());
-            let upper = match &upper_bound {
-                Some(upper) => Bound::Excluded(upper.as_slice()),
-                None => Bound::Unbounded,
-            };
-            let lsm_iter = inner.scan_with_prefix_hint(lower, upper, read_ts, &prefix)?;
-            let mut local_iter = TxnLocalIterator::new(
-                local_storage,
-                |map| map.range::<Bytes, _>((map_bound(lower), map_bound(upper))),
-                (Bytes::new(), Bytes::new()),
-            );
-            local_iter.next()?;
-            let merged = TwoMergeIterator::create(local_iter, lsm_iter)?;
-            Ok(AsyncTxnScan {
-                inner: TxnIterator::create(read_set, read_guard, lifecycle_guard, merged)?,
-                blocking,
-            })
+            let cursor_blocking = blocking.clone();
+            blocking
+                .run_result(move || {
+                    let upper_bound = prefix_upper_bound(&prefix);
+                    let lower = Bound::Included(prefix.as_ref());
+                    let upper = match &upper_bound {
+                        Some(upper) => Bound::Excluded(upper.as_slice()),
+                        None => Bound::Unbounded,
+                    };
+                    let lsm_iter = inner.scan_with_prefix_hint(lower, upper, read_ts, &prefix)?;
+                    let mut local_iter = TxnLocalIterator::new(
+                        local_storage,
+                        |map| map.range::<Bytes, _>((map_bound(lower), map_bound(upper))),
+                        (Bytes::new(), Bytes::new()),
+                    );
+                    local_iter.next()?;
+                    let merged = TwoMergeIterator::create(local_iter, lsm_iter)?;
+                    Ok(AsyncTxnScan {
+                        inner: Arc::new(Mutex::new(TxnIterator::create(
+                            read_set,
+                            read_guard,
+                            lifecycle_guard,
+                            merged,
+                        )?)),
+                        blocking: cursor_blocking,
+                    })
+                })
+                .await
         }
     }
 
@@ -750,48 +770,31 @@ impl StorageIterator for TxnIterator {
 
 /// Owned async cursor over a transaction snapshot.
 pub struct AsyncTxnScan {
-    inner: TxnIterator,
-    #[allow(dead_code)]
+    inner: Arc<Mutex<TxnIterator>>,
     blocking: BlockingExecutor,
 }
 
 impl AsyncTxnScan {
-    pub async fn try_next(&mut self) -> Result<Option<(Bytes, Bytes)>> {
-        if !self.inner.is_valid() {
-            return Ok(None);
+    pub fn try_next(
+        &mut self,
+    ) -> impl std::future::Future<Output = Result<Option<(Bytes, Bytes)>>> + Send {
+        let inner = Arc::clone(&self.inner);
+        let blocking = self.blocking.clone();
+        async move {
+            blocking
+                .run_result(move || {
+                    let mut inner = inner.lock();
+                    if !inner.is_valid() {
+                        return Ok(None);
+                    }
+                    let kv = (
+                        Bytes::copy_from_slice(inner.key()),
+                        Bytes::from(inner.value().to_vec()),
+                    );
+                    inner.next()?;
+                    Ok(Some(kv))
+                })
+                .await
         }
-        let kv = (
-            Bytes::copy_from_slice(self.inner.key()),
-            Bytes::from(self.inner.value().to_vec()),
-        );
-        self.inner.next()?;
-        Ok(Some(kv))
-    }
-}
-
-impl StorageIterator for AsyncTxnScan {
-    type KeyType<'a>
-        = &'a [u8]
-    where
-        Self: 'a;
-
-    fn value(&self) -> &[u8] {
-        self.inner.value()
-    }
-
-    fn key(&self) -> Self::KeyType<'_> {
-        self.inner.key()
-    }
-
-    fn is_valid(&self) -> bool {
-        self.inner.is_valid()
-    }
-
-    fn next(&mut self) -> Result<()> {
-        self.inner.next()
-    }
-
-    fn num_active_iterators(&self) -> usize {
-        self.inner.num_active_iterators()
     }
 }

--- a/kv-engine/src/mvcc/txn.rs
+++ b/kv-engine/src/mvcc/txn.rs
@@ -272,6 +272,7 @@ impl Transaction {
         let committed = Arc::clone(&self.committed);
         let read_ts = self.read_ts;
         let prefix = Bytes::copy_from_slice(prefix);
+        let upper_bound = prefix_upper_bound(&prefix);
         let blocking = self.blocking.clone();
         async move {
             anyhow::ensure!(
@@ -285,13 +286,24 @@ impl Transaction {
             let cursor_blocking = blocking.clone();
             blocking
                 .run_result(move || {
-                    let upper_bound = prefix_upper_bound(&prefix);
-                    let lower = Bound::Included(prefix.as_ref());
-                    let upper = match &upper_bound {
-                        Some(upper) => Bound::Excluded(upper.as_slice()),
-                        None => Bound::Unbounded,
+                    let (lsm_iter, lower, upper) = if prefix.is_empty() {
+                        (
+                            inner.scan_with_ts(Bound::Unbounded, Bound::Unbounded, read_ts)?,
+                            Bound::Unbounded,
+                            Bound::Unbounded,
+                        )
+                    } else {
+                        let lower = Bound::Included(prefix.as_ref());
+                        let upper = match &upper_bound {
+                            Some(upper) => Bound::Excluded(upper.as_slice()),
+                            None => Bound::Unbounded,
+                        };
+                        (
+                            inner.scan_with_prefix_hint(lower, upper, read_ts, &prefix)?,
+                            lower,
+                            upper,
+                        )
                     };
-                    let lsm_iter = inner.scan_with_prefix_hint(lower, upper, read_ts, &prefix)?;
                     let mut local_iter = TxnLocalIterator::new(
                         local_storage,
                         |map| map.range::<Bytes, _>((map_bound(lower), map_bound(upper))),

--- a/kv-engine/src/tests/async_api.rs
+++ b/kv-engine/src/tests/async_api.rs
@@ -563,6 +563,7 @@ fn txn_scan_async_merges_local_and_engine_state() {
             (bytes::Bytes::from("d"), bytes::Bytes::from("txn_d")),
         ]
     );
+    drop(scan);
     drop(txn);
     crate::future_ext::block_on(engine.close_async()).expect("close");
 }
@@ -595,6 +596,7 @@ fn txn_prefix_scan_async_filters_prefix() {
             (bytes::Bytes::from("ac"), bytes::Bytes::from("v4")),
         ]
     );
+    drop(scan);
     drop(txn);
     crate::future_ext::block_on(engine.close_async()).expect("close");
 }

--- a/kv-engine/src/tests/async_api.rs
+++ b/kv-engine/src/tests/async_api.rs
@@ -422,6 +422,26 @@ fn txn_commit_async_is_send() {
 }
 
 #[test]
+fn txn_scan_async_is_send() {
+    fn assert_send<T: Send>(_: T) {}
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let engine = crate::future_ext::block_on(KvEngine::open_async(
+        dir.path(),
+        LsmStorageOptions::default_for_test(),
+    ))
+    .expect("open");
+    let txn = engine.new_txn_async().expect("new_txn");
+    let scan = crate::future_ext::block_on(
+        txn.scan_async(std::ops::Bound::Unbounded, std::ops::Bound::Unbounded),
+    )
+    .expect("scan");
+    assert_send(scan);
+    drop(txn);
+    crate::future_ext::block_on(engine.close_async()).expect("close");
+}
+
+#[test]
 fn txn_commit_async_already_committed_is_error() {
     let dir = tempfile::tempdir().expect("tempdir");
     let engine = crate::future_ext::block_on(KvEngine::open_async(
@@ -506,6 +526,93 @@ fn txn_get_async_after_commit_does_not_mutate_read_set() {
     let after = txn.read_set.as_ref().expect("read_set").lock().len();
     assert!(format!("{err}").contains("already committed"));
     assert_eq!(before, after);
+    drop(txn);
+    crate::future_ext::block_on(engine.close_async()).expect("close");
+}
+
+#[test]
+fn txn_scan_async_merges_local_and_engine_state() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let engine = crate::future_ext::block_on(KvEngine::open_async(
+        dir.path(),
+        LsmStorageOptions::default_for_test(),
+    ))
+    .expect("open");
+    crate::future_ext::block_on(engine.put_async(b"a", b"engine_a")).expect("put");
+    crate::future_ext::block_on(engine.put_async(b"b", b"engine_b")).expect("put");
+    crate::future_ext::block_on(engine.put_async(b"c", b"engine_c")).expect("put");
+
+    let txn = engine.new_txn_async().expect("new_txn");
+    txn.put(b"b", b"txn_b").expect("put");
+    txn.delete(b"c").expect("delete");
+    txn.put(b"d", b"txn_d").expect("put");
+
+    let mut scan = crate::future_ext::block_on(
+        txn.scan_async(std::ops::Bound::Unbounded, std::ops::Bound::Unbounded),
+    )
+    .expect("scan");
+    let mut items = Vec::new();
+    while let Some((k, v)) = crate::future_ext::block_on(scan.try_next()).expect("try_next") {
+        items.push((k, v));
+    }
+    assert_eq!(
+        items,
+        vec![
+            (bytes::Bytes::from("a"), bytes::Bytes::from("engine_a")),
+            (bytes::Bytes::from("b"), bytes::Bytes::from("txn_b")),
+            (bytes::Bytes::from("d"), bytes::Bytes::from("txn_d")),
+        ]
+    );
+    drop(txn);
+    crate::future_ext::block_on(engine.close_async()).expect("close");
+}
+
+#[test]
+fn txn_prefix_scan_async_filters_prefix() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let engine = crate::future_ext::block_on(KvEngine::open_async(
+        dir.path(),
+        LsmStorageOptions::default_for_test(),
+    ))
+    .expect("open");
+    crate::future_ext::block_on(engine.put_async(b"aa", b"v1")).expect("put");
+    crate::future_ext::block_on(engine.put_async(b"ab", b"v2")).expect("put");
+    crate::future_ext::block_on(engine.put_async(b"ba", b"v3")).expect("put");
+
+    let txn = engine.new_txn_async().expect("new_txn");
+    txn.put(b"ac", b"v4").expect("put");
+    txn.delete(b"ab").expect("delete");
+
+    let mut scan = crate::future_ext::block_on(txn.prefix_scan_async(b"a")).expect("prefix_scan");
+    let mut items = Vec::new();
+    while let Some((k, v)) = crate::future_ext::block_on(scan.try_next()).expect("try_next") {
+        items.push((k, v));
+    }
+    assert_eq!(
+        items,
+        vec![
+            (bytes::Bytes::from("aa"), bytes::Bytes::from("v1")),
+            (bytes::Bytes::from("ac"), bytes::Bytes::from("v4")),
+        ]
+    );
+    drop(txn);
+    crate::future_ext::block_on(engine.close_async()).expect("close");
+}
+
+#[test]
+fn txn_scan_async_rejects_serializable_transactions() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut opts = LsmStorageOptions::default_for_test();
+    opts.serializable = true;
+    let engine = crate::future_ext::block_on(KvEngine::open_async(dir.path(), opts)).expect("open");
+    let txn = engine.new_txn_async().expect("new_txn");
+    let err = match crate::future_ext::block_on(
+        txn.scan_async(std::ops::Bound::Unbounded, std::ops::Bound::Unbounded),
+    ) {
+        Ok(_) => panic!("serializable scan should fail"),
+        Err(err) => err,
+    };
+    assert!(format!("{err}").contains("not supported for serializable transactions"));
     drop(txn);
     crate::future_ext::block_on(engine.close_async()).expect("close");
 }

--- a/kv-engine/src/tests/async_api.rs
+++ b/kv-engine/src/tests/async_api.rs
@@ -619,6 +619,37 @@ fn txn_prefix_scan_async_filters_prefix() {
 }
 
 #[test]
+fn txn_prefix_scan_async_empty_prefix_matches_full_scan() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let engine = crate::future_ext::block_on(KvEngine::open_async(
+        dir.path(),
+        LsmStorageOptions::default_for_test(),
+    ))
+    .expect("open");
+    crate::future_ext::block_on(engine.put_async(b"aa", b"v1")).expect("put");
+    crate::future_ext::block_on(engine.put_async(b"ba", b"v2")).expect("put");
+
+    let txn = engine.new_txn_async().expect("new_txn");
+    txn.put(b"ca", b"v3").expect("put");
+    let mut scan = crate::future_ext::block_on(txn.prefix_scan_async(b"")).expect("prefix_scan");
+    let mut items = Vec::new();
+    while let Some((k, v)) = crate::future_ext::block_on(scan.try_next()).expect("try_next") {
+        items.push((k, v));
+    }
+    assert_eq!(
+        items,
+        vec![
+            (bytes::Bytes::from("aa"), bytes::Bytes::from("v1")),
+            (bytes::Bytes::from("ba"), bytes::Bytes::from("v2")),
+            (bytes::Bytes::from("ca"), bytes::Bytes::from("v3")),
+        ]
+    );
+    drop(scan);
+    drop(txn);
+    crate::future_ext::block_on(engine.close_async()).expect("close");
+}
+
+#[test]
 fn txn_scan_async_rejects_serializable_transactions() {
     let dir = tempfile::tempdir().expect("tempdir");
     let mut opts = LsmStorageOptions::default_for_test();

--- a/kv-engine/src/tests/async_api.rs
+++ b/kv-engine/src/tests/async_api.rs
@@ -442,6 +442,23 @@ fn txn_scan_async_is_send() {
 }
 
 #[test]
+fn txn_prefix_scan_async_is_send() {
+    fn assert_send<T: Send>(_: T) {}
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let engine = crate::future_ext::block_on(KvEngine::open_async(
+        dir.path(),
+        LsmStorageOptions::default_for_test(),
+    ))
+    .expect("open");
+    let txn = engine.new_txn_async().expect("new_txn");
+    let scan = crate::future_ext::block_on(txn.prefix_scan_async(b"p")).expect("prefix_scan");
+    assert_send(scan);
+    drop(txn);
+    crate::future_ext::block_on(engine.close_async()).expect("close");
+}
+
+#[test]
 fn txn_commit_async_already_committed_is_error() {
     let dir = tempfile::tempdir().expect("tempdir");
     let engine = crate::future_ext::block_on(KvEngine::open_async(

--- a/kv-engine/src/tests/compaction_integration_2.rs
+++ b/kv-engine/src/tests/compaction_integration_2.rs
@@ -6,7 +6,7 @@ use crate::{
         TieredCompactionOptions,
     },
     lsm_storage::{KvEngine, LsmStorageOptions},
-    tests::harness::dump_files_in_dir,
+    tests::harness::{dump_files_in_dir, skip_if_io_uring_unavailable},
 };
 
 #[test]
@@ -49,6 +49,9 @@ fn test_integration(compaction_options: CompactionOptions) {
         ..LsmStorageOptions::default_for_test()
     };
     options.enable_wal = true;
+    if skip_if_io_uring_unavailable(&options) {
+        return;
+    }
     let storage = KvEngine::open(&dir, options.clone()).unwrap();
     for i in 0..=20 {
         storage.put(b"0", format!("v{i}").as_bytes()).unwrap();

--- a/kv-engine/src/tests/harness.rs
+++ b/kv-engine/src/tests/harness.rs
@@ -13,13 +13,50 @@ use crate::{
     },
     iterators::{StorageIterator, merge_iterator::MergeIterator},
     key::{KeySlice, KeyVec, TS_ENABLED},
-    lsm_storage::{BlockCache, KvEngine, LsmStorageInner, LsmStorageState},
+    lsm_storage::{BlockCache, KvEngine, LsmStorageInner, LsmStorageOptions, LsmStorageState},
     table::{SsTable, SsTableBuilder, SsTableIterator},
     vlog::KvKind,
+    wal::Wal,
 };
 
 /// Tombstone value used in tests — a single `KvKind::Tombstone` byte.
 pub const TOMBSTONE_VALUE: &[u8] = &[KvKind::Tombstone as u8];
+
+pub fn is_io_uring_unavailable_error(e: &anyhow::Error) -> bool {
+    e.chain().any(|cause| {
+        cause
+            .downcast_ref::<std::io::Error>()
+            .and_then(|io| io.raw_os_error())
+            .is_some_and(|code| matches!(code, 1 | 12 | 38)) // EPERM | ENOMEM | ENOSYS
+    })
+}
+
+pub fn skip_if_io_uring_unavailable(opts: &LsmStorageOptions) -> bool {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("probe");
+    match KvEngine::open(&db_path, opts.clone()) {
+        Ok(engine) => {
+            let _ = engine.close();
+            false
+        }
+        Err(e) if is_io_uring_unavailable_error(&e) => {
+            eprintln!("skipping test (io_uring unavailable): {e}");
+            true
+        }
+        Err(e) => panic!("unexpected probe open failure: {e}"),
+    }
+}
+
+pub fn create_wal_or_skip(path: &Path) -> Option<Wal> {
+    match Wal::create(path) {
+        Ok(wal) => Some(wal),
+        Err(e) if is_io_uring_unavailable_error(&e) => {
+            eprintln!("skipping test (io_uring unavailable): {e}");
+            None
+        }
+        Err(e) => panic!("unexpected wal create failure: {e}"),
+    }
+}
 
 #[derive(Clone)]
 pub struct MockIterator {

--- a/kv-engine/src/tests/lsm_storage_extra.rs
+++ b/kv-engine/src/tests/lsm_storage_extra.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use tempfile::tempdir;
 
+use super::harness::skip_if_io_uring_unavailable;
 use crate::{
     compact::CompactionOptions,
     iterators::StorageIterator,
@@ -190,6 +191,9 @@ fn test_reopen_after_flushes_preserves_mvcc_point_gets() {
     let mut opts = LsmStorageOptions::default_for_test();
     opts.enable_wal = true;
     opts.manifest_snapshot_threshold_bytes = 256;
+    if skip_if_io_uring_unavailable(&opts) {
+        return;
+    }
 
     {
         let engine = KvEngine::open(&dir, opts.clone()).unwrap();

--- a/kv-engine/src/tests/scan_flush.rs
+++ b/kv-engine/src/tests/scan_flush.rs
@@ -3,7 +3,7 @@ use std::{ops::Bound, sync::Arc, time::Duration};
 use bytes::Bytes;
 use tempfile::tempdir;
 
-use self::harness::{check_lsm_iter_result_by_key, sync};
+use self::harness::{check_lsm_iter_result_by_key, skip_if_io_uring_unavailable, sync};
 use super::*;
 use crate::{
     iterators::StorageIterator,
@@ -318,6 +318,9 @@ fn test_wal_gc_with_background_flush_thread() {
         ..LsmStorageOptions::default_for_test()
     };
     options.enable_wal = true;
+    if skip_if_io_uring_unavailable(&options) {
+        return;
+    }
     let storage = KvEngine::open(&dir, options).unwrap();
 
     // Manually freeze multiple memtables so the background flush thread has

--- a/kv-engine/src/tests/vlog_integration_tests/advanced.rs
+++ b/kv-engine/src/tests/vlog_integration_tests/advanced.rs
@@ -117,6 +117,9 @@ fn test_crash_recovery_after_partial_flush() {
     let dir = tempfile::tempdir().unwrap();
     let mut options = options_with_vlog_enabled(256, 1 << 20);
     options.enable_wal = true;
+    if super::super::harness::skip_if_io_uring_unavailable(&options) {
+        return;
+    }
 
     // Phase 1: Write data and simulate crash
     {

--- a/kv-engine/src/tests/wal.rs
+++ b/kv-engine/src/tests/wal.rs
@@ -9,6 +9,7 @@ use crossbeam_channel::bounded;
 use crossbeam_skiplist::SkipMap;
 use tempfile::tempdir;
 
+use super::harness::create_wal_or_skip;
 use crate::{
     lsm_storage::{LsmStorageInner, LsmStorageOptions},
     wal::Wal,
@@ -25,7 +26,9 @@ fn test_wal_batch_round_trip() {
     let skiplist = new_skiplist();
 
     // Create WAL and write a batch.
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
     wal.put_batch(&[(&[1, 2, 3], &[4, 5, 6]), (&[7, 8], &[9])], 42)
         .unwrap();
     wal.sync().unwrap();
@@ -52,7 +55,9 @@ fn test_wal_put_uses_batch_format() {
     let skiplist = new_skiplist();
 
     // Create WAL and write individual entries via put().
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
     wal.put(b"key1", b"val1").unwrap();
     wal.put(b"key2", b"val2").unwrap();
     wal.sync().unwrap();
@@ -78,7 +83,9 @@ fn test_wal_max_ts_across_batches() {
     let path = dir.path().join("test.wal");
     let skiplist = new_skiplist();
 
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
     wal.put_batch(&[(&[1], &[10])], 5).unwrap();
     wal.put_batch(&[(&[2], &[20])], 10).unwrap();
     wal.put_batch(&[(&[3], &[30])], 3).unwrap();
@@ -97,7 +104,9 @@ fn test_wal_truncated_batch_skipped() {
     let skiplist = new_skiplist();
 
     // Write two complete batches, then truncate the file mid-way through a third.
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
     wal.put_batch(&[(&[1], &[10])], 1).unwrap();
     wal.put_batch(&[(&[2], &[20])], 2).unwrap();
     wal.sync().unwrap();
@@ -137,7 +146,9 @@ fn test_wal_empty_recovery() {
     let skiplist = new_skiplist();
 
     // Create an empty WAL (header only, no entries).
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
     wal.sync().unwrap();
     drop(wal);
 
@@ -152,7 +163,9 @@ fn test_wal_multiple_entries_per_batch() {
     let path = dir.path().join("test.wal");
     let skiplist = new_skiplist();
 
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
     wal.put_batch(&[(&[1], &[10]), (&[2], &[20]), (&[3], &[30])], 7)
         .unwrap();
     wal.sync().unwrap();
@@ -239,7 +252,9 @@ fn test_wal_crc_mismatch_stops_recovery() {
     let skiplist = new_skiplist();
 
     // Write two valid batches.
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
     wal.put_batch(&[(&[1], &[10])], 1).unwrap();
     wal.put_batch(&[(&[2], &[20])], 2).unwrap();
     wal.sync().unwrap();
@@ -290,7 +305,9 @@ fn test_wal_batch_entry_count_exceeds_data() {
     let skiplist = new_skiplist();
 
     // Write a valid batch first.
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
     wal.put_batch(&[(&[1], &[10])], 5).unwrap();
     wal.sync().unwrap();
 
@@ -320,7 +337,9 @@ fn test_wal_entry_data_corruption_detected_by_crc() {
     let skiplist = new_skiplist();
 
     // Write two valid batches.
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
     wal.put_batch(&[(&[1], &[10])], 1).unwrap();
     wal.put_batch(&[(&[2], &[20])], 2).unwrap();
     wal.sync().unwrap();
@@ -363,7 +382,9 @@ fn test_wal_empty_batch_with_commit_ts() {
     let path = dir.path().join("test.wal");
     let skiplist = new_skiplist();
 
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
     // Write a batch with 0 entries but a non-zero commit_ts.
     wal.put_batch(&[], 42).unwrap();
     wal.sync().unwrap();
@@ -378,7 +399,10 @@ fn test_wal_empty_batch_with_commit_ts() {
 fn test_wal_group_commit_handles_late_arrival() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("group_commit.wal");
-    let wal = Arc::new(Wal::create(&path).unwrap());
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
+    let wal = Arc::new(wal);
     let start = Arc::new(Barrier::new(4));
     let (tx, rx) = bounded(3);
 
@@ -499,7 +523,9 @@ fn test_wal_append_after_recovery() {
     let skiplist = new_skiplist();
 
     // Write a batch.
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
     wal.put_batch(&[(&[1], &[10])], 5).unwrap();
     wal.sync().unwrap();
     drop(wal);
@@ -526,7 +552,9 @@ fn test_wal_key_too_large() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("test.wal");
 
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
     // Key exactly at the limit should succeed.
     let big_key = vec![0u8; u16::MAX as usize];
     wal.put(&big_key, b"v").unwrap();
@@ -546,7 +574,9 @@ fn test_wal_value_too_large() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("test.wal");
 
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
     let too_big_val = vec![0u8; u16::MAX as usize + 1];
     let result = wal.put(b"k", &too_big_val);
     assert!(result.is_err(), "expected error for oversized value");
@@ -561,7 +591,9 @@ fn test_wal_batch_key_too_large() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("test.wal");
 
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
     let too_big_key = vec![0u8; u16::MAX as usize + 1];
     let result = wal.put_batch(&[(&too_big_key, b"v")], 1);
     assert!(result.is_err(), "expected error for oversized batch key");
@@ -576,7 +608,9 @@ fn test_wal_batch_value_too_large() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("test.wal");
 
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
     let too_big_val = vec![0u8; u16::MAX as usize + 1];
     let result = wal.put_batch(&[(b"k", too_big_val.as_slice())], 1);
     assert!(result.is_err(), "expected error for oversized batch value");
@@ -623,7 +657,9 @@ fn test_wal_truncates_trailing_garbage_on_recovery() {
 
     // Write two valid batches.
     {
-        let wal = Wal::create(&path).unwrap();
+        let Some(wal) = create_wal_or_skip(&path) else {
+            return;
+        };
         wal.put_batch(&[(b"k1", b"v1")], 10).unwrap();
         wal.put_batch(&[(b"k2", b"v2")], 20).unwrap();
         wal.sync().unwrap();
@@ -776,7 +812,9 @@ fn test_wal_v3_range_tombstone_batch_round_trip() {
     let range_ts = crate::range_tombstone::RangeTombstoneSet::new();
 
     // Create WAL and write a range tombstone batch.
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
     wal.put_range_tombstone_batch(
         &[
             (b"a" as &[u8], b"m" as &[u8]),
@@ -808,7 +846,9 @@ fn test_wal_v3_mixed_point_and_range_recovery() {
     let skiplist = new_skiplist();
     let range_ts = crate::range_tombstone::RangeTombstoneSet::new();
 
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
     // Write a point batch.
     wal.put_batch(&[(b"key1", b"val1")], 10).unwrap();
     // Write a range tombstone batch.
@@ -836,7 +876,9 @@ fn test_wal_v3_point_batch_backward_compat() {
     let path = dir.path().join("test_v3_compat.wal");
     let skiplist = new_skiplist();
 
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
     wal.put_batch(&[(b"key1", b"val1"), (b"key2", b"val2")], 42)
         .unwrap();
     wal.sync().unwrap();
@@ -858,7 +900,9 @@ fn test_wal_v3_recover_with_tombstones() {
     let path = dir.path().join("test_v3_tomb.wal");
     let skiplist = new_skiplist();
 
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
     wal.put_batch(&[(b"key1", b"val1")], 10).unwrap();
     // Write a tombstone batch (delete key1).
     wal.put_batch(&[(b"key1", &[] as &[u8])], 20).unwrap();
@@ -880,7 +924,9 @@ fn test_wal_v3_recover_with_range_tombstones_skipped() {
     let path = dir.path().join("test_v3_skip.wal");
     let skiplist = new_skiplist();
 
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
     wal.put_batch(&[(b"key1", b"val1")], 10).unwrap();
     wal.put_range_tombstone_batch(&[(b"a", b"z")], 20).unwrap();
     wal.put_batch(&[(b"key2", b"val2")], 30).unwrap();
@@ -901,7 +947,9 @@ fn test_wal_v3_multiple_range_tombstone_batches() {
     let skiplist = new_skiplist();
     let range_ts = crate::range_tombstone::RangeTombstoneSet::new();
 
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
     wal.put_range_tombstone_batch(&[(b"a", b"m")], 10).unwrap();
     wal.put_range_tombstone_batch(&[(b"x", b"z")], 20).unwrap();
     wal.sync().unwrap();
@@ -922,7 +970,9 @@ fn test_wal_v3_empty_batch_recovery() {
     let path = dir.path().join("test_v3_empty.wal");
     let skiplist = new_skiplist();
 
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
     wal.sync().unwrap();
     drop(wal);
 
@@ -938,7 +988,9 @@ fn test_wal_v3_truncated_batch_recovery() {
     let path = dir.path().join("test_v3_trunc.wal");
     let _skiplist = new_skiplist();
 
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
     wal.put_batch(&[(b"key1", b"val1")], 10).unwrap();
     wal.put_batch(&[(b"key2", b"val2")], 20).unwrap();
     wal.sync().unwrap();
@@ -1021,7 +1073,9 @@ fn test_memtable_recover_from_wal_vlog() {
 
     // Write entries directly to WAL since for_testing_put_slice doesn't write to WAL.
     {
-        let wal = Wal::create(&path).unwrap();
+        let Some(wal) = create_wal_or_skip(&path) else {
+            return;
+        };
         wal.put_batch(&[(b"key1", b"val1")], 10).unwrap();
         wal.put_batch(&[(b"key2", b"val2")], 20).unwrap();
         wal.sync().unwrap();
@@ -1040,7 +1094,9 @@ fn test_memtable_recover_from_wal_plain() {
     let path = dir.path().join("test_plain_recover.wal");
 
     {
-        let wal = Wal::create(&path).unwrap();
+        let Some(wal) = create_wal_or_skip(&path) else {
+            return;
+        };
         wal.put_batch(&[(b"key1", b"val1")], 10).unwrap();
         wal.put_batch(&[(b"key2", b"val2")], 20).unwrap();
         wal.sync().unwrap();
@@ -1105,7 +1161,9 @@ fn test_range_overlap_with_point_entries_excluded_bounds() {
 fn test_wal_put_batch_key_too_large() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("test_large_key.wal");
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
 
     // Key larger than u16::MAX should be rejected.
     let large_key = vec![0u8; u16::MAX as usize + 1];
@@ -1117,7 +1175,9 @@ fn test_wal_put_batch_key_too_large() {
 fn test_wal_put_batch_value_too_large() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("test_large_val.wal");
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
 
     // Value larger than u16::MAX should be rejected.
     let large_val = vec![0u8; u16::MAX as usize + 1];
@@ -1129,7 +1189,9 @@ fn test_wal_put_batch_value_too_large() {
 fn test_wal_put_range_tombstone_batch_key_too_large() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("test_large_rt.wal");
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
 
     let large_key = vec![0u8; u16::MAX as usize + 1];
     let result = wal.put_range_tombstone_batch(&[(&large_key, b"z")], 10);
@@ -1141,7 +1203,9 @@ fn test_wal_put_range_tombstone_batch_requires_mvcc() {
     // Non-MVCC WAL should reject range tombstone batches.
     let dir = tempdir().unwrap();
     let path = dir.path().join("test_no_mvcc.wal");
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
 
     // Default WAL is MVCC-enabled, so this should work.
     let result = wal.put_range_tombstone_batch(&[(b"a", b"z")], 10);
@@ -1179,7 +1243,9 @@ fn test_wal_submit_and_commit_flushes_legacy_wal() {
 fn test_wal_submit_and_commit_empty_wal_is_noop() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("empty_submit_and_commit.wal");
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
 
     wal.submit_and_commit(0).unwrap();
 }
@@ -1188,7 +1254,9 @@ fn test_wal_submit_and_commit_empty_wal_is_noop() {
 fn test_wal_submit_and_commit_rejects_unassigned_ticket() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("future_submit_and_commit.wal");
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
 
     wal.put_batch(&[(b"k", b"v")], 1).unwrap();
     let err = wal.submit_and_commit(1).unwrap_err();
@@ -1202,7 +1270,9 @@ fn test_wal_submit_and_commit_rejects_unassigned_ticket() {
 fn test_wal_put_key_too_large() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("test_put_large.wal");
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
 
     let large_key = vec![0u8; u16::MAX as usize + 1];
     let result = wal.put(&large_key, b"val");
@@ -1213,7 +1283,9 @@ fn test_wal_put_key_too_large() {
 fn test_wal_put_value_too_large() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("test_put_large_val.wal");
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
 
     let large_val = vec![0u8; u16::MAX as usize + 1];
     let result = wal.put(b"key", &large_val);
@@ -1227,7 +1299,9 @@ fn test_wal_recover_corrupted_magic() {
 
     // Write a valid WAL.
     {
-        let wal = Wal::create(&path).unwrap();
+        let Some(wal) = create_wal_or_skip(&path) else {
+            return;
+        };
         wal.put_batch(&[(b"key1", b"val1")], 10).unwrap();
         wal.sync().unwrap();
     }
@@ -1251,7 +1325,9 @@ fn test_wal_recover_corrupted_crc() {
 
     // Write a valid WAL.
     {
-        let wal = Wal::create(&path).unwrap();
+        let Some(wal) = create_wal_or_skip(&path) else {
+            return;
+        };
         wal.put_batch(&[(b"key1", b"val1")], 10).unwrap();
         wal.sync().unwrap();
     }
@@ -1361,7 +1437,9 @@ fn test_wal_recover_empty_file() {
 
     // Create and immediately close a WAL (just header).
     {
-        let wal = Wal::create(&path).unwrap();
+        let Some(wal) = create_wal_or_skip(&path) else {
+            return;
+        };
         wal.sync().unwrap();
     }
 
@@ -1377,7 +1455,9 @@ fn test_wal_recover_with_range_tombstones_empty() {
     let path = dir.path().join("test_rt_empty.wal");
 
     {
-        let wal = Wal::create(&path).unwrap();
+        let Some(wal) = create_wal_or_skip(&path) else {
+            return;
+        };
         wal.sync().unwrap();
     }
 
@@ -1441,7 +1521,9 @@ fn test_wal_empty_drain_skips_fsync() {
     // avoiding an unnecessary flush+fsync.
     let dir = tempdir().unwrap();
     let path = dir.path().join("empty_drain.wal");
-    let wal = Wal::create(&path).unwrap();
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
 
     // Sync with nothing in the queue — should succeed without error.
     wal.sync().unwrap();
@@ -1465,7 +1547,10 @@ fn test_wal_group_commit_multiple_writers() {
     // successful durability through the ticket-based commit barrier.
     let dir = tempdir().unwrap();
     let path = dir.path().join("batch_slots.wal");
-    let wal = Arc::new(Wal::create(&path).unwrap());
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
+    let wal = Arc::new(wal);
     let start = Arc::new(Barrier::new(3));
     let (tx, rx) = bounded(3);
 

--- a/rfcs/014-async-operations.md
+++ b/rfcs/014-async-operations.md
@@ -1,6 +1,6 @@
 # RFC 014: Async Operations End-to-End
 
-**Status:** Proposed
+**Status:** Active (partially implemented)
 **Date:** 2026-07-02
 **Author:** kv-engine Contributors
 **References:**
@@ -13,14 +13,16 @@
 ## 1. Summary
 
 This RFC proposes changing kv-engine's **user-visible operation surface** from
-fully synchronous methods to an **async-first API**:
+fully synchronous methods to a **dual-surface API with engine-owned async
+entrypoints**:
 
-1. `KvEngine::open`, `close`, `get`, `batch_get`, `put`, `delete`,
-   `delete_range`, `write_batch`, `sync`, and compaction-filter management
-   become `async`.
+1. `KvEngine` exposes async entrypoints such as `open_async`, `close_async`,
+   `get_async`, `batch_get_async`, `put_async`, `delete_async`,
+   `delete_range_async`, `write_batch_async`, `sync_async`, and async scan
+   cursors.
 2. Transaction methods that may observe engine state or publish changes
-   (`get`, `scan`, `prefix_scan`, `commit`) become `async`, while purely
-   in-memory helpers may remain synchronous.
+   (`get`, `commit`, and eventually scan operations) gain async variants, while
+   purely in-memory helpers may remain synchronous.
 3. Range iteration moves from today's synchronous iterator stack to an
    async-aware cursor API.
 4. Test-only control paths such as `force_flush` and `drain_flush` remain
@@ -43,7 +45,7 @@ signatures. The value of this RFC is instead:
 
 The recommended implementation is therefore **staged**:
 
-1. land an async public API first;
+1. land engine-owned async entrypoints first;
 2. preserve current storage semantics and correctness invariants;
 3. migrate internals to async execution only where profiling or integration
    pressure justifies it.
@@ -112,8 +114,9 @@ correctness**, with internal async overlap as a secondary, targeted benefit.
 
 ## 3. Goals
 
-1. Provide an async-first public API that integrates cleanly with async Rust
-   applications.
+1. Provide engine-owned async entrypoints that integrate cleanly with async
+   Rust applications without forcing callers to wrap every operation in
+   `spawn_blocking`.
 2. Preserve current durability, visibility, MVCC, and crash-recovery
    guarantees.
 3. Keep the migration incremental enough that correctness can be maintained
@@ -254,30 +257,34 @@ If an async refactor makes those less obvious, the refactor is incomplete.
 
 ### 7.1 `KvEngine`
 
-The public surface becomes async-first:
+The shipped Phase 1 surface is dual-surface rather than canonical-async:
 
 ```rust
 impl KvEngine {
-    pub async fn open(path: impl AsRef<Path>, options: LsmStorageOptions) -> Result<Arc<Self>>;
-    pub async fn close(&self) -> Result<()>;
+    pub async fn open_async(path: impl AsRef<Path>, options: LsmStorageOptions) -> Result<Arc<Self>>;
+    pub async fn close_async(&self) -> Result<()>;
 
-    pub async fn get(&self, key: &[u8]) -> Result<Option<Bytes>>;
-    pub async fn batch_get(&self, keys: &[&[u8]]) -> Vec<Result<Option<Bytes>>>;
-    pub async fn put(&self, key: &[u8], value: &[u8]) -> Result<()>;
-    pub async fn delete(&self, key: &[u8]) -> Result<()>;
-    pub async fn delete_range(&self, start: &[u8], end: &[u8]) -> Result<()>;
-    pub async fn write_batch<T: AsRef<[u8]>>(&self, batch: &[WriteBatchRecord<T>]) -> Result<()>;
-    pub async fn sync(&self) -> Result<()>;
+    pub async fn get_async(&self, key: &[u8]) -> Result<Option<Bytes>>;
+    pub async fn batch_get_async(&self, keys: &[&[u8]]) -> Vec<Result<Option<Bytes>>>;
+    pub async fn put_async(&self, key: &[u8], value: &[u8]) -> Result<()>;
+    pub async fn delete_async(&self, key: &[u8]) -> Result<()>;
+    pub async fn delete_range_async(&self, start: &[u8], end: &[u8]) -> Result<()>;
+    pub async fn write_batch_async<T: AsRef<[u8]>>(&self, batch: &[WriteBatchRecord<T>]) -> Result<()>;
+    pub async fn sync_async(&self) -> Result<()>;
 
-    pub async fn scan(&self, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> Result<AsyncScan>;
-    pub async fn prefix_scan(&self, prefix: &[u8]) -> Result<AsyncScan>;
+    pub async fn scan_async(&self, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> Result<AsyncScan>;
+    pub async fn prefix_scan_async(&self, prefix: &[u8]) -> Result<AsyncScan>;
 
-    pub fn new_txn(&self) -> Result<Arc<Transaction>>;
+    pub fn new_txn_async(&self) -> Result<Arc<Transaction>>;
 }
 ```
 
-Compaction-filter management should also move to async for consistency, even if
-some implementations remain immediate in early phases.
+The synchronous API remains available for compatibility, CLI use, tests, and
+benchmarks. This RFC now treats that dual-surface shape as the adopted Phase 1
+design rather than a temporary naming accident.
+
+Compaction-filter management should eventually gain async symmetry for
+consistency, even if some implementations remain synchronous in early phases.
 
 `force_flush` and `drain_flush` are intentionally omitted from the normal async
 surface. In the current engine they are race-prone control hooks used only in
@@ -341,16 +348,16 @@ would be a deliberate compatibility regression, not the default design.
 
 ### 7.3 Transactions
 
-Transactions become selectively async:
+Transactions are currently selectively async:
 
 ```rust
 impl Transaction {
-    pub async fn get(&self, key: &[u8]) -> Result<Option<Bytes>>;
-    pub async fn scan(self: &Arc<Self>, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> Result<AsyncTxnScan>;
-    pub async fn prefix_scan(self: &Arc<Self>, prefix: &[u8]) -> Result<AsyncTxnScan>;
+    pub fn get_async(&self, key: &[u8]) -> impl Future<Output = Result<Option<Bytes>>> + Send;
+    pub fn scan(self: &Arc<Self>, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> Result<TxnIterator>;
+    pub fn prefix_scan(self: &Arc<Self>, prefix: &[u8]) -> Result<TxnIterator>;
     pub fn put(&self, key: &[u8], value: &[u8]) -> Result<()>;
     pub fn delete(&self, key: &[u8]) -> Result<()>;
-    pub async fn commit(&self) -> Result<()>;
+    pub fn commit_async(&self) -> impl Future<Output = Result<()>> + Send;
 }
 ```
 
@@ -359,8 +366,10 @@ This split is intentional:
 1. `new_txn`, `Transaction::put`, and `Transaction::delete` are purely
    in-memory operations in the current architecture and should remain
    synchronous unless their semantics change materially.
-2. `get`, scan operations, and `commit` remain async because they may consult
-   engine state, cross blocking boundaries, or publish changes.
+2. `get` and `commit` gain async variants because they may consult engine
+   state, cross blocking boundaries, or publish changes.
+3. transaction scan operations remain synchronous today and are an explicit
+   remaining gap (`AsyncTxnScan`) rather than silently omitted scope.
 
 Transaction confinement remains part of the contract:
 
@@ -780,20 +789,23 @@ closer to the engine's existing iterator style.
 
 ## 13. Compatibility and Migration
 
-This RFC intentionally treats the change as a major API break.
+The current implementation does not treat this migration as an immediate major
+API break. Instead it ships async entrypoints alongside the synchronous API.
 
-Caller migration is straightforward but global:
+Caller migration is therefore incremental:
 
-1. call sites become `await`-based;
-2. scan loops switch from synchronous iterator advancement to
-   `while let Some((k, v)) = scan.try_next().await?`;
-3. transactions become async;
-4. explicit graceful shutdown becomes `engine.close().await?`.
+1. async callers can move operation-by-operation onto `*_async` methods;
+2. non-transactional scan loops switch to
+   `while let Some((k, v)) = scan.try_next().await?` once they adopt
+   `scan_async`;
+3. transaction call sites can adopt `get_async` and `commit_async` first;
+4. explicit graceful shutdown becomes `engine.close_async().await?`.
 
-The CLI, tests, and any benchmark harnesses must add an async runtime boundary.
+The CLI, tests, and benchmark harnesses may continue using the synchronous
+surface or introduce explicit runtime boundaries where async coverage is needed.
 
-To reduce migration pressure, the implementation may also provide an optional
-blocking facade or `blocking-api` feature for synchronous tools and benchmarks.
+This dual-surface design reduces migration pressure at the cost of carrying
+both APIs for a period of time.
 
 ---
 
@@ -810,9 +822,10 @@ blocking facade or `blocking-api` feature for synchronous tools and benchmarks.
 
 ### Phase 1: Public Async API
 
-1. convert `KvEngine` methods to async;
-2. convert transaction methods to async;
-3. add `AsyncScan` and `AsyncTxnScan`;
+1. add `KvEngine::*_async` entrypoints. Completed.
+2. add async transaction `get`/`commit` entrypoints while keeping local-write
+   helpers synchronous. Completed.
+3. add `AsyncScan` and `AsyncTxnScan`.
 4. keep existing correctness behavior and reuse as much synchronous core logic
    as possible;
 5. preserve serializable-mode scan rejections;
@@ -822,22 +835,33 @@ blocking facade or `blocking-api` feature for synchronous tools and benchmarks.
    async API.
 9. define how admitted foreground writes are tracked across `Closing`.
 
+Phase 1 shipped with one explicit remaining gap: transaction scans are still
+synchronous and `AsyncTxnScan` has not landed yet.
+
 ### Phase 2: Async Shutdown and Background Ownership
 
-1. replace notifier/join lifecycle with async task ownership;
-2. make `close().await` the canonical graceful shutdown path;
-3. preserve the current split close contract for WAL and non-WAL engines;
+1. replace notifier/join lifecycle with async-visible state management and
+   admission tracking. Partially completed.
+2. make `close_async().await` the canonical graceful shutdown path. Completed.
+3. preserve the current split close contract for WAL and non-WAL engines.
+   Completed.
 4. preserve a bounded `Drop` cleanup story rather than pure fire-and-forget
    cancellation.
 5. enforce and test the Open/Closing/Closed state machine.
 6. add explicit registration/tracking for live scans, transactions, and
    admitted foreground writes if shutdown semantics depend on them.
 
+Phase 2 shipped without replacing background thread ownership with runtime
+tasks. The lifecycle contract is implemented, but the engine still uses the
+existing flush/compaction thread model under the async surface.
+
 ### Phase 3: Targeted Internal Async Execution
 
 1. move `open()` recovery orchestration behind async tasks;
 2. move flush/compaction orchestration to async tasks;
 3. measure whether selective overlap improves tail latency or throughput.
+
+Phase 3 has not started.
 
 ### Phase 4: Internal Iterator Rework
 


### PR DESCRIPTION
## Summary

Follow up RFC 014 after PR #152 by aligning the RFC with the shipped async surface and adding owned async scan cursors for transactions.

## Changes
- Align RFC 014 with the adopted dual-surface async API and current phased rollout
- Add AsyncTxnScan with scan_async and prefix_scan_async on Transaction
- Refactor transaction-owned scan state so async cursors retain MVCC, read-set, and lifecycle state without holding the full transaction handle
- Add async transaction scan coverage for send-compatibility, merged local and engine visibility, prefix filtering, and serializable rejection

## Verification
- cargo fmt --all
- cargo test -p kv-engine async_api -- --nocapture

## Notes
- This keeps the synchronous transaction scan API intact for compatibility while closing the main remaining Phase 1 gap called out in RFC 014.
- Maintenance and admin async surface cleanup remains a follow-up slice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `scan_async` and `prefix_scan_async` for asynchronous range and prefix queries.
  * Introduced an `AsyncTxnScan` cursor for consuming scan results incrementally.
* **Bug Fixes**
  * Improved consistency for async scans so transaction-local inserts/deletes are reflected correctly, with stable key ordering and accurate prefix filtering.
  * Async scans now properly reject unsupported serializable transactions.
* **Tests**
  * Added async scan coverage, including ordering/filtering and error behavior.
  * Updated integration tests to skip when io_uring is unavailable; made WAL creation failures skip instead of fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->