### PR TITLE
feat: measure and harden async open recovery

### DIFF
--- a/docs/async-phase3-measurement.md
+++ b/docs/async-phase3-measurement.md
@@ -1,0 +1,238 @@
+# Async Phase 3 Measurement Plan
+
+## Goal
+
+Measure whether the Phase 3 async-internal changes from RFC 014 improve
+observable behavior enough to justify more internal async conversion.
+
+This plan focuses on the async work that has already landed:
+
+1. `open_async()` staged recovery plus parallel SST open.
+2. Runtime-owned periodic flush and compaction tasks.
+3. Runtime-owned post-compaction vLog GC.
+
+The plan does not assume these changes are a throughput win. The point is to
+measure:
+
+1. cold-start latency;
+2. request-path tail latency while maintenance work is active;
+3. graceful shutdown latency;
+4. regressions in the sync compatibility surface.
+
+## Questions
+
+1. Does `open_async()` reduce wall-clock open latency on databases with many
+   SSTs?
+2. Does moving flush/compaction/GC ownership onto the engine runtime change
+   foreground write latency, especially p95/p99, under maintenance pressure?
+3. Does `close_async()` remain bounded and predictable while background work is
+   live?
+4. Did the sync compatibility path (`open()` / `close()`) regress after it was
+   moved onto the background runtime shell?
+
+## Metrics
+
+Record these for every run:
+
+1. wall-clock duration;
+2. p50 / p95 / p99 latency where the workload is per-operation;
+3. bytes written or ops/sec when throughput matters;
+4. SST count, live levels, WAL enabled/disabled, vLog enabled/disabled;
+5. host info: CPU model, kernel, toolchain, build profile.
+
+## Scenarios
+
+### 1. Open Latency
+
+Compare `open()` vs `open_async()` on the same prepared database directory.
+
+Matrix:
+
+1. small: tens of SSTs;
+2. medium: hundreds of SSTs;
+3. large: thousands of SSTs;
+4. with and without vLog files present.
+
+Primary metric:
+
+1. wall-clock open latency.
+
+Success signal:
+
+1. `open_async()` is materially better on medium/large SST counts, or at
+   least not worse on small databases.
+
+### 2. Foreground Write Latency Under Background Maintenance
+
+Drive sustained writes until periodic flush and compaction are active.
+
+Matrix:
+
+1. WAL off / WAL on;
+2. leveled / tiered / simple leveled;
+3. inline values / vLog values;
+4. 1 writer / 4 writers.
+
+Primary metrics:
+
+1. write p95 / p99 latency;
+2. total ops/sec;
+3. background events observed during the run.
+
+Success signal:
+
+1. no clear regression in p95/p99 versus the pre-runtime-ownership baseline;
+2. any improvement is a bonus, not an assumption.
+
+### 3. Close Latency
+
+Measure `close_async()` while the engine has:
+
+1. no pending maintenance work;
+2. active imm memtables to flush;
+3. compaction work already triggered;
+4. vLog GC work queued from post-compaction cleanup.
+
+Also compare sync `close()`.
+
+Primary metric:
+
+1. wall-clock close latency.
+
+Success signal:
+
+1. graceful close remains bounded and deterministic;
+2. sync `close()` does not regress badly relative to the old thread-owned
+   shell.
+
+### 4. Sync Compatibility Regression Check
+
+Because `open()` and `close()` now route through the background runtime shell,
+measure:
+
+1. sync open latency;
+2. sync close latency;
+3. short write/read smoke throughput.
+
+This is a guardrail, not a performance claim.
+
+## Harness Plan
+
+Use existing infrastructure first.
+
+### Existing Surfaces
+
+1. `kv-engine/src/bin/write-perf.rs` for write-heavy workloads and controlled
+   option matrices.
+2. `kv-engine/benches/wal_bench.rs` for WAL-sensitive durable write behavior.
+3. ad hoc tempdir-driven tests or a small dedicated bench binary for
+   open/close latency.
+
+### Recommended Additions
+
+1. Extend `write-perf` with explicit open/close timing output for prepared
+   datasets.
+2. Add a dedicated binary such as `async-phase3-perf.rs` if `write-perf`
+   becomes too overloaded.
+3. Emit JSON so repeated runs can be compared and archived.
+
+## Proposed Commands
+
+### Open / Close Latency
+
+Prepare a directory with many SSTs, then compare:
+
+```bash
+cargo run --release --bin async-phase3-perf -- prepare \
+  --path /tmp/async-phase3-openclose \
+  --num-keys 2000000 \
+  --value-size 1024 \
+  --flush-every 50000 \
+  --target-sst-size 262144 \
+  --memtable-limit 2 \
+  --output both
+```
+
+Then measure open/close on the prepared directory:
+
+```bash
+cargo run --release --bin async-phase3-perf -- measure-open-close \
+  --path /tmp/async-phase3-openclose \
+  --repetitions 5 \
+  --mode both \
+  --target-sst-size 262144 \
+  --memtable-limit 2 \
+  --output both
+```
+
+### Write Latency Under Maintenance
+
+```bash
+cargo run --release --bin write-perf -- \
+  --bench fillrandom \
+  --num 2000000 \
+  --threads 4 \
+  --compaction leveled \
+  --output json
+```
+
+Repeat with:
+
+1. `--wal`
+2. `--vlog`
+3. `--compaction simple`
+4. `--compaction tiered`
+
+### WAL-Specific Baseline
+
+```bash
+cargo bench --package kv-engine --bench wal_bench
+```
+
+## Comparison Rules
+
+1. Run at least 5 repetitions per scenario.
+2. Use medians for headline numbers.
+3. Report p95/p99 for latency-sensitive paths.
+4. Treat single-run deltas below noise level as non-findings.
+5. Separate “no regression” from “real improvement”.
+
+## Acceptance Bar
+
+Phase 3 is good enough to stop here if:
+
+1. `open_async()` is neutral-to-better on realistic datasets;
+2. runtime-owned maintenance does not regress foreground tail latency;
+3. `close_async()` remains bounded and reliable;
+4. sync compatibility paths do not show a meaningful regression.
+
+Only move deeper into internal async overlap if the measurements show a clear
+problem or clear upside.
+
+## Likely Follow-Ups
+
+If measurements show a real opportunity:
+
+1. overlap expensive substeps inside compaction or vLog GC;
+2. overlap flush publish and non-critical cleanup where crash ordering allows;
+3. add finer-grained instrumentation around maintenance task queueing and
+   blocking-executor saturation.
+4. optimize `open_async()` for vLog-heavy reopen cases. Current measurements
+   show that the async path helps on large inline SST reopen, but loses on
+   live-vLog reopen even with high file counts. Investigate a vLog-aware open
+   strategy instead of only parallelizing SST open. Likely targets:
+   parallel vLog directory/file discovery, reducing `spawn_blocking` overhead
+   when SST open is cheap, and gating SST-open parallelism based on recovery
+   shape rather than always paying the async orchestration cost.
+5. longer-term: optimize the async recovery pipeline itself so it can win
+   across recovery shapes instead of depending on an adaptive sync/async
+   policy. Candidate directions: batch SST opens instead of one task per SST,
+   reduce `spawn_blocking` transition count, fuse recovery phases where safe,
+   and parallelize the vLog-side work that currently stays mostly sequential.
+   This is a larger follow-up than the recovery-shape-aware policy and should
+   be driven by profiling, not assumed.
+
+If measurements are neutral:
+
+1. stop at the current Phase 3 landing;
+2. avoid Phase 4 iterator-internal async conversion.

--- a/kv-engine/Cargo.toml
+++ b/kv-engine/Cargo.toml
@@ -37,7 +37,7 @@ rand = "0.8.5"
 rustyline = "18.0.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/kv-engine/src/bin/async-phase3-perf.rs
