### PR TITLE
rfcs: add RFC 016 for native TTL support

### DIFF
--- a/rfcs/016-ttl.md
+++ b/rfcs/016-ttl.md
@@ -418,6 +418,15 @@ This helper is used by `SsTableIterator::value()`, `parse_value_kind`, memtable
 `resolve`, and any other site that needs to strip metadata to reach the logical
 value or ValuePointer bytes.
 
+**Defensive bounds check.** Every site that slices into a TTL-prefixed value must
+validate the length before indexing. For `TtlInline` (kind 0x03), the value must
+be at least 9 bytes (1 kind + 8 expire_at_secs). For `TtlValuePointer` (0x04),
+it must be at least 25 bytes (1 + 8 + 16). A corrupted or truncated on-disk
+entry that passes the 9-byte check but is actually a shorter `TtlValuePointer`
+could cause a panic when decoding the pointer bytes. Use `value.len() >=
+kind.payload_offset() + min_expected_payload` or return `None`/an error rather
+than panicking.
+
 ### 6.4 TTL Read Path
 
 #### 6.4.1 Optional Read-Path Filtering
@@ -934,11 +943,14 @@ The scanner is a lightweight periodic task that:
    `now_secs > max_ttl_expire_ts` (all TTL entries expired).
 2. For each candidate SST, checks if wholesale drop is safe (Section 6.5.2,
    Optimization 2).
-3. If safe, performs a metadata-only deletion: removes the SST from the
-   `LsmStorageState` level, writes a manifest record to make the deletion
-   durable, and unreferences any vLog files. This bypasses the compaction
-   pipeline entirely since the SST is already at the bottommost level and no
-   per-key iteration is needed.
+3. If safe, performs a metadata-only deletion: re-checks `watermark.is_none()`
+   and applies the state mutation atomically under the `state_lock` (and MVCC
+   lock if applicable) to prevent a TOCTOU race where a reader starts and pins
+   a watermark between the safety check and state publication. Removes the SST
+   from the `LsmStorageState` level, writes a manifest record to make the
+   deletion durable, and unreferences any vLog files. This bypasses the
+   compaction pipeline entirely since the SST is already at the bottommost
+   level and no per-key iteration is needed.
 4. If not fully safe (some entries above watermark or other conditions not met),
    records the SST for prioritization in the next regular compaction round.
 

--- a/rfcs/016-ttl.md
+++ b/rfcs/016-ttl.md
@@ -175,7 +175,7 @@ pub enum KvKind {
     Tombstone = 2,
     /// Inline value with TTL. Payload: [expire_at_secs: u64 BE][user_value...]
     TtlInline = 3,
-    /// Value pointer with TTL. Payload: [expire_at_secs: u64 BE][ValuePointer: 12 bytes LE]
+    /// Value pointer with TTL. Payload: [expire_at_secs: u64 BE][ValuePointer: 16 bytes LE]
     TtlValuePointer = 4,
 }
 ```
@@ -185,10 +185,10 @@ Encoding rules:
 | Kind | Byte | Payload |
 |---|---|---|
 | Inline | `0x00` | `[user_value...]` |
-| ValuePointer | `0x01` | `[file_id: u32 LE][offset: u32 LE][len: u32 LE]` (12 bytes) |
+| ValuePointer | `0x01` | `[file_id: u32 LE][offset: u64 LE][size: u32 LE]` (16 bytes) |
 | Tombstone | `0x02` | (empty) |
 | TtlInline | `0x03` | `[expire_at_secs: u64 BE][user_value...]` |
-| TtlValuePointer | `0x04` | `[expire_at_secs: u64 BE][file_id: u32 LE][offset: u32 LE][len: u32 LE]` (20 bytes) |
+| TtlValuePointer | `0x04` | `[expire_at_secs: u64 BE][file_id: u32 LE][offset: u64 LE][size: u32 LE]` (24 bytes) |
 
 Helper methods on `KvKind`:
 
@@ -234,9 +234,10 @@ impl TtlMetadata {
         if !kind.is_ttl() {
             return None;
         }
-        // Safety: is_ttl() guarantees the value has at least 9 bytes
-        // (1 kind + 8 expire_at_secs).
-        debug_assert!(raw_value.len() >= 9, "truncated TTL value");
+        // A TTL value must have at least 1 kind byte + 8 expire_at_secs bytes.
+        if raw_value.len() < 9 {
+            return None;
+        }
         let expire_at_secs = u64::from_be_bytes(raw_value[1..9].try_into().unwrap());
         Some((
             Self { expire_at_secs, value_kind: kind },
@@ -347,7 +348,12 @@ fn compute_expire_at(ttl: Duration) -> u64 {
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .expect("system clock before Unix epoch");
-    now.as_secs().saturating_add(ttl.as_secs())
+    // Round sub-second TTLs up to the next whole second so that
+    // a 500 ms TTL behaves as "expire at start of next second"
+    // rather than silently collapsing to zero (which would expire
+    // at the current wall-clock second boundary, giving <1s of life).
+    let ttl_secs = ttl.as_secs().saturating_add(if ttl.subsec_nanos() > 0 { 1 } else { 0 });
+    now.as_secs().saturating_add(ttl_secs)
 }
 ```
 
@@ -380,9 +386,9 @@ Sites that need changes (file paths relative to `kv-engine/src/`):
 
 | File | Location | Current behavior | Required change |
 |---|---|---|---|
-| `mem_table.rs` | `flush()` (~line 808–814) | Checks `val[0] == 0x01 \|\| val[0] == 0x02` to decide pass-through vs strip-KvKind. TTL variants match neither. | Add `val[0] == 0x03 \|\| val[0] == 0x04` to the pass-through condition. TTL values are opaque blobs — pass them through unchanged like ValuePointer and Tombstone. |
-| `mem_table.rs` | `resolve` (~line 1194–1199) | For non-ValuePointer, non-Tombstone values, strips only the KvKind byte (`val.slice(1..)`). A TtlInline value would leak the 8-byte `expire_at` into the caller-visible value. | After confirming `val[0]` is not 0x01–0x04, strip 9 bytes for TTL variants: `if val[0] == 0x03 \|\| val[0] == 0x04 { val.slice(9..) } else { val.slice(1..) }`. |
-| `mem_table.rs` | `collect_vlog_file_ids` (~line 568–573) | Only decodes `ValuePointer` for byte `0x01`. TtlValuePointer (0x04) vLog references are missed, risking premature file deletion. | Also decode for byte `0x04`, reading the ValuePointer from bytes `[9..21]` instead of `[1..13]`. |
+| `mem_table.rs` | `flush()` (~line 808–814) | Checks `val[0] == 0x01 \|\| val[0] == 0x02` to decide pass-through vs strip-KvKind. TTL variants match neither. | Handle `TtlValuePointer` (0x04) the same as `ValuePointer` (pass through unchanged). Handle `TtlInline` (0x03) the same as `Inline` (0x00): if the value exceeds `min_value_size`, write the user value to the vLog and convert to `TtlValuePointer` with the same `expire_at_secs`; otherwise pass the `TtlInline` value through unchanged. |
+| `mem_table.rs` | `resolve` (~line 1194–1199) | For non-ValuePointer, non-Tombstone values, strips only the KvKind byte (`val.slice(1..)`). A TtlInline value would leak the 8-byte `expire_at` into the caller-visible value. | Check TTL variants first, then fall through: `if val[0] == 0x03 \|\| val[0] == 0x04 { val.slice(9..) } else { val.slice(1..) }`. The existing ValuePointer (0x01) and Tombstone (0x02) branches are handled before this point. |
+| `mem_table.rs` | `collect_vlog_file_ids` (~line 568–573) | Only decodes `ValuePointer` for byte `0x01`. TtlValuePointer (0x04) vLog references are missed, risking premature file deletion. | Also decode for byte `0x04`, reading the ValuePointer from bytes `[9..25]` instead of `[1..17]`. |
 | `table/builder.rs` | `add_raw` (~line 188–198) | Only tracks vLog references for byte `0x01`. TtlValuePointer files are not tracked. | Also check byte `0x04` and decode ValuePointer from offset 9. |
 | `table/iterator.rs` | `value()` (~line 168–205) | Match on `KvKind::from_u8(kind)` with arms for Inline, Tombstone, ValuePointer. TTL variants return `None` from `from_u8`, hitting the fallthrough (which panics or produces wrong output). | Add arms for `TtlInline` (strip 9-byte prefix) and `TtlValuePointer` (strip 9-byte prefix, resolve vLog). Reuse a helper `KvKind::payload_offset(self) -> usize` (returns 1 for Inline/ValuePointer/Tombstone, 9 for TTL variants). |
 | `lsm_storage.rs` | `parse_value_kind` (~line 3849–3866) | Match on `from_u8` result; `None` maps to Inline and strips 1 byte. TTL variants return `None`, so `expire_at` leaks into the value. | Map bytes 3 and 4 to new `KvKind` variants with `payload_offset = 9`. |
@@ -390,7 +396,7 @@ Sites that need changes (file paths relative to `kv-engine/src/`):
 | `lsm_storage.rs` | `resolve_vlog_value_bytes` (~line 3798–3824) | Match on `ValuePointer`, `Tombstone`, wildcard `_` for Inline. TtlValuePointer would hit the wildcard arm (treated as Inline). | Add `TtlValuePointer` arm that decodes the ValuePointer from offset 9. |
 | `lsm_storage.rs` | `values_match` (~line 5225–5235) | Match on `(Inline, Inline)` and `(ValuePointer, ValuePointer)`. TTL variants produce `false`, which is safe but breaks CAS for vLog GC. | Add `(TtlInline, TtlInline) => ...` and `(TtlValuePointer, TtlValuePointer) => ...` arms with byte-wise comparison of the full TTL-prefixed values. |
 | `lsm_storage.rs` | `build_point_batch_entries` / `build_non_mvcc_batch_entries` (~line 4540–4616) | Match exhaustively on `WriteBatchRecord` variants. `PutWithTtl` not handled. | Add `PutWithTtl(key, val, ttl_secs)` arm that computes `expire_at` and prepends `[KvKind::TtlInline][expire_at: 8][val]`. |
-| `vlog/gc.rs` | `check_liveness` (~line 193–206) | Match on `ValuePointer` only. TtlValuePointer falls to `_ => Ok(false)`, incorrectly reporting live TTL entries as dead. | Handle `TtlValuePointer` the same as `ValuePointer` (check pointer equality). Optionally also check if TTL has expired and report as dead if so. |
+| `vlog/gc.rs` | `check_liveness` (~line 193–206) | Match on `ValuePointer` only. TtlValuePointer falls to `_ => Ok(false)`, incorrectly reporting live TTL entries as dead. | Handle `TtlValuePointer` the same as `ValuePointer` (decode pointer from correct offset and check pointer equality). Do NOT add a TTL-expiry check here — expiration belongs in compaction and read filtering; dropping the vLog payload while LSM still points at it would cause stale-pointer reads. |
 | `vlog/gc.rs` | `compact_file` (~line 277–344) | Constructs replacement values with `KvKind::ValuePointer`. TTL prefix is lost on rewrite. | When the old entry has a TTL prefix, construct the replacement with `KvKind::TtlValuePointer` and preserve `expire_at_secs`. |
 | `wal.rs` | Entry decode (~line 822–827, 915–919) | Uses WAL-internal kind bytes (0=Put, 1=PointTombstone, 2=RangeTombstone), not KvKind. TTL writes use WAL kind 0 (Put) with TTL-prefixed values. | **No change needed.** WAL treats values as opaque bytes. Recovery calls `handle_put(key, value)` which inserts the TTL-prefixed bytes into the skiplist unchanged. |
 
@@ -616,14 +622,19 @@ entry has expired and the SST is safe to drop:
 ```rust
 fn can_wholesale_drop_sst(
     sst: &SsTable,
+    sst_level: usize,
+    num_levels: usize,
     now_secs: u64,
     watermark: Option<u64>,
-    compact_to_bottom_level: bool,
     compaction_filters: &[InstalledCompactionFilter],
 ) -> bool {
     sst.ttl_metadata.max_ttl_expire_ts > 0
         && now_secs > sst.ttl_metadata.max_ttl_expire_ts
-        && compact_to_bottom_level
+        // The SST must already reside at the bottommost LSM level.  A wholesale
+        // drop of an upper-level SST whose keys shadow older versions in lower
+        // levels would resurrect those older versions when the lower-level SSTs
+        // are compacted normally.
+        && sst_level == num_levels.saturating_sub(1)
         && watermark.is_some_and(|wm| sst.max_ts <= wm)
         // Safety: must not drop range tombstones that still cover lower levels.
         && sst.range_tombstones.is_none()
@@ -638,8 +649,10 @@ without reading any blocks. The conditions for safety are:
 
 1. `max_ttl_expire_ts > 0` — the SST has TTL entries.
 2. `now_secs > max_ttl_expire_ts` — all TTL entries have expired.
-3. `compact_to_bottom_level` — no lower level could hold an older version that
-   would be resurrected by dropping this SST.
+3. `sst_level == num_levels - 1` — the SST is at the bottommost LSM level. If it
+   were at an upper level, its entries shadow older versions in lower levels;
+   wholesale-dropping the upper-level SST would let those older versions survive
+   and be written to the output, resurrecting expired keys.
 4. `sst.max_ts <= watermark` — all point entries in the SST are below the MVCC
    watermark, so no active reader needs them.
 5. `sst.range_tombstones.is_none()` — dropping an SST with range tombstones would
@@ -782,8 +795,8 @@ TTL with value separation uses `KvKind::TtlValuePointer`. The encoding is:
 [0x04][expire_at_secs: u64 BE][file_id: u32 LE][offset: u32 LE][len: u32 LE]
 ```
 
-This is 21 bytes total (1 kind + 8 ttl + 12 pointer), compared with 13 bytes for
-a non-TTL `ValuePointer` (1 kind + 12 pointer).
+This is 25 bytes total (1 kind + 8 ttl + 16 pointer), compared with 17 bytes for
+a non-TTL `ValuePointer` (1 kind + 16 pointer).
 
 **vLog GC liveness.** The vLog GC liveness check (`check_liveness` in
 `vlog/gc.rs`) consults the LSM for the latest version of a key. The existing code
@@ -805,17 +818,12 @@ match current_kind {
 }
 ```
 
-Additionally, the check can optionally treat a TTL-expired entry as dead even if
-the pointer matches:
-
-```rust
-if current_kind.is_ttl() {
-    let (ttl_meta, _) = TtlMetadata::parse(&current_value).unwrap();
-    if now_secs > ttl_meta.expire_at_secs {
-        return Ok(false); // expired — no need to retain
-    }
-}
-```
+TTL expiry is **not** evaluated in vLog GC liveness. A `TtlValuePointer` remains
+the latest on-disk value until compaction removes it. If vLog GC treated an
+expired TTL entry as dead while the LSM still points at it, a stale pointer would
+be left in the SST, and subsequent reads (with read-path filtering disabled) could
+read reclaimed vLog data. Expiration is handled exclusively by compaction and
+optional read-path filtering.
 
 When the latest version carries a TTL, GC handles two cases:
 
@@ -826,12 +834,18 @@ When the latest version carries a TTL, GC handles two cases:
 
 **vLog GC rewrite.** The `compact_file` method (in `vlog/gc.rs`) constructs
 replacement values with `KvKind::ValuePointer`. TTL entries must preserve their
-`expire_at_secs` when rewritten:
+`expire_at_secs` when rewritten. Note that `TtlMetadata::parse` returns the
+**pointer bytes** (not the user value) as its payload when the kind is
+`TtlValuePointer`. The rewrite must decode the pointer, read the actual user
+value from the old vLog, append that to the new vLog, then construct a new
+`TtlValuePointer` with the preserved expiration time:
 
 ```rust
 // During vLog GC, when rewriting a live TTL value:
