### PR TITLE
refactor: deduplicate cache single-flight logic, remove dead code, clean imports

### DIFF
--- a/kv-engine/src/cache.rs
+++ b/kv-engine/src/cache.rs
@@ -90,50 +90,17 @@ impl BlockCache {
     ///
     /// Concurrent misses on the same key are coalesced: only the first
     /// thread runs `f`; others wait and read from cache.
+    ///
+    /// Delegates to [`try_get_with`] so the single-flight miss-coalescing
+    /// logic lives in one place.
     pub fn get_or_insert<F>(&self, sst_id: usize, block_idx: usize, f: F) -> Arc<Block>
     where
         F: FnOnce() -> Arc<Block>,
     {
-        let key = (sst_id, block_idx);
-        if let Some(v) = self.inner.get(&key) {
-            self.hits.fetch_add(1, Ordering::Relaxed);
-            return v;
+        match self.try_get_with(sst_id, block_idx, || Ok::<_, std::convert::Infallible>(f())) {
+            Ok(v) => v,
+            Err(never) => match never {},
         }
-        self.misses.fetch_add(1, Ordering::Relaxed);
-        // Single-flight: acquire a per-key lock so only one thread loads.
-        let waiter = {
-            let mut w = self.waiters.lock();
-            w.entry(key).or_default().clone()
-        };
-        let _guard = waiter.lock();
-        // Double-check after acquiring the per-key lock.
-        if let Some(v) = self.inner.get(&key) {
-            // Only remove if we own this exact waiter (not a newer one).
-            let mut w = self.waiters.lock();
-            if w.get(&key).is_some_and(|cur| Arc::ptr_eq(cur, &waiter)) {
-                w.remove(&key);
-            }
-            return v;
-        }
-        let v = f();
-        let evicted = self.inner.force_put(key, v.clone(), 1);
-        self.admitted.fetch_add(1, Ordering::Relaxed);
-        self.evicted
-            .fetch_add(evicted.len() as u64, Ordering::Relaxed);
-        self.sst_blocks
-            .lock()
-            .entry(sst_id)
-            .or_default()
-            .insert(key);
-        self.count.fetch_add(1, Ordering::Relaxed);
-        {
-            let mut w = self.waiters.lock();
-            if w.get(&key).is_some_and(|cur| Arc::ptr_eq(cur, &waiter)) {
-                w.remove(&key);
-            }
-        }
-
-        v
     }
 
     /// Like [`get_or_insert`], but the closure returns `Result`.

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -4,7 +4,7 @@ mod tiered;
 
 use std::{collections::HashSet, sync::Arc};
 
-use anyhow::{Ok, Result};
+use anyhow::Result;
 pub use leveled::{LeveledCompactionController, LeveledCompactionOptions, LeveledCompactionTask};
 use serde::{Deserialize, Serialize};
 pub use simple_leveled::{

--- a/kv-engine/src/iterators/concat_iterator.rs
+++ b/kv-engine/src/iterators/concat_iterator.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::{Ok, Result};
+use anyhow::Result;
 
 use super::StorageIterator;
 use crate::{
@@ -171,18 +171,10 @@ impl StorageIterator for SstConcatIterator {
     type KeyType<'a> = KeySlice<'a>;
 
     fn key(&'_ self) -> KeySlice<'_> {
-        // if !self.is_valid() {
-        //     return KeySlice::from_slice(&[]);
-        // }
-
         self.current.as_ref().unwrap().key()
     }
 
     fn value(&self) -> &[u8] {
-        // if !self.is_valid() {
-        //     return &[];
-        // }
-
         self.current.as_ref().unwrap().value()
     }
 
@@ -191,10 +183,6 @@ impl StorageIterator for SstConcatIterator {
     }
 
     fn next(&mut self) -> Result<()> {
-        // if !self.is_valid() {
-        //     return Ok(());
-        // }
-
         self.current.as_mut().unwrap().next()?;
 
         while let Some(ref current) = self.current {

--- a/kv-engine/src/iterators/merge_iterator.rs
+++ b/kv-engine/src/iterators/merge_iterator.rs
@@ -3,7 +3,7 @@ use std::{
     collections::{BinaryHeap, binary_heap::PeekMut},
 };
 
-use anyhow::{Ok, Result};
+use anyhow::Result;
 
 use super::StorageIterator;
 use crate::key::KeySlice;

--- a/kv-engine/src/iterators/two_merge_iterator.rs
+++ b/kv-engine/src/iterators/two_merge_iterator.rs
@@ -1,4 +1,4 @@
-use anyhow::{Ok, Result};
+use anyhow::Result;
 
 use super::StorageIterator;
 

--- a/kv-engine/src/lsm_iterator.rs
+++ b/kv-engine/src/lsm_iterator.rs
@@ -1,6 +1,6 @@
 use std::ops::Bound;
 
-use anyhow::{Ok, Result, bail};
+use anyhow::{Result, bail};
 
 use crate::{
     iterators::{

--- a/kv-engine/src/vlog/gc.rs
+++ b/kv-engine/src/vlog/gc.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use ahash::AHashSet;
 
-use anyhow::{Ok, Result, anyhow};
+use anyhow::{Result, anyhow};
 use bytes::Bytes;
 
 use crate::{


### PR DESCRIPTION
## Summary

Small refactoring pass — deduplicate duplicated code, remove dead code, and clean up non-idiomatic imports.

## Changes

- **cache.rs**: `get_or_insert` now delegates to `try_get_with` by wrapping the closure in `Ok::<_, Infallible>`. Removes ~40 lines of duplicated single-flight miss-coalescing logic. Zero runtime overhead after monomorphization.

- **concat_iterator.rs**: Removed commented-out validity guard code in `key()`, `value()`, and `next()` methods.

- **compact.rs, lsm_iterator.rs, merge_iterator.rs, two_merge_iterator.rs, vlog/gc.rs**: Removed non-idiomatic `anyhow::Ok` import — `Ok` is in Rust's prelude.

## Verification

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets` clean
- [x] `cargo test` — 615 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified cache miss handling to use a shared internal path, improving consistency in how block lookups are coalesced and inserted.
* **Style**
  * Cleaned up several import lists by removing unused symbols.
  * Removed outdated commented code from iterator handling, making the code easier to read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->