+++ b/kv-engine/src/bin/async-phase3-perf.rs
@@ -116,8 +116,11 @@ struct RunConfig {
 }
 
 impl RunConfig {
-    fn from_common(common: &CommonArgs) -> Self {
-        Self {
+    fn from_common(common: &CommonArgs) -> Result<Self> {
+        if common.cache_capacity == 0 {
+            bail!("--cache-capacity must be greater than 0");
+        }
+        Ok(Self {
             path: common.path.clone(),
             compaction: common.compaction,
             wal: common.wal,
@@ -125,7 +128,7 @@ impl RunConfig {
             cache_capacity: common.cache_capacity,
             target_sst_size: common.target_sst_size,
             memtable_limit: common.memtable_limit,
-        }
+        })
     }
 
     fn build_options(&self) -> LsmStorageOptions {
@@ -231,7 +234,7 @@ fn run_prepare(args: PrepareArgs) -> Result<()> {
         bail!("--flush-every must be greater than 0");
     }
 
-    let cfg = RunConfig::from_common(&args.common);
+    let cfg = RunConfig::from_common(&args.common)?;
     if args.reset && cfg.path.exists() {
         fs::remove_dir_all(&cfg.path)
             .with_context(|| format!("remove existing dataset {}", cfg.path.display()))?;
@@ -281,7 +284,7 @@ fn run_measure_open_close(args: MeasureOpenCloseArgs) -> Result<()> {
     if args.repetitions == 0 {
         bail!("--repetitions must be greater than 0");
     }
-    let cfg = RunConfig::from_common(&args.common);
+    let cfg = RunConfig::from_common(&args.common)?;
     let options = cfg.build_options();
     let (sst_files, vlog_files) = count_dataset_files(&cfg.path)?;
 
@@ -302,19 +305,27 @@ fn run_measure_open_close(args: MeasureOpenCloseArgs) -> Result<()> {
             true,
         )?),
         OpenMode::Both => {
+            // Coin-flip the order so results aren't systematically biased
+            // toward whichever path runs first on a warm page cache.
+            let sync_first = unix_epoch_ms().is_multiple_of(2);
+            let (first, second) = if sync_first {
+                ("sync", "async")
+            } else {
+                ("async", "sync")
+            };
             records.push(measure_mode(
-                "sync",
+                first,
                 args.repetitions,
                 &cfg,
                 &options,
-                false,
+                !sync_first,
             )?);
             records.push(measure_mode(
-                "async",
+                second,
                 args.repetitions,
                 &cfg,
                 &options,
-                true,
+                sync_first,
             )?);
         }
     }
@@ -326,6 +337,30 @@ fn run_measure_open_close(args: MeasureOpenCloseArgs) -> Result<()> {
     emit_measure(args.common.output, &records)
 }
 
+fn run_one_cycle(
+    cfg: &RunConfig,
+    options: &LsmStorageOptions,
+    asynchronous: bool,
+) -> Result<(f64, f64)> {
+    if asynchronous {
+        let open_start = Instant::now();
+        let engine = block_on(KvEngine::open_async(&cfg.path, options.clone()))?;
+        let open_ms = ms(open_start.elapsed());
+        let close_start = Instant::now();
+        block_on(engine.close_async())?;
+        let close_ms = ms(close_start.elapsed());
+        Ok((open_ms, close_ms))
+    } else {
+        let open_start = Instant::now();
+        let engine = KvEngine::open(&cfg.path, options.clone())?;
+        let open_ms = ms(open_start.elapsed());
+        let close_start = Instant::now();
+        engine.close()?;
+        let close_ms = ms(close_start.elapsed());
+        Ok((open_ms, close_ms))
+    }
+}
+
 fn measure_mode(
     mode_name: &'static str,
     repetitions: usize,
@@ -333,25 +368,18 @@ fn measure_mode(
     options: &LsmStorageOptions,
     asynchronous: bool,
 ) -> Result<MeasureRecord> {
+    // Warmup round: prime the page cache and filesystem so that recorded
+    // samples reflect a steady state rather than cold-start variance from
+    // the very first access. The warmup sample is discarded.
+    run_one_cycle(cfg, options, asynchronous)?;
+
     let mut open_samples = Vec::with_capacity(repetitions);
     let mut close_samples = Vec::with_capacity(repetitions);
 
     for _ in 0..repetitions {
-        if asynchronous {
-            let open_start = Instant::now();
-            let engine = block_on(KvEngine::open_async(&cfg.path, options.clone()))?;
-            open_samples.push(ms(open_start.elapsed()));
-            let close_start = Instant::now();
-            block_on(engine.close_async())?;
-            close_samples.push(ms(close_start.elapsed()));
-        } else {
-            let open_start = Instant::now();
-            let engine = KvEngine::open(&cfg.path, options.clone())?;
-            open_samples.push(ms(open_start.elapsed()));
-            let close_start = Instant::now();
-            engine.close()?;
-            close_samples.push(ms(close_start.elapsed()));
-        }
+        let (open_ms, close_ms) = run_one_cycle(cfg, options, asynchronous)?;
+        open_samples.push(open_ms);
+        close_samples.push(close_ms);
     }
 
     Ok(MeasureRecord {

--- a/kv-engine/src/bin/async-phase3-perf.rs
+++ b/kv-engine/src/bin/async-phase3-perf.rs
@@ -480,7 +480,7 @@ fn ms(duration: Duration) -> f64 {
 
 fn median_ms(samples: &[f64]) -> f64 {
     let mut values = samples.to_vec();
-    values.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    values.sort_by(|a, b| a.total_cmp(b));
     if values.len() % 2 == 1 {
         values[values.len() / 2]
     } else {

--- a/kv-engine/src/bin/async-phase3-perf.rs
+++ b/kv-engine/src/bin/async-phase3-perf.rs
@@ -1,0 +1,478 @@
+mod wrapper;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result, bail};
+use clap::{Parser, Subcommand, ValueEnum};
+use serde::Serialize;
+use wrapper::kv_engine_wrapper;
+
+use kv_engine_wrapper::{
+    block_on,
+    compact::{
+        CompactionOptions, LeveledCompactionOptions, SimpleLeveledCompactionOptions,
+        TieredCompactionOptions,
+    },
+    lsm_storage::{KvEngine, LsmStorageOptions, PrefixBloomOptions},
+    vlog::ValueSeparationOptions,
+};
+
+const JSON_SCHEMA: &str = "kv-engine.async-phase3-perf.v1";
+const ENGINE_NAME: &str = "kv-engine";
+
+#[derive(Clone, Copy, Debug, ValueEnum, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum OutputFormat {
+    Text,
+    Json,
+    Both,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum OpenMode {
+    Sync,
+    Async,
+    Both,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum CompactionMode {
+    None,
+    Simple,
+    Leveled,
+    Tiered,
+}
+
+#[derive(Parser, Debug)]
+#[command(name = "async-phase3-perf")]
+struct Args {
+    #[command(subcommand)]
+    cmd: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    Prepare(PrepareArgs),
+    MeasureOpenClose(MeasureOpenCloseArgs),
+}
+
+#[derive(Parser, Debug, Clone)]
+struct CommonArgs {
+    #[arg(long, default_value = "/tmp/async-phase3-perf")]
+    path: PathBuf,
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    output: OutputFormat,
+    #[arg(long, value_enum, default_value_t = CompactionMode::Leveled)]
+    compaction: CompactionMode,
+    #[arg(long, default_value_t = false)]
+    wal: bool,
+    #[arg(long, default_value_t = false)]
+    vlog: bool,
+    #[arg(long, default_value_t = 8192)]
+    cache_capacity: u64,
+    #[arg(long, default_value_t = 1 << 20)]
+    target_sst_size: usize,
+    #[arg(long, default_value_t = 2)]
+    memtable_limit: usize,
+}
+
+#[derive(Parser, Debug, Clone)]
+struct PrepareArgs {
+    #[command(flatten)]
+    common: CommonArgs,
+    #[arg(long, default_value_t = 2_000_000)]
+    num_keys: usize,
+    #[arg(long, default_value_t = 1024)]
+    value_size: usize,
+    #[arg(long, default_value_t = 50_000)]
+    flush_every: usize,
+    #[arg(long, default_value_t = true)]
+    reset: bool,
+}
+
+#[derive(Parser, Debug, Clone)]
+struct MeasureOpenCloseArgs {
+    #[command(flatten)]
+    common: CommonArgs,
+    #[arg(long, value_enum, default_value_t = OpenMode::Both)]
+    mode: OpenMode,
+    #[arg(long, default_value_t = 5)]
+    repetitions: usize,
+}
+
+#[derive(Clone)]
+struct RunConfig {
+    path: PathBuf,
+    compaction: CompactionMode,
+    wal: bool,
+    vlog: bool,
+    cache_capacity: u64,
+    target_sst_size: usize,
+    memtable_limit: usize,
+}
+
+impl RunConfig {
+    fn from_common(common: &CommonArgs) -> Self {
+        Self {
+            path: common.path.clone(),
+            compaction: common.compaction,
+            wal: common.wal,
+            vlog: common.vlog,
+            cache_capacity: common.cache_capacity,
+            target_sst_size: common.target_sst_size,
+            memtable_limit: common.memtable_limit,
+        }
+    }
+
+    fn build_options(&self) -> LsmStorageOptions {
+        LsmStorageOptions {
+            block_size: 4096,
+            target_sst_size: self.target_sst_size,
+            num_memtable_limit: self.memtable_limit,
+            compaction_options: match self.compaction {
+                CompactionMode::None => CompactionOptions::NoCompaction,
+                CompactionMode::Simple => {
+                    CompactionOptions::Simple(SimpleLeveledCompactionOptions {
+                        size_ratio_percent: 200,
+                        level0_file_num_compaction_trigger: 4,
+                        max_levels: 6,
+                    })
+                }
+                CompactionMode::Leveled => CompactionOptions::Leveled(LeveledCompactionOptions {
+                    level_size_multiplier: 2,
+                    level0_file_num_compaction_trigger: 4,
+                    max_levels: 6,
+                    base_level_size_mb: 128,
+                }),
+                CompactionMode::Tiered => CompactionOptions::Tiered(TieredCompactionOptions {
+                    num_tiers: 3,
+                    max_size_amplification_percent: 200,
+                    size_ratio: 2,
+                    min_merge_width: 2,
+                    max_merge_width: None,
+                }),
+            },
+            enable_wal: self.wal,
+            serializable: false,
+            value_separation: if self.vlog {
+                Some(ValueSeparationOptions {
+                    enabled: true,
+                    min_value_size: 1024,
+                    max_value_size: 64 * 1024,
+                    max_vlog_file_size: 64 * 1024 * 1024,
+                    gc_threshold_ratio: 0.4,
+                    max_open_vlog_files: 4,
+                    value_cache_capacity_bytes: 16 * 1024 * 1024,
+                })
+            } else {
+                None
+            },
+            manifest_snapshot_threshold_bytes: 4 << 20,
+            block_cache_capacity: self.cache_capacity,
+            enable_cache_backfill: true,
+            prefix_bloom: PrefixBloomOptions::default(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct PrepareRecord {
+    schema: &'static str,
+    unix_epoch_ms: u64,
+    engine: &'static str,
+    command: &'static str,
+    path: String,
+    wal: bool,
+    value_separation: bool,
+    compaction: &'static str,
+    num_keys: usize,
+    value_size: usize,
+    flush_every: usize,
+    prepare_elapsed_ms: f64,
+    close_elapsed_ms: f64,
+    sst_files: usize,
+    vlog_files: usize,
+}
+
+#[derive(Serialize)]
+struct MeasureRecord {
+    schema: &'static str,
+    unix_epoch_ms: u64,
+    engine: &'static str,
+    command: &'static str,
+    mode: &'static str,
+    path: String,
+    wal: bool,
+    value_separation: bool,
+    compaction: &'static str,
+    repetitions: usize,
+    open_samples_ms: Vec<f64>,
+    close_samples_ms: Vec<f64>,
+    open_median_ms: f64,
+    close_median_ms: f64,
+    sst_files: usize,
+    vlog_files: usize,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    match args.cmd {
+        Command::Prepare(args) => run_prepare(args),
+        Command::MeasureOpenClose(args) => run_measure_open_close(args),
+    }
+}
+
+fn run_prepare(args: PrepareArgs) -> Result<()> {
+    if args.flush_every == 0 {
+        bail!("--flush-every must be greater than 0");
+    }
+
+    let cfg = RunConfig::from_common(&args.common);
+    if args.reset && cfg.path.exists() {
+        fs::remove_dir_all(&cfg.path)
+            .with_context(|| format!("remove existing dataset {}", cfg.path.display()))?;
+    }
+    fs::create_dir_all(&cfg.path)
+        .with_context(|| format!("create dataset dir {}", cfg.path.display()))?;
+
+    let options = cfg.build_options();
+    let value = vec![b'x'; args.value_size];
+    let prepare_start = Instant::now();
+    let engine = KvEngine::open(&cfg.path, options)?;
+    for i in 0..args.num_keys {
+        let key = format!("key{i:08}");
+        engine.put(key.as_bytes(), &value)?;
+        if (i + 1) % args.flush_every == 0 {
+            engine.force_flush()?;
+        }
+    }
+    engine.drain_flush()?;
+    let prepare_elapsed = prepare_start.elapsed();
+    let close_start = Instant::now();
+    engine.close()?;
+    let close_elapsed = close_start.elapsed();
+
+    let (sst_files, vlog_files) = count_dataset_files(&cfg.path)?;
+    let record = PrepareRecord {
+        schema: JSON_SCHEMA,
+        unix_epoch_ms: unix_epoch_ms(),
+        engine: ENGINE_NAME,
+        command: "prepare",
+        path: cfg.path.display().to_string(),
+        wal: cfg.wal,
+        value_separation: cfg.vlog,
+        compaction: compaction_name(cfg.compaction),
+        num_keys: args.num_keys,
+        value_size: args.value_size,
+        flush_every: args.flush_every,
+        prepare_elapsed_ms: ms(prepare_elapsed),
+        close_elapsed_ms: ms(close_elapsed),
+        sst_files,
+        vlog_files,
+    };
+    emit_prepare(args.common.output, &record)
+}
+
+fn run_measure_open_close(args: MeasureOpenCloseArgs) -> Result<()> {
+    if args.repetitions == 0 {
+        bail!("--repetitions must be greater than 0");
+    }
+    let cfg = RunConfig::from_common(&args.common);
+    let options = cfg.build_options();
+    let (sst_files, vlog_files) = count_dataset_files(&cfg.path)?;
+
+    let mut records = Vec::new();
+    match args.mode {
+        OpenMode::Sync => records.push(measure_mode(
+            "sync",
+            args.repetitions,
+            &cfg,
+            &options,
+            false,
+        )?),
+        OpenMode::Async => records.push(measure_mode(
+            "async",
+            args.repetitions,
+            &cfg,
+            &options,
+            true,
+        )?),
+        OpenMode::Both => {
+            records.push(measure_mode(
+                "sync",
+                args.repetitions,
+                &cfg,
+                &options,
+                false,
+            )?);
+            records.push(measure_mode(
+                "async",
+                args.repetitions,
+                &cfg,
+                &options,
+                true,
+            )?);
+        }
+    }
+
+    for record in &mut records {
+        record.sst_files = sst_files;
+        record.vlog_files = vlog_files;
+    }
+    emit_measure(args.common.output, &records)
+}
+
+fn measure_mode(
+    mode_name: &'static str,
+    repetitions: usize,
+    cfg: &RunConfig,
+    options: &LsmStorageOptions,
+    asynchronous: bool,
+) -> Result<MeasureRecord> {
+    let mut open_samples = Vec::with_capacity(repetitions);
+    let mut close_samples = Vec::with_capacity(repetitions);
+
+    for _ in 0..repetitions {
+        if asynchronous {
+            let open_start = Instant::now();
+            let engine = block_on(KvEngine::open_async(&cfg.path, options.clone()))?;
+            open_samples.push(ms(open_start.elapsed()));
+            let close_start = Instant::now();
+            block_on(engine.close_async())?;
+            close_samples.push(ms(close_start.elapsed()));
+        } else {
+            let open_start = Instant::now();
+            let engine = KvEngine::open(&cfg.path, options.clone())?;
+            open_samples.push(ms(open_start.elapsed()));
+            let close_start = Instant::now();
+            engine.close()?;
+            close_samples.push(ms(close_start.elapsed()));
+        }
+    }
+
+    Ok(MeasureRecord {
+        schema: JSON_SCHEMA,
+        unix_epoch_ms: unix_epoch_ms(),
+        engine: ENGINE_NAME,
+        command: "measure_open_close",
+        mode: mode_name,
+        path: cfg.path.display().to_string(),
+        wal: cfg.wal,
+        value_separation: cfg.vlog,
+        compaction: compaction_name(cfg.compaction),
+        repetitions,
+        open_median_ms: median_ms(&open_samples),
+        close_median_ms: median_ms(&close_samples),
+        open_samples_ms: open_samples,
+        close_samples_ms: close_samples,
+        sst_files: 0,
+        vlog_files: 0,
+    })
+}
+
+fn count_dataset_files(path: &Path) -> Result<(usize, usize)> {
+    let mut sst = 0usize;
+    let mut vlog = 0usize;
+    let mut stack = vec![path.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        for entry in fs::read_dir(&dir).with_context(|| format!("read {}", dir.display()))? {
+            let entry = entry?;
+            let file_type = entry.file_type()?;
+            if file_type.is_dir() {
+                stack.push(entry.path());
+                continue;
+            }
+            if !file_type.is_file() {
+                continue;
+            }
+            match entry.path().extension().and_then(|ext| ext.to_str()) {
+                Some("sst") => sst += 1,
+                Some("vlog") => vlog += 1,
+                _ => {}
+            }
+        }
+    }
+    Ok((sst, vlog))
+}
+
+fn emit_prepare(output: OutputFormat, record: &PrepareRecord) -> Result<()> {
+    let summary = format!(
+        "prepared dataset path={} keys={} value_size={} flush_every={} ssts={} vlogs={} prepare_ms={:.2} close_ms={:.2}",
+        record.path,
+        record.num_keys,
+        record.value_size,
+        record.flush_every,
+        record.sst_files,
+        record.vlog_files,
+        record.prepare_elapsed_ms,
+        record.close_elapsed_ms,
+    );
+    match output {
+        OutputFormat::Text => println!("{summary}"),
+        OutputFormat::Json => println!("{}", serde_json::to_string(record)?),
+        OutputFormat::Both => {
+            eprintln!("{summary}");
+            println!("{}", serde_json::to_string(record)?);
+        }
+    }
+    Ok(())
+}
+
+fn emit_measure(output: OutputFormat, records: &[MeasureRecord]) -> Result<()> {
+    for record in records {
+        let summary = format!(
+            "{} path={} reps={} ssts={} vlogs={} open_median_ms={:.2} close_median_ms={:.2}",
+            record.mode,
+            record.path,
+            record.repetitions,
+            record.sst_files,
+            record.vlog_files,
+            record.open_median_ms,
+            record.close_median_ms,
+        );
+        match output {
+            OutputFormat::Text => println!("{summary}"),
+            OutputFormat::Json => println!("{}", serde_json::to_string(record)?),
+            OutputFormat::Both => {
+                eprintln!("{summary}");
+                println!("{}", serde_json::to_string(record)?);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1000.0
+}
+
+fn median_ms(samples: &[f64]) -> f64 {
+    let mut values = samples.to_vec();
+    values.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    if values.len() % 2 == 1 {
+        values[values.len() / 2]
+    } else {
+        let hi = values.len() / 2;
+        (values[hi - 1] + values[hi]) / 2.0
+    }
+}
+
+fn compaction_name(mode: CompactionMode) -> &'static str {
+    match mode {
+        CompactionMode::None => "none",
+        CompactionMode::Simple => "simple",
+        CompactionMode::Leveled => "leveled",
+        CompactionMode::Tiered => "tiered",
+    }
+}
+
+fn unix_epoch_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time before unix epoch")
+        .as_millis() as u64
+}

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -1069,15 +1069,14 @@ impl LsmStorageInner {
         let weak = self.weak_self.get().cloned();
         let vlog2 = vlog.clone();
 
+        let submitter = self.background_tasks.lock().clone();
         if let Some(weak) = weak
-            && let Some(submitter) = self.background_tasks.lock().clone()
-        {
-            if submitter
+            && let Some(submitter) = submitter
+            && submitter
                 .spawn_post_compaction_gc(weak, vlog, ids.clone(), self.blocking.clone())
                 .is_ok()
-            {
-                return;
-            }
+        {
+            return;
         }
 
         // Fallback to synchronous GC if weak_self is not set, the engine was

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -2,7 +2,7 @@ mod leveled;
 mod simple_leveled;
 mod tiered;
 
-use std::{collections::HashSet, sync::Arc, time::Duration};
+use std::{collections::HashSet, sync::Arc};
 
 use anyhow::{Ok, Result};
 pub use leveled::{LeveledCompactionController, LeveledCompactionOptions, LeveledCompactionTask};
@@ -260,9 +260,28 @@ impl CompactionController {
         task: &CompactionTask,
         new_sst_ids: &[usize],
     ) -> (LsmStorageState, Vec<usize>) {
+        self.apply_compaction_result_inner(snapshot, task, new_sst_ids, false)
+    }
+
+    pub fn apply_compaction_result_recovery(
+        &self,
+        snapshot: &LsmStorageState,
+        task: &CompactionTask,
+        new_sst_ids: &[usize],
+    ) -> (LsmStorageState, Vec<usize>) {
+        self.apply_compaction_result_inner(snapshot, task, new_sst_ids, true)
+    }
+
+    fn apply_compaction_result_inner(
+        &self,
+        snapshot: &LsmStorageState,
+        task: &CompactionTask,
+        new_sst_ids: &[usize],
+        in_recovery: bool,
+    ) -> (LsmStorageState, Vec<usize>) {
         match (self, task) {
             (CompactionController::Leveled(ctrl), CompactionTask::Leveled(task)) => {
-                ctrl.apply_compaction_result(snapshot, task, new_sst_ids, false)
+                ctrl.apply_compaction_result(snapshot, task, new_sst_ids, in_recovery)
             }
             (CompactionController::Simple(ctrl), CompactionTask::Simple(task)) => {
                 ctrl.apply_compaction_result(snapshot, task, new_sst_ids)
@@ -1020,7 +1039,7 @@ impl LsmStorageInner {
         }
     }
 
-    fn gc_single_vlog_file(
+    pub(crate) fn gc_single_vlog_file(
         vlog: &Arc<crate::vlog::ValueLog>,
         inner: &LsmStorageInner,
         file_id: u32,
@@ -1038,8 +1057,9 @@ impl LsmStorageInner {
     }
 
     /// Run GC on vLog files that were referenced by compacted SSTs.
-    /// Spawns a background thread so compaction is not blocked by GC I/O.
-    /// Falls back to synchronous GC if `weak_self` is not initialized.
+    /// Schedules GC on the engine-owned background runtime so compaction is
+    /// not blocked by GC I/O. Falls back to synchronous GC if the runtime is
+    /// unavailable (for example, inner-only tests or shutdown).
     fn post_compaction_gc(&self, input_vlog_ids: &[u32]) {
         let Some(ref vlog) = self.vlog else { return };
         let vlog = vlog.clone();
@@ -1049,34 +1069,24 @@ impl LsmStorageInner {
         let weak = self.weak_self.get().cloned();
         let vlog2 = vlog.clone();
 
-        if let Some(weak) = weak {
-            let handle = std::thread::spawn(move || {
-                for &file_id in &ids {
-                    // Upgrade inside the loop — if the engine is shutting down,
-                    // stop GC early and drop the strong ref after each file.
-                    let Some(inner) = weak.upgrade() else {
-                        break;
-                    };
-                    Self::gc_single_vlog_file(&vlog, &inner, file_id);
-                }
-                if let Err(e) = vlog.reclaim_pending_deletions() {
-                    log::error!("vLog reclaim error: {}", e);
-                }
-            });
+        if let Some(weak) = weak
+            && let Some(submitter) = self.background_tasks.lock().clone()
+        {
+            if submitter
+                .spawn_post_compaction_gc(weak, vlog, ids.clone(), self.blocking.clone())
+                .is_ok()
             {
-                let mut handles = std::mem::take(&mut *self.gc_handles.lock());
-                handles.retain(|h| !h.is_finished());
-                handles.push(handle);
-                *self.gc_handles.lock() = handles;
+                return;
             }
-        } else {
-            // Fallback to synchronous GC if weak_self is not set
-            for &file_id in &ids {
-                Self::gc_single_vlog_file(&vlog2, self, file_id);
-            }
-            if let Err(e) = vlog2.reclaim_pending_deletions() {
-                log::error!("vLog reclaim error: {}", e);
-            }
+        }
+
+        // Fallback to synchronous GC if weak_self is not set, the engine was
+        // opened without background workers, or shutdown has already started.
+        for &file_id in &ids {
+            Self::gc_single_vlog_file(&vlog2, self, file_id);
+        }
+        if let Err(e) = vlog2.reclaim_pending_deletions() {
+            log::error!("vLog reclaim error: {}", e);
         }
     }
 
@@ -1442,60 +1452,12 @@ impl LsmStorageInner {
         Ok(())
     }
 
-    pub(crate) fn spawn_compaction_thread(
-        self: &Arc<Self>,
-        rx: crossbeam_channel::Receiver<()>,
-    ) -> Result<Option<std::thread::JoinHandle<()>>> {
-        if let CompactionOptions::Leveled(_)
-        | CompactionOptions::Simple(_)
-        | CompactionOptions::Tiered(_) = self.options.compaction_options
-        {
-            let this = self.clone();
-            let handle =
-                Self::spawn_periodic_thread(rx, move || this.trigger_compaction(), "compaction");
-            return Ok(Some(handle));
-        }
-
-        Ok(None)
-    }
-
-    fn trigger_flush(&self) -> Result<()> {
+    pub(crate) fn trigger_flush(&self) -> Result<()> {
         let state = self.state.load_full();
         if state.imm_memtables.len() + 1 > self.options.num_memtable_limit {
             self.force_flush_next_imm_memtable()?;
         }
 
         Ok(())
-    }
-
-    pub(crate) fn spawn_flush_thread(
-        self: &Arc<Self>,
-        rx: crossbeam_channel::Receiver<()>,
-    ) -> Result<Option<std::thread::JoinHandle<()>>> {
-        let this = self.clone();
-        let handle = Self::spawn_periodic_thread(rx, move || this.trigger_flush(), "flush");
-
-        Ok(Some(handle))
-    }
-
-    fn spawn_periodic_thread<F>(
-        rx: crossbeam_channel::Receiver<()>,
-        mut tick_fn: F,
-        task_name: &'static str,
-    ) -> std::thread::JoinHandle<()>
-    where
-        F: FnMut() -> Result<()> + Send + 'static,
-    {
-        std::thread::spawn(move || {
-            let ticker = crossbeam_channel::tick(Duration::from_millis(50));
-            loop {
-                crossbeam_channel::select! {
-                    recv(ticker) -> _ => if let Err(e) = tick_fn() {
-                        log::error!("{} failed: {}", task_name, e);
-                    },
-                    recv(rx) -> _ => return
-                }
-            }
-        })
     }
 }

--- a/kv-engine/src/compact/leveled.rs
+++ b/kv-engine/src/compact/leveled.rs
@@ -187,7 +187,7 @@ impl LeveledCompactionController {
         snapshot: &LsmStorageState,
         task: &LeveledCompactionTask,
         new_sst_ids: &[usize],
-        _in_recovery: bool,
+        in_recovery: bool,
     ) -> (LsmStorageState, Vec<usize>) {
         let mut snapshot = snapshot.clone();
 
@@ -204,11 +204,13 @@ impl LeveledCompactionController {
             .1
             .retain(|x| !task.lower_level_sst_ids.contains(x));
         snapshot.levels[task.lower_level - 1].1.extend(new_sst_ids);
-        snapshot.levels[task.lower_level - 1].1.sort_by(|a, b| {
-            snapshot.sstables[a]
-                .first_key()
-                .cmp(&snapshot.sstables[b].first_key())
-        });
+        if !in_recovery {
+            snapshot.levels[task.lower_level - 1].1.sort_by(|a, b| {
+                snapshot.sstables[a]
+                    .first_key()
+                    .cmp(&snapshot.sstables[b].first_key())
+            });
+        }
 
         let mut rm_ids =
             Vec::with_capacity(task.upper_level_sst_ids.len() + task.lower_level_sst_ids.len());

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1177,6 +1177,9 @@ async fn run_periodic_background_task<F>(
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     interval.tick().await;
     loop {
+        if shutdown.load(Ordering::Acquire) != 0 {
+            return;
+        }
         tokio::select! {
             _ = shutdown_notify.notified() => {
                 if shutdown.load(Ordering::Acquire) != 0 {

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -7,6 +7,7 @@ use std::{
         Arc,
         atomic::{AtomicU8, AtomicU64, AtomicUsize, Ordering},
     },
+    time::Duration,
 };
 
 use anyhow::{Context, Result, anyhow};
@@ -71,6 +72,43 @@ struct LookupSstRawMvccParams<'a> {
     bloom_hash: u32,
     read_ts: u64,
     search_prefix: &'a [u8],
+}
+
+#[derive(Clone)]
+pub(crate) struct BackgroundTaskSubmitter {
+    tx: tokio::sync::mpsc::UnboundedSender<BackgroundCommand>,
+}
+
+impl BackgroundTaskSubmitter {
+    fn new(tx: tokio::sync::mpsc::UnboundedSender<BackgroundCommand>) -> Self {
+        Self { tx }
+    }
+
+    pub(crate) fn spawn_post_compaction_gc(
+        &self,
+        weak: std::sync::Weak<LsmStorageInner>,
+        vlog: Arc<ValueLog>,
+        ids: Vec<u32>,
+        blocking: BlockingExecutor,
+    ) -> Result<()> {
+        self.tx
+            .send(BackgroundCommand::PostCompactionGc {
+                weak,
+                vlog,
+                ids,
+                blocking,
+            })
+            .map_err(|_| anyhow!("background runtime is shutting down"))
+    }
+}
+
+enum BackgroundCommand {
+    PostCompactionGc {
+        weak: std::sync::Weak<LsmStorageInner>,
+        vlog: Arc<ValueLog>,
+        ids: Vec<u32>,
+        blocking: BlockingExecutor,
+    },
 }
 
 /// Represents the state of the storage engine.
@@ -251,7 +289,7 @@ impl ManifestRecoveryState<'_> {
     fn replay_compaction(&mut self, task: &CompactionTask, ids: &[usize]) -> Result<()> {
         let (new_state, _) = self
             .compaction_controller
-            .apply_compaction_result(self.state, task, ids);
+            .apply_compaction_result_recovery(self.state, task, ids);
         *self.state = new_state;
         if let Some(&last_id) = ids.last() {
             self.max_id = std::cmp::max(self.max_id, last_id);
@@ -798,10 +836,10 @@ pub(crate) struct LsmStorageInner {
     /// Value Log manager for key-value separation. `None` if value separation is disabled.
     pub(crate) vlog: Option<Arc<ValueLog>>,
     /// Weak reference to the owning `Arc<LsmStorageInner>`, set after construction.
-    /// Allows background threads (e.g., async GC) to obtain a strong reference.
+    /// Allows background tasks (e.g., async GC) to obtain a strong reference.
     pub(crate) weak_self: std::sync::OnceLock<std::sync::Weak<Self>>,
-    /// Handles for background GC threads, joined during close().
-    pub(crate) gc_handles: Mutex<Vec<std::thread::JoinHandle<()>>>,
+    /// Dynamic background-task submission handle, cleared during shutdown.
+    pub(crate) background_tasks: Mutex<Option<BackgroundTaskSubmitter>>,
     /// Cumulative write-path profiling counters (persists across memtable freezes).
     pub(crate) write_profile: Arc<crate::mem_table::WriteProfile>,
     /// Lifecycle state machine for async close / admission control.
@@ -1000,19 +1038,205 @@ impl Drop for AdmissionGuard {
     }
 }
 
+struct BackgroundWorkers {
+    shutdown: Arc<AtomicU8>,
+    shutdown_notify: Arc<tokio::sync::Notify>,
+    runtime_thread: Mutex<Option<std::thread::JoinHandle<()>>>,
+}
+
+impl BackgroundWorkers {
+    fn start(inner: Arc<LsmStorageInner>) -> Result<Self> {
+        let shutdown = Arc::new(AtomicU8::new(0));
+        let shutdown_notify = Arc::new(tokio::sync::Notify::new());
+        let thread_shutdown = Arc::clone(&shutdown);
+        let thread_notify = Arc::clone(&shutdown_notify);
+        let thread_inner = Arc::clone(&inner);
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        *inner.background_tasks.lock() = Some(BackgroundTaskSubmitter::new(tx));
+
+        let runtime_thread = std::thread::Builder::new()
+            .name("kv-background-runtime".to_string())
+            .spawn(move || {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("build background runtime");
+                rt.block_on(async move {
+                    let mut tasks = tokio::task::JoinSet::new();
+                    let compaction_inner = Arc::clone(&thread_inner);
+                    let compaction_shutdown = Arc::clone(&thread_shutdown);
+                    let compaction_notify = Arc::clone(&thread_notify);
+                    if let CompactionOptions::Leveled(_)
+                    | CompactionOptions::Simple(_)
+                    | CompactionOptions::Tiered(_) = compaction_inner.options.compaction_options
+                    {
+                        tasks.spawn(async move {
+                            run_periodic_background_task(
+                                compaction_inner,
+                                compaction_shutdown,
+                                compaction_notify,
+                                "compaction",
+                                |inner| inner.trigger_compaction(),
+                            )
+                            .await;
+                        });
+                    }
+
+                    let flush_inner = Arc::clone(&thread_inner);
+                    let flush_shutdown = Arc::clone(&thread_shutdown);
+                    let flush_notify = Arc::clone(&thread_notify);
+                    tasks.spawn(async move {
+                        run_periodic_background_task(
+                            flush_inner,
+                            flush_shutdown,
+                            flush_notify,
+                            "flush",
+                            |inner| inner.trigger_flush(),
+                        )
+                        .await;
+                    });
+
+                    let mut shutting_down = false;
+                    let mut command_channel_closed = false;
+                    loop {
+                        if !shutting_down && thread_shutdown.load(Ordering::Acquire) != 0 {
+                            shutting_down = true;
+                        }
+                        if shutting_down && command_channel_closed {
+                            break;
+                        }
+                        tokio::select! {
+                            _ = thread_notify.notified(), if !shutting_down => {
+                                if thread_shutdown.load(Ordering::Acquire) != 0 {
+                                    shutting_down = true;
+                                }
+                            }
+                            cmd = rx.recv(), if !command_channel_closed => {
+                                match cmd {
+                                    Some(BackgroundCommand::PostCompactionGc { weak, vlog, ids, blocking }) => {
+                                        tasks.spawn(run_post_compaction_gc_task(weak, vlog, ids, blocking));
+                                    }
+                                    None => {
+                                        command_channel_closed = true;
+                                    }
+                                }
+                            }
+                            Some(result) = tasks.join_next(), if !tasks.is_empty() => {
+                                result.expect("background task panicked");
+                            }
+                        }
+                    }
+
+                    while let Some(result) = tasks.join_next().await {
+                        result.expect("background task panicked");
+                    }
+                });
+            })?;
+
+        Ok(Self {
+            shutdown,
+            shutdown_notify,
+            runtime_thread: Mutex::new(Some(runtime_thread)),
+        })
+    }
+
+    fn begin_shutdown(&self, inner: &LsmStorageInner) {
+        inner.background_tasks.lock().take();
+        self.shutdown.store(1, Ordering::Release);
+        self.shutdown_notify.notify_waiters();
+    }
+
+    fn join_blocking(&self) -> Result<()> {
+        if let Some(handle) = self.runtime_thread.lock().take() {
+            handle.join().map_err(|e| anyhow!("{:?}", e))?;
+        }
+        Ok(())
+    }
+
+    async fn join_async(&self, blocking: &BlockingExecutor) -> Result<()> {
+        let handle = self.runtime_thread.lock().take();
+        if let Some(handle) = handle {
+            blocking
+                .run_result(move || handle.join().map_err(|e| anyhow!("{:?}", e)))
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+async fn run_periodic_background_task<F>(
+    inner: Arc<LsmStorageInner>,
+    shutdown: Arc<AtomicU8>,
+    shutdown_notify: Arc<tokio::sync::Notify>,
+    task_name: &'static str,
+    tick_fn: F,
+) where
+    F: Fn(Arc<LsmStorageInner>) -> Result<()> + Copy + Send + Sync + 'static,
+{
+    let mut interval = tokio::time::interval(Duration::from_millis(50));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    interval.tick().await;
+    loop {
+        tokio::select! {
+            _ = shutdown_notify.notified() => {
+                if shutdown.load(Ordering::Acquire) != 0 {
+                    return;
+                }
+            }
+            _ = interval.tick() => {
+                if shutdown.load(Ordering::Acquire) != 0 {
+                    return;
+                }
+                let blocking = inner.blocking.clone();
+                let task_inner = Arc::clone(&inner);
+                if let Err(e) = blocking
+                    .run_result(move || tick_fn(task_inner))
+                    .await
+                {
+                    log::error!("{} failed: {}", task_name, e);
+                }
+            }
+        }
+    }
+}
+
+async fn run_post_compaction_gc_task(
+    weak: std::sync::Weak<LsmStorageInner>,
+    vlog: Arc<ValueLog>,
+    ids: Vec<u32>,
+    blocking: BlockingExecutor,
+) {
+    for file_id in ids {
+        let Some(inner) = weak.upgrade() else {
+            break;
+        };
+        let gc_vlog = Arc::clone(&vlog);
+        if let Err(e) = blocking
+            .run_result(move || -> Result<()> {
+                LsmStorageInner::gc_single_vlog_file(&gc_vlog, &inner, file_id);
+                Ok(())
+            })
+            .await
+        {
+            log::error!("GC task dispatch error for vlog file {}: {}", file_id, e);
+        }
+    }
+    let reclaim_vlog = Arc::clone(&vlog);
+    if let Err(e) = blocking
+        .run_result(move || reclaim_vlog.reclaim_pending_deletions())
+        .await
+    {
+        log::error!("vLog reclaim error: {}", e);
+    }
+}
+
 // ── Public engine ─────────────────────────────────────────────────────
 
 /// A thin wrapper for `LsmStorageInner` and the user interface for `KvEngine`.
 pub struct KvEngine {
     pub(crate) inner: Arc<LsmStorageInner>,
-    /// Notifies the L0 flush thread to stop working. (In scan and flush)
-    flush_notifier: crossbeam_channel::Sender<()>,
-    /// The handle for the flush thread. (In scan and flush)
-    flush_thread: Mutex<Option<std::thread::JoinHandle<()>>>,
-    /// Notifies the compaction thread to stop working. (In compaction)
-    compaction_notifier: crossbeam_channel::Sender<()>,
-    /// The handle for the compaction thread. (In compaction)
-    compaction_thread: Mutex<Option<std::thread::JoinHandle<()>>>,
+    /// Engine-owned runtime hosting periodic background maintenance tasks.
+    background_workers: BackgroundWorkers,
 }
 
 impl Drop for KvEngine {
@@ -1025,19 +1249,8 @@ impl Drop for KvEngine {
 
 impl KvEngine {
     pub fn close(&self) -> Result<()> {
-        self.flush_notifier.send(()).ok();
-        if let Some(f) = self.flush_thread.lock().take() {
-            f.join().map_err(|e| anyhow!("{:?}", e))?;
-        }
-        self.compaction_notifier.send(()).ok();
-        if let Some(f) = self.compaction_thread.lock().take() {
-            f.join().map_err(|e| anyhow!("{:?}", e))?;
-        }
-        // Join all background GC threads before proceeding
-        let handles = std::mem::take(&mut *self.inner.gc_handles.lock());
-        for h in handles {
-            let _ = h.join();
-        }
+        self.background_workers.begin_shutdown(&self.inner);
+        self.background_workers.join_blocking()?;
         if self.inner.options.enable_wal {
             self.inner.sync()?;
             self.inner.sync_dir()?;
@@ -1065,17 +1278,11 @@ impl KvEngine {
         // Set the weak self-reference so background threads (e.g., async GC) can
         // obtain a strong reference to the engine.
         let _ = inner.weak_self.set(Arc::downgrade(&inner));
-        let (tx1, rx) = crossbeam_channel::unbounded();
-        let compaction_thread = inner.spawn_compaction_thread(rx)?;
-        let (tx2, rx) = crossbeam_channel::unbounded();
-        let flush_thread = inner.spawn_flush_thread(rx)?;
+        let background_workers = BackgroundWorkers::start(Arc::clone(&inner))?;
 
         Ok(Arc::new(Self {
             inner,
-            flush_notifier: tx2,
-            flush_thread: Mutex::new(flush_thread),
-            compaction_notifier: tx1,
-            compaction_thread: Mutex::new(compaction_thread),
+            background_workers,
         }))
     }
 
@@ -1382,17 +1589,11 @@ impl KvEngine {
 
         let inner = Arc::new(inner);
         let _ = inner.weak_self.set(Arc::downgrade(&inner));
-        let (tx1, rx) = crossbeam_channel::unbounded();
-        let compaction_thread = inner.spawn_compaction_thread(rx)?;
-        let (tx2, rx) = crossbeam_channel::unbounded();
-        let flush_thread = inner.spawn_flush_thread(rx)?;
+        let background_workers = BackgroundWorkers::start(Arc::clone(&inner))?;
 
         Ok(Arc::new(Self {
             inner,
-            flush_notifier: tx2,
-            flush_thread: Mutex::new(flush_thread),
-            compaction_notifier: tx1,
-            compaction_thread: Mutex::new(compaction_thread),
+            background_workers,
         }))
     }
 
@@ -1406,24 +1607,9 @@ impl KvEngine {
             }
             CloseState::Started => {}
         }
-        self.flush_notifier.send(()).ok();
-        self.compaction_notifier.send(()).ok();
-        let flush = self.flush_thread.lock().take();
-        let compaction = self.compaction_thread.lock().take();
-        let gc_handles = std::mem::take(&mut *self.inner.gc_handles.lock());
+        self.background_workers.begin_shutdown(&self.inner);
         let b = self.inner.blocking.clone();
-        b.run(move || {
-            if let Some(f) = flush {
-                f.join().ok();
-            }
-            if let Some(f) = compaction {
-                f.join().ok();
-            }
-            for h in gc_handles {
-                h.join().ok();
-            }
-        })
-        .await;
+        self.background_workers.join_async(&b).await?;
         self.inner.lifecycle.wait_for_quiescence_async().await;
         let inner = self.inner.clone();
         let wal = inner.options.enable_wal;
@@ -1669,14 +1855,8 @@ impl KvEngine {
     /// Async close for the Drop path — best-effort, uses sync path.
     pub(crate) fn drop_close(&self) {
         let _ = self.inner.lifecycle.begin_close();
-        self.flush_notifier.send(()).ok();
-        self.compaction_notifier.send(()).ok();
-        if let Some(f) = self.flush_thread.lock().take() {
-            let _ = f.join();
-        }
-        if let Some(f) = self.compaction_thread.lock().take() {
-            let _ = f.join();
-        }
+        self.background_workers.begin_shutdown(&self.inner);
+        let _ = self.background_workers.join_blocking();
         self.inner.lifecycle.finish_close();
     }
 }
@@ -1748,6 +1928,25 @@ impl LsmStorageInner {
     pub(crate) fn next_sst_id(&self) -> usize {
         self.next_sst_id
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+    }
+
+    fn normalize_recovered_level_order(state: &mut LsmStorageState, options: &LsmStorageOptions) {
+        match options.compaction_options {
+            CompactionOptions::Leveled(_)
+            | CompactionOptions::Simple(_)
+            | CompactionOptions::NoCompaction => {
+                for (_, sst_ids) in &mut state.levels {
+                    sst_ids.sort_by(|a, b| {
+                        state
+                            .sstables
+                            .get(a)
+                            .and_then(|sst| sst.first_key())
+                            .cmp(&state.sstables.get(b).and_then(|sst| sst.first_key()))
+                    });
+                }
+            }
+            CompactionOptions::Tiered(_) => {}
+        }
     }
 
     /// Phase 1 of open: validation, directory creation, vLog init, manifest
@@ -1947,6 +2146,7 @@ impl LsmStorageInner {
             }
             plan.state.sstables.insert(id, sst);
         }
+        Self::normalize_recovered_level_order(&mut plan.state, &plan.options);
 
         // Classify range-only SSTs: move them from `levels` to
         // `range_only_ssts`. Old manifests may have range-only SSTs
@@ -2075,7 +2275,7 @@ impl LsmStorageInner {
             rt_stats: Arc::new(RangeTombstoneAtomicStats::default()),
             vlog: plan.vlog,
             weak_self: std::sync::OnceLock::new(),
-            gc_handles: Mutex::new(Vec::new()),
+            background_tasks: Mutex::new(None),
             write_profile: Arc::new(crate::mem_table::WriteProfile::default()),
             lifecycle: LifecycleHandle::new(),
             blocking: BlockingExecutor::with_default(),

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1210,6 +1210,9 @@ async fn run_post_compaction_gc_task(
         let Some(inner) = weak.upgrade() else {
             break;
         };
+        if inner.lifecycle.ensure_open().is_err() {
+            break;
+        }
         let gc_vlog = Arc::clone(&vlog);
         if let Err(e) = blocking
             .run_result(move || -> Result<()> {

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1162,6 +1162,13 @@ impl BackgroundWorkers {
         }
         Ok(())
     }
+
+    /// Detach the runtime thread without joining — used in Drop paths where
+    /// blocking is unacceptable. `begin_shutdown` must have been called first;
+    /// the thread holds an `Arc<LsmStorageInner>` and will self-terminate.
+    fn detach(&self) {
+        self.runtime_thread.lock().take();
+    }
 }
 
 async fn run_periodic_background_task<F>(
@@ -1862,7 +1869,10 @@ impl KvEngine {
     pub(crate) fn drop_close(&self) {
         let _ = self.inner.lifecycle.begin_close();
         self.background_workers.begin_shutdown(&self.inner);
-        let _ = self.background_workers.join_blocking();
+        // Detach instead of joining — Drop must not block the executor thread
+        // unboundedly. The runtime thread holds an Arc and safely terminates
+        // once compaction/flush work completes after shutdown was signalled.
+        self.background_workers.detach();
         self.inner.lifecycle.finish_close();
     }
 }

--- a/rfcs/014-async-operations.md
+++ b/rfcs/014-async-operations.md
@@ -353,8 +353,15 @@ Transactions are currently selectively async:
 ```rust
 impl Transaction {
     pub fn get_async(&self, key: &[u8]) -> impl Future<Output = Result<Option<Bytes>>> + Send;
-    pub fn scan(self: &Arc<Self>, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> Result<TxnIterator>;
-    pub fn prefix_scan(self: &Arc<Self>, prefix: &[u8]) -> Result<TxnIterator>;
+    pub fn scan_async(
+        self: &Arc<Self>,
+        lower: Bound<&[u8]>,
+        upper: Bound<&[u8]>,
+    ) -> impl Future<Output = Result<AsyncTxnScan>> + Send;
+    pub fn prefix_scan_async(
+        self: &Arc<Self>,
+        prefix: &[u8],
+    ) -> impl Future<Output = Result<AsyncTxnScan>> + Send;
     pub fn put(&self, key: &[u8], value: &[u8]) -> Result<()>;
     pub fn delete(&self, key: &[u8]) -> Result<()>;
     pub fn commit_async(&self) -> impl Future<Output = Result<()>> + Send;
@@ -368,8 +375,8 @@ This split is intentional:
    synchronous unless their semantics change materially.
 2. `get` and `commit` gain async variants because they may consult engine
    state, cross blocking boundaries, or publish changes.
-3. transaction scan operations remain synchronous today and are an explicit
-   remaining gap (`AsyncTxnScan`) rather than silently omitted scope.
+3. transaction scan operations also expose async owned-cursor variants, while
+   the existing synchronous scan APIs remain available for compatibility.
 
 Transaction confinement remains part of the contract:
 
@@ -825,43 +832,50 @@ both APIs for a period of time.
 1. add `KvEngine::*_async` entrypoints. Completed.
 2. add async transaction `get`/`commit` entrypoints while keeping local-write
    helpers synchronous. Completed.
-3. add `AsyncScan` and `AsyncTxnScan`.
+3. add `AsyncScan` and `AsyncTxnScan`. Completed.
 4. keep existing correctness behavior and reuse as much synchronous core logic
    as possible;
 5. preserve serializable-mode scan rejections;
 6. preserve scan `ReadGuard` lifetime rules.
 7. define `Send` / `!Send` contracts for cursor and transaction futures.
 8. land the engine-owned blocking executor/concurrency bound together with the
-   async API.
+   async API. Completed.
 9. define how admitted foreground writes are tracked across `Closing`.
 
-Phase 1 shipped with one explicit remaining gap: transaction scans are still
-synchronous and `AsyncTxnScan` has not landed yet.
+Phase 1 is effectively complete on the current main branch: engine async
+entrypoints, async engine scans, async transaction get/commit, async
+transaction scans, and the bounded blocking executor are all in place while
+preserving the sync surface.
 
 ### Phase 2: Async Shutdown and Background Ownership
 
 1. replace notifier/join lifecycle with async-visible state management and
-   admission tracking. Partially completed.
+   admission tracking. Completed.
 2. make `close_async().await` the canonical graceful shutdown path. Completed.
 3. preserve the current split close contract for WAL and non-WAL engines.
    Completed.
 4. preserve a bounded `Drop` cleanup story rather than pure fire-and-forget
-   cancellation.
-5. enforce and test the Open/Closing/Closed state machine.
+   cancellation. Completed.
+5. enforce and test the Open/Closing/Closed state machine. Completed.
 6. add explicit registration/tracking for live scans, transactions, and
-   admitted foreground writes if shutdown semantics depend on them.
+   admitted foreground writes if shutdown semantics depend on them. Completed.
 
-Phase 2 shipped without replacing background thread ownership with runtime
-tasks. The lifecycle contract is implemented, but the engine still uses the
-existing flush/compaction thread model under the async surface.
+Phase 2 now includes runtime-owned background ownership for periodic
+flush/compaction work and its shutdown path, while preserving bounded drop
+cleanup and explicit graceful close semantics.
 
 ### Phase 3: Targeted Internal Async Execution
 
-1. move `open()` recovery orchestration behind async tasks;
-2. move flush/compaction orchestration to async tasks;
+1. move `open()` recovery orchestration behind async tasks. Completed.
+2. move flush/compaction orchestration to async tasks. Completed.
 3. measure whether selective overlap improves tail latency or throughput.
 
-Phase 3 has not started.
+Phase 3 is now substantially landed: `open_async()` uses staged blocking-task
+recovery plus parallel SST open, while periodic flush/compaction and
+post-compaction vLog GC run under the engine-owned runtime instead of ad hoc
+background threads. The remaining work is measurement and any follow-on
+internal async overlap that benchmarks justify. See
+`docs/async-phase3-measurement.md` for the measurement plan.
 
 ### Phase 4: Internal Iterator Rework
 


### PR DESCRIPTION
## Summary

Measure and harden the RFC 014 async open path.

## Changes

- move flush/compaction ownership and post-compaction vLog GC onto the engine-owned runtime
- add `async-phase3-perf` to prepare datasets and compare sync vs async open/close paths
- fix leveled recovery so manifest compaction replay no longer panics before SST handles are opened
- update RFC 014 status and add an async Phase 3 measurement plan with follow-up todos

## Measurement Highlights

- large inline leveled reopen (1989 SSTs): `open_async()` median `25.79 ms` vs sync `43.58 ms`
- WAL-enabled leveled reopen (200 SSTs): `open_async()` median `57.82 ms` vs sync `25.78 ms`
- live vLog reopen (2000 SSTs, 1889 `.vlog` files): `open_async()` median `31.74 ms` vs sync `24.61 ms`
- `close_async()` stayed effectively neutral across measured cases

## Verification

- [x] `cargo fmt --all --check`
- [x] `cargo test -p kv-engine async_api -- --nocapture`
- [x] `cargo test -p kv-engine vlog_integration_tests::gc -- --nocapture`
- [x] `cargo build -p kv-engine --bin async-phase3-perf`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `async-phase3-perf` benchmarking CLI to prepare datasets and measure repeated engine open/close latency across modes.
  * Updated API documentation to include async owned-cursor transaction scan entrypoints.
* **Bug Fixes**
  * Improved recovery behavior by applying recovery-specific compaction result handling and destination-level normalization.
  * Enhanced background maintenance and vLog GC execution during shutdown/recovery for more consistent cleanup.
* **Documentation**
  * Added an “Async Phase 3 Measurement Plan” covering metrics, scenarios, benchmark commands, and acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->