-let (ttl_meta, payload) = TtlMetadata::parse(&old_value).unwrap();
-let new_pointer = new_vlog.append(payload);  // append only the user value
+let (ttl_meta, pointer_bytes) = TtlMetadata::parse(&old_value).unwrap();
+let old_pointer = ValuePointer::try_decode(pointer_bytes).unwrap();
+let user_value = old_vlog.read(&old_pointer, &key)?;
+let new_pointer = new_vlog.append(&user_value);
 let new_value = encode_ttl_value_pointer(ttl_meta.expire_at_secs, new_pointer);
 // CAS-update the LSM entry to point to `new_value`.
 ```
@@ -906,9 +920,9 @@ The scanner is a lightweight periodic task that:
 The scanner does NOT iterate individual keys — it uses only per-SST metadata
 (`max_ttl_expire_ts`). This makes it O(number of SSTs), not O(number of keys).
 
-The scanner must not trigger compactions when there are active readers (same
-`can_publish_filter_deletion` gate), because compaction cannot physically drop
-entries while readers are active.
+The scanner must not trigger compactions when there are active readers (use
+`can_publish_ttl_deletion`, not `can_publish_filter_deletion`), because compaction
+cannot physically drop entries while readers are active.
 
 ### 6.11 Concurrency and Correctness
 

--- a/rfcs/016-ttl.md
+++ b/rfcs/016-ttl.md
@@ -387,7 +387,7 @@ Sites that need changes (file paths relative to `kv-engine/src/`):
 | File | Location | Current behavior | Required change |
 |---|---|---|---|
 | `mem_table.rs` | `flush()` (~line 808–814) | Checks `val[0] == 0x01 \|\| val[0] == 0x02` to decide pass-through vs strip-KvKind. TTL variants match neither. | Handle `TtlValuePointer` (0x04) the same as `ValuePointer` (pass through unchanged). Handle `TtlInline` (0x03) the same as `Inline` (0x00): if the value exceeds `min_value_size`, write the user value to the vLog and convert to `TtlValuePointer` with the same `expire_at_secs`; otherwise pass the `TtlInline` value through unchanged. |
-| `mem_table.rs` | `resolve` (~line 1194–1199) | For non-ValuePointer, non-Tombstone values, strips only the KvKind byte (`val.slice(1..)`). TTL variants would leak the 8-byte `expire_at` into the caller-visible value. | `TtlValuePointer` (0x04) must be routed to the same vLog deref path as `ValuePointer` (0x01) — it contains a 16-byte `ValuePointer` payload, not the user value. `TtlInline` (0x03) strips 9 bytes to return the user value: `if val[0] == 0x03 { val.slice(9..) }`. The existing ValuePointer (0x01) and Tombstone (0x02) branches are handled before these checks. |
+| `mem_table.rs` | `resolve_item_value` (~line 1194–1199) in `MemTableIterator` | For non-ValuePointer, non-Tombstone values, strips only the KvKind byte (`val.slice(1..)`). TTL variants would leak the 8-byte `expire_at` into the caller-visible value. | `TtlValuePointer` (0x04) must be routed to the same vLog deref path as `ValuePointer` (0x01) — it contains a 16-byte `ValuePointer` payload, not the user value. `TtlInline` (0x03) strips 9 bytes to return the user value: `if val[0] == 0x03 { val.slice(9..) }`. The existing ValuePointer (0x01) and Tombstone (0x02) branches are handled before these checks. |
 | `mem_table.rs` | `collect_vlog_file_ids` (~line 568–573) | Only decodes `ValuePointer` for byte `0x01`. TtlValuePointer (0x04) vLog references are missed, risking premature file deletion. | Also decode for byte `0x04`, reading the ValuePointer from bytes `[9..25]` instead of `[1..17]`. |
 | `table/builder.rs` | `add_raw` (~line 188–198) | Only tracks vLog references for byte `0x01`. TtlValuePointer files are not tracked. | Also check byte `0x04` and decode ValuePointer from offset 9. |
 | `table/iterator.rs` | `value()` (~line 168–205) | Match on `KvKind::from_u8(kind)` with arms for Inline, Tombstone, ValuePointer. TTL variants return `None` from `from_u8`, hitting the fallthrough (which panics or produces wrong output). | Add arms for `TtlInline` (strip 9-byte prefix) and `TtlValuePointer` (strip 9-byte prefix, resolve vLog). Reuse a helper `KvKind::payload_offset(self) -> usize` (returns 1 for Inline/ValuePointer/Tombstone, 9 for TTL variants). |
@@ -641,7 +641,8 @@ fn can_wholesale_drop_sst(
         // drop of an upper-level SST whose keys shadow older versions in lower
         // levels would resurrect those older versions when the lower-level SSTs
         // are compacted normally.
-        && sst_level == num_levels.saturating_sub(1)
+        // Level numbers are 1-based; `num_levels` is the bottommost level.
+        && sst_level == num_levels
         // Wholesale drop is only safe when there are no active readers at all.
         // Even if sst.max_ts <= watermark, active readers with read_ts above
         // sst.max_ts still expect to see the entries when read-filtering is
@@ -663,8 +664,8 @@ without reading any blocks. The conditions for safety are:
    (TTL + non-TTL) cannot be wholesale-dropped because non-TTL entries never
    expire and would be silently lost.
 3. `now_secs > max_ttl_expire_ts` — all TTL entries have expired.
-4. `sst_level == num_levels - 1` — the SST is at the bottommost LSM level. If it
-   were at an upper level, its entries shadow older versions in lower levels;
+4. `sst_level == num_levels` — the SST is at the bottommost LSM level (levels are
+   1-based in kv-engine). If it were at an upper level, its entries shadow older versions in lower levels;
    wholesale-dropping the upper-level SST would let those older versions survive
    and be written to the output, resurrecting expired keys.
 4. `sst.max_ts <= watermark` — all point entries in the SST are below the MVCC
@@ -757,9 +758,9 @@ these defaults for non-v8 SSTs.
 Existing SST and WAL readers treat TTL-prefixed values as opaque byte sequences,
 so TTL entries written by a v8 binary are readable by older binaries (the older
 binary will see the raw `[0x03][expire_at: u64 BE][value...]` bytes as the value).
-This is a deliberate compatibility choice: it allows downgrade *for read-only
-access*, though compaction and new writes in a downgraded binary will not
-understand TTL.
+This is a deliberate compatibility choice: it allows older binaries to parse the
+raw bytes if they somehow bypass the manifest v5 / SST v8 version checks, though
+downgrade is officially unsupported once the manifest and SSTs are upgraded.
 
 ### 6.7 Manifest Changes
 
@@ -848,17 +849,15 @@ When the latest version carries a TTL, GC handles two cases:
 
 **vLog GC rewrite.** The `compact_file` method (in `vlog/gc.rs`) constructs
 replacement values with `KvKind::ValuePointer`. TTL entries must preserve their
-`expire_at_secs` when rewritten. Note that `TtlMetadata::parse` returns the
-**pointer bytes** (not the user value) as its payload when the kind is
-`TtlValuePointer`. During vLog GC, `analyze_file` reads only entry headers to
-determine liveness; the raw user values are not buffered in memory. The rewrite
-must use `self.vlog.read_entry(&live_ref.ptr)` to read the value from disk,
-append it to the new vLog, and construct a new `TtlValuePointer` with the
-preserved expiration time:
+`expire_at_secs` when rewritten. To support this, `LiveEntryRef` (in
+`vlog/gc.rs`) must be extended with an `expire_at_secs: Option<u64>` field,
+populated during the liveness check in `analyze_file` (which already retrieves
+the LSM value and kind). This avoids a redundant LSM lookup per entry during
+`compact_file`. The rewrite reads the value from disk, appends it to the new
+vLog, and constructs a new `TtlValuePointer` with the preserved expiration time:
 
 ```rust
 // During vLog GC, when rewriting a live TTL value:
-let (ttl_meta, _pointer_bytes) = TtlMetadata::parse(&entry_value).unwrap();
 let (key, user_value) = self.vlog.read_entry(&live_ref.ptr)?;
 let bytes_written = new_vlog.append(&key, &user_value)?;
 let new_pointer = ValuePointer {
@@ -866,7 +865,8 @@ let new_pointer = ValuePointer {
     offset: new_vlog.offset() - bytes_written as u64,
     size: bytes_written as u32,
 };
-let new_value = encode_ttl_value_pointer(ttl_meta.expire_at_secs, new_pointer);
+let new_value = encode_ttl_value_pointer(
+    live_ref.expire_at_secs.unwrap_or(0), new_pointer);
 // CAS-update the LSM entry to point to `new_value`.
 ```
 

--- a/rfcs/016-ttl.md
+++ b/rfcs/016-ttl.md
@@ -1019,13 +1019,10 @@ cannot physically drop entries while readers are active.
 > compaction scheduler lock) and the scanner must skip any SST present in
 > that set.
 >
-> **Cross-platform file deletion.** On Windows, deleting a file while it is
-> still open by a reader or compaction thread fails with a sharing violation.
-> SST file deletion should be deferred until all handles are closed (e.g.,
-> via reference counting or by scheduling deletion after the compaction
-> round and all active iterators on the SST have been dropped). On Unix,
-> the file can be unlinked immediately and the space is reclaimed when the
-> last fd is closed.
+> **File deletion.** The engine targets Linux only. On Unix, SST files can
+> be unlinked immediately while still open by readers or compaction threads;
+> the space is reclaimed when the last fd is closed, so no reference-counting
+> or deferred-deletion mechanism is needed.
 
 ### 6.11 Concurrency and Correctness
 

--- a/rfcs/016-ttl.md
+++ b/rfcs/016-ttl.md
@@ -629,6 +629,16 @@ let has_expirable = sst.ttl_metadata.max_ttl_expire_ts > 0
 If `has_expirable` is false, no entry in this SST has expired, and the per-entry
 TTL check can be skipped for all entries from this SST.
 
+> **Note:** Implementing this optimization cleanly is challenging because
+> compaction reads through a merged iterator (e.g., `MergeIterator` or
+> `TwoMergeIterator`) that abstracts away the source SST of each entry. Exposing
+> the source SST through the `StorageIterator` interface would violate its
+> abstraction. Since `KvKind::is_ttl()` is a simple single-byte check already
+> performed on the hot path, the overhead of checking non-TTL entries is
+> negligible. This optimization may be deferred or implemented by passing
+> per-iterator TTL metadata through a side channel rather than modifying the
+> iterator trait.
+
 **Optimization 2: Wholesale-drop SSTs with all entries expired.** If every TTL
 entry has expired and the SST is safe to drop:
 
@@ -675,18 +685,23 @@ without reading any blocks. The conditions for safety are:
    expire and would be silently lost.
 3. `now_secs > max_ttl_expire_ts` — all TTL entries have expired.
 4. `sst_level == num_levels` — the SST is at the bottommost LSM level (levels are
-   1-based in kv-engine). If it were at an upper level, its entries shadow older versions in lower levels;
-   wholesale-dropping the upper-level SST would let those older versions survive
-   and be written to the output, resurrecting expired keys.
+   1-based in kv-engine). If it were at an upper level, its entries shadow older
+   versions in lower levels; wholesale-dropping the upper-level SST would let those
+   older versions survive and be written to the output, resurrecting expired keys.
+   **This condition applies to Leveled and Simple Leveled compaction strategies**
+   where levels follow a sequential 1-based hierarchy. For Tiered compaction,
+   tiers may have overlapping key ranges and do not follow a simple sequential
+   order; wholesale drop is **not** safe under Tiered compaction and must be
+   disabled.
 5. `can_publish_ttl_deletion` — no active MVCC readers exist. When MVCC is
    enabled, `watermark` is always `Some(ts)`, so `watermark.is_none()` would never
    be true. This gate correctly checks whether the MVCC watermark has zero active
    readers, preventing snapshot isolation violations.
-7. `sst.range_tombstones.is_none()` — dropping an SST with range tombstones would
+6. `sst.range_tombstones.is_none()` — dropping an SST with range tombstones would
    silently remove those tombstones, resurrecting older versions in lower levels
    that the tombstones were hiding. SSTs carrying range tombstones must be
    iterated normally so that range-tombstone fragment merge/GC can run.
-8. `compaction_filters.is_empty()` — wholesale drop skips all per-entry iteration,
+7. `compaction_filters.is_empty()` — wholesale drop skips all per-entry iteration,
    so installed compaction filters would never inspect the keys and could miss
    predicate matches. When filters are active, the SST must be iterated normally.
 
@@ -829,9 +844,16 @@ a non-TTL `ValuePointer` (1 kind + 16 pointer).
 `vlog/gc.rs`) consults the LSM for the latest version of a key. The existing code
 matches on `KvKind::ValuePointer` only; a `TtlValuePointer` would fall to the
 wildcard `_ => Ok(false)` arm and be incorrectly reported as dead. This check
-must be updated:
+must be updated to handle TTL variants and to return the optional expiration
+timestamp alongside the liveness boolean so `analyze_file` can propagate it
+into `LiveEntryRef` without a redundant LSM lookup:
 
 ```rust
+// check_liveness return type changes from Result<bool> to
+// Result<Option<Option<u64>>> where:
+//   Ok(None)         — entry is dead
+//   Ok(Some(None))   — entry is live, no TTL
+//   Ok(Some(Some(ts))) — entry is live, expires at `ts`
 // In check_liveness (vlog/gc.rs), handle TTL variants:
 match current_kind {
     KvKind::ValuePointer | KvKind::TtlValuePointer => {
@@ -957,11 +979,15 @@ The scanner is a lightweight periodic task that:
    and applies the state mutation atomically under the `state_lock` (and MVCC
    lock if applicable) to prevent a TOCTOU race where a reader starts and pins
    a watermark between the safety check and state publication. Removes the SST
-   from the `LsmStorageState` level, deletes the SST file from disk to reclaim
-   storage space, writes a manifest record to make the deletion durable, and
-   unreferences any vLog files. This bypasses the
-   compaction pipeline entirely since the SST is already at the bottommost
-   level and no per-key iteration is needed.
+   from the `LsmStorageState` level, writes a manifest record to make the
+   deletion durable, deletes the SST file from disk to reclaim storage space,
+   and unreferences any vLog files. The manifest record is written and synced
+   **before** the physical SST file is deleted from disk to ensure crash
+   safety: if the engine crashes between the manifest write and the file
+   deletion, recovery replays the manifest and sees the SST has been removed;
+   if the file deletion failed, it is re-attempted on next scan. This
+   bypasses the compaction pipeline entirely since the SST is already at the
+   bottommost level and no per-key iteration is needed.
 4. If not fully safe (some entries above watermark or other conditions not met),
    records the SST for prioritization in the next regular compaction round.
 

--- a/rfcs/016-ttl.md
+++ b/rfcs/016-ttl.md
@@ -347,7 +347,7 @@ The expiration time is computed at the point of `put_with_ttl` call:
 fn compute_expire_at(ttl: Duration) -> u64 {
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
-        .expect("system clock before Unix epoch");
+        .unwrap_or(Duration::ZERO);
     // Round sub-second TTLs up to the next whole second so that
     // a 500 ms TTL behaves as "expire at start of next second"
     // rather than silently collapsing to zero (which would expire
@@ -387,12 +387,12 @@ Sites that need changes (file paths relative to `kv-engine/src/`):
 | File | Location | Current behavior | Required change |
 |---|---|---|---|
 | `mem_table.rs` | `flush()` (~line 808–814) | Checks `val[0] == 0x01 \|\| val[0] == 0x02` to decide pass-through vs strip-KvKind. TTL variants match neither. | Handle `TtlValuePointer` (0x04) the same as `ValuePointer` (pass through unchanged). Handle `TtlInline` (0x03) the same as `Inline` (0x00): if the value exceeds `min_value_size`, write the user value to the vLog and convert to `TtlValuePointer` with the same `expire_at_secs`; otherwise pass the `TtlInline` value through unchanged. |
-| `mem_table.rs` | `resolve` (~line 1194–1199) | For non-ValuePointer, non-Tombstone values, strips only the KvKind byte (`val.slice(1..)`). A TtlInline value would leak the 8-byte `expire_at` into the caller-visible value. | Check TTL variants first, then fall through: `if val[0] == 0x03 \|\| val[0] == 0x04 { val.slice(9..) } else { val.slice(1..) }`. The existing ValuePointer (0x01) and Tombstone (0x02) branches are handled before this point. |
+| `mem_table.rs` | `resolve` (~line 1194–1199) | For non-ValuePointer, non-Tombstone values, strips only the KvKind byte (`val.slice(1..)`). TTL variants would leak the 8-byte `expire_at` into the caller-visible value. | `TtlValuePointer` (0x04) must be routed to the same vLog deref path as `ValuePointer` (0x01) — it contains a 16-byte `ValuePointer` payload, not the user value. `TtlInline` (0x03) strips 9 bytes to return the user value: `if val[0] == 0x03 { val.slice(9..) }`. The existing ValuePointer (0x01) and Tombstone (0x02) branches are handled before these checks. |
 | `mem_table.rs` | `collect_vlog_file_ids` (~line 568–573) | Only decodes `ValuePointer` for byte `0x01`. TtlValuePointer (0x04) vLog references are missed, risking premature file deletion. | Also decode for byte `0x04`, reading the ValuePointer from bytes `[9..25]` instead of `[1..17]`. |
 | `table/builder.rs` | `add_raw` (~line 188–198) | Only tracks vLog references for byte `0x01`. TtlValuePointer files are not tracked. | Also check byte `0x04` and decode ValuePointer from offset 9. |
 | `table/iterator.rs` | `value()` (~line 168–205) | Match on `KvKind::from_u8(kind)` with arms for Inline, Tombstone, ValuePointer. TTL variants return `None` from `from_u8`, hitting the fallthrough (which panics or produces wrong output). | Add arms for `TtlInline` (strip 9-byte prefix) and `TtlValuePointer` (strip 9-byte prefix, resolve vLog). Reuse a helper `KvKind::payload_offset(self) -> usize` (returns 1 for Inline/ValuePointer/Tombstone, 9 for TTL variants). |
 | `lsm_storage.rs` | `parse_value_kind` (~line 3849–3866) | Match on `from_u8` result; `None` maps to Inline and strips 1 byte. TTL variants return `None`, so `expire_at` leaks into the value. | Map bytes 3 and 4 to new `KvKind` variants with `payload_offset = 9`. |
-| `lsm_storage.rs` | `resolve_value` (~line 3780–3788) | Match on `ValuePointer`, `Inline \| Tombstone`. Non-exhaustive after adding TTL variants. | Add `TtlInline \| TtlValuePointer \| ...` to the Inline/Tombstone arm (TTL values are resolved the same way — inline bytes are returned, ValuePointer is dereferenced). |
+| `lsm_storage.rs` | `resolve_value` (~line 3780–3788) | Match on `ValuePointer`, `Inline \| Tombstone`. Non-exhaustive after adding TTL variants. | Add `TtlInline` to the `Inline/Tombstone` arm (strips prefix, returns user value bytes directly). Add `TtlValuePointer` to the `ValuePointer` arm so it is dereferenced via `resolve_vlog_value_bytes` — placing it in `Inline/Tombstone` would return raw pointer bytes as the user value, bypassing vLog lookup. |
 | `lsm_storage.rs` | `resolve_vlog_value_bytes` (~line 3798–3824) | Match on `ValuePointer`, `Tombstone`, wildcard `_` for Inline. TtlValuePointer would hit the wildcard arm (treated as Inline). | Add `TtlValuePointer` arm that decodes the ValuePointer from offset 9. |
 | `lsm_storage.rs` | `values_match` (~line 5225–5235) | Match on `(Inline, Inline)` and `(ValuePointer, ValuePointer)`. TTL variants produce `false`, which is safe but breaks CAS for vLog GC. | Add `(TtlInline, TtlInline) => ...` and `(TtlValuePointer, TtlValuePointer) => ...` arms with byte-wise comparison of the full TTL-prefixed values. |
 | `lsm_storage.rs` | `build_point_batch_entries` / `build_non_mvcc_batch_entries` (~line 4540–4616) | Match exhaustively on `WriteBatchRecord` variants. `PutWithTtl` not handled. | Add `PutWithTtl(key, val, ttl_secs)` arm that computes `expire_at` and prepends `[KvKind::TtlInline][expire_at: 8][val]`. |
@@ -635,7 +635,8 @@ fn can_wholesale_drop_sst(
         // levels would resurrect those older versions when the lower-level SSTs
         // are compacted normally.
         && sst_level == num_levels.saturating_sub(1)
-        && watermark.is_some_and(|wm| sst.max_ts <= wm)
+        // When there are no active readers, all versions are safe to drop.
+        && watermark.map_or(true, |wm| sst.max_ts <= wm)
         // Safety: must not drop range tombstones that still cover lower levels.
         && sst.range_tombstones.is_none()
         // Safety: compaction filters may have a predicate on keys in this SST.
@@ -792,7 +793,7 @@ read `min_ttl_expire_ts` and `max_ttl_expire_ts`.
 TTL with value separation uses `KvKind::TtlValuePointer`. The encoding is:
 
 ```text
-[0x04][expire_at_secs: u64 BE][file_id: u32 LE][offset: u32 LE][len: u32 LE]
+[0x04][expire_at_secs: u64 BE][file_id: u32 LE][offset: u64 LE][size: u32 LE]
 ```
 
 This is 25 bytes total (1 kind + 8 ttl + 16 pointer), compared with 17 bytes for
@@ -836,22 +837,24 @@ When the latest version carries a TTL, GC handles two cases:
 replacement values with `KvKind::ValuePointer`. TTL entries must preserve their
 `expire_at_secs` when rewritten. Note that `TtlMetadata::parse` returns the
 **pointer bytes** (not the user value) as its payload when the kind is
-`TtlValuePointer`. The rewrite must decode the pointer, read the actual user
-value from the old vLog, append that to the new vLog, then construct a new
+`TtlValuePointer`. Since vLog GC performs a sequential scan of the old vLog file,
+the raw user value is already available in memory from that scan — no additional
+disk read is needed. The rewrite decodes the old pointer, maps it to the
+already-buffered user value, appends that to the new vLog, and constructs a new
 `TtlValuePointer` with the preserved expiration time:
 
 ```rust
 // During vLog GC, when rewriting a live TTL value:
-let (ttl_meta, pointer_bytes) = TtlMetadata::parse(&old_value).unwrap();
-let old_pointer = ValuePointer::try_decode(pointer_bytes).unwrap();
-let user_value = old_vlog.read(&old_pointer, &key)?;
+// `user_value` is the raw value bytes already read during the sequential scan
+// of the old vLog file.
+let (ttl_meta, _pointer_bytes) = TtlMetadata::parse(&entry_value).unwrap();
 let new_pointer = new_vlog.append(&user_value);
 let new_value = encode_ttl_value_pointer(ttl_meta.expire_at_secs, new_pointer);
 // CAS-update the LSM entry to point to `new_value`.
 ```
 
 where `encode_ttl_value_pointer` constructs
-`[KvKind::TtlValuePointer as u8][expire_at_secs: u64 BE][file_id: u32 LE][offset: u32 LE][len: u32 LE]`.
+`[KvKind::TtlValuePointer as u8][expire_at_secs: u64 BE][file_id: u32 LE][offset: u64 LE][size: u32 LE]`.
 
 **TTL and vLog file deletion.** The invariant from RFC 010, Section 10.4 applies:
 a vLog file can be deleted only after no live SST references it. TTL-expired

--- a/rfcs/016-ttl.md
+++ b/rfcs/016-ttl.md
@@ -277,8 +277,8 @@ impl KvEngine {
     /// When `LsmStorageOptions::ttl_read_filtering` is enabled, the key
     /// becomes invisible to reads once `now() > expire_at`.
     ///
-    /// # Panics
-    /// Panics if the system clock is before the Unix epoch.
+    /// If the system clock is before the Unix epoch, the current time is
+    /// treated as the Unix epoch (January 1, 1970) rather than panicking.
     pub fn put_with_ttl(
         &self,
         key: &[u8],
@@ -642,8 +642,11 @@ fn can_wholesale_drop_sst(
         // levels would resurrect those older versions when the lower-level SSTs
         // are compacted normally.
         && sst_level == num_levels.saturating_sub(1)
-        // When there are no active readers, all versions are safe to drop.
-        && watermark.map_or(true, |wm| sst.max_ts <= wm)
+        // Wholesale drop is only safe when there are no active readers at all.
+        // Even if sst.max_ts <= watermark, active readers with read_ts above
+        // sst.max_ts still expect to see the entries when read-filtering is
+        // disabled, and dropping the SST mid-snapshot violates isolation.
+        && watermark.is_none()
         // Safety: must not drop range tombstones that still cover lower levels.
         && sst.range_tombstones.is_none()
         // Safety: compaction filters may have a predicate on keys in this SST.
@@ -856,8 +859,13 @@ preserved expiration time:
 ```rust
 // During vLog GC, when rewriting a live TTL value:
 let (ttl_meta, _pointer_bytes) = TtlMetadata::parse(&entry_value).unwrap();
-let user_value = self.vlog.read_entry(&live_ref.ptr)?;
-let new_pointer = new_vlog.append(&user_value);
+let (key, user_value) = self.vlog.read_entry(&live_ref.ptr)?;
+let bytes_written = new_vlog.append(&key, &user_value)?;
+let new_pointer = ValuePointer {
+    file_id: new_file_id,
+    offset: new_vlog.offset() - bytes_written as u64,
+    size: bytes_written as u32,
+};
 let new_value = encode_ttl_value_pointer(ttl_meta.expire_at_secs, new_pointer);
 // CAS-update the LSM entry to point to `new_value`.
 ```

--- a/rfcs/016-ttl.md
+++ b/rfcs/016-ttl.md
@@ -395,7 +395,7 @@ Sites that need changes (file paths relative to `kv-engine/src/`):
 | `lsm_storage.rs` | `resolve_value` (~line 3780–3788) | Match on `ValuePointer`, `Inline \| Tombstone`. Non-exhaustive after adding TTL variants. | Add `TtlInline` to the `Inline/Tombstone` arm (strips prefix, returns user value bytes directly). Add `TtlValuePointer` to the `ValuePointer` arm so it is dereferenced via `resolve_vlog_value_bytes` — placing it in `Inline/Tombstone` would return raw pointer bytes as the user value, bypassing vLog lookup. |
 | `lsm_storage.rs` | `resolve_vlog_value_bytes` (~line 3798–3824) | Match on `ValuePointer`, `Tombstone`, wildcard `_` for Inline. TtlValuePointer would hit the wildcard arm (treated as Inline). | Add `TtlValuePointer` arm that decodes the ValuePointer from offset 9. |
 | `lsm_storage.rs` | `values_match` (~line 5225–5235) | Match on `(Inline, Inline)` and `(ValuePointer, ValuePointer)`. TTL variants produce `false`, which is safe but breaks CAS for vLog GC. | Add `(TtlInline, TtlInline) => ...` and `(TtlValuePointer, TtlValuePointer) => ...` arms with byte-wise comparison of the full TTL-prefixed values. |
-| `lsm_storage.rs` | `build_point_batch_entries` / `build_non_mvcc_batch_entries` (~line 4540–4616) | Match exhaustively on `WriteBatchRecord` variants. `PutWithTtl` not handled. | Add `PutWithTtl(key, val, ttl_secs)` arm that computes `expire_at` and prepends `[KvKind::TtlInline][expire_at: 8][val]`. |
+| `lsm_storage.rs` | `build_point_batch_entries` / `build_non_mvcc_batch_entries` (~line 4540–4616) | Match exhaustively on `WriteBatchRecord` variants. `PutWithTtl` not handled. | Add `PutWithTtl(key, val, ttl_secs)` arm that computes `expire_at` and prepends `[KvKind::TtlInline][expire_at: 8][val]`. **Lifetime note:** the value bytes must be copied (e.g., `val.to_vec()`) before constructing the TTL-prefixed value to avoid holding a reference into memtable skiplist memory that could be invalidated by concurrent writes within the same batch pipeline. |
 | `vlog/gc.rs` | `check_liveness` (~line 193–206) | Match on `ValuePointer` only. TtlValuePointer falls to `_ => Ok(false)`, incorrectly reporting live TTL entries as dead. | Handle `TtlValuePointer` the same as `ValuePointer` (decode pointer from correct offset and check pointer equality). Do NOT add a TTL-expiry check here — expiration belongs in compaction and read filtering; dropping the vLog payload while LSM still points at it would cause stale-pointer reads. |
 | `vlog/gc.rs` | `compact_file` (~line 277–344) | Constructs replacement values with `KvKind::ValuePointer`. TTL prefix is lost on rewrite. | When the old entry has a TTL prefix, construct the replacement with `KvKind::TtlValuePointer` and preserve `expire_at_secs`. |
 | `wal.rs` | Entry decode (~line 822–827, 915–919) | Uses WAL-internal kind bytes (0=Put, 1=PointTombstone, 2=RangeTombstone), not KvKind. TTL writes use WAL kind 0 (Put) with TTL-prefixed values. | **No change needed.** WAL treats values as opaque bytes. Recovery calls `handle_put(key, value)` which inserts the TTL-prefixed bytes into the skiplist unchanged. |
@@ -650,6 +650,7 @@ fn can_wholesale_drop_sst(
     now_secs: u64,
     can_publish_ttl_deletion: bool,
     compaction_filters: &[InstalledCompactionFilter],
+    compaction_strategy: CompactionStrategy,
 ) -> bool {
     sst.ttl_metadata.max_ttl_expire_ts > 0
         // Must NOT contain any non-TTL entries — a mixed SST cannot
@@ -673,6 +674,12 @@ fn can_wholesale_drop_sst(
         // Safety: compaction filters may have a predicate on keys in this SST.
         // Wholesale drop skips all iteration, so filters would never fire.
         && compaction_filters.is_empty()
+        // Safety: NoCompaction strategy has no bottommost level — all SSTs
+        // are at level 0 and no compaction ever runs, so there is no
+        // opportunity for older versions in lower levels to be shadowed
+        // and properly handled. Wholesale drops are only safe when a
+        // level hierarchy exists (Leveled, Simple Leveled, Tiered).
+        && compaction_strategy != NoCompaction
 }
 ```
 
@@ -704,6 +711,10 @@ without reading any blocks. The conditions for safety are:
 7. `compaction_filters.is_empty()` — wholesale drop skips all per-entry iteration,
    so installed compaction filters would never inspect the keys and could miss
    predicate matches. When filters are active, the SST must be iterated normally.
+8. `compaction_strategy != NoCompaction` — the `NoCompaction` strategy has no
+   level hierarchy (all SSTs stay at level 0), so there is no concept of a
+   bottommost level and no compaction to handle shadowed older versions.
+   Wholesale drops are only safe when a level hierarchy exists.
 
 If condition 4 is not met (some entries above watermark), the SST must still be
 iterated normally to preserve the above-watermark entries. The non-TTL and

--- a/rfcs/016-ttl.md
+++ b/rfcs/016-ttl.md
@@ -452,7 +452,7 @@ fn is_ttl_expired(raw_value: &[u8]) -> bool {
     if let Some((ttl_meta, _payload)) = TtlMetadata::parse(raw_value) {
         let now = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap()
+            .unwrap_or(Duration::ZERO)
             .as_secs();
         now > ttl_meta.expire_at_secs
     } else {
@@ -638,7 +638,7 @@ fn can_wholesale_drop_sst(
     sst_level: usize,
     num_levels: usize,
     now_secs: u64,
-    watermark: Option<u64>,
+    can_publish_ttl_deletion: bool,
     compaction_filters: &[InstalledCompactionFilter],
 ) -> bool {
     sst.ttl_metadata.max_ttl_expire_ts > 0
@@ -653,10 +653,11 @@ fn can_wholesale_drop_sst(
         // Level numbers are 1-based; `num_levels` is the bottommost level.
         && sst_level == num_levels
         // Wholesale drop is only safe when there are no active readers at all.
-        // Even if sst.max_ts <= watermark, active readers with read_ts above
-        // sst.max_ts still expect to see the entries when read-filtering is
-        // disabled, and dropping the SST mid-snapshot violates isolation.
-        && watermark.is_none()
+        // When MVCC is enabled, `watermark` is always `Some(ts)` (even with zero
+        // readers it equals `latest_commit_ts`), so `watermark.is_none()` would
+        // never be true. Use `can_publish_ttl_deletion` which correctly checks
+        // whether the MVCC watermark has zero active readers.
+        && can_publish_ttl_deletion
         // Safety: must not drop range tombstones that still cover lower levels.
         && sst.range_tombstones.is_none()
         // Safety: compaction filters may have a predicate on keys in this SST.
@@ -832,10 +833,14 @@ must be updated:
 // In check_liveness (vlog/gc.rs), handle TTL variants:
 match current_kind {
     KvKind::ValuePointer | KvKind::TtlValuePointer => {
-        // Decode pointer from offset 1 (ValuePointer) or 9 (TtlValuePointer).
-        let ptr_offset = current_kind.payload_offset();
-        let current_ptr = ValuePointer::try_decode(&current_value[ptr_offset..]);
-        Ok(current_ptr == Some(old_ptr))
+        if let Some(ref val) = current_val {
+            // Decode pointer from offset 1 (ValuePointer) or 9 (TtlValuePointer).
+            let ptr_offset = current_kind.payload_offset();
+            let current_ptr = ValuePointer::try_decode(&val[ptr_offset..]);
+            Ok(current_ptr == Some(old_ptr))
+        } else {
+            Ok(false)
+        }
     }
     KvKind::Tombstone => Ok(false), // deleted — dead
     _ => Ok(false), // Inline / TtlInline — not a vLog reference
@@ -874,8 +879,11 @@ let new_pointer = ValuePointer {
     offset: new_vlog.offset() - bytes_written as u64,
     size: bytes_written as u32,
 };
-let new_value = encode_ttl_value_pointer(
-    live_ref.expire_at_secs.unwrap_or(0), new_pointer);
+let new_value = if let Some(expire_at) = live_ref.expire_at_secs {
+    encode_ttl_value_pointer(expire_at, new_pointer)
+} else {
+    new_pointer.encode()  // regular ValuePointer, no TTL
+};
 // CAS-update the LSM entry to point to `new_value`.
 ```
 

--- a/rfcs/016-ttl.md
+++ b/rfcs/016-ttl.md
@@ -678,13 +678,15 @@ without reading any blocks. The conditions for safety are:
    1-based in kv-engine). If it were at an upper level, its entries shadow older versions in lower levels;
    wholesale-dropping the upper-level SST would let those older versions survive
    and be written to the output, resurrecting expired keys.
-4. `sst.max_ts <= watermark` — all point entries in the SST are below the MVCC
-   watermark, so no active reader needs them.
-5. `sst.range_tombstones.is_none()` — dropping an SST with range tombstones would
+5. `can_publish_ttl_deletion` — no active MVCC readers exist. When MVCC is
+   enabled, `watermark` is always `Some(ts)`, so `watermark.is_none()` would never
+   be true. This gate correctly checks whether the MVCC watermark has zero active
+   readers, preventing snapshot isolation violations.
+7. `sst.range_tombstones.is_none()` — dropping an SST with range tombstones would
    silently remove those tombstones, resurrecting older versions in lower levels
    that the tombstones were hiding. SSTs carrying range tombstones must be
    iterated normally so that range-tombstone fragment merge/GC can run.
-6. `compaction_filters.is_empty()` — wholesale drop skips all per-entry iteration,
+8. `compaction_filters.is_empty()` — wholesale drop skips all per-entry iteration,
    so installed compaction filters would never inspect the keys and could miss
    predicate matches. When filters are active, the SST must be iterated normally.
 
@@ -748,9 +750,9 @@ For SSTs with no TTL entries, `min_ttl_expire_ts = u64::MAX` and
 `max_ttl_expire_ts = 0`. These sentinel values are chosen so that:
 
 - `sst.max_ttl_expire_ts == 0` is a fast check for "no TTL entries".
-- `now_secs <= sst.min_ttl_expire_ts` is never true when `min_ttl_expire_ts == u64::MAX`
-  (assuming realistic wall-clock values), so the "no expired entries" fast path
-  correctly falls through.
+- `now_secs > sst.min_ttl_expire_ts` is never true when `min_ttl_expire_ts == u64::MAX`,
+  so the "has expirable entries" check correctly returns false for SSTs with no
+  TTL entries.
 
 Legacy SSTs (v2–v7) implicitly have `min_ttl_expire_ts = u64::MAX` and
 `max_ttl_expire_ts = 0` since they contain no TTL entries. `SsTable::open` sets
@@ -873,7 +875,7 @@ vLog, and constructs a new `TtlValuePointer` with the preserved expiration time:
 ```rust
 // During vLog GC, when rewriting a live TTL value:
 let (key, user_value) = self.vlog.read_entry(&live_ref.ptr)?;
-let bytes_written = new_vlog.append(&key, &user_value)?;
+let bytes_written = new_vlog.append(&key, &value)?;
 let new_pointer = ValuePointer {
     file_id: new_file_id,
     offset: new_vlog.offset() - bytes_written as u64,
@@ -951,12 +953,13 @@ The scanner is a lightweight periodic task that:
    `now_secs > max_ttl_expire_ts` (all TTL entries expired).
 2. For each candidate SST, checks if wholesale drop is safe (Section 6.5.2,
    Optimization 2).
-3. If safe, performs a metadata-only deletion: re-checks `watermark.is_none()`
+3. If safe, performs a metadata-only deletion: re-checks `can_publish_ttl_deletion`
    and applies the state mutation atomically under the `state_lock` (and MVCC
    lock if applicable) to prevent a TOCTOU race where a reader starts and pins
    a watermark between the safety check and state publication. Removes the SST
-   from the `LsmStorageState` level, writes a manifest record to make the
-   deletion durable, and unreferences any vLog files. This bypasses the
+   from the `LsmStorageState` level, deletes the SST file from disk to reclaim
+   storage space, writes a manifest record to make the deletion durable, and
+   unreferences any vLog files. This bypasses the
    compaction pipeline entirely since the SST is already at the bottommost
    level and no per-key iteration is needed.
 4. If not fully safe (some entries above watermark or other conditions not met),

--- a/rfcs/016-ttl.md
+++ b/rfcs/016-ttl.md
@@ -849,11 +849,16 @@ timestamp alongside the liveness boolean so `analyze_file` can propagate it
 into `LiveEntryRef` without a redundant LSM lookup:
 
 ```rust
-// check_liveness return type changes from Result<bool> to
-// Result<Option<Option<u64>>> where:
-//   Ok(None)         — entry is dead
-//   Ok(Some(None))   — entry is live, no TTL
-//   Ok(Some(Some(ts))) — entry is live, expires at `ts`
+/// Self-documenting enum for liveness status returned by check_liveness.
+pub enum Liveness {
+    /// Entry is dead — can be garbage collected.
+    Dead,
+    /// Entry is live. `expire_at` is `Some(ts)` for TTL entries,
+    /// `None` for non-TTL entries.
+    Live { expire_at: Option<u64> },
+}
+
+// check_liveness return type changes from Result<bool> to Result<Liveness>
 // In check_liveness (vlog/gc.rs), handle TTL variants:
 match current_kind {
     KvKind::ValuePointer | KvKind::TtlValuePointer => {

--- a/rfcs/016-ttl.md
+++ b/rfcs/016-ttl.md
@@ -883,12 +883,19 @@ be left in the SST, and subsequent reads (with read-path filtering disabled) cou
 read reclaimed vLog data. Expiration is handled exclusively by compaction and
 optional read-path filtering.
 
-When the latest version carries a TTL, GC handles two cases:
+When the latest version carries a TTL, GC does **not** decide liveness based on
+TTL expiry — it follows the same pointer-based rule as non-TTL entries. The two
+outcomes are:
 
-1. **TTL not yet expired.** The value is live and must be retained. GC copies the
-   TTL-prefixed value pointer into the new vLog file during `compact_file`.
-2. **TTL expired.** The value is dead. GC drops it (same as a tombstone or
-   overwritten value).
+1. **LSM still references this entry (live).** GC copies the TTL-prefixed value
+   pointer into the new vLog file during `compact_file`, preserving the
+   `expire_at_secs` and `KvKind::TtlValuePointer` encoding unchanged.
+2. **LSM no longer references this entry (dead — overwritten or deleted).**
+   GC drops it, same as any non-TTL entry.
+
+TTL expiry alone is never a reason to drop a vLog entry; expiration is handled
+exclusively by compaction. This ensures a stale vLog pointer is never left in
+the LSM.
 
 **vLog GC rewrite.** The `compact_file` method (in `vlog/gc.rs`) constructs
 replacement values with `KvKind::ValuePointer`. TTL entries must preserve their
@@ -1002,6 +1009,23 @@ The scanner does NOT iterate individual keys — it uses only per-SST metadata
 The scanner must not trigger compactions when there are active readers (use
 `can_publish_ttl_deletion`, not `can_publish_filter_deletion`), because compaction
 cannot physically drop entries while readers are active.
+
+> **Coordination with active compactions.** The scanner must check that no SST
+> candidate is currently part of an active compaction's input set. Compaction
+> selects inputs and iterates them without holding the `state_lock`; if the
+> scanner deletes an SST that compaction is actively reading, the compaction
+> will resurrect its expired entries in the output SST. The implementation
+> should track active compaction input SSTs (e.g., in a `HashSet` under the
+> compaction scheduler lock) and the scanner must skip any SST present in
+> that set.
+>
+> **Cross-platform file deletion.** On Windows, deleting a file while it is
+> still open by a reader or compaction thread fails with a sharing violation.
+> SST file deletion should be deferred until all handles are closed (e.g.,
+> via reference counting or by scheduling deletion after the compaction
+> round and all active iterators on the SST have been dropped). On Unix,
+> the file can be unlinked immediately and the space is reclaimed when the
+> last fd is closed.
 
 ### 6.11 Concurrency and Correctness
 

--- a/rfcs/016-ttl.md
+++ b/rfcs/016-ttl.md
@@ -536,7 +536,7 @@ computed separately from `can_publish_filter_deletion`. The existing
 and no-active-readers checks: ```rust
 // In compact.rs, added alongside the existing can_publish_filter_deletion:
 let can_publish_ttl_deletion = compact_to_bottom_level
-    && self.mvcc.as_ref().is_some_and(|m| m.can_publish_filter_deletion());
+    && self.mvcc.as_ref().map_or(true, |m| m.can_publish_filter_deletion());
 ```
 
 This ensures that no active MVCC reader can observe a partially-compacted state
@@ -600,6 +600,10 @@ pub struct SsTableTtlMetadata {
     /// The maximum `expire_at_secs` among all TTL entries in this SST.
     /// 0 if the SST contains no TTL entries.
     pub max_ttl_expire_ts: u64,
+    /// Whether this SST contains any non-TTL entries (Inline, ValuePointer,
+    /// Tombstone). If true, the SST cannot be wholesale-dropped even if all
+    /// TTL entries have expired, because non-TTL entries never expire.
+    pub has_non_ttl_entries: bool,
 }
 ```
 
@@ -629,6 +633,9 @@ fn can_wholesale_drop_sst(
     compaction_filters: &[InstalledCompactionFilter],
 ) -> bool {
     sst.ttl_metadata.max_ttl_expire_ts > 0
+        // Must NOT contain any non-TTL entries — a mixed SST cannot
+        // be wholesale-dropped because non-TTL entries never expire.
+        && !sst.ttl_metadata.has_non_ttl_entries
         && now_secs > sst.ttl_metadata.max_ttl_expire_ts
         // The SST must already reside at the bottommost LSM level.  A wholesale
         // drop of an upper-level SST whose keys shadow older versions in lower
@@ -649,8 +656,11 @@ When a wholesale drop occurs, the SST is removed from the compaction output
 without reading any blocks. The conditions for safety are:
 
 1. `max_ttl_expire_ts > 0` — the SST has TTL entries.
-2. `now_secs > max_ttl_expire_ts` — all TTL entries have expired.
-3. `sst_level == num_levels - 1` — the SST is at the bottommost LSM level. If it
+2. `!has_non_ttl_entries` — the SST contains *only* TTL entries. A mixed SST
+   (TTL + non-TTL) cannot be wholesale-dropped because non-TTL entries never
+   expire and would be silently lost.
+3. `now_secs > max_ttl_expire_ts` — all TTL entries have expired.
+4. `sst_level == num_levels - 1` — the SST is at the bottommost LSM level. If it
    were at an upper level, its entries shadow older versions in lower levels;
    wholesale-dropping the upper-level SST would let those older versions survive
    and be written to the output, resurrecting expired keys.
@@ -837,17 +847,16 @@ When the latest version carries a TTL, GC handles two cases:
 replacement values with `KvKind::ValuePointer`. TTL entries must preserve their
 `expire_at_secs` when rewritten. Note that `TtlMetadata::parse` returns the
 **pointer bytes** (not the user value) as its payload when the kind is
-`TtlValuePointer`. Since vLog GC performs a sequential scan of the old vLog file,
-the raw user value is already available in memory from that scan — no additional
-disk read is needed. The rewrite decodes the old pointer, maps it to the
-already-buffered user value, appends that to the new vLog, and constructs a new
-`TtlValuePointer` with the preserved expiration time:
+`TtlValuePointer`. During vLog GC, `analyze_file` reads only entry headers to
+determine liveness; the raw user values are not buffered in memory. The rewrite
+must use `self.vlog.read_entry(&live_ref.ptr)` to read the value from disk,
+append it to the new vLog, and construct a new `TtlValuePointer` with the
+preserved expiration time:
 
 ```rust
 // During vLog GC, when rewriting a live TTL value:
-// `user_value` is the raw value bytes already read during the sequential scan
-// of the old vLog file.
 let (ttl_meta, _pointer_bytes) = TtlMetadata::parse(&entry_value).unwrap();
+let user_value = self.vlog.read_entry(&live_ref.ptr)?;
 let new_pointer = new_vlog.append(&user_value);
 let new_value = encode_ttl_value_pointer(ttl_meta.expire_at_secs, new_pointer);
 // CAS-update the LSM entry to point to `new_value`.
@@ -913,12 +922,17 @@ pub struct LsmStorageOptions {
 The scanner is a lightweight periodic task that:
 
 1. Iterates all levels and collects SSTs where `max_ttl_expire_ts > 0`
-   (has TTL entries) AND `now_secs > max_ttl_expire_ts` (all TTL entries expired).
+   (has TTL entries) AND `!has_non_ttl_entries` (no non-TTL entries) AND
+   `now_secs > max_ttl_expire_ts` (all TTL entries expired).
 2. For each candidate SST, checks if wholesale drop is safe (Section 6.5.2,
    Optimization 2).
-3. If safe, triggers a compaction of that SST to the bottom level.
-4. If not fully safe (some entries above watermark), records the SST for
-   prioritization in the next regular compaction round.
+3. If safe, performs a metadata-only deletion: removes the SST from the
+   `LsmStorageState` level, writes a manifest record to make the deletion
+   durable, and unreferences any vLog files. This bypasses the compaction
+   pipeline entirely since the SST is already at the bottommost level and no
+   per-key iteration is needed.
+4. If not fully safe (some entries above watermark or other conditions not met),
+   records the SST for prioritization in the next regular compaction round.
 
 The scanner does NOT iterate individual keys — it uses only per-SST metadata
 (`max_ttl_expire_ts`). This makes it O(number of SSTs), not O(number of keys).

--- a/rfcs/016-ttl.md
+++ b/rfcs/016-ttl.md
@@ -909,7 +909,7 @@ vLog, and constructs a new `TtlValuePointer` with the preserved expiration time:
 ```rust
 // During vLog GC, when rewriting a live TTL value:
 let (key, user_value) = self.vlog.read_entry(&live_ref.ptr)?;
-let bytes_written = new_vlog.append(&key, &value)?;
+let bytes_written = new_vlog.append(&key, &user_value)?;
 let new_pointer = ValuePointer {
     file_id: new_file_id,
     offset: new_vlog.offset() - bytes_written as u64,

--- a/rfcs/016-ttl.md
+++ b/rfcs/016-ttl.md
@@ -1,0 +1,1329 @@
+# RFC 016: Native Time-To-Live (TTL) Support
+
+**Status:** Proposed
+**Date:** 2026-07-08
+**Author:** kv-engine Contributors
+**Tracking Issue:** N/A (design RFC)
+
+---
+
+## 1. Summary
+
+This RFC proposes adding native TTL (Time-To-Live) support to kv-engine. A caller
+specifies a per-key TTL duration at write time, and the engine guarantees that the
+key will be automatically cleaned up once the wall-clock expiration time has passed.
+
+The MVP provides:
+
+1. A `put_with_ttl(key, value, ttl_duration)` API and `WriteBatchRecord::PutWithTtl`
+   support.
+2. Wall-clock-based expiration: `expire_at = now() + ttl_duration`, encoded at the
+   value level as new `KvKind` variants (`TtlInline = 3`, `TtlValuePointer = 4`),
+   each followed by an 8-byte big-endian Unix epoch second.
+3. Compaction-time physical cleanup as the primary removal mechanism. Expired TTL
+   entries are dropped during compaction when the no-active-readers safety gate is
+   satisfied, mirroring the existing compaction filter deletion model (RFC 009).
+4. Optional read-path TTL filtering, controlled by
+   `LsmStorageOptions::ttl_read_filtering`, that returns `None` for expired keys
+   even before compaction rewrites the containing SST.
+5. Per-SST TTL metadata (`min_ttl_expire_ts`, `max_ttl_expire_ts`) for O(1)
+   compaction-level TTL eligibility checks, allowing entire SSTs to be skipped or
+   wholesale-dropped.
+6. An optional background TTL expiry scanner that proactively identifies and
+   triggers compaction on SSTs with fully-expired TTL entries.
+
+TTL is a **native engine feature**, not a re-packaged compaction filter. It does
+not require callers to embed expiration timestamps in keys or values. The design
+integrates with the existing MVCC watermark model (RFC 005), value separation /
+vLog (RFC 001), range tombstones (RFC 010), and compaction GC rules.
+
+---
+
+## 2. Motivation
+
+Today, callers who need time-based expiration must implement it themselves using
+one of the following patterns:
+
+1. **Embed TTL in keys or values.** Store `expire_at` in the user-key prefix and
+   use a compaction filter to drop matching keys once the prefix encodes an expired
+   timestamp. This works (RFC 009 explicitly mentions this as a compaction filter
+   use case) but forces every caller to invent their own encoding, prevents the
+   engine from optimizing TTL-aware operations, and makes cross-application TTL
+   semantics inconsistent.
+
+2. **Issue explicit `delete` calls from a background sweeper.** A user-level
+   scanner periodically reads keys, checks embedded expiration metadata, and
+   issues `delete` for expired keys. This has high write amplification (one
+   tombstone per expired key), consumes application resources, and requires
+   coordinating the sweeper with the application lifecycle.
+
+3. **Use range tombstones for time-bucketed data.** For data organized by time
+   buckets (e.g., `logs:2026-07-01:`), a range tombstone can cleanly delete an
+   entire bucket after it expires. This works for contiguous time ranges but does
+   not handle per-key TTL with scattered expiration times.
+
+Common use cases that would benefit from native TTL:
+
+- **Session stores.** User session keys that expire after a fixed idle timeout.
+- **Distributed caches.** Cache entries with per-key TTL that should self-expire.
+- **Rate-limit counters.** Per-user counters that auto-reset after a time window.
+- **Temporary workflow state.** Keys that are only valid for the duration of a job.
+- **Distributed locks.** Lock keys with a timeout to prevent deadlock.
+
+A native TTL feature provides consistent semantics, reduces write amplification,
+eliminates per-application TTL encoding, and allows the engine to optimize cleanup
+through compaction and SST-level metadata.
+
+---
+
+## 3. Goals
+
+1. Provide a `put_with_ttl(key, value, ttl: Duration)` API that computes
+   `expire_at = now() + ttl` and persists it with the value.
+2. Support `WriteBatchRecord::PutWithTtl` so TTL keys can be written atomically
+   with other operations in a batch.
+3. Encode TTL at the value level using new `KvKind` variants, preserving backward
+   compatibility with existing SST, WAL, memtable, and vLog formats while adding a
+   predictable 9-byte overhead per TTL entry.
+4. Perform compaction-time physical cleanup of expired TTL entries — the same
+   eventual-cleanup model used by compaction filters (RFC 009).
+5. Provide optional read-path TTL filtering (opt-in via
+   `LsmStorageOptions::ttl_read_filtering`) so that expired keys are invisible to
+   `get`, `scan`, and `prefix_scan` even before compaction removes them.
+6. Track per-SST `min_ttl_expire_ts` and `max_ttl_expire_ts` so the compaction
+   loop can skip TTL checks for SSTs that contain no expirable entries and can
+   wholesale-drop SSTs where every TTL entry has expired.
+7. Integrate correctly with MVCC snapshots, value separation (vLog), range
+   tombstones, WAL recovery, flush, compaction GC, and manifest snapshots.
+8. Preserve the existing tombstone and MVCC version GC rules — TTL cleanup must
+   not resurrect older versions.
+9. Expose observability through TTL-specific stats.
+10. Ensure that `put` and `delete` on an existing TTL key work predictably:
+    overwriting a TTL key without TTL strips the TTL; deleting a TTL key writes a
+    normal tombstone.
+
+---
+
+## 4. Non-Goals
+
+1. **Sub-second TTL precision.** The MVP uses Unix epoch seconds. Millisecond or
+   microsecond expiration is future work.
+2. **TTL extension or refresh on read.** A `get` on a TTL key does not extend the
+   TTL. Touch-on-read semantics require a separate API if needed.
+3. **Per-column-family or per-prefix default TTL.** Every TTL is specified per-key
+   at write time. A default TTL for all writes under a prefix is future work.
+4. **TTL-based range tombstones.** TTL is a point-key feature. A range tombstone
+   with an expiration time is future work.
+5. **TTL as a first-class MVCC isolation boundary.** The MVP does not capture
+   wall-clock time in `ReadGuard`. The optional read-path check uses `now()` at
+   each access; a long-running scan can observe keys disappear mid-iteration. This
+   is documented behavior (Section 6.4.1).
+6. **Immediate, synchronous reclamation.** Physical removal of expired entries
+   happens during compaction, not at the instant of expiration.
+7. **Changing the internal key format.** TTL is encoded in the value, not the key.
+8. **TTL for transaction-local writes.** `Transaction::put_with_ttl` is deferred.
+   Transaction-local TTL writes in the MVP embed the TTL in `WriteOp` and are
+   encoded at commit time, but conflict tracking does not consider TTL.
+
+---
+
+## 5. Design Overview
+
+TTL is implemented as a **value-level annotation** that carries a wall-clock
+expiration timestamp. The key insight is that TTL is conceptually a
+**time-delayed tombstone**: at write time, the caller specifies how long the value
+should live; the engine records `expire_at = wall_clock_now + ttl_duration`; once
+`wall_clock_now > expire_at`, the key is eligible for cleanup.
+
+The feature has three layers:
+
+```text
+Layer 1: Encoding
+  Value prefix: [KvKind (1 byte)][expire_at_secs: u64 BE (8 bytes, optional)]
+  New KvKind variants: TtlInline (3), TtlValuePointer (4)
+
+Layer 2: Visibility (opt-in read-path filtering)
+  get / scan / prefix_scan check: if kind is TTL and now() > expire_at, return None
+  Controlled by LsmStorageOptions::ttl_read_filtering
+
+Layer 3: Cleanup (compaction-time)
+  During compaction, drop TTL entries where now() > expire_at
+  Safety gate: requires no active MVCC readers (same underlying check as
+  `can_publish_filter_deletion`, but does NOT require installed compaction filters)
+  Per-SST metadata accelerates eligibility checks
+```
+
+The design mirrors the proven compaction filter model from RFC 009 for the
+physical cleanup layer while adding wall-clock evaluation that compaction filters
+cannot express (compaction filters only consult timestamps embedded in user keys,
+not dynamically evaluated wall-clock predicates).
+
+---
+
+## 6. Detailed Design
+
+### 6.1 TTL Value Encoding
+
+New `KvKind` variants carry an expiration timestamp after the kind byte:
+
+```rust
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum KvKind {
+    Inline = 0,
+    ValuePointer = 1,
+    Tombstone = 2,
+    /// Inline value with TTL. Payload: [expire_at_secs: u64 BE][user_value...]
+    TtlInline = 3,
+    /// Value pointer with TTL. Payload: [expire_at_secs: u64 BE][ValuePointer: 12 bytes LE]
+    TtlValuePointer = 4,
+}
+```
+
+Encoding rules:
+
+| Kind | Byte | Payload |
+|---|---|---|
+| Inline | `0x00` | `[user_value...]` |
+| ValuePointer | `0x01` | `[file_id: u32 LE][offset: u32 LE][len: u32 LE]` (12 bytes) |
+| Tombstone | `0x02` | (empty) |
+| TtlInline | `0x03` | `[expire_at_secs: u64 BE][user_value...]` |
+| TtlValuePointer | `0x04` | `[expire_at_secs: u64 BE][file_id: u32 LE][offset: u32 LE][len: u32 LE]` (20 bytes) |
+
+Helper methods on `KvKind`:
+
+```rust
+impl KvKind {
+    pub fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0 => Some(Self::Inline),
+            1 => Some(Self::ValuePointer),
+            2 => Some(Self::Tombstone),
+            3 => Some(Self::TtlInline),
+            4 => Some(Self::TtlValuePointer),
+            _ => None,
+        }
+    }
+
+    pub fn is_ttl(self) -> bool {
+        matches!(self, Self::TtlInline | Self::TtlValuePointer)
+    }
+
+    pub fn is_tombstone_value(self) -> bool {
+        matches!(self, Self::Tombstone)
+    }
+}
+```
+
+A `TtlMetadata` parser extracts the expiration timestamp and inner payload:
+
+```rust
+/// Parsed TTL metadata from a TTL-prefixed value.
+#[derive(Clone, Copy, Debug)]
+pub struct TtlMetadata {
+    pub expire_at_secs: u64,
+    pub value_kind: KvKind,
+}
+
+impl TtlMetadata {
+    /// If `raw_value` starts with a TTL kind, parse and return metadata
+    /// plus the value payload (for TtlInline) or ValuePointer bytes
+    /// (for TtlValuePointer). Returns `None` for non-TTL kinds.
+    pub fn parse(raw_value: &[u8]) -> Option<(Self, &[u8])> {
+        let kind = KvKind::from_u8(*raw_value.first()?)?;
+        if !kind.is_ttl() {
+            return None;
+        }
+        // Safety: is_ttl() guarantees the value has at least 9 bytes
+        // (1 kind + 8 expire_at_secs).
+        debug_assert!(raw_value.len() >= 9, "truncated TTL value");
+        let expire_at_secs = u64::from_be_bytes(raw_value[1..9].try_into().unwrap());
+        Some((
+            Self { expire_at_secs, value_kind: kind },
+            &raw_value[9..],
+        ))
+    }
+}
+```
+
+The 8-byte `expire_at_secs` field is stored big-endian so that comparing the raw
+bytes of two TTL values with the same user key and different expiration times
+preserves temporal ordering. In practice, only one version per user key survives
+MVCC version collapse, so ordering across versions is a non-issue, but big-endian
+is the conventional encoding for network-order timestamps.
+
+**Why value-level instead of key-level encoding?** Encoding TTL in the key would
+require changing the internal key format `[memcomparable_user_key][!ts: u64 BE]`
+to include an expiration timestamp, which would affect key ordering, bloom filter
+hashing, memtable comparisons, and every seek path. Value-level encoding isolates
+the TTL change to value parsing and compaction decision logic. The tradeoff is
+that compaction must parse at least the first 9 bytes of each value to determine
+TTL eligibility; this is mitigated by per-SST metadata (Section 6.5.2) and the
+fact that compaction already reads the value prefix for `KvKind` checks.
+
+### 6.2 TTL API
+
+#### 6.2.1 Public API
+
+```rust
+impl KvEngine {
+    /// Write a key-value pair with a time-to-live duration.
+    ///
+    /// The expiration time is computed as `now() + ttl` using the system
+    /// wall clock (`std::time::SystemTime`). The key will be eligible for
+    /// cleanup after the expiration time has passed.
+    ///
+    /// When `LsmStorageOptions::ttl_read_filtering` is enabled, the key
+    /// becomes invisible to reads once `now() > expire_at`.
+    ///
+    /// # Panics
+    /// Panics if the system clock is before the Unix epoch.
+    pub fn put_with_ttl(
+        &self,
+        key: &[u8],
+        value: &[u8],
+        ttl: Duration,
+    ) -> Result<()>;
+}
+```
+
+A TTL of zero produces `expire_at = wall_clock_now`, meaning the entry expires
+at the end of the current wall-clock second — after that second boundary, the
+entry is eligible for cleanup. To write a key that never expires regardless of
+TTL, use the standard `put` API instead. This avoids a separate sentinel value
+for "no expiration" and keeps the encoding compact.
+
+#### 6.2.2 WriteBatch Support
+
+```rust
+pub enum WriteBatchRecord<T: AsRef<[u8]>> {
+    Put(T, T),
+    /// Put with TTL. (key, value, ttl_duration_secs).
+    PutWithTtl(T, T, u64),
+    Del(T),
+    DelRange(T, T),
+}
+```
+
+`PutWithTtl` uses `u64` seconds for the TTL duration to keep the batch API
+compatible with serialization. Mixed batches containing `Put`, `PutWithTtl`,
+`Del`, and `DelRange` are allowed; the existing rule that `DelRange` cannot mix
+with point operations in the same batch still applies (RFC 010, Section 7.2).
+
+#### 6.2.3 TTL Override Semantics
+
+When a key with an existing TTL is overwritten:
+
+| Operation | New State |
+|---|---|
+| `put(key, value)` (no TTL) | Key becomes a non-TTL key. Old TTL is removed. |
+| `put_with_ttl(key, value, ttl)` | Key gets the new expiration time. Old TTL is replaced. |
+| `delete(key)` | A normal tombstone is written. Old TTL is removed (the key is explicitly deleted now). |
+
+This follows the principle that the latest write completely determines the key's
+state. A TTL key overridden by a non-TTL `put` loses its expiration. A TTL key
+explicitly deleted becomes a tombstone and is cleaned up by normal tombstone GC,
+not TTL cleanup.
+
+### 6.3 TTL Write Path
+
+`put_with_ttl` follows the same commit protocol as `put` (RFC 005, Section 6.2):
+
+1. Validate key size.
+2. Acquire locks (`commit_lock` if serializable, `active_memtable_lock`).
+3. Reserve a commit timestamp.
+4. Prepend the TTL value prefix: `[KvKind::TtlInline][expire_at_secs: u64 BE][value]`
+   or `[KvKind::TtlValuePointer][expire_at_secs: u64 BE][value_pointer]`.
+5. Write to WAL with the TTL-prefixed value.
+6. Insert into memtable skiplist.
+7. Advance `current_ts`.
+8. Record write set (if serializable).
+9. Check memtable freeze.
+
+The expiration time is computed at the point of `put_with_ttl` call:
+
+```rust
+fn compute_expire_at(ttl: Duration) -> u64 {
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("system clock before Unix epoch");
+    now.as_secs().saturating_add(ttl.as_secs())
+}
+```
+
+Using `SystemTime::now()` means TTL depends on the host's wall clock. Clock skew
+across nodes is a caller concern (consistent with how Redis, Memcached, and
+RocksDB's TTL compaction filter handle wall-clock TTL). The engine does not
+provide clock synchronization.
+
+**Write batch atomicity.** All records in a `write_batch` share one commit
+timestamp. `PutWithTtl` records compute their individual `expire_at` values at
+the time of the batch call, not the commit time. The difference between
+batch-accept time and commit time is bounded by WAL sync latency (typically
+milliseconds), which is negligible for TTL durations measured in seconds.
+
+**Value separation (vLog) path.** When `TtlValuePointer` is used, the value is
+stored in the vLog with the same TTL-prefixed value-pointer encoding. vLog entries
+remain opaque byte sequences — the vLog does not inspect TTL metadata. See
+Section 6.8 for vLog GC handling.
+
+#### 6.3.1 Code Site Audit: Value-Prefix Inspections
+
+Adding `KvKind::TtlInline` (3) and `KvKind::TtlValuePointer` (4) creates two new
+value-prefix bytes. The codebase has many sites that inspect `raw_value[0]` and
+branch on `0x01` (ValuePointer) or `0x02` (Tombstone) with a fallthrough that
+assumes "everything else is Inline." Every such site must be audited and updated.
+The key principle is: **a TTL value has the same payload layout as its non-TTL
+counterpart, just shifted by 8 bytes (the `expire_at_secs` field).**
+
+Sites that need changes (file paths relative to `kv-engine/src/`):
+
+| File | Location | Current behavior | Required change |
+|---|---|---|---|
+| `mem_table.rs` | `flush()` (~line 808–814) | Checks `val[0] == 0x01 \|\| val[0] == 0x02` to decide pass-through vs strip-KvKind. TTL variants match neither. | Add `val[0] == 0x03 \|\| val[0] == 0x04` to the pass-through condition. TTL values are opaque blobs — pass them through unchanged like ValuePointer and Tombstone. |
+| `mem_table.rs` | `resolve` (~line 1194–1199) | For non-ValuePointer, non-Tombstone values, strips only the KvKind byte (`val.slice(1..)`). A TtlInline value would leak the 8-byte `expire_at` into the caller-visible value. | After confirming `val[0]` is not 0x01–0x04, strip 9 bytes for TTL variants: `if val[0] == 0x03 \|\| val[0] == 0x04 { val.slice(9..) } else { val.slice(1..) }`. |
+| `mem_table.rs` | `collect_vlog_file_ids` (~line 568–573) | Only decodes `ValuePointer` for byte `0x01`. TtlValuePointer (0x04) vLog references are missed, risking premature file deletion. | Also decode for byte `0x04`, reading the ValuePointer from bytes `[9..21]` instead of `[1..13]`. |
+| `table/builder.rs` | `add_raw` (~line 188–198) | Only tracks vLog references for byte `0x01`. TtlValuePointer files are not tracked. | Also check byte `0x04` and decode ValuePointer from offset 9. |
+| `table/iterator.rs` | `value()` (~line 168–205) | Match on `KvKind::from_u8(kind)` with arms for Inline, Tombstone, ValuePointer. TTL variants return `None` from `from_u8`, hitting the fallthrough (which panics or produces wrong output). | Add arms for `TtlInline` (strip 9-byte prefix) and `TtlValuePointer` (strip 9-byte prefix, resolve vLog). Reuse a helper `KvKind::payload_offset(self) -> usize` (returns 1 for Inline/ValuePointer/Tombstone, 9 for TTL variants). |
+| `lsm_storage.rs` | `parse_value_kind` (~line 3849–3866) | Match on `from_u8` result; `None` maps to Inline and strips 1 byte. TTL variants return `None`, so `expire_at` leaks into the value. | Map bytes 3 and 4 to new `KvKind` variants with `payload_offset = 9`. |
+| `lsm_storage.rs` | `resolve_value` (~line 3780–3788) | Match on `ValuePointer`, `Inline \| Tombstone`. Non-exhaustive after adding TTL variants. | Add `TtlInline \| TtlValuePointer \| ...` to the Inline/Tombstone arm (TTL values are resolved the same way — inline bytes are returned, ValuePointer is dereferenced). |
+| `lsm_storage.rs` | `resolve_vlog_value_bytes` (~line 3798–3824) | Match on `ValuePointer`, `Tombstone`, wildcard `_` for Inline. TtlValuePointer would hit the wildcard arm (treated as Inline). | Add `TtlValuePointer` arm that decodes the ValuePointer from offset 9. |
+| `lsm_storage.rs` | `values_match` (~line 5225–5235) | Match on `(Inline, Inline)` and `(ValuePointer, ValuePointer)`. TTL variants produce `false`, which is safe but breaks CAS for vLog GC. | Add `(TtlInline, TtlInline) => ...` and `(TtlValuePointer, TtlValuePointer) => ...` arms with byte-wise comparison of the full TTL-prefixed values. |
+| `lsm_storage.rs` | `build_point_batch_entries` / `build_non_mvcc_batch_entries` (~line 4540–4616) | Match exhaustively on `WriteBatchRecord` variants. `PutWithTtl` not handled. | Add `PutWithTtl(key, val, ttl_secs)` arm that computes `expire_at` and prepends `[KvKind::TtlInline][expire_at: 8][val]`. |
+| `vlog/gc.rs` | `check_liveness` (~line 193–206) | Match on `ValuePointer` only. TtlValuePointer falls to `_ => Ok(false)`, incorrectly reporting live TTL entries as dead. | Handle `TtlValuePointer` the same as `ValuePointer` (check pointer equality). Optionally also check if TTL has expired and report as dead if so. |
+| `vlog/gc.rs` | `compact_file` (~line 277–344) | Constructs replacement values with `KvKind::ValuePointer`. TTL prefix is lost on rewrite. | When the old entry has a TTL prefix, construct the replacement with `KvKind::TtlValuePointer` and preserve `expire_at_secs`. |
+| `wal.rs` | Entry decode (~line 822–827, 915–919) | Uses WAL-internal kind bytes (0=Put, 1=PointTombstone, 2=RangeTombstone), not KvKind. TTL writes use WAL kind 0 (Put) with TTL-prefixed values. | **No change needed.** WAL treats values as opaque bytes. Recovery calls `handle_put(key, value)` which inserts the TTL-prefixed bytes into the skiplist unchanged. |
+
+A helper method `KvKind::payload_offset(self) -> usize` centralizes the offset
+calculation:
+
+```rust
+impl KvKind {
+    /// Number of metadata bytes before the logical payload.
+    /// 1 for non-TTL kinds (just the kind byte), 9 for TTL kinds
+    /// (kind byte + 8-byte expire_at_secs).
+    pub fn payload_offset(self) -> usize {
+        if self.is_ttl() { 9 } else { 1 }
+    }
+}
+```
+
+This helper is used by `SsTableIterator::value()`, `parse_value_kind`, memtable
+`resolve`, and any other site that needs to strip metadata to reach the logical
+value or ValuePointer bytes.
+
+### 6.4 TTL Read Path
+
+#### 6.4.1 Optional Read-Path Filtering
+
+The read-path check is opt-in through a new option:
+
+```rust
+pub struct LsmStorageOptions {
+    // ... existing fields ...
+    /// When enabled, the read path checks TTL expiration against the current
+    /// wall clock and returns `None` for expired keys even before compaction
+    /// physically removes them. Defaults to `false` (eventual compaction-time
+    /// cleanup only).
+    pub ttl_read_filtering: bool,
+}
+```
+
+When `ttl_read_filtering` is enabled, `get`, `scan`, and `prefix_scan` apply an
+additional visibility check after the MVCC version has been selected:
+
+```rust
+fn is_ttl_expired(raw_value: &[u8]) -> bool {
+    if let Some((ttl_meta, _payload)) = TtlMetadata::parse(raw_value) {
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        now > ttl_meta.expire_at_secs
+    } else {
+        false
+    }
+}
+```
+
+`get` logic:
+
+```text
+candidate = newest visible point version at read_ts
+  ↓
+if candidate is None: return None
+  ↓
+if ttl_read_filtering and is_ttl_expired(candidate.raw_value): return None
+  ↓
+return candidate.value
+```
+
+`scan` logic:
+
+```text
+for each visible user key at read_ts:
+    if ttl_read_filtering and is_ttl_expired(version.raw_value):
+        skip  // behaves like a tombstone for this key
+    else:
+        yield key
+```
+
+**Snapshot isolation note.** When `ttl_read_filtering` is enabled, a key can
+disappear from a snapshot mid-scan if the wall clock crosses `expire_at` during
+iteration. This is a deliberate relaxation of strict snapshot isolation for TTL
+keys. Callers who require immutable snapshots should disable `ttl_read_filtering`
+and rely on compaction-time cleanup only. Future work (Section 13) can add a
+wall-clock capture to `ReadGuard` for TTL-strict snapshots.
+
+#### 6.4.2 Read Path When Filtering Is Disabled (Default)
+
+When `ttl_read_filtering` is `false` (the default), the read path is completely
+unchanged. TTL keys remain visible until compaction removes them. This is the
+default because:
+
+- It preserves strict MVCC snapshot isolation.
+- It avoids per-read wall-clock system calls.
+- It matches RocksDB's TTL behavior (compaction-time only).
+- It is the simpler, less surprising default.
+
+#### 6.4.3 Interaction With Range Tombstones
+
+On the read path, range tombstone visibility and TTL visibility are independent
+checks. A key is invisible if EITHER:
+
+- A range tombstone covers it at `read_ts`, OR
+- `ttl_read_filtering` is enabled and the key's TTL has expired.
+
+The order of checks is: MVCC version selection, then range tombstone covering
+check, then TTL expiry check. Both can independently suppress a key.
+
+### 6.5 Compaction Integration
+
+#### 6.5.1 TTL Cleanup Decision
+
+TTL cleanup is inserted into `compact_from_iter` after the existing MVCC
+watermark check and compaction filter check. The decision logic is:
+
+```rust
+fn should_drop_for_ttl(
+    raw_value: &[u8],
+    can_publish_deletions: bool,
+    now_secs: u64,
+) -> bool {
+    if !can_publish_deletions {
+        return false;
+    }
+    if let Some((ttl_meta, _payload)) = TtlMetadata::parse(raw_value) {
+        now_secs > ttl_meta.expire_at_secs
+    } else {
+        false
+    }
+}
+```
+
+The `can_publish_deletions` gate is a new `can_publish_ttl_deletion` flag,
+computed separately from `can_publish_filter_deletion`. The existing
+`can_publish_filter_deletion` variable in `compact.rs` requires three conditions:
+`compact_to_bottom_level`, `!compaction_filters.is_empty()`, and
+`mvcc.can_publish_filter_deletion()` (no active readers). The TTL gate drops the
+"non-empty filters" requirement and only requires the bottom-level compaction
+and no-active-readers checks: ```rust
+// In compact.rs, added alongside the existing can_publish_filter_deletion:
+let can_publish_ttl_deletion = compact_to_bottom_level
+    && self.mvcc.as_ref().is_some_and(|m| m.can_publish_filter_deletion());
+```
+
+This ensures that no active MVCC reader can observe a partially-compacted state
+where some SSTs have dropped expired keys and others have not.
+
+**Why a separate gate from compaction filters.** The existing
+`can_publish_filter_deletion` requires `!compaction_filters.is_empty()` — if no
+filters are installed, it is always `false`. TTL cleanup must work independently
+of whether compaction filters are installed. Both gates share the same underlying
+MVCC check (`watermark.watermark().is_none()`), but TTL does not require installed
+filters.
+
+**Why this gate is necessary.** A reader with a `ReadGuard` at `read_ts` can
+issue multiple `get` calls against the current `LsmStorageState`. If compaction
+publishes a state where some SSTs have dropped TTL-expired keys while the reader
+is still active, the reader could observe different results for the same key
+within the same snapshot — breaking repeatable read. By requiring zero active
+readers, we guarantee that no reader can observe the transition between pre-cleanup
+and post-cleanup states.
+
+**Interaction with existing MVCC GC.** The TTL drop decision is independent of
+the MVCC watermark. A TTL-expired entry can be dropped even if `key_ts > watermark`,
+because TTL expiration is a wall-clock predicate, not a version-age predicate.
+However, the decision is still gated on `can_publish_ttl_deletion` so that MVCC
+snapshot isolation is preserved for the state transition.
+
+**Interaction with `should_keep_compaction_entry`.** The existing keep/drop logic
+handles MVCC version collapse and tombstone GC. TTL cleanup is an additional drop
+reason. The overall decision in the compaction loop becomes:
+
+```rust
+let keep_for_mvcc = self.should_keep_compaction_entry(...);
+let drop_for_filter = keep_for_mvcc
+    && can_publish_filter_deletion
+    && compaction_filters.iter().any(|f| f.matches(...));
+let drop_for_ttl = keep_for_mvcc
+    && !drop_for_filter
+    && should_drop_for_ttl(raw_value, can_publish_ttl_deletion, now_secs);
+
+if keep_for_mvcc && !drop_for_filter && !drop_for_ttl {
+    builder.add_raw(iter.key(), iter.raw_value())?;
+}
+```
+
+The TTL check runs after the filter check, so a filter match takes precedence over
+TTL (both result in the entry being dropped; the distinction matters for stats
+attribution).
+
+#### 6.5.2 Per-SST TTL Metadata
+
+Each SST stores `min_ttl_expire_ts` and `max_ttl_expire_ts` in its footer.
+Semantics:
+
+```rust
+/// TTL metadata for an SST.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SsTableTtlMetadata {
+    /// The minimum `expire_at_secs` among all TTL entries in this SST.
+    /// `u64::MAX` if the SST contains no TTL entries.
+    pub min_ttl_expire_ts: u64,
+    /// The maximum `expire_at_secs` among all TTL entries in this SST.
+    /// 0 if the SST contains no TTL entries.
+    pub max_ttl_expire_ts: u64,
+}
+```
+
+These are used for two fast-path optimizations during compaction:
+
+**Optimization 1: Skip SSTs with no expirable entries.** Before iterating entries,
+the compaction loop checks:
+
+```rust
+let has_expirable = sst.ttl_metadata.max_ttl_expire_ts > 0
+    && now_secs > sst.ttl_metadata.min_ttl_expire_ts;
+```
+
+If `has_expirable` is false, no entry in this SST has expired, and the per-entry
+TTL check can be skipped for all entries from this SST.
+
+**Optimization 2: Wholesale-drop SSTs with all entries expired.** If every TTL
+entry has expired and the SST is safe to drop:
+
+```rust
+fn can_wholesale_drop_sst(
+    sst: &SsTable,
+    now_secs: u64,
+    watermark: Option<u64>,
+    compact_to_bottom_level: bool,
+    compaction_filters: &[InstalledCompactionFilter],
+) -> bool {
+    sst.ttl_metadata.max_ttl_expire_ts > 0
+        && now_secs > sst.ttl_metadata.max_ttl_expire_ts
+        && compact_to_bottom_level
+        && watermark.is_some_and(|wm| sst.max_ts <= wm)
+        // Safety: must not drop range tombstones that still cover lower levels.
+        && sst.range_tombstones.is_none()
+        // Safety: compaction filters may have a predicate on keys in this SST.
+        // Wholesale drop skips all iteration, so filters would never fire.
+        && compaction_filters.is_empty()
+}
+```
+
+When a wholesale drop occurs, the SST is removed from the compaction output
+without reading any blocks. The conditions for safety are:
+
+1. `max_ttl_expire_ts > 0` — the SST has TTL entries.
+2. `now_secs > max_ttl_expire_ts` — all TTL entries have expired.
+3. `compact_to_bottom_level` — no lower level could hold an older version that
+   would be resurrected by dropping this SST.
+4. `sst.max_ts <= watermark` — all point entries in the SST are below the MVCC
+   watermark, so no active reader needs them.
+5. `sst.range_tombstones.is_none()` — dropping an SST with range tombstones would
+   silently remove those tombstones, resurrecting older versions in lower levels
+   that the tombstones were hiding. SSTs carrying range tombstones must be
+   iterated normally so that range-tombstone fragment merge/GC can run.
+6. `compaction_filters.is_empty()` — wholesale drop skips all per-entry iteration,
+   so installed compaction filters would never inspect the keys and could miss
+   predicate matches. When filters are active, the SST must be iterated normally.
+
+If condition 4 is not met (some entries above watermark), the SST must still be
+iterated normally to preserve the above-watermark entries. The non-TTL and
+above-watermark TTL entries are written to the output; expired below-watermark
+TTL entries are dropped per-key.
+
+#### 6.5.3 SST Builder Changes
+
+`SsTableBuilder` tracks TTL metadata during construction:
+
+```rust
+pub struct SsTableBuilder {
+    // ... existing fields ...
+    /// Minimum expiration timestamp among all TTL entries added.
+    min_ttl_expire_ts: u64,  // u64::MAX if no TTL entries
+    /// Maximum expiration timestamp among all TTL entries added.
+    max_ttl_expire_ts: u64,  // 0 if no TTL entries
+}
+```
+
+When `add_raw` or `add` is called with a TTL-prefixed value, the builder extracts
+`expire_at_secs` and updates `min_ttl_expire_ts` and `max_ttl_expire_ts`.
+
+The `SsTable` struct gains:
+
+```rust
+pub struct SsTable {
+    // ... existing fields ...
+    pub ttl_metadata: SsTableTtlMetadata,
+}
+```
+
+### 6.6 SST Format Changes
+
+#### 6.6.1 Footer Version 8
+
+A new footer version extends v7 with TTL metadata fields:
+
+```text
+SST_FOOTER_VERSION_V8: u8 = 8
+```
+
+Footer v8 layout (41 bytes):
+
+```text
+Offset  Size  Field
+------  ----  -----
+  0      4    bloom_offset: u32
+  4      4    prefix_bloom_offset: u32
+  8      4    range_tombstone_offset: u32
+ 12      8    min_ttl_expire_ts: u64        ← NEW
+ 20      8    max_ttl_expire_ts: u64        ← NEW
+ 28      8    max_ts: u64
+ 36      4    magic: u32 (0x4D56_4343)
+ 40      1    version: u8 = 8
+```
+
+For SSTs with no TTL entries, `min_ttl_expire_ts = u64::MAX` and
+`max_ttl_expire_ts = 0`. These sentinel values are chosen so that:
+
+- `sst.max_ttl_expire_ts == 0` is a fast check for "no TTL entries".
+- `now_secs <= sst.min_ttl_expire_ts` is never true when `min_ttl_expire_ts == u64::MAX`
+  (assuming realistic wall-clock values), so the "no expired entries" fast path
+  correctly falls through.
+
+Legacy SSTs (v2–v7) implicitly have `min_ttl_expire_ts = u64::MAX` and
+`max_ttl_expire_ts = 0` since they contain no TTL entries. `SsTable::open` sets
+these defaults for non-v8 SSTs.
+
+#### 6.6.2 Backward Compatibility
+
+| Artifact | Old files read by v8 binary | New v8 artifact read by old binary |
+|---|---|---|
+| Manifest v4 | Yes | N/A (manifest handles this) |
+| SST v2–v7 | Yes (TTL metadata defaults applied) | N/A |
+| SST v8 | N/A | No (rejected by version check) |
+| WAL | Yes (TTL entries are opaque bytes) | N/A |
+
+Existing SST and WAL readers treat TTL-prefixed values as opaque byte sequences,
+so TTL entries written by a v8 binary are readable by older binaries (the older
+binary will see the raw `[0x03][expire_at: u64 BE][value...]` bytes as the value).
+This is a deliberate compatibility choice: it allows downgrade *for read-only
+access*, though compaction and new writes in a downgraded binary will not
+understand TTL.
+
+### 6.7 Manifest Changes
+
+Manifest format version bump to 5:
+
+```rust
+pub const MANIFEST_FORMAT_VERSION: u32 = 5;
+```
+
+Version meanings:
+
+| Version | Features |
+|---|---|
+| 2 | MVCC |
+| 3 | MVCC + compaction filters |
+| 4 | MVCC + compaction filters + range tombstones |
+| 5 | MVCC + compaction filters + range tombstones + TTL |
+
+The MVP does not add new manifest record types because TTL is encoded in values,
+not as separate metadata. The format version bump is required so that older
+binaries reject databases containing SST v8 files (which include TTL metadata in
+their footers).
+
+The existing `Flush`, `FlushV2`, `Compaction`, `CompactionV2`, and `CompactionV3`
+records continue to work unchanged — the SST IDs they reference may now point to
+v8 files, but the manifest does not need to know the SST format version; that is
+determined when `SsTable::open` reads the footer.
+
+**Upgrade behavior:**
+
+1. Existing manifest v4 databases open under a v5 binary.
+2. A manifest v5 snapshot is written atomically before any SST v8 is created.
+3. Existing SSTs (v2–v7) remain readable; new SSTs are written as v8.
+4. Once upgraded, downgrade is unsupported (older binaries reject manifest v5 and
+   SST v8).
+
+**Recovery.** WAL recovery repopulates memtables from WAL entries. TTL-prefixed
+values are restored as opaque bytes; the memtable does not parse TTL metadata on
+insert. SST recovery already reads `max_ts` from the footer; v8 SSTs additionally
+read `min_ttl_expire_ts` and `max_ttl_expire_ts`.
+
+### 6.8 vLog Interaction
+
+TTL with value separation uses `KvKind::TtlValuePointer`. The encoding is:
+
+```text
+[0x04][expire_at_secs: u64 BE][file_id: u32 LE][offset: u32 LE][len: u32 LE]
+```
+
+This is 21 bytes total (1 kind + 8 ttl + 12 pointer), compared with 13 bytes for
+a non-TTL `ValuePointer` (1 kind + 12 pointer).
+
+**vLog GC liveness.** The vLog GC liveness check (`check_liveness` in
+`vlog/gc.rs`) consults the LSM for the latest version of a key. The existing code
+matches on `KvKind::ValuePointer` only; a `TtlValuePointer` would fall to the
+wildcard `_ => Ok(false)` arm and be incorrectly reported as dead. This check
+must be updated:
+
+```rust
+// In check_liveness (vlog/gc.rs), handle TTL variants:
+match current_kind {
+    KvKind::ValuePointer | KvKind::TtlValuePointer => {
+        // Decode pointer from offset 1 (ValuePointer) or 9 (TtlValuePointer).
+        let ptr_offset = current_kind.payload_offset();
+        let current_ptr = ValuePointer::try_decode(&current_value[ptr_offset..]);
+        Ok(current_ptr == Some(old_ptr))
+    }
+    KvKind::Tombstone => Ok(false), // deleted — dead
+    _ => Ok(false), // Inline / TtlInline — not a vLog reference
+}
+```
+
+Additionally, the check can optionally treat a TTL-expired entry as dead even if
+the pointer matches:
+
+```rust
+if current_kind.is_ttl() {
+    let (ttl_meta, _) = TtlMetadata::parse(&current_value).unwrap();
+    if now_secs > ttl_meta.expire_at_secs {
+        return Ok(false); // expired — no need to retain
+    }
+}
+```
+
+When the latest version carries a TTL, GC handles two cases:
+
+1. **TTL not yet expired.** The value is live and must be retained. GC copies the
+   TTL-prefixed value pointer into the new vLog file during `compact_file`.
+2. **TTL expired.** The value is dead. GC drops it (same as a tombstone or
+   overwritten value).
+
+**vLog GC rewrite.** The `compact_file` method (in `vlog/gc.rs`) constructs
+replacement values with `KvKind::ValuePointer`. TTL entries must preserve their
+`expire_at_secs` when rewritten:
+
+```rust
+// During vLog GC, when rewriting a live TTL value:
+let (ttl_meta, payload) = TtlMetadata::parse(&old_value).unwrap();
+let new_pointer = new_vlog.append(payload);  // append only the user value
+let new_value = encode_ttl_value_pointer(ttl_meta.expire_at_secs, new_pointer);
+// CAS-update the LSM entry to point to `new_value`.
+```
+
+where `encode_ttl_value_pointer` constructs
+`[KvKind::TtlValuePointer as u8][expire_at_secs: u64 BE][file_id: u32 LE][offset: u32 LE][len: u32 LE]`.
+
+**TTL and vLog file deletion.** The invariant from RFC 010, Section 10.4 applies:
+a vLog file can be deleted only after no live SST references it. TTL-expired
+entries dropped during compaction remove their vLog references from the output
+SSTs, making the vLog file eligible for deletion through the normal reference
+counting path.
+
+### 6.9 Range Tombstone Interaction
+
+TTL and range tombstones interact as follows:
+
+1. **A range tombstone does not override or extend TTL.** A range tombstone hides
+   keys in its range at its commit timestamp. A key inside the range that has TTL
+   is independently subject to both the range tombstone (visibility) and TTL
+   (cleanup). The two mechanisms are orthogonal.
+
+2. **TTL cleanup does not affect range tombstone semantics.** During compaction,
+   a TTL-expired entry is dropped. The range tombstone covering that key is
+   unaffected (it may still be needed to hide other keys or older versions in
+   lower levels).
+
+3. **TTL and range tombstone ordering in compaction.** In the compaction loop,
+   TTL cleanup is checked after range-tombstone-based drop. If a range tombstone
+   already covers the key, the entry may be dropped via the existing range
+   tombstone GC path (RFC 010, Section 10.1). If the range tombstone does not
+   allow dropping (e.g., the covering tombstone is not retained in this
+   compaction), the TTL check runs independently.
+
+4. **A `DeleteRange` on a key range that includes TTL keys does not cancel the
+   TTL.** It writes a tombstone that hides them. If the range tombstone is later
+   GC'd but the TTL key has not yet been cleaned up, the key could resurrect.
+   This is prevented by the standard compaction closure rules: a covering
+   tombstone is only dropped at bottommost compaction after all live files in
+   the range are included.
+
+### 6.10 Background TTL Scanner (Optional)
+
+An optional background scanner periodically identifies SSTs with expirable TTL
+entries and triggers compaction to reclaim space. This is useful when:
+
+- `ttl_read_filtering` is disabled and users want faster physical reclamation.
+- Workloads have low write throughput, meaning natural compaction may not visit
+  TTL-heavy SSTs promptly.
+
+```rust
+pub struct LsmStorageOptions {
+    // ... existing fields ...
+    /// When `Some`, a background task periodically scans SST TTL metadata
+    /// and triggers compaction on SSTs with fully-expired entries. The
+    /// duration controls the scan interval. Defaults to `None` (no
+    /// background scanner).
+    pub ttl_background_scanner_interval: Option<Duration>,
+}
+```
+
+The scanner is a lightweight periodic task that:
+
+1. Iterates all levels and collects SSTs where `max_ttl_expire_ts > 0`
+   (has TTL entries) AND `now_secs > max_ttl_expire_ts` (all TTL entries expired).
+2. For each candidate SST, checks if wholesale drop is safe (Section 6.5.2,
+   Optimization 2).
+3. If safe, triggers a compaction of that SST to the bottom level.
+4. If not fully safe (some entries above watermark), records the SST for
+   prioritization in the next regular compaction round.
+
+The scanner does NOT iterate individual keys — it uses only per-SST metadata
+(`max_ttl_expire_ts`). This makes it O(number of SSTs), not O(number of keys).
+
+The scanner must not trigger compactions when there are active readers (same
+`can_publish_filter_deletion` gate), because compaction cannot physically drop
+entries while readers are active.
+
+### 6.11 Concurrency and Correctness
+
+#### 6.11.1 Foreground Operations
+
+Foreground `put`, `delete`, `put_with_ttl` do not evaluate TTL. They interact
+only through normal LSM state publication. Memtable entries are never TTL-filtered;
+only SST entries during compaction are evaluated.
+
+#### 6.11.2 Clock Skew and Monotonicity
+
+TTL uses `SystemTime::now()`, which is subject to NTP adjustments and manual
+clock changes. The engine does not protect against these. Callers deploying across
+nodes with clock skew should account for this (e.g., by adding a safety margin to
+TTL durations).
+
+A malicious or erroneous clock change (e.g., setting the system clock forward by
+years) could cause all TTL keys to expire instantly. This is a known limitation
+shared by Redis, RocksDB, and other systems that use wall-clock TTL. Mitigations
+are caller-side (use `CLOCK_MONOTONIC` for relative durations, or add a
+`min_expire_at` floor) and can be added as a future engine option.
+
+#### 6.11.3 Crash Safety
+
+The crash contract is:
+
+1. TTL metadata is embedded in WAL entries and SST values, so it survives crashes.
+2. Compaction is recorded atomically through the manifest. TTL-based drops during
+   compaction are reflected in the new SST — there is no separate TTL journal.
+3. If a crash occurs during compaction, the partially-written SST is discarded and
+   the old SSTs remain (standard atomic compaction semantics).
+4. The background scanner is best-effort; on restart, the scanner state resets
+   and re-scans from scratch. This is safe because it only triggers compactions,
+   which are already atomic.
+
+---
+
+## 7. API and Option Changes
+
+### 7.1 New Public Methods
+
+```rust
+impl KvEngine {
+    pub fn put_with_ttl(
+        &self,
+        key: &[u8],
+        value: &[u8],
+        ttl: Duration,
+    ) -> Result<()>;
+}
+```
+
+### 7.2 Extended Types
+
+```rust
+pub enum WriteBatchRecord<T: AsRef<[u8]>> {
+    Put(T, T),
+    PutWithTtl(T, T, u64),  // (key, value, ttl_seconds)
+    Del(T),
+    DelRange(T, T),
+}
+```
+
+### 7.3 New LsmStorageOptions Fields
+
+```rust
+pub struct LsmStorageOptions {
+    // ... existing fields ...
+    /// Enable read-path TTL filtering. Default: false.
+    pub ttl_read_filtering: bool,
+    /// Interval for the background TTL scanner. Default: None.
+    pub ttl_background_scanner_interval: Option<Duration>,
+}
+```
+
+### 7.4 New KvKind Variants
+
+```rust
+pub enum KvKind {
+    Inline = 0,
+    ValuePointer = 1,
+    Tombstone = 2,
+    TtlInline = 3,
+    TtlValuePointer = 4,
+}
+```
+
+### 7.5 TTL Stats
+
+```rust
+/// Cumulative TTL statistics for the storage engine.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct TtlStats {
+    /// Number of `put_with_ttl` calls since engine start.
+    pub ttl_puts: u64,
+    /// Number of TTL entries dropped during compaction.
+    pub ttl_entries_dropped: u64,
+    /// Number of bytes reclaimed from TTL drops during compaction.
+    pub ttl_bytes_dropped: u64,
+    /// Number of SSTs wholesale-dropped (all TTL entries expired).
+    pub ttl_ssts_wholesale_dropped: u64,
+    /// Number of read yields suppressed by read-path TTL filtering.
+    /// Zero when `ttl_read_filtering` is disabled.
+    pub ttl_read_suppressions: u64,
+}
+
+impl KvEngine {
+    pub fn ttl_stats(&self) -> TtlStats;
+}
+```
+
+---
+
+## 8. Testing Plan
+
+### 8.1 Unit Tests
+
+1. `TtlMetadata::parse` correctly extracts `expire_at_secs` and payload for
+   `TtlInline` and `TtlValuePointer`.
+2. `TtlMetadata::parse` returns `None` for non-TTL kinds (`Inline`,
+   `ValuePointer`, `Tombstone`).
+3. `TtlMetadata::parse` handles truncated TTL values (fewer than 9 bytes).
+4. `KvKind::from_u8` recognizes variants 3 and 4.
+5. `KvKind::is_ttl()` returns true for `TtlInline` and `TtlValuePointer`, false
+   for others.
+6. `compute_expire_at` correctly computes Unix timestamp + duration.
+7. `SsTableBuilder` tracks `min_ttl_expire_ts` and `max_ttl_expire_ts` across
+   mixed TTL and non-TTL entries.
+8. SST v8 footer encode/decode round-trips TTL metadata, including sentinel
+   values for SSTs with no TTL entries.
+9. SST v7 opened by v8 binary has default TTL metadata
+   (`min = u64::MAX, max = 0`).
+10. Overwriting a TTL key with `put` (no TTL) produces a `KvKind::Inline` value.
+11. Deleting a TTL key writes a `KvKind::Tombstone`.
+
+### 8.2 Integration Tests
+
+1. `put_with_ttl` + `get`: key is visible before expiration.
+2. `put_with_ttl` + force_full_compaction + `get`: key dropped if expired (with
+   no active readers).
+3. `put_with_ttl` + `put` (overwrite without TTL) + compaction: key survives
+   because TTL was removed.
+4. `put_with_ttl` + `delete` + compaction: tombstone survives, key is deleted.
+5. WriteBatch with mixed `Put`, `PutWithTtl`, `Del`: all three operations apply
+   correctly.
+6. With `ttl_read_filtering = true`, expired key returns `None` even before
+   compaction.
+7. With `ttl_read_filtering = true`, a scan skips expired keys but yields
+   non-expired keys.
+8. With an active `ReadGuard`, compaction does NOT drop TTL-expired entries
+   (the `can_publish_ttl_deletion` gate).
+9. After the `ReadGuard` is dropped, a subsequent compaction drops the expired
+   entries.
+10. Per-SST TTL metadata: a compaction that encounters an SST with
+    `max_ttl_expire_ts < now` and `max_ts <= watermark` drops the entire SST
+    when bottommost.
+11. TTL with value separation: `TtlValuePointer` is written to SST, value stored
+    in vLog; vLog GC correctly rewrites live TTL entries and drops expired ones.
+12. TTL + range tombstone: a range-deleted key that also has TTL is hidden by the
+    range tombstone; compaction can drop it via either path.
+13. WAL recovery: after crash, a TTL key written to WAL is recovered with its TTL
+    metadata intact.
+14. Manifest upgrade: v4 database opens under v5 binary, manifest snapshot is
+    upgraded before first SST v8 is written.
+15. Downgrade rejection: older binary rejects manifest v5 and SST v8.
+16. SST v8 with range tombstones and TTL metadata: footer contains both
+    `range_tombstone_offset` and TTL fields.
+17. Background TTL scanner correctly identifies SSTs with all TTL entries expired.
+18. TTL stats are accurate after writes, reads, and compactions.
+
+### 8.3 Existing Test Regression
+
+All existing tests must continue to pass, including:
+
+1. MVCC watermark tests (RFC 005).
+2. Compaction filter tests (RFC 009).
+3. Range tombstone tests (RFC 010).
+4. vLog GC tests (RFC 001).
+5. SST open/read tests for v2–v7 files.
+6. WAL recovery tests.
+
+---
+
+## 9. Performance
+
+### 9.1 Expected Costs
+
+| Operation | Without TTL | With TTL (none expired) | With TTL (some expired) |
+|---|---|---|---|
+| `put` | 1× | ~1× (unchanged) | ~1× |
+| `put_with_ttl` | N/A | ~1× + 9 bytes value overhead | ~1× + 9 bytes |
+| `get` (filtering off) | 1× | 1× | 1× |
+| `get` (filtering on) | 1× | ~1× + 1 `SystemTime::now()` call | ~1× + 1 call |
+| `scan` (filtering on) | 1× | ~1× + per-key `SystemTime::now()` | ~1× + per-key call |
+| Compaction (no TTL SSTs) | 1× | ~1× (skip via SST metadata) | ~1× |
+| Compaction (TTL SSTs, none expired) | N/A | ~1× + per-key 9-byte parse | N/A |
+| Compaction (all expired, wholesale drop) | N/A | N/A | 0 (SST skipped entirely) |
+
+### 9.2 Overhead Analysis
+
+- **Value size overhead**: 9 bytes per TTL entry (1 kind byte + 8 expire_ts bytes).
+  For a 100-byte value, this is 9%. For a 4KB value, it is 0.2%.
+- **Memtable memory overhead**: Same 9 bytes per TTL entry. Negligible.
+- **SST footer overhead**: 8 bytes per SST (min_ttl + max_ttl vs sentinels). An
+  SST of 64MB with footer overhead of 41 bytes (v8) vs 33 bytes (v7) = ~0.00001%.
+- **Compaction CPU overhead**: Parsing 9 bytes per value for TTL detection.
+  Amortized by block-level processing; the block is already in memory and the
+  value header is already being read for `KvKind` detection. The additional
+  overhead is a few ALU ops for u64 extraction and comparison.
+- **`SystemTime::now()` cost**: When `ttl_read_filtering` is enabled, each
+  read-path operation calls `SystemTime::now()`. On Linux, this is ~20–25ns via
+  vDSO (`clock_gettime`). For a point-get, this is negligible. For a scan
+  yielding 1M keys, this adds ~20–25ms, which is acceptable given that iterating
+  1M keys is already a multi-second operation.
+
+### 9.3 Benchmark Gates
+
+Before the feature is considered complete:
+
+1. Point-get throughput with `ttl_read_filtering` enabled vs disabled: no more
+   than 5% regression.
+2. Scan throughput with `ttl_read_filtering` enabled vs disabled: no more than
+   10% regression.
+3. Compaction throughput with TTL metadata vs without: no more than 5% regression.
+4. TTL wholesale-drop: compaction time proportional to number of SSTs dropped,
+   not number of keys (validating O(SSTs) not O(keys) behavior).
+5. vLog GC with TTL entries: same throughput as non-TTL vLog GC.
+
+---
+
+## 10. Alternatives Considered
+
+### 10.1 Key-Level TTL Encoding
+
+**Alternative:** Encode `expire_at` in the internal key as an additional suffix:
+`[memcomparable_user_key][!expire_at: u64 BE][!ts: u64 BE]`.
+
+**Rejected because:**
+
+- Changes the internal key comparison, requiring updates to memtable SkipMap
+  ordering, block binary search, bloom filter hashing, and every iterator merge.
+- Makes keys with different TTLs sort as different keys, breaking the existing
+  MVCC version-collapse logic which assumes all versions of a user key share the
+  same user-key prefix.
+- Increases encoded key size by 8 bytes for every key (not just TTL keys), since
+  the field must be present or use a sentinel.
+- RocksDB, LevelDB, and FoundationDB all use value-level or separate metadata for
+  TTL, not key-level encoding.
+
+### 10.2 Write a Tombstone at Expiration Time
+
+**Alternative:** A background timer writes a tombstone at each key's expiration
+time, similar to Redis's passive expiration.
+
+**Rejected because:**
+
+- For millions of TTL keys, this generates millions of tombstones, causing write
+  amplification and requiring those tombstones to themselves be compacted.
+- Requires an in-memory priority queue of expiration times, which does not
+  survive crashes and must be rebuilt on restart.
+- The existing compaction infrastructure can already clean up expired data at
+  zero additional write cost.
+
+### 10.3 TTL-Only Compaction Filter
+
+**Alternative:** Do not add native TTL; instead provide a built-in
+`CompactionFilterKind::Ttl` that reads TTL metadata from user-encoded values.
+
+**Rejected because:**
+
+- Requires callers to adopt a specific value encoding, losing the flexibility of
+  engine-native TTL.
+- Cannot provide read-path filtering (compaction filters are read-path invisible
+  by design).
+- Cannot provide SST-level TTL metadata for fast-path optimizations.
+- The engine already has `KvKind` for value metadata — TTL is a natural extension
+  of that metadata, not an external filter.
+
+### 10.4 MVCC Timestamp as TTL
+
+**Alternative:** Use the existing MVCC logical timestamp as a proxy for wall-clock
+time by exposing a `ttl_secs` option that drops versions older than
+`latest_commit_ts - ttl_secs_as_versions`.
+
+**Rejected because:**
+
+- MVCC timestamps are logical counters, not wall-clock time. There is no fixed
+  relationship between commit rate and wall time.
+- Under high write throughput, a key could expire in seconds; under low
+  throughput, "expired" keys could persist indefinitely.
+- This conflates version GC with time-based expiration, which are separate
+  concepts.
+
+---
+
+## 11. Rollout Plan
+
+### Phase 1: Value Encoding and KvKind Extension
+
+1. Add `KvKind::TtlInline` (3) and `KvKind::TtlValuePointer` (4) variants.
+2. Implement `TtlMetadata::parse`, `KvKind::is_ttl()`, and `KvKind::payload_offset()`.
+3. Update `KvKind::from_u8` to recognize values 3 and 4.
+4. Audit and update every code site that inspects `raw_value[0]` to branch on
+   `0x01`/`0x02` with a fallthrough assumption of "Inline." See the table in
+   Section 6.3.1 for the full list. Key sites: `mem_table.rs` (flush, resolve,
+   collect_vlog_file_ids), `table/builder.rs` (add_raw), `table/iterator.rs`
+   (value), `lsm_storage.rs` (parse_value_kind, resolve_value,
+   resolve_vlog_value_bytes, values_match, build_point_batch_entries).
+5. Add `put_with_ttl` to `LsmStorageInner` with TTL prefix encoding.
+6. Extend `WriteBatchRecord` with `PutWithTtl` and update all exhaustive match
+   arms (`write_batch_key`, `build_point_batch_entries`,
+   `build_non_mvcc_batch_entries`).
+7. Ensure WAL encode/decode passes TTL-prefixed values through transparently
+   (should work without changes — WAL treats values as opaque bytes).
+8. Add unit tests for TTL value encoding/decoding.
+
+### Phase 2: SST Format v8 and Metadata
+
+1. Define `SST_FOOTER_VERSION_V8` and the 41-byte footer layout.
+2. Extend `SsTableBuilder` to track `min_ttl_expire_ts` and `max_ttl_expire_ts`.
+3. Extend `SsTable::open` to read v8 footer and populate `ttl_metadata`.
+4. Update `SsTable` struct with `ttl_metadata: SsTableTtlMetadata`.
+5. Add backward-compatible defaults for v2–v7 SSTs.
+6. Write integration tests for SST v8 encode/decode with TTL metadata.
+
+### Phase 3: Compaction Integration
+
+1. Add `can_publish_ttl_deletion` gate in `compact_from_iter` (same underlying
+   MVCC check as `can_publish_filter_deletion`, but without the
+   `!compaction_filters.is_empty()` requirement).
+2. Add `should_drop_for_ttl` check in the compaction loop, gated by
+   `can_publish_ttl_deletion`.
+3. Implement per-SST TTL fast-path: skip TTL checks when SST has no TTL entries
+   (`max_ttl_expire_ts == 0`).
+4. Implement wholesale-drop optimization with all safety checks: all TTL entries
+   expired, bottommost compaction, below watermark, no range tombstones, no
+   installed compaction filters.
+5. Update `check_liveness` and `compact_file` in `vlog/gc.rs` to handle
+   `TtlValuePointer` (decode pointer from offset 9, optionally treat expired
+   entries as dead, preserve TTL prefix on rewrite).
+6. Add `TtlStats` counters and wire them into the compaction path.
+7. Write integration tests: TTL expiration + compaction, read guard gate,
+   wholesale drop, vLog GC with TTL entries.
+
+### Phase 4: Read-Path Filtering (Optional/Opt-in)
+
+1. Add `LsmStorageOptions::ttl_read_filtering`.
+2. Implement TTL expiry check in the `get` path, after MVCC version selection.
+3. Implement TTL expiry check in the `scan` and `prefix_scan` paths.
+4. Add `TtlStats::ttl_read_suppressions`.
+5. Write integration tests for read-path filtering.
+
+### Phase 5: Public API, Manifest, and Background Scanner
+
+1. Expose `KvEngine::put_with_ttl`.
+2. Bump `MANIFEST_FORMAT_VERSION` to 5.
+3. Implement manifest v4-to-v5 upgrade (write v5 snapshot before first SST v8).
+4. Add `LsmStorageOptions::ttl_background_scanner_interval`.
+5. Implement the background TTL scanner as a periodic task on the background
+   executor.
+6. Add `KvEngine::ttl_stats()`.
+7. Add benchmark coverage and enforce performance gates.
+8. Document TTL semantics in the engine API docs, including snapshot isolation
+   caveats and wall-clock considerations.
+
+---
+
+## 12. Open Questions
+
+1. **Absolute deadline API.** Should `put_with_ttl` accept a `SystemTime` absolute
+   deadline in addition to a `Duration`? This would allow callers to synchronize
+   TTL across nodes using a known deadline (e.g., "expire at midnight UTC").
+2. **Backpressure signal.** Should the background scanner publish a metric or
+   callback when it detects expired SSTs that cannot be cleaned due to active
+   readers (backpressure signal)?
+3. **Per-scan TTL flag.** Should `ttl_read_filtering` be per-scan rather than
+   global? A scan could accept a flag `respect_ttl: bool` for finer-grained
+   control.
+4. **TTL for range tombstones.** Should TTL apply to range tombstones? A
+   `DeleteRange` with a TTL could auto-expire, limiting the read-path overhead
+   and tombstone accumulation window.
+5. **`touch(key)` operation.** Should the engine provide a `touch(key)` operation
+   that resets the TTL of an existing key without rewriting its value?
+
+---
+
+## 13. Future Work
+
+1. **TTL-strict snapshots.** Extend `ReadGuard` to capture wall-clock time at
+   snapshot creation, so that a long-running scan sees a consistent TTL view
+   (keys that expire after snapshot creation remain visible for the scan's
+   duration).
+2. **Millisecond TTL precision.** Use `u64` milliseconds instead of seconds for
+   `expire_at`, enabling sub-second TTL.
+3. **Default TTL per prefix or column family.** Allow setting a default TTL for
+   all writes under a key prefix, avoiding per-key `put_with_ttl` calls.
+4. **TTL compaction priority.** Boost compaction priority for levels containing
+   SSTs with a high fraction of expired TTL entries.
+5. **TTL-aware block cache eviction.** Preferentially evict blocks from SSTs
+   whose TTL entries have expired.
+6. **Transaction-local `put_with_ttl`.** Support TTL writes inside transactions,
+   with conflict detection aware of TTL expiration.
+7. **`expire_at` override in `write_batch` for absolute deadlines.** Allow
+   specifying an absolute `expire_at` timestamp directly instead of deriving it
+   from a duration.
+
+---
+
+## 14. References
+
+- [RFC 001: Key-Value Separation](../rfcs/001-key-value-separation.md) — vLog architecture, KvKind encoding.
+- [RFC 005: MVCC](../rfcs/005-mvcc.md) — watermark model, ReadGuard, version GC.
+- [RFC 009: Compaction Filters](../rfcs/009-compaction-filter.md) — `can_publish_filter_deletion` gate, eventual cleanup model.
+- [RFC 010: Delete Range](../rfcs/010-delete-range.md) — range tombstone semantics, vLog integration, fragmentation.
+- [RocksDB TTL Compaction Filter](https://github.com/facebook/rocksdb/wiki/TTL-Compaction-Filter) — upstream TTL model.
+- [Redis TTL](https://redis.io/docs/latest/commands/expire/) — passive + active expiration model.
+- [FoundationDB TTL](https://apple.github.io/foundationdb/developer-guide.html#time-to-live) — wall-clock TTL in a transactional KV store.
+- [ScyllaDB TTL](https://opensource.docs.scylladb.com/stable/cql/time-to-live.html) — per-column TTL with compaction-time cleanup.

--- a/rfcs/016-ttl.md
+++ b/rfcs/016-ttl.md
@@ -386,7 +386,7 @@ Sites that need changes (file paths relative to `kv-engine/src/`):
 
 | File | Location | Current behavior | Required change |
 |---|---|---|---|
-| `mem_table.rs` | `flush()` (~line 808–814) | Checks `val[0] == 0x01 \|\| val[0] == 0x02` to decide pass-through vs strip-KvKind. TTL variants match neither. | Handle `TtlValuePointer` (0x04) the same as `ValuePointer` (pass through unchanged). Handle `TtlInline` (0x03) the same as `Inline` (0x00): if the value exceeds `min_value_size`, write the user value to the vLog and convert to `TtlValuePointer` with the same `expire_at_secs`; otherwise pass the `TtlInline` value through unchanged. |
+| `mem_table.rs` | `flush()` (~line 808–814) | Checks `val[0] == 0x01 \|\| val[0] == 0x02` to decide pass-through vs strip-KvKind. TTL variants match neither. Stripping just the KvKind byte from TtlInline and passing to `builder.add()` would embed the 8-byte `expire_at` into the user value and lose the TTL kind — the builder returns a plain `ValuePointer` or `Inline` kind. | `SsTableBuilder` must be extended with an `add_with_ttl(key, value, expire_at_secs)` method that preserves the TTL kind and metadata. In `flush()`, detect TTL variants (`val[0] == 0x03 \|\| val[0] == 0x04`) and route to the new method. TtlValuePointer passes through unchanged (pointer already encodes the vLog reference). TtlInline: if the user value exceeds `min_value_size`, write only the user value to vLog and call `add_with_ttl` with `TtlValuePointer`; otherwise pass the full 9-byte TTL-prefixed value through. |
 | `mem_table.rs` | `resolve_item_value` (~line 1194–1199) in `MemTableIterator` | For non-ValuePointer, non-Tombstone values, strips only the KvKind byte (`val.slice(1..)`). TTL variants would leak the 8-byte `expire_at` into the caller-visible value. | `TtlValuePointer` (0x04) must be routed to the same vLog deref path as `ValuePointer` (0x01) — it contains a 16-byte `ValuePointer` payload, not the user value. `TtlInline` (0x03) strips 9 bytes to return the user value: `if val[0] == 0x03 { val.slice(9..) }`. The existing ValuePointer (0x01) and Tombstone (0x02) branches are handled before these checks. |
 | `mem_table.rs` | `collect_vlog_file_ids` (~line 568–573) | Only decodes `ValuePointer` for byte `0x01`. TtlValuePointer (0x04) vLog references are missed, risking premature file deletion. | Also decode for byte `0x04`, reading the ValuePointer from bytes `[9..25]` instead of `[1..17]`. |
 | `table/builder.rs` | `add_raw` (~line 188–198) | Only tracks vLog references for byte `0x01`. TtlValuePointer files are not tracked. | Also check byte `0x04` and decode ValuePointer from offset 9. |
@@ -395,7 +395,7 @@ Sites that need changes (file paths relative to `kv-engine/src/`):
 | `lsm_storage.rs` | `resolve_value` (~line 3780–3788) | Match on `ValuePointer`, `Inline \| Tombstone`. Non-exhaustive after adding TTL variants. | Add `TtlInline` to the `Inline/Tombstone` arm (strips prefix, returns user value bytes directly). Add `TtlValuePointer` to the `ValuePointer` arm so it is dereferenced via `resolve_vlog_value_bytes` — placing it in `Inline/Tombstone` would return raw pointer bytes as the user value, bypassing vLog lookup. |
 | `lsm_storage.rs` | `resolve_vlog_value_bytes` (~line 3798–3824) | Match on `ValuePointer`, `Tombstone`, wildcard `_` for Inline. TtlValuePointer would hit the wildcard arm (treated as Inline). | Add `TtlValuePointer` arm that decodes the ValuePointer from offset 9. |
 | `lsm_storage.rs` | `values_match` (~line 5225–5235) | Match on `(Inline, Inline)` and `(ValuePointer, ValuePointer)`. TTL variants produce `false`, which is safe but breaks CAS for vLog GC. | Add `(TtlInline, TtlInline) => ...` and `(TtlValuePointer, TtlValuePointer) => ...` arms with byte-wise comparison of the full TTL-prefixed values. |
-| `lsm_storage.rs` | `build_point_batch_entries` / `build_non_mvcc_batch_entries` (~line 4540–4616) | Match exhaustively on `WriteBatchRecord` variants. `PutWithTtl` not handled. | Add `PutWithTtl(key, val, ttl_secs)` arm that computes `expire_at` and prepends `[KvKind::TtlInline][expire_at: 8][val]`. **Lifetime note:** the value bytes must be copied (e.g., `val.to_vec()`) before constructing the TTL-prefixed value to avoid holding a reference into memtable skiplist memory that could be invalidated by concurrent writes within the same batch pipeline. |
+| `lsm_storage.rs` | `build_point_batch_entries` / `build_non_mvcc_batch_entries` (~line 4540–4616) | Match exhaustively on `WriteBatchRecord` variants. `PutWithTtl` not handled. Returns `Vec<(&[u8], &[u8], bool)>` — references into batch values. A TTL-prefixed value cannot be returned as a reference to a temporary. | Add `PutWithTtl(key, val, ttl_secs)` arm that computes `expire_at` and prepends `[KvKind::TtlInline][expire_at: 8][val]`. **Signature change required:** the return type must be changed from borrowed slices (e.g., `Vec<(&[u8], &[u8], bool)>`) to owned values (e.g., `Vec<(Bytes, Bytes, bool)>`) so the newly-constructed TTL-prefixed value can be returned without dangling references. |
 | `vlog/gc.rs` | `check_liveness` (~line 193–206) | Match on `ValuePointer` only. TtlValuePointer falls to `_ => Ok(false)`, incorrectly reporting live TTL entries as dead. | Handle `TtlValuePointer` the same as `ValuePointer` (decode pointer from correct offset and check pointer equality). Do NOT add a TTL-expiry check here — expiration belongs in compaction and read filtering; dropping the vLog payload while LSM still points at it would cause stale-pointer reads. |
 | `vlog/gc.rs` | `compact_file` (~line 277–344) | Constructs replacement values with `KvKind::ValuePointer`. TTL prefix is lost on rewrite. | When the old entry has a TTL prefix, construct the replacement with `KvKind::TtlValuePointer` and preserve `expire_at_secs`. |
 | `wal.rs` | Entry decode (~line 822–827, 915–919) | Uses WAL-internal kind bytes (0=Put, 1=PointTombstone, 2=RangeTombstone), not KvKind. TTL writes use WAL kind 0 (Put) with TTL-prefixed values. | **No change needed.** WAL treats values as opaque bytes. Recovery calls `handle_put(key, value)` which inserts the TTL-prefixed bytes into the skiplist unchanged. |
@@ -877,13 +877,24 @@ match current_kind {
             // Decode pointer from offset 1 (ValuePointer) or 9 (TtlValuePointer).
             let ptr_offset = current_kind.payload_offset();
             let current_ptr = ValuePointer::try_decode(&val[ptr_offset..]);
-            Ok(current_ptr == Some(old_ptr))
+            let is_live = current_ptr == Some(old_ptr);
+            let expire_at = if current_kind == KvKind::TtlValuePointer {
+                // extract expire_at_secs from bytes 1..9
+                Some(u64::from_be_bytes(val[1..9].try_into().unwrap()))
+            } else {
+                None
+            };
+            Ok(if is_live {
+                Liveness::Live { expire_at }
+            } else {
+                Liveness::Dead
+            })
         } else {
-            Ok(false)
+            Ok(Liveness::Dead)
         }
     }
-    KvKind::Tombstone => Ok(false), // deleted — dead
-    _ => Ok(false), // Inline / TtlInline — not a vLog reference
+    KvKind::Tombstone => Ok(Liveness::Dead), // deleted — dead
+    _ => Ok(Liveness::Dead), // Inline / TtlInline — not a vLog reference
 }
 ```
 


### PR DESCRIPTION
## Summary

Proposes native TTL (Time-To-Live) support for kv-engine with value-level encoding, compaction-time cleanup, optional read-path filtering, and per-SST metadata optimizations.

## Key Design Decisions

- **Value-level encoding** — new `KvKind::TtlInline` (3) and `KvKind::TtlValuePointer` (4) variants, each followed by `expire_at_secs: u64 BE` (9 bytes overhead). Avoids changing the internal key format.
- **Compaction-time cleanup** — primary removal mechanism, gated by a new `can_publish_ttl_deletion` flag (no active MVCC readers required, but unlike compaction filters, does not require installed filters).
- **Opt-in read-path filtering** — `ttl_read_filtering` option makes expired keys invisible to get/scan before compaction.
- **Per-SST TTL metadata** — `min_ttl_expire_ts`/`max_ttl_expire_ts` in SST footer v8 for O(1) eligibility checks and wholesale-drop optimization (6 safety conditions).
- **SST footer v8** — 41 bytes, extends v7 with two `u64` TTL fields. Manifest format version bump to 5.
- **5-phase rollout** — value encoding → SST v8 → compaction integration → read-path filtering → public API/scanner.

## Changes

- New file: `rfcs/016-ttl.md` (1329 lines)
- Follows existing RFC format (sections 1–14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an RFC for native per-key TTL, detailing expiry-aware read semantics, TTL overwrite behavior, range-tombstone interaction, and compaction-time cleanup rules.
  * Documented SST/manifest format changes for TTL metadata and how TTL state is preserved across log GC.
* **Planned Features**
  * Add TTL write APIs (including `put_with_ttl`) and TTL observability (`ttl_stats`).
  * Support opt-in TTL visibility filtering and an optional background TTL expiry scanner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->