### PR TITLE
feat: add standalone MVCC GC scheduling

### DIFF
--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -1412,9 +1412,7 @@ impl LsmStorageInner {
 
     fn sst_has_expired_ttl_entries(sst: &SsTable, now_secs: u64) -> bool {
         let ttl_meta = &sst.ttl_metadata;
-        ttl_meta.ttl_entry_count > 0
-            && ttl_meta.max_ttl_expire_ts > 0
-            && ttl_meta.max_ttl_expire_ts <= now_secs
+        ttl_meta.ttl_entry_count > 0 && ttl_meta.max_ttl_expire_ts <= now_secs
     }
 
     fn bottom_level_has_overlapping_user_ranges(
@@ -1428,14 +1426,16 @@ impl LsmStorageInner {
                 let first = sst.first_key()?;
                 let last = sst.last_key()?;
                 let first_user = if crate::key::TS_ENABLED {
-                    first.decode_user_key()
+                    let raw = first.raw_ref();
+                    &raw[..raw.len().saturating_sub(8)]
                 } else {
-                    first.raw_ref().to_vec()
+                    first.raw_ref()
                 };
                 let last_user = if crate::key::TS_ENABLED {
-                    last.decode_user_key()
+                    let raw = last.raw_ref();
+                    &raw[..raw.len().saturating_sub(8)]
                 } else {
-                    last.raw_ref().to_vec()
+                    last.raw_ref()
                 };
                 Some((first_user, last_user))
             })
@@ -1445,8 +1445,8 @@ impl LsmStorageInner {
             return false;
         }
 
-        ranges.sort_by(|a, b| a.0.cmp(&b.0));
-        let mut current_end = ranges[0].1.clone();
+        ranges.sort_by(|a, b| a.0.cmp(b.0));
+        let mut current_end = ranges[0].1;
         for (start, end) in ranges.into_iter().skip(1) {
             if start <= current_end {
                 return true;

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -333,7 +333,7 @@ mod tests {
         let sst_a = storage.next_sst_id();
         let sst_b = storage.next_sst_id();
         let sst_a_obj = build_test_sst(&storage, sst_a, b"a", 3);
-        let sst_b_obj = build_test_sst(&storage, sst_b, b"b", 4);
+        let sst_b_obj = build_test_sst(&storage, sst_b, b"a", 4);
         let mut snapshot = storage.state.load().as_ref().clone();
         snapshot.levels[0].1.extend([sst_a, sst_b]);
         snapshot.sstables.insert(sst_a, sst_a_obj);
@@ -351,6 +351,38 @@ mod tests {
             }
             other => panic!("expected simple task, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_generate_mvcc_gc_task_simple_skips_disjoint_bottom_level() {
+        let dir = tempdir().unwrap();
+        let options = LsmStorageOptions {
+            compaction_options: CompactionOptions::Simple(SimpleLeveledCompactionOptions {
+                size_ratio_percent: 200,
+                level0_file_num_compaction_trigger: 8,
+                max_levels: 3,
+            }),
+            ..LsmStorageOptions::default_for_test()
+        };
+        let storage = LsmStorageInner::open(&dir, options).unwrap();
+        storage.mvcc.as_ref().unwrap().update_commit_ts(10);
+
+        let sst_a = storage.next_sst_id();
+        let sst_b = storage.next_sst_id();
+        let sst_a_obj = build_test_sst(&storage, sst_a, b"a", 3);
+        let sst_b_obj = build_test_sst(&storage, sst_b, b"b", 4);
+        let mut snapshot = storage.state.load().as_ref().clone();
+        snapshot.levels[0].1.extend([sst_a, sst_b]);
+        snapshot.sstables.insert(sst_a, sst_a_obj);
+        snapshot.sstables.insert(sst_b, sst_b_obj);
+        storage.state.store(Arc::new(snapshot));
+
+        assert!(
+            storage
+                .generate_mvcc_gc_task(storage.state.load().as_ref())
+                .is_none(),
+            "disjoint bottom-level SSTs should not trigger standalone MVCC GC"
+        );
     }
 
     #[test]
@@ -387,6 +419,40 @@ mod tests {
             }
             other => panic!("expected tiered task, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_generate_mvcc_gc_task_tiered_skips_disjoint_bottom_level() {
+        let dir = tempdir().unwrap();
+        let options = LsmStorageOptions {
+            compaction_options: CompactionOptions::Tiered(TieredCompactionOptions {
+                num_tiers: 3,
+                max_size_amplification_percent: 200,
+                size_ratio: 1,
+                min_merge_width: 2,
+                max_merge_width: None,
+            }),
+            ..LsmStorageOptions::default_for_test()
+        };
+        let storage = LsmStorageInner::open(&dir, options).unwrap();
+        storage.mvcc.as_ref().unwrap().update_commit_ts(10);
+
+        let sst_a = storage.next_sst_id();
+        let sst_b = storage.next_sst_id();
+        let sst_a_obj = build_test_sst(&storage, sst_a, b"a", 3);
+        let sst_b_obj = build_test_sst(&storage, sst_b, b"b", 4);
+        let mut snapshot = storage.state.load().as_ref().clone();
+        snapshot.levels = vec![(1, vec![sst_a, sst_b])];
+        snapshot.sstables.insert(sst_a, sst_a_obj);
+        snapshot.sstables.insert(sst_b, sst_b_obj);
+        storage.state.store(Arc::new(snapshot));
+
+        assert!(
+            storage
+                .generate_mvcc_gc_task(storage.state.load().as_ref())
+                .is_none(),
+            "disjoint bottom-tier SSTs should not trigger standalone MVCC GC"
+        );
     }
 
     #[test]
@@ -1351,6 +1417,47 @@ impl LsmStorageInner {
             && ttl_meta.max_ttl_expire_ts <= now_secs
     }
 
+    fn bottom_level_has_overlapping_user_ranges(
+        snapshot: &LsmStorageState,
+        sst_ids: &[usize],
+    ) -> bool {
+        let mut ranges = sst_ids
+            .iter()
+            .filter_map(|id| {
+                let sst = snapshot.sstables.get(id)?;
+                let first = sst.first_key()?;
+                let last = sst.last_key()?;
+                let first_user = if crate::key::TS_ENABLED {
+                    first.decode_user_key()
+                } else {
+                    first.raw_ref().to_vec()
+                };
+                let last_user = if crate::key::TS_ENABLED {
+                    last.decode_user_key()
+                } else {
+                    last.raw_ref().to_vec()
+                };
+                Some((first_user, last_user))
+            })
+            .collect::<Vec<_>>();
+
+        if ranges.len() < 2 {
+            return false;
+        }
+
+        ranges.sort_by(|a, b| a.0.cmp(&b.0));
+        let mut current_end = ranges[0].1.clone();
+        for (start, end) in ranges.into_iter().skip(1) {
+            if start <= current_end {
+                return true;
+            }
+            if end > current_end {
+                current_end = end;
+            }
+        }
+        false
+    }
+
     fn collect_input_range_only_ids(
         &self,
         task: &CompactionTask,
@@ -1449,12 +1556,21 @@ impl LsmStorageInner {
                 if bottom_level_ids.iter().any(|id| reserved.contains(id)) {
                     return None;
                 }
-                let has_candidate = bottom_level_ids.iter().any(|id| {
-                    snapshot.sstables.get(id).is_some_and(|sst| {
-                        sst.max_ts() <= cutoff || Self::sst_has_expired_ttl_entries(sst, now_secs)
-                    })
+                let has_expired_ttl = bottom_level_ids.iter().any(|id| {
+                    snapshot
+                        .sstables
+                        .get(id)
+                        .is_some_and(|sst| Self::sst_has_expired_ttl_entries(sst, now_secs))
                 });
-                if !has_candidate {
+                let has_old_versions = bottom_level_ids.iter().any(|id| {
+                    snapshot
+                        .sstables
+                        .get(id)
+                        .is_some_and(|sst| sst.max_ts() <= cutoff)
+                });
+                let has_overlap =
+                    Self::bottom_level_has_overlapping_user_ranges(snapshot, bottom_level_ids);
+                if !has_expired_ttl && !(has_old_versions && has_overlap) {
                     return None;
                 }
                 Some(CompactionTask::Simple(SimpleLeveledCompactionTask {
@@ -1469,12 +1585,21 @@ impl LsmStorageInner {
                 if bottom_level_ids.iter().any(|id| reserved.contains(id)) {
                     return None;
                 }
-                let candidate = bottom_level_ids.iter().any(|id| {
-                    snapshot.sstables.get(id).is_some_and(|sst| {
-                        sst.max_ts() <= cutoff || Self::sst_has_expired_ttl_entries(sst, now_secs)
-                    })
+                let has_expired_ttl = bottom_level_ids.iter().any(|id| {
+                    snapshot
+                        .sstables
+                        .get(id)
+                        .is_some_and(|sst| Self::sst_has_expired_ttl_entries(sst, now_secs))
                 });
-                if !candidate {
+                let has_old_versions = bottom_level_ids.iter().any(|id| {
+                    snapshot
+                        .sstables
+                        .get(id)
+                        .is_some_and(|sst| sst.max_ts() <= cutoff)
+                });
+                let has_overlap =
+                    Self::bottom_level_has_overlapping_user_ranges(snapshot, bottom_level_ids);
+                if !has_expired_ttl && !(has_old_versions && has_overlap) {
                     return None;
                 }
                 Some(CompactionTask::Tiered(TieredCompactionTask {

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -121,6 +121,7 @@ mod tests {
         key::KeySlice,
         lsm_storage::{LsmStorageInner, LsmStorageOptions},
         table::SsTableBuilder,
+        vlog::{KvKind, encode_ttl_value},
     };
 
     fn build_test_sst(
@@ -132,6 +133,26 @@ mod tests {
         let mut builder = SsTableBuilder::new(storage.options.block_size);
         let encoded = KeySlice::for_testing_from_slice_with_ts(key, ts);
         builder.add(encoded.as_key_slice(), b"v").unwrap();
+        Arc::new(
+            builder
+                .build(sst_id, None, storage.path_of_sst(sst_id))
+                .unwrap(),
+        )
+    }
+
+    fn build_test_ttl_sst(
+        storage: &LsmStorageInner,
+        sst_id: usize,
+        key: &[u8],
+        ts: u64,
+        expire_at_secs: u64,
+    ) -> Arc<SsTable> {
+        let mut builder = SsTableBuilder::new(storage.options.block_size);
+        let encoded = KeySlice::for_testing_from_slice_with_ts(key, ts);
+        let value = encode_ttl_value(KvKind::TtlInline, expire_at_secs, b"v");
+        builder
+            .add_with_ttl(encoded.as_key_slice(), &value)
+            .unwrap();
         Arc::new(
             builder
                 .build(sst_id, None, storage.path_of_sst(sst_id))
@@ -329,6 +350,42 @@ mod tests {
                 assert_eq!(task.upper_level_sst_ids, vec![sst_a, sst_b]);
             }
             other => panic!("expected simple task, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_generate_mvcc_gc_task_tiered_accepts_expired_ttl_sst() {
+        let dir = tempdir().unwrap();
+        let options = LsmStorageOptions {
+            compaction_options: CompactionOptions::Tiered(TieredCompactionOptions {
+                num_tiers: 3,
+                max_size_amplification_percent: 200,
+                size_ratio: 1,
+                min_merge_width: 2,
+                max_merge_width: None,
+            }),
+            ..LsmStorageOptions::default_for_test()
+        };
+        let storage = LsmStorageInner::open(&dir, options).unwrap();
+        storage.mvcc.as_ref().unwrap().update_commit_ts(1);
+
+        let sst_id = storage.next_sst_id();
+        let expire_at_secs = crate::vlog::wall_clock_secs().saturating_sub(1);
+        let sst = build_test_ttl_sst(&storage, sst_id, b"a", 10, expire_at_secs);
+        let mut snapshot = storage.state.load().as_ref().clone();
+        snapshot.levels = vec![(1, vec![sst_id])];
+        snapshot.sstables.insert(sst_id, sst);
+        storage.state.store(Arc::new(snapshot));
+
+        let task = storage
+            .generate_mvcc_gc_task(storage.state.load().as_ref())
+            .expect("expected GC task");
+        match task {
+            CompactionTask::Tiered(task) => {
+                assert_eq!(task.tiers, vec![(1, vec![sst_id])]);
+                assert!(task.bottom_tier_included);
+            }
+            other => panic!("expected tiered task, got {other:?}"),
         }
     }
 
@@ -1287,6 +1344,13 @@ impl LsmStorageInner {
         }
     }
 
+    fn sst_has_expired_ttl_entries(sst: &SsTable, now_secs: u64) -> bool {
+        let ttl_meta = &sst.ttl_metadata;
+        ttl_meta.ttl_entry_count > 0
+            && ttl_meta.max_ttl_expire_ts > 0
+            && ttl_meta.max_ttl_expire_ts <= now_secs
+    }
+
     fn collect_input_range_only_ids(
         &self,
         task: &CompactionTask,
@@ -1356,9 +1420,7 @@ impl LsmStorageInner {
                         let sst = snapshot.sstables.get(id)?;
                         let ttl_meta = &sst.ttl_metadata;
                         let fully_old = sst.max_ts() <= cutoff;
-                        let ttl_candidate = ttl_meta.ttl_entry_count > 0
-                            && ttl_meta.max_ttl_expire_ts > 0
-                            && ttl_meta.max_ttl_expire_ts <= now_secs;
+                        let ttl_candidate = Self::sst_has_expired_ttl_entries(sst, now_secs);
                         if !fully_old && !ttl_candidate {
                             return None;
                         }
@@ -1389,10 +1451,7 @@ impl LsmStorageInner {
                 }
                 let has_candidate = bottom_level_ids.iter().any(|id| {
                     snapshot.sstables.get(id).is_some_and(|sst| {
-                        sst.max_ts() <= cutoff
-                            || (sst.ttl_metadata.ttl_entry_count > 0
-                                && sst.ttl_metadata.max_ttl_expire_ts > 0
-                                && sst.ttl_metadata.max_ttl_expire_ts <= now_secs)
+                        sst.max_ts() <= cutoff || Self::sst_has_expired_ttl_entries(sst, now_secs)
                     })
                 });
                 if !has_candidate {
@@ -1411,10 +1470,9 @@ impl LsmStorageInner {
                     return None;
                 }
                 let candidate = bottom_level_ids.iter().any(|id| {
-                    snapshot
-                        .sstables
-                        .get(id)
-                        .is_some_and(|sst| sst.max_ts() <= cutoff)
+                    snapshot.sstables.get(id).is_some_and(|sst| {
+                        sst.max_ts() <= cutoff || Self::sst_has_expired_ttl_entries(sst, now_secs)
+                    })
                 });
                 if !candidate {
                     return None;

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -62,7 +62,18 @@ struct CompactionEntryDecision<'a> {
     is_tombstone: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+struct ReservedSsts<'a> {
+    inner: &'a LsmStorageInner,
+    ids: Vec<usize>,
+}
+
+impl Drop for ReservedSsts<'_> {
+    fn drop(&mut self) {
+        self.inner.release_reserved_ssts(&self.ids);
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum CompactionTask {
     Leveled(LeveledCompactionTask),
     Tiered(TieredCompactionTask),
@@ -104,6 +115,29 @@ impl CompactionTask {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
+
+    use crate::{
+        key::KeySlice,
+        lsm_storage::{LsmStorageInner, LsmStorageOptions},
+        table::SsTableBuilder,
+    };
+
+    fn build_test_sst(
+        storage: &LsmStorageInner,
+        sst_id: usize,
+        key: &[u8],
+        ts: u64,
+    ) -> Arc<SsTable> {
+        let mut builder = SsTableBuilder::new(storage.options.block_size);
+        let encoded = KeySlice::for_testing_from_slice_with_ts(key, ts);
+        builder.add(encoded.as_key_slice(), b"v").unwrap();
+        Arc::new(
+            builder
+                .build(sst_id, None, storage.path_of_sst(sst_id))
+                .unwrap(),
+        )
+    }
 
     #[test]
     fn test_compact_to_bottom_level() {
@@ -224,6 +258,78 @@ mod tests {
             bottom_tier_included: true,
         });
         assert!(!tiered_major.is_upper_level_compaction());
+    }
+
+    #[test]
+    fn test_generate_mvcc_gc_task_uses_effective_bottommost_level() {
+        let dir = tempdir().unwrap();
+        let options = LsmStorageOptions {
+            compaction_options: CompactionOptions::Leveled(LeveledCompactionOptions {
+                level_size_multiplier: 2,
+                level0_file_num_compaction_trigger: 8,
+                max_levels: 3,
+                base_level_size_mb: 128,
+            }),
+            ..LsmStorageOptions::default_for_test()
+        };
+        let storage = LsmStorageInner::open(&dir, options).unwrap();
+        storage.mvcc.as_ref().unwrap().update_commit_ts(10);
+
+        let sst_id = storage.next_sst_id();
+        let sst = build_test_sst(&storage, sst_id, b"a", 3);
+        let mut snapshot = storage.state.load().as_ref().clone();
+        snapshot.levels[0].1.push(sst_id);
+        snapshot.sstables.insert(sst_id, sst);
+        storage.state.store(Arc::new(snapshot));
+
+        let task = storage
+            .generate_mvcc_gc_task(storage.state.load().as_ref())
+            .expect("expected GC task");
+        match task {
+            CompactionTask::Leveled(task) => {
+                assert_eq!(task.upper_level, Some(1));
+                assert_eq!(task.lower_level, 1);
+                assert_eq!(task.upper_level_sst_ids, vec![sst_id]);
+            }
+            other => panic!("expected leveled task, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_generate_mvcc_gc_task_simple_rewrites_entire_bottom_level() {
+        let dir = tempdir().unwrap();
+        let options = LsmStorageOptions {
+            compaction_options: CompactionOptions::Simple(SimpleLeveledCompactionOptions {
+                size_ratio_percent: 200,
+                level0_file_num_compaction_trigger: 8,
+                max_levels: 3,
+            }),
+            ..LsmStorageOptions::default_for_test()
+        };
+        let storage = LsmStorageInner::open(&dir, options).unwrap();
+        storage.mvcc.as_ref().unwrap().update_commit_ts(10);
+
+        let sst_a = storage.next_sst_id();
+        let sst_b = storage.next_sst_id();
+        let sst_a_obj = build_test_sst(&storage, sst_a, b"a", 3);
+        let sst_b_obj = build_test_sst(&storage, sst_b, b"b", 4);
+        let mut snapshot = storage.state.load().as_ref().clone();
+        snapshot.levels[0].1.extend([sst_a, sst_b]);
+        snapshot.sstables.insert(sst_a, sst_a_obj);
+        snapshot.sstables.insert(sst_b, sst_b_obj);
+        storage.state.store(Arc::new(snapshot));
+
+        let task = storage
+            .generate_mvcc_gc_task(storage.state.load().as_ref())
+            .expect("expected GC task");
+        match task {
+            CompactionTask::Simple(task) => {
+                assert_eq!(task.upper_level, Some(1));
+                assert_eq!(task.lower_level, 1);
+                assert_eq!(task.upper_level_sst_ids, vec![sst_a, sst_b]);
+            }
+            other => panic!("expected simple task, got {other:?}"),
+        }
     }
 
     #[test]
@@ -1005,6 +1111,9 @@ impl LsmStorageInner {
             l0_sstables: ssts_to_compact.0.clone(),
             l1_sstables: ssts_to_compact.1.clone(),
         };
+        let Some(_reservation) = self.reserve_task_inputs(&task) else {
+            return Ok(());
+        };
 
         let (new_ssts, new_range_only_ssts, compact_vlog_ids, apply_filters) =
             self.compact(&task)?;
@@ -1207,6 +1316,118 @@ impl LsmStorageInner {
         }
     }
 
+    fn reserve_ssts(&self, mut sst_ids: Vec<usize>) -> Option<ReservedSsts<'_>> {
+        sst_ids.sort_unstable();
+        sst_ids.dedup();
+        if self.try_reserve_ssts(&sst_ids) {
+            Some(ReservedSsts {
+                inner: self,
+                ids: sst_ids,
+            })
+        } else {
+            None
+        }
+    }
+
+    fn reserve_task_inputs(&self, task: &CompactionTask) -> Option<ReservedSsts<'_>> {
+        let input_sst_ids = Self::collect_compaction_input_sst_ids(task);
+        let target_level = Self::compaction_target_level(task);
+        let mut reserved_ids = input_sst_ids.clone();
+        reserved_ids.extend(self.collect_input_range_only_ids(task, target_level, &input_sst_ids));
+        self.reserve_ssts(reserved_ids)
+    }
+
+    fn generate_mvcc_gc_task(&self, snapshot: &LsmStorageState) -> Option<CompactionTask> {
+        let cutoff = self.mvcc.as_ref().map(|mvcc| mvcc.watermark())?;
+        let reserved = self.snapshot_reserved_ssts();
+        let now_secs = crate::vlog::wall_clock_secs();
+        let (bottom_level_num, bottom_level_ids) = snapshot
+            .levels
+            .iter()
+            .rev()
+            .find(|(_, ids)| !ids.is_empty())?;
+
+        match &self.options.compaction_options {
+            crate::compact::CompactionOptions::Leveled(_) => {
+                let best = bottom_level_ids
+                    .iter()
+                    .filter(|id| !reserved.contains(id))
+                    .filter_map(|id| {
+                        let sst = snapshot.sstables.get(id)?;
+                        let ttl_meta = &sst.ttl_metadata;
+                        let fully_old = sst.max_ts() <= cutoff;
+                        let ttl_candidate = ttl_meta.ttl_entry_count > 0
+                            && ttl_meta.max_ttl_expire_ts > 0
+                            && ttl_meta.max_ttl_expire_ts <= now_secs;
+                        if !fully_old && !ttl_candidate {
+                            return None;
+                        }
+                        let ttl_ratio = if ttl_meta.total_entry_count == 0 {
+                            0.0
+                        } else {
+                            ttl_meta.ttl_entry_count as f64 / ttl_meta.total_entry_count as f64
+                        };
+                        Some((*id, fully_old, ttl_candidate, ttl_ratio, sst.table_size()))
+                    })
+                    .max_by(|a, b| {
+                        a.1.cmp(&b.1)
+                            .then(a.2.cmp(&b.2))
+                            .then_with(|| a.3.total_cmp(&b.3))
+                            .then(a.4.cmp(&b.4))
+                    })?;
+                Some(CompactionTask::Leveled(LeveledCompactionTask {
+                    upper_level: Some(*bottom_level_num),
+                    upper_level_sst_ids: vec![best.0],
+                    lower_level: *bottom_level_num,
+                    lower_level_sst_ids: Vec::new(),
+                    is_lower_level_bottom_level: true,
+                }))
+            }
+            crate::compact::CompactionOptions::Simple(_) => {
+                if bottom_level_ids.iter().any(|id| reserved.contains(id)) {
+                    return None;
+                }
+                let has_candidate = bottom_level_ids.iter().any(|id| {
+                    snapshot.sstables.get(id).is_some_and(|sst| {
+                        sst.max_ts() <= cutoff
+                            || (sst.ttl_metadata.ttl_entry_count > 0
+                                && sst.ttl_metadata.max_ttl_expire_ts > 0
+                                && sst.ttl_metadata.max_ttl_expire_ts <= now_secs)
+                    })
+                });
+                if !has_candidate {
+                    return None;
+                }
+                Some(CompactionTask::Simple(SimpleLeveledCompactionTask {
+                    upper_level: Some(*bottom_level_num),
+                    upper_level_sst_ids: bottom_level_ids.clone(),
+                    lower_level: *bottom_level_num,
+                    lower_level_sst_ids: Vec::new(),
+                    is_lower_level_bottom_level: true,
+                }))
+            }
+            crate::compact::CompactionOptions::Tiered(_) => {
+                if bottom_level_ids.iter().any(|id| reserved.contains(id)) {
+                    return None;
+                }
+                let candidate = bottom_level_ids.iter().any(|id| {
+                    snapshot
+                        .sstables
+                        .get(id)
+                        .is_some_and(|sst| sst.max_ts() <= cutoff)
+                });
+                if !candidate {
+                    return None;
+                }
+                Some(CompactionTask::Tiered(TieredCompactionTask {
+                    tiers: vec![(*bottom_level_num, bottom_level_ids.clone())],
+                    bottom_tier_included: true,
+                }))
+            }
+            crate::compact::CompactionOptions::NoCompaction => None,
+        }
+    }
+
     fn remove_sst_files<I>(&self, sst_ids: I) -> Result<()>
     where
         I: IntoIterator<Item = usize>,
@@ -1378,6 +1599,10 @@ impl LsmStorageInner {
         if candidates.is_empty() {
             return Ok(0);
         }
+        let _reservation = match self.reserve_ssts(candidates.clone()) {
+            Some(reservation) => reservation,
+            None => return Ok(0),
+        };
 
         // Phase 2: under state_lock, re-compute bottom level and filter
         // candidates to avoid TOCTOU race with concurrent compactions.
@@ -1470,20 +1695,8 @@ impl LsmStorageInner {
         Ok(count)
     }
 
-    /// Check whether any mixed SSTs have a high enough proportion of
-    /// expired TTL entries to justify compaction.
-    pub(crate) fn trigger_compaction(&self) -> Result<()> {
-        // TTL background scan: drop fully-expired TTL-only SSTs at the
-        // bottommost level. Mixed SSTs with expired entries are prioritized
-        // by the compaction controller's generate_compaction_task.
-        self.try_ttl_wholesale_drop()?;
-
-        let task = self
-            .compaction_controller
-            .generate_compaction_task(self.state.load_full().as_ref());
-        let Some(t) = task.as_ref() else {
-            return Ok(());
-        };
+    fn publish_compaction_task(&self, task: &CompactionTask) -> Result<()> {
+        let t = task;
         let (new_ssts, new_range_only_ssts, compact_vlog_ids, apply_filters) = self.compact(t)?;
         let new_sst_ids = new_ssts.iter().map(|x| x.sst_id()).collect::<Vec<_>>();
         let new_range_only_sst_ids: Vec<usize> =
@@ -1580,9 +1793,8 @@ impl LsmStorageInner {
                 );
             }
 
-            let task = task.expect("task checked for Some above");
             let manifest_record = ManifestRecord::CompactionV3(
-                task,
+                task.clone(),
                 new_sst_ids,
                 compact_vlog_ids,
                 new_range_only_sst_ids,
@@ -1608,6 +1820,32 @@ impl LsmStorageInner {
         // Run GC on vLog files that may have stale entries
         if !input_vlog_ids.is_empty() {
             self.post_compaction_gc(&input_vlog_ids);
+        }
+
+        Ok(())
+    }
+
+    /// Check whether any mixed SSTs have a high enough proportion of
+    /// expired TTL entries to justify compaction.
+    pub(crate) fn trigger_compaction(&self) -> Result<()> {
+        // TTL background scan: drop fully-expired TTL-only SSTs at the
+        // bottommost level. Mixed SSTs with expired entries are prioritized
+        // by the compaction controller's generate_compaction_task.
+        self.try_ttl_wholesale_drop()?;
+
+        let snapshot = self.state.load_full();
+        if let Some(task) = self
+            .compaction_controller
+            .generate_compaction_task(snapshot.as_ref())
+            && let Some(_reservation) = self.reserve_task_inputs(&task)
+        {
+            return self.publish_compaction_task(&task);
+        }
+
+        if let Some(task) = self.generate_mvcc_gc_task(snapshot.as_ref())
+            && let Some(_reservation) = self.reserve_task_inputs(&task)
+        {
+            return self.publish_compaction_task(&task);
         }
 
         Ok(())

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -1435,7 +1435,7 @@ impl LsmStorageInner {
             return false;
         }
 
-        ranges.sort_by(|a, b| a.0.cmp(b.0));
+        ranges.sort_unstable_by(|a, b| a.0.cmp(b.0));
         let mut current_end = ranges[0].1;
         for (start, end) in ranges.into_iter().skip(1) {
             if start <= current_end {

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -1772,10 +1772,6 @@ impl LsmStorageInner {
         if candidates.is_empty() {
             return Ok(0);
         }
-        let _reservation = match self.reserve_ssts(candidates.clone()) {
-            Some(reservation) => reservation,
-            None => return Ok(0),
-        };
 
         // Phase 2: under state_lock, re-compute bottom level and filter
         // candidates to avoid TOCTOU race with concurrent compactions.
@@ -1815,6 +1811,10 @@ impl LsmStorageInner {
         if expired_ids.is_empty() {
             return Ok(0);
         }
+        let _reservation = match self.reserve_ssts(expired_ids.clone()) {
+            Some(reservation) => reservation,
+            None => return Ok(0),
+        };
         let count = expired_ids.len();
         let mut snapshot = snapshot;
         for &id in &expired_ids {

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -1425,18 +1425,8 @@ impl LsmStorageInner {
                 let sst = snapshot.sstables.get(id)?;
                 let first = sst.first_key()?;
                 let last = sst.last_key()?;
-                let first_user = if crate::key::TS_ENABLED {
-                    let raw = first.raw_ref();
-                    &raw[..raw.len().saturating_sub(8)]
-                } else {
-                    first.raw_ref()
-                };
-                let last_user = if crate::key::TS_ENABLED {
-                    let raw = last.raw_ref();
-                    &raw[..raw.len().saturating_sub(8)]
-                } else {
-                    last.raw_ref()
-                };
+                let first_user = first.encoded_user_key();
+                let last_user = last.encoded_user_key();
                 Some((first_user, last_user))
             })
             .collect::<Vec<_>>();

--- a/kv-engine/src/compact/leveled.rs
+++ b/kv-engine/src/compact/leveled.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::lsm_storage::LsmStorageState;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LeveledCompactionTask {
     // if upper_level is `None`, then it is L0 compaction
     pub upper_level: Option<usize>,

--- a/kv-engine/src/compact/simple_leveled.rs
+++ b/kv-engine/src/compact/simple_leveled.rs
@@ -9,7 +9,7 @@ pub struct SimpleLeveledCompactionOptions {
     pub max_levels: usize,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SimpleLeveledCompactionTask {
     // if upper_level is `None`, then it is L0 compaction
     pub upper_level: Option<usize>,

--- a/kv-engine/src/compact/tiered.rs
+++ b/kv-engine/src/compact/tiered.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::lsm_storage::LsmStorageState;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TieredCompactionTask {
     pub tiers: Vec<(usize, Vec<usize>)>,
     pub bottom_tier_included: bool,

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fs::{self, File},
     ops::Bound,
     path::{Path, PathBuf},
@@ -891,6 +891,7 @@ pub(crate) struct LsmStorageInner {
     pub(crate) compaction_controller: CompactionController,
     pub(crate) manifest: Option<Manifest>,
     pub(crate) mvcc: Option<Arc<LsmMvccInner>>,
+    reserved_ssts: Mutex<HashSet<usize>>,
     compaction_filters: Mutex<CompactionFilterRegistry>,
     filter_stats: Arc<CompactionFilterAtomicStats>,
     pub(crate) rt_stats: Arc<RangeTombstoneAtomicStats>,
@@ -2312,6 +2313,34 @@ impl LsmStorageInner {
         self.next_sst_id.load(std::sync::atomic::Ordering::SeqCst)
     }
 
+    pub(crate) fn try_reserve_ssts(&self, sst_ids: &[usize]) -> bool {
+        if sst_ids.is_empty() {
+            return true;
+        }
+
+        let mut reserved = self.reserved_ssts.lock();
+        if sst_ids.iter().any(|id| reserved.contains(id)) {
+            return false;
+        }
+        reserved.extend(sst_ids.iter().copied());
+        true
+    }
+
+    pub(crate) fn release_reserved_ssts(&self, sst_ids: &[usize]) {
+        if sst_ids.is_empty() {
+            return;
+        }
+
+        let mut reserved = self.reserved_ssts.lock();
+        for id in sst_ids {
+            reserved.remove(id);
+        }
+    }
+
+    pub(crate) fn snapshot_reserved_ssts(&self) -> HashSet<usize> {
+        self.reserved_ssts.lock().clone()
+    }
+
     pub(crate) fn plan_parallel_scan_shards(
         &self,
         lower: Bound<&[u8]>,
@@ -3074,6 +3103,7 @@ impl LsmStorageInner {
             manifest: Some(plan.manifest),
             options: plan.options.into(),
             mvcc: Some(Arc::new(LsmMvccInner::new(plan.max_commit_ts))),
+            reserved_ssts: Mutex::new(HashSet::new()),
             compaction_filters: Mutex::new(CompactionFilterRegistry {
                 active_filters: plan.recovered_compaction_filters,
                 next_compaction_filter_id: plan.next_compaction_filter_id,

--- a/kv-engine/src/tests/async_api.rs
+++ b/kv-engine/src/tests/async_api.rs
@@ -112,6 +112,19 @@ fn seeded_parallel_prefix_scan_engine() -> (TempDir, Arc<KvEngine>) {
     (dir, engine)
 }
 
+fn flush_no_compaction_l0_to_l1(engine: &Arc<KvEngine>) {
+    let mut snapshot = engine.inner.state.load().as_ref().clone();
+    let mut level_ids = snapshot.l0_sstables.clone();
+    level_ids.sort_by(|a, b| {
+        let a_key = snapshot.sstables[a].first_key();
+        let b_key = snapshot.sstables[b].first_key();
+        a_key.cmp(&b_key)
+    });
+    snapshot.levels[0].1 = level_ids;
+    snapshot.l0_sstables.clear();
+    engine.inner.state.store(Arc::new(snapshot));
+}
+
 // ── Compile-time Send checks (RFC 014 §15 item 12) ──────────────
 
 #[test]
@@ -824,15 +837,14 @@ fn parallel_scan_split_boundary_key_is_returned_once() {
 fn scan_parallel_async_matches_sync_scan_with_range_tombstones() {
     let _guard = compaction_parallel_scan_test_lock();
     let dir = tempfile::tempdir().expect("tempdir");
-    let mut opts = LsmStorageOptions::default_for_compaction_test(CompactionOptions::Simple(
-        SimpleLeveledCompactionOptions {
-            size_ratio_percent: 200,
-            level0_file_num_compaction_trigger: 100,
-            max_levels: 2,
+    let engine = KvEngine::open(
+        dir.path(),
+        LsmStorageOptions {
+            compaction_options: CompactionOptions::NoCompaction,
+            ..LsmStorageOptions::default_for_test()
         },
-    ));
-    opts.target_sst_size = 256;
-    let engine = KvEngine::open(dir.path(), opts).expect("open");
+    )
+    .expect("open");
 
     for batch in 0..12u32 {
         for i in 0..256u32 {
@@ -849,9 +861,7 @@ fn scan_parallel_async_matches_sync_scan_with_range_tombstones() {
         .expect("delete_range");
     engine.force_flush().expect("force_flush");
     engine.drain_flush().expect("drain_flush");
-    engine
-        .force_full_compaction()
-        .expect("force_full_compaction");
+    flush_no_compaction_l0_to_l1(&engine);
 
     let planned = engine.inner.plan_parallel_scan_shards(
         std::ops::Bound::Unbounded,

--- a/kv-engine/src/tests/async_api.rs
+++ b/kv-engine/src/tests/async_api.rs
@@ -108,6 +108,11 @@ fn seeded_parallel_prefix_scan_engine() -> (TempDir, Arc<KvEngine>) {
         snapshot.levels[0].1.push(sst_id);
         snapshot.sstables.insert(sst_id, sst);
     }
+    snapshot.levels[0].1.sort_by(|a, b| {
+        let a_key = snapshot.sstables[a].first_key();
+        let b_key = snapshot.sstables[b].first_key();
+        a_key.cmp(&b_key)
+    });
     engine.inner.state.store(Arc::new(snapshot));
     (dir, engine)
 }

--- a/kv-engine/src/tests/async_api.rs
+++ b/kv-engine/src/tests/async_api.rs
@@ -74,6 +74,44 @@ fn seeded_parallel_scan_engine() -> (TempDir, Arc<KvEngine>) {
     (dir, engine)
 }
 
+fn seeded_parallel_prefix_scan_engine() -> (TempDir, Arc<KvEngine>) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let engine = KvEngine::open(
+        dir.path(),
+        LsmStorageOptions {
+            compaction_options: CompactionOptions::NoCompaction,
+            ..LsmStorageOptions::default_for_test()
+        },
+    )
+    .expect("open");
+
+    let mut snapshot = engine.inner.state.load().as_ref().clone();
+    for shard in 0..4u32 {
+        let sst_id = engine.inner.next_sst_id();
+        let data = (0..256u32)
+            .map(|i| {
+                let user_prefix = if shard % 2 == 0 { "user:" } else { "other:" };
+                let key = Bytes::from(format!("{user_prefix}{shard:02}-{i:03}"));
+                let value = Bytes::from(format!(
+                    "value-{shard:02}-{i:03}-payload-{:0>96}",
+                    shard * 1_000 + i
+                ));
+                (key, value)
+            })
+            .collect::<Vec<_>>();
+        let sst = Arc::new(generate_sst(
+            sst_id,
+            engine.inner.path_of_sst(sst_id),
+            data,
+            Some(engine.inner.block_cache.clone()),
+        ));
+        snapshot.levels[0].1.push(sst_id);
+        snapshot.sstables.insert(sst_id, sst);
+    }
+    engine.inner.state.store(Arc::new(snapshot));
+    (dir, engine)
+}
+
 // ── Compile-time Send checks (RFC 014 §15 item 12) ──────────────
 
 #[test]
@@ -660,30 +698,7 @@ fn scan_parallel_async_matches_sync_scan_on_multi_shard_plan() {
 #[test]
 fn prefix_scan_parallel_async_matches_sync_scan_on_multi_shard_plan() {
     let _guard = compaction_parallel_scan_test_lock();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let mut opts = LsmStorageOptions::default_for_compaction_test(CompactionOptions::Simple(
-        SimpleLeveledCompactionOptions {
-            size_ratio_percent: 200,
-            level0_file_num_compaction_trigger: 100,
-            max_levels: 2,
-        },
-    ));
-    opts.target_sst_size = 256;
-    let engine = KvEngine::open(dir.path(), opts).expect("open");
-
-    for batch in 0..8u32 {
-        for i in 0..192u32 {
-            let user_prefix = if batch % 2 == 0 { "user:" } else { "other:" };
-            let key = format!("{user_prefix}{batch:02}-{i:03}");
-            let value = format!("value-{batch:02}-{i:03}-payload-{:0>64}", batch * 1_000 + i);
-            engine.put(key.as_bytes(), value.as_bytes()).expect("put");
-        }
-        engine.force_flush().expect("force_flush");
-    }
-    engine.drain_flush().expect("drain_flush");
-    engine
-        .force_full_compaction()
-        .expect("force_full_compaction");
+    let (_dir, engine) = seeded_parallel_prefix_scan_engine();
 
     let planned = engine.inner.plan_parallel_scan_shards(
         std::ops::Bound::Included(b"user:"),

--- a/kv-engine/src/tests/async_api.rs
+++ b/kv-engine/src/tests/async_api.rs
@@ -7,11 +7,13 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 
 use bytes::Bytes;
+use tempfile::TempDir;
 
 use crate::{
     compact::{CompactionOptions, SimpleLeveledCompactionOptions},
     iterators::StorageIterator,
     lsm_storage::{CacheAdmission, KvEngine, LsmStorageOptions, ParallelScanOptions},
+    tests::harness::generate_sst,
     vlog::ValueSeparationOptions,
 };
 
@@ -33,6 +35,43 @@ fn collect_parallel_rows(
         rows.extend(chunk.into_rows());
     }
     Ok(rows)
+}
+
+fn seeded_parallel_scan_engine() -> (TempDir, Arc<KvEngine>) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let engine = KvEngine::open(
+        dir.path(),
+        LsmStorageOptions {
+            compaction_options: CompactionOptions::NoCompaction,
+            ..LsmStorageOptions::default_for_test()
+        },
+    )
+    .expect("open");
+
+    let mut snapshot = engine.inner.state.load().as_ref().clone();
+    for shard in 0..4u32 {
+        let sst_id = engine.inner.next_sst_id();
+        let data = (0..256u32)
+            .map(|i| {
+                let key = Bytes::from(format!("k{shard:02}-{i:03}"));
+                let value = Bytes::from(format!(
+                    "value-{shard:02}-{i:03}-payload-{:0>96}",
+                    shard * 1_000 + i
+                ));
+                (key, value)
+            })
+            .collect::<Vec<_>>();
+        let sst = Arc::new(generate_sst(
+            sst_id,
+            engine.inner.path_of_sst(sst_id),
+            data,
+            Some(engine.inner.block_cache.clone()),
+        ));
+        snapshot.levels[0].1.push(sst_id);
+        snapshot.sstables.insert(sst_id, sst);
+    }
+    engine.inner.state.store(Arc::new(snapshot));
+    (dir, engine)
 }
 
 // ── Compile-time Send checks (RFC 014 §15 item 12) ──────────────
@@ -499,29 +538,7 @@ fn parallel_scan_planner_falls_back_when_memtable_or_l0_dominate() {
 #[test]
 fn parallel_scan_planner_uses_multiple_l1_splits_after_compaction() {
     let _guard = compaction_parallel_scan_test_lock();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let mut opts = LsmStorageOptions::default_for_compaction_test(CompactionOptions::Simple(
-        SimpleLeveledCompactionOptions {
-            size_ratio_percent: 200,
-            level0_file_num_compaction_trigger: 100,
-            max_levels: 2,
-        },
-    ));
-    opts.target_sst_size = 256;
-    let engine = KvEngine::open(dir.path(), opts).expect("open");
-
-    for batch in 0..12u32 {
-        for i in 0..256u32 {
-            let key = format!("k{batch:02}-{i:03}");
-            let value = format!("value-{batch:02}-{i:03}-payload-{:0>96}", batch * 1_000 + i);
-            engine.put(key.as_bytes(), value.as_bytes()).expect("put");
-        }
-        engine.force_flush().expect("force_flush");
-    }
-    engine.drain_flush().expect("drain_flush");
-    engine
-        .force_full_compaction()
-        .expect("force_full_compaction");
+    let (_dir, engine) = seeded_parallel_scan_engine();
 
     let shards = engine.inner.plan_parallel_scan_shards(
         std::ops::Bound::Unbounded,
@@ -568,10 +585,10 @@ fn scan_parallel_async_matches_sync_scan_on_multi_shard_plan() {
     opts.target_sst_size = 256;
     let engine = KvEngine::open(dir.path(), opts).expect("open");
 
-    for batch in 0..8u32 {
-        for i in 0..192u32 {
+    for batch in 0..12u32 {
+        for i in 0..256u32 {
             let key = format!("k{batch:02}-{i:03}");
-            let value = format!("value-{batch:02}-{i:03}-payload-{:0>64}", batch * 1_000 + i);
+            let value = format!("value-{batch:02}-{i:03}-payload-{:0>96}", batch * 1_000 + i);
             engine.put(key.as_bytes(), value.as_bytes()).expect("put");
         }
         engine.force_flush().expect("force_flush");
@@ -742,29 +759,7 @@ fn parallel_scan_empty_range_returns_none() {
 #[test]
 fn parallel_scan_split_boundary_key_is_returned_once() {
     let _guard = compaction_parallel_scan_test_lock();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let mut opts = LsmStorageOptions::default_for_compaction_test(CompactionOptions::Simple(
-        SimpleLeveledCompactionOptions {
-            size_ratio_percent: 200,
-            level0_file_num_compaction_trigger: 100,
-            max_levels: 2,
-        },
-    ));
-    opts.target_sst_size = 256;
-    let engine = KvEngine::open(dir.path(), opts).expect("open");
-
-    for batch in 0..8u32 {
-        for i in 0..192u32 {
-            let key = format!("k{batch:02}-{i:03}");
-            let value = format!("value-{batch:02}-{i:03}-payload-{:0>64}", batch * 1_000 + i);
-            engine.put(key.as_bytes(), value.as_bytes()).expect("put");
-        }
-        engine.force_flush().expect("force_flush");
-    }
-    engine.drain_flush().expect("drain_flush");
-    engine
-        .force_full_compaction()
-        .expect("force_full_compaction");
+    let (_dir, engine) = seeded_parallel_scan_engine();
 
     let planned = engine.inner.plan_parallel_scan_shards(
         std::ops::Bound::Unbounded,
@@ -824,10 +819,10 @@ fn scan_parallel_async_matches_sync_scan_with_range_tombstones() {
     opts.target_sst_size = 256;
     let engine = KvEngine::open(dir.path(), opts).expect("open");
 
-    for batch in 0..8u32 {
-        for i in 0..192u32 {
+    for batch in 0..12u32 {
+        for i in 0..256u32 {
             let key = format!("k{batch:02}-{i:03}");
-            let value = format!("value-{batch:02}-{i:03}-payload-{:0>64}", batch * 1_000 + i);
+            let value = format!("value-{batch:02}-{i:03}-payload-{:0>96}", batch * 1_000 + i);
             engine.put(key.as_bytes(), value.as_bytes()).expect("put");
         }
         engine.force_flush().expect("force_flush");
@@ -975,29 +970,7 @@ fn scan_parallel_async_matches_sync_scan_with_value_separation() {
 #[test]
 fn parallel_scan_surfaces_later_shard_error_in_order() {
     let _guard = compaction_parallel_scan_test_lock();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let mut opts = LsmStorageOptions::default_for_compaction_test(CompactionOptions::Simple(
-        SimpleLeveledCompactionOptions {
-            size_ratio_percent: 200,
-            level0_file_num_compaction_trigger: 100,
-            max_levels: 2,
-        },
-    ));
-    opts.target_sst_size = 256;
-    let engine = KvEngine::open(dir.path(), opts).expect("open");
-
-    for batch in 0..8u32 {
-        for i in 0..192u32 {
-            let key = format!("k{batch:02}-{i:03}");
-            let value = format!("value-{batch:02}-{i:03}-payload-{:0>64}", batch * 1_000 + i);
-            engine.put(key.as_bytes(), value.as_bytes()).expect("put");
-        }
-        engine.force_flush().expect("force_flush");
-    }
-    engine.drain_flush().expect("drain_flush");
-    engine
-        .force_full_compaction()
-        .expect("force_full_compaction");
+    let (_dir, engine) = seeded_parallel_scan_engine();
 
     let planned = engine.inner.plan_parallel_scan_shards(
         std::ops::Bound::Unbounded,
@@ -1100,29 +1073,7 @@ fn parallel_scan_stats_track_single_shard_fallback() {
 
 #[test]
 fn parallel_scan_stats_track_multi_shard_execution() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let mut opts = LsmStorageOptions::default_for_compaction_test(CompactionOptions::Simple(
-        SimpleLeveledCompactionOptions {
-            size_ratio_percent: 200,
-            level0_file_num_compaction_trigger: 100,
-            max_levels: 2,
-        },
-    ));
-    opts.target_sst_size = 256;
-    let engine = KvEngine::open(dir.path(), opts).expect("open");
-
-    for batch in 0..8u32 {
-        for i in 0..192u32 {
-            let key = format!("k{batch:02}-{i:03}");
-            let value = format!("value-{batch:02}-{i:03}-payload-{:0>64}", batch * 1_000 + i);
-            engine.put(key.as_bytes(), value.as_bytes()).expect("put");
-        }
-        engine.force_flush().expect("force_flush");
-    }
-    engine.drain_flush().expect("drain_flush");
-    engine
-        .force_full_compaction()
-        .expect("force_full_compaction");
+    let (_dir, engine) = seeded_parallel_scan_engine();
 
     let mut scan = crate::future_ext::block_on(engine.scan_parallel_async(
         std::ops::Bound::Unbounded,

--- a/kv-engine/src/tests/async_api.rs
+++ b/kv-engine/src/tests/async_api.rs
@@ -625,29 +625,7 @@ fn parallel_scan_planner_uses_multiple_l1_splits_after_compaction() {
 #[test]
 fn scan_parallel_async_matches_sync_scan_on_multi_shard_plan() {
     let _guard = compaction_parallel_scan_test_lock();
-    let dir = tempfile::tempdir().expect("tempdir");
-    let mut opts = LsmStorageOptions::default_for_compaction_test(CompactionOptions::Simple(
-        SimpleLeveledCompactionOptions {
-            size_ratio_percent: 200,
-            level0_file_num_compaction_trigger: 100,
-            max_levels: 2,
-        },
-    ));
-    opts.target_sst_size = 256;
-    let engine = KvEngine::open(dir.path(), opts).expect("open");
-
-    for batch in 0..12u32 {
-        for i in 0..256u32 {
-            let key = format!("k{batch:02}-{i:03}");
-            let value = format!("value-{batch:02}-{i:03}-payload-{:0>96}", batch * 1_000 + i);
-            engine.put(key.as_bytes(), value.as_bytes()).expect("put");
-        }
-        engine.force_flush().expect("force_flush");
-    }
-    engine.drain_flush().expect("drain_flush");
-    engine
-        .force_full_compaction()
-        .expect("force_full_compaction");
+    let (_dir, engine) = seeded_parallel_scan_engine();
 
     let planned = engine.inner.plan_parallel_scan_shards(
         std::ops::Bound::Unbounded,

--- a/kv-engine/src/tests/compaction.rs
+++ b/kv-engine/src/tests/compaction.rs
@@ -437,6 +437,112 @@ fn test_watermark_gc_preserves_tombstone_at_non_bottom_level() {
 }
 
 #[test]
+fn test_trigger_compaction_runs_mvcc_gc_when_ordinary_compaction_is_idle() {
+    use crate::compact::{CompactionOptions, LeveledCompactionOptions};
+
+    let dir = tempdir().unwrap();
+    let options = LsmStorageOptions {
+        compaction_options: CompactionOptions::Leveled(LeveledCompactionOptions {
+            level_size_multiplier: 2,
+            level0_file_num_compaction_trigger: 8,
+            max_levels: 1,
+            base_level_size_mb: 128,
+        }),
+        num_memtable_limit: 2,
+        target_sst_size: 1 << 20,
+        ..LsmStorageOptions::default_for_test()
+    };
+    let storage = Arc::new(LsmStorageInner::open(&dir, options).unwrap());
+
+    storage.put(b"a", b"v1").unwrap();
+    sync(&storage);
+
+    let reader = storage.new_txn().unwrap();
+
+    storage.put(b"a", b"v2").unwrap();
+    sync(&storage);
+    storage.put(b"a", b"v3").unwrap();
+    sync(&storage);
+
+    storage.force_full_compaction().unwrap();
+
+    let mut before_gc = construct_merge_iterator_over_storage(&storage.state.load());
+    check_iter_result_by_key(
+        &mut before_gc,
+        vec![
+            (Bytes::from_static(b"a"), Bytes::from_static(b"v3")),
+            (Bytes::from_static(b"a"), Bytes::from_static(b"v2")),
+            (Bytes::from_static(b"a"), Bytes::from_static(b"v1")),
+        ],
+    );
+
+    drop(reader);
+    storage.trigger_compaction().unwrap();
+
+    let mut after_gc = construct_merge_iterator_over_storage(&storage.state.load());
+    check_iter_result_by_key(
+        &mut after_gc,
+        vec![(Bytes::from_static(b"a"), Bytes::from_static(b"v3"))],
+    );
+}
+
+#[test]
+fn test_trigger_compaction_skips_reserved_mvcc_gc_candidate() {
+    use crate::compact::{CompactionOptions, LeveledCompactionOptions};
+
+    let dir = tempdir().unwrap();
+    let options = LsmStorageOptions {
+        compaction_options: CompactionOptions::Leveled(LeveledCompactionOptions {
+            level_size_multiplier: 2,
+            level0_file_num_compaction_trigger: 8,
+            max_levels: 1,
+            base_level_size_mb: 128,
+        }),
+        num_memtable_limit: 2,
+        target_sst_size: 1 << 20,
+        ..LsmStorageOptions::default_for_test()
+    };
+    let storage = Arc::new(LsmStorageInner::open(&dir, options).unwrap());
+
+    storage.put(b"a", b"v1").unwrap();
+    sync(&storage);
+
+    let reader = storage.new_txn().unwrap();
+
+    storage.put(b"a", b"v2").unwrap();
+    sync(&storage);
+    storage.put(b"a", b"v3").unwrap();
+    sync(&storage);
+
+    storage.force_full_compaction().unwrap();
+    drop(reader);
+
+    let reserved_sst = storage.state.load().levels[0].1[0];
+    assert!(storage.try_reserve_ssts(&[reserved_sst]));
+
+    storage.trigger_compaction().unwrap();
+
+    let mut while_reserved = construct_merge_iterator_over_storage(&storage.state.load());
+    check_iter_result_by_key(
+        &mut while_reserved,
+        vec![
+            (Bytes::from_static(b"a"), Bytes::from_static(b"v3")),
+            (Bytes::from_static(b"a"), Bytes::from_static(b"v2")),
+            (Bytes::from_static(b"a"), Bytes::from_static(b"v1")),
+        ],
+    );
+
+    storage.release_reserved_ssts(&[reserved_sst]);
+    storage.trigger_compaction().unwrap();
+
+    let mut after_release = construct_merge_iterator_over_storage(&storage.state.load());
+    check_iter_result_by_key(
+        &mut after_release,
+        vec![(Bytes::from_static(b"a"), Bytes::from_static(b"v3"))],
+    );
+}
+
+#[test]
 fn test_compaction_filter_respects_cutoff_ts() {
     let dir = tempdir().unwrap();
     let storage =

--- a/rfcs/001-key-value-separation.md
+++ b/rfcs/001-key-value-separation.md
@@ -1581,24 +1581,56 @@ entries for GC CAS rewrites. Recovery proceeds in three phases:
 - **After SST is committed to manifest**: all vLog pointers in the SST are guaranteed valid (vLog was fsynced first).
 - **Partial vLog write**: detected by CRC32 mismatch and skipped during reads.
 
-**GC crash safety**: GC's `compact_file` fsyncs the new vLog BEFORE performing any CAS operations (Phase 1 → Phase 2 ordering). Each successful `compare_and_set_with_kind` appends a kind-tagged WAL entry before exposing the pointer in the memtable. On crash:
-- **Before CAS**: WAL replay restores the old ValuePointer (pre-CAS state). The new vLog file is orphaned but harmless — it will be cleaned up on the next GC pass or startup orphan sweep.
-- **After CAS, before SST flush**: WAL replay restores the NEW ValuePointer (post-CAS state). This is safe because the new vLog was fsynced before the CAS (Phase 1 ordering), so the pointer is always valid.
-- **After CAS is flushed to SST**: the new ValuePointer is durable in the SST. The new vLog file is referenced by the SST and will not be deleted.
+**GC crash safety**: GC's `compact_file` fsyncs the new vLog BEFORE performing any CAS operations (Phase 1 -> Phase 2 ordering). The current implementation publishes successful GC rewrites to the active memtable with `put_raw_batch_no_wal()` rather than appending a WAL entry. This makes GC rewrites idempotent but non-durable until a later flush. On crash:
+- **Before CAS**: the old `ValuePointer` remains the durable state. The new vLog file is orphaned but harmless and will be cleaned up on the next GC pass or startup orphan sweep.
+- **After CAS, before memtable flush**: the rewritten pointer may be lost because it only lived in memory. This is still safe because the old SST entry still points to the old vLog file, and the old file will not be reclaimed while any SST reference remains.
+- **After CAS is flushed to SST**: the new `ValuePointer` is durable in the SST. The new vLog file is referenced by the SST and will not be deleted.
+
+### GC Operational Workflow
+
+The implemented vLog GC flow is:
+
+1. **Track SST -> vLog references.** Flush and compaction register the set of
+   vLog file IDs referenced by each SST, populating both `sst_to_vlogs` and
+   `vlog_to_ssts`.
+2. **Pick candidate files.** `trigger_gc()` (manual) or post-compaction GC
+   collects the vLog file IDs currently referenced by live SSTs.
+3. **Analyze liveness.** For each vLog file, GC scans its `.vidx` file when
+   present (or falls back to header iteration) and asks the LSM whether each
+   entry's exact pointer is still live.
+4. **Rewrite live entries.** If the file's stale ratio exceeds the configured
+   threshold, GC copies only the live entries into a new vLog file, persists
+   its `.vidx`, and fsyncs the vLog directory entry before publishing pointer
+   updates.
+5. **CAS-publish rewritten pointers.**
+   - **Non-MVCC:** compare-and-set by user key.
+   - **MVCC:** compare-and-set by the exact `(user_key, ts)` internal key, so GC
+     updates the precise historical version that still points at the old
+     `ValuePointer` rather than whichever version is newest.
+6. **Schedule old-file deletion.** After the CAS loop, GC marks the old vLog
+   file as pending deletion.
+7. **Reclaim only when refcount reaches zero.** `reclaim_pending_deletions()`
+   consults the reverse map (`vlog_to_ssts`). A file is deleted only when no
+   SST still references it.
+
+In short: analyze liveness -> rewrite live values -> CAS pointers -> wait for
+SST refs to disappear -> delete the old vLog file.
 
 ## WAL Interaction
 
 The WAL stores `(key, value, KvKind)` for every write. Normal user writes store
 the full value with `KvKind::Inline`, preserving the same latency profile as a
-non-separated LSM tree. GC CAS rewrites store the encoded `ValuePointer` with
-`KvKind::ValuePointer` so recovery can reconstruct the post-GC memtable state
-without payload sniffing. Value separation for normal user writes still happens
-**during flush** (memtable → SST), not during the put path:
+non-separated LSM tree. Value separation for normal user writes still happens
+**during flush** (memtable -> SST), not during the put path. GC CAS rewrites are
+an exception: they skip the WAL and publish directly to the active memtable, so
+recovery falls back to the pre-GC SST state if a crash happens before the
+rewritten pointer is flushed:
 
-- **Write path (put)**: value + `KvKind::Inline` → WAL → **WAL fsync** → memtable.
+- **Write path (put)**: value + `KvKind::Inline` -> WAL -> **WAL fsync** -> memtable.
   `max_value_size` validation is deferred to flush time (in `ValueLogBuilder::add`),
   not performed at `put`/`write_batch` time.
-- **GC CAS path**: encoded `ValuePointer` + `KvKind::ValuePointer` → WAL → memtable
+- **GC CAS path**: encoded `ValuePointer` + `KvKind::{ValuePointer,TtlValuePointer}` -> memtable
+  via `put_raw_batch_no_wal()` after the new vLog file is durable.
 - **Flush path**: scan memtable → for each entry with `value.len() >= min_value_size`:
   1. append value to vLog buffer (in-memory)
   2. add `ValuePointer` to in-memory SST block

--- a/todo.md
+++ b/todo.md
@@ -5,6 +5,56 @@
 
 ---
 
+## RFC 017: Standalone MVCC GC Follow-up
+
+**RFC:** [rfcs/017-mvcc-garbage-collection.md](rfcs/017-mvcc-garbage-collection.md)
+**Status:** partially implemented on `feat/mvcc-gc-scheduler`
+
+### Landed slice
+
+- [x] Periodic background wakeup can trigger MVCC GC even when ordinary
+  compaction is idle
+- [x] MVCC watermark is used as the effective GC cutoff
+- [x] Candidate generation exists for leveled, simple, and tiered modes
+- [x] SST reservations prevent overlapping GC / compaction ownership
+- [x] TTL-aware bottom-level candidate picking exists
+- [x] Current compaction rewrite path remains the execution mechanism
+
+### Remaining implementation work
+
+- [ ] Split RFC 017 candidate picking into a dedicated picker surface instead of
+  keeping all policy embedded in `generate_mvcc_gc_task()`
+- [ ] Add the missing stats surfaces the RFC assumes for candidate scoring
+  Current code mostly uses `max_ts`, TTL metadata, overlap shape, and
+  reservations. The RFC still calls out tombstone density,
+  range-tombstone density, and redundant-version estimates.
+- [ ] Define the minimum viable GC scoring policy beyond `max_ts` / TTL
+  metadata
+  Start with cheap metadata-only scoring, then layer in richer reclaim signals
+  only where they improve candidate quality measurably.
+- [ ] Tighten scheduler backpressure / retry semantics
+  Document and implement what happens when reservation succeeds but submission
+  cannot proceed, and make retry behavior explicit rather than implicit in the
+  periodic wakeup loop.
+- [ ] Add deterministic tests for ordinary-compaction vs GC-compaction
+  coexistence and reservation conflicts
+- [ ] Add deterministic tests for stats-driven candidate selection once those
+  stats exist
+- [ ] Add tests showing TTL-heavy SSTs are selected without size-pressure
+- [ ] Add tests showing standalone MVCC GC improves later vLog reclaim
+  opportunities by removing obsolete pointer-bearing versions
+- [ ] Reconcile RFC 017 wording with the actually shipped slice
+  If richer stats-driven scoring is deferred, keep the RFC explicit that it is
+  future work rather than already implemented behavior.
+
+### Current PR-loop blockers on `feat/mvcc-gc-scheduler`
+
+- [ ] Clear the remaining GitHub `sanitizers-unit` failure on the latest PR head
+- [ ] Keep the PR review loop running until CI is green or a concrete new
+  blocker appears
+
+---
+
 ## Phase 1: Timestamped Keys ✅
 
 PR #70 (merged 2026-06-07). Internal key encoding, MVCC-aware reads/scans/compaction, watermark scaffolding.


### PR DESCRIPTION
## Summary

Add a standalone MVCC-GC scheduling path that can rewrite GC-worthy SSTs even when ordinary size-based compaction is idle.

## Changes
- add shared SST reservations so ordinary compaction, force-full compaction, and TTL wholesale-drop do not overlap on the same inputs
- teach `trigger_compaction()` to fall back to MVCC-GC candidate picking when the normal compaction controller has no work
- pick GC work from the effective bottommost non-empty level and keep Simple compaction on whole-level rewrites to avoid dropping unrelated SSTs
- add focused tests for idle MVCC-GC scheduling, reservation conflicts, effective-bottom selection, and Simple controller task generation

## Verification
- [x] `cargo fmt --all`
- [x] `cargo test --package kv-engine test_trigger_compaction_ -- --nocapture`
- [x] `cargo test --package kv-engine generate_mvcc_gc_task -- --nocapture`
- [x] `cargo test --package kv-engine test_watermark_gc_ -- --nocapture`
- [x] `cargo test --package kv-engine test_task1_full_compaction -- --nocapture`
- [x] `cargo test --package kv-engine test_ttl_wholesale_drop_pure_ttl_sst -- --nocapture`
- [x] `cargo clippy --package kv-engine --all-features --all-targets -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compaction and MVCC garbage collection safety by adding SST reservation tracking to prevent concurrent reclamation.
  * Ensured compaction/GC is only published after reserving required inputs, with safe early exit on contention.
  * Refined post-compaction state/manifest updates, file cleanup, and vLog GC scheduling.

* **Documentation**
  * Updated GC correctness/crash-safety documentation with the revised vLog fsync, pointer publication, and WAL/CAS interaction flow.

* **Tests**
  * Expanded MVCC GC integration tests for idle triggers and reserved-candidate behavior, including TTL expiration selection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->