### PR TITLE
feat: finish MVCC GC range-only follow-up

### DIFF
--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -2727,6 +2727,8 @@ impl LsmStorageInner {
                     for &id in &new_range_only_sst_ids {
                         ro_ids.push(id);
                     }
+                    ro_ids.sort_unstable();
+                    ro_ids.dedup();
                 } else {
                     snapshot
                         .range_only_ssts

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -886,9 +886,18 @@ mod tests {
         assert!(storage.try_reserve_ssts(&[ordinary_sst]));
         assert_eq!(
             storage.trigger_compaction().unwrap(),
-            CompactionTriggerOutcome::Deferred
+            CompactionTriggerOutcome::Submitted
         );
         assert_eq!(storage.state.load().l0_sstables, vec![ordinary_sst]);
+
+        assert_eq!(
+            storage.get(b"gc").unwrap(),
+            Some(bytes::Bytes::from_static(b"v"))
+        );
+        assert_eq!(
+            storage.get(b"l0").unwrap(),
+            Some(bytes::Bytes::from_static(b"v"))
+        );
 
         storage.release_reserved_ssts(&[ordinary_sst]);
         assert_eq!(
@@ -2157,6 +2166,7 @@ impl LsmStorageInner {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn pick_mvcc_gc_task(
         &self,
         snapshot: &LsmStorageState,
@@ -2215,12 +2225,12 @@ impl LsmStorageInner {
             .filter(|(id, _)| !reserved.contains(id))
             .filter_map(|(id, is_range_only)| {
                 let sst = snapshot.sstables.get(&id)?;
-                let stats = Arc::clone(sst).mvcc_gc_stats().ok()?;
                 let fully_old = sst.max_ts() <= cutoff;
                 let ttl_candidate = Self::sst_has_expired_ttl_entries(sst, now_secs);
                 if !fully_old && !ttl_candidate {
                     return None;
                 }
+                let stats = Arc::clone(sst).mvcc_gc_stats().ok()?;
                 if fully_old
                     && !ttl_candidate
                     && stats.point_tombstone_count == 0

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -86,6 +86,20 @@ pub enum CompactionTask {
     },
 }
 
+/// Outcome of a periodic compaction trigger attempt.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CompactionTriggerOutcome {
+    /// No compaction work was available.
+    Idle,
+    /// Work existed but could not reserve the required SST inputs.
+    Deferred,
+    /// A compaction attempt ran to completion without returning an error.
+    ///
+    /// The late publish path may still discard freshly built outputs during
+    /// safety revalidation under `state_lock`.
+    Submitted,
+}
+
 impl CompactionTask {
     fn compact_to_bottom_level(&self) -> bool {
         match self {
@@ -153,6 +167,45 @@ mod tests {
         builder
             .add_with_ttl(encoded.as_key_slice(), &value)
             .unwrap();
+        Arc::new(
+            builder
+                .build(sst_id, None, storage.path_of_sst(sst_id))
+                .unwrap(),
+        )
+    }
+
+    fn build_test_multi_version_sst(
+        storage: &LsmStorageInner,
+        sst_id: usize,
+        key: &[u8],
+        tses: &[u64],
+    ) -> Arc<SsTable> {
+        let mut builder = SsTableBuilder::new(storage.options.block_size);
+        for &ts in tses {
+            let encoded = KeySlice::for_testing_from_slice_with_ts(key, ts);
+            builder.add(encoded.as_key_slice(), b"v").unwrap();
+        }
+        Arc::new(
+            builder
+                .build(sst_id, None, storage.path_of_sst(sst_id))
+                .unwrap(),
+        )
+    }
+
+    fn build_test_multi_ttl_sst(
+        storage: &LsmStorageInner,
+        sst_id: usize,
+        key: &[u8],
+        tses_and_expire_secs: &[(u64, u64)],
+    ) -> Arc<SsTable> {
+        let mut builder = SsTableBuilder::new(storage.options.block_size);
+        for &(ts, expire_at_secs) in tses_and_expire_secs {
+            let encoded = KeySlice::for_testing_from_slice_with_ts(key, ts);
+            let value = encode_ttl_value(KvKind::TtlInline, expire_at_secs, b"v");
+            builder
+                .add_with_ttl(encoded.as_key_slice(), &value)
+                .unwrap();
+        }
         Arc::new(
             builder
                 .build(sst_id, None, storage.path_of_sst(sst_id))
@@ -361,6 +414,488 @@ mod tests {
                 .is_none(),
             "fully-old leveled SSTs without reclaimable MVCC entries should be skipped"
         );
+    }
+
+    #[test]
+    fn test_generate_mvcc_gc_task_leveled_prefers_redundant_versions_over_plain_sst() {
+        let dir = tempdir().unwrap();
+        let options = LsmStorageOptions {
+            compaction_options: CompactionOptions::Leveled(LeveledCompactionOptions {
+                level_size_multiplier: 2,
+                level0_file_num_compaction_trigger: 8,
+                max_levels: 3,
+                base_level_size_mb: 128,
+            }),
+            ..LsmStorageOptions::default_for_test()
+        };
+        let storage = LsmStorageInner::open(&dir, options).unwrap();
+        storage.mvcc.as_ref().unwrap().update_commit_ts(10);
+
+        let sst_with_redundancy = storage.next_sst_id();
+        let plain_sst = storage.next_sst_id();
+        let redundant_obj =
+            build_test_multi_version_sst(&storage, sst_with_redundancy, b"a", &[4, 3]);
+        let plain_obj = build_test_sst(&storage, plain_sst, b"b", 4);
+
+        let mut snapshot = storage.state.load().as_ref().clone();
+        snapshot.levels[0]
+            .1
+            .extend([sst_with_redundancy, plain_sst]);
+        snapshot.sstables.insert(sst_with_redundancy, redundant_obj);
+        snapshot.sstables.insert(plain_sst, plain_obj);
+        storage.state.store(Arc::new(snapshot));
+
+        let task = storage
+            .generate_mvcc_gc_task(storage.state.load().as_ref())
+            .expect("expected GC task");
+        match task {
+            CompactionTask::Leveled(task) => {
+                assert_eq!(task.upper_level, Some(1));
+                assert_eq!(task.lower_level, 1);
+                assert_eq!(task.upper_level_sst_ids, vec![sst_with_redundancy]);
+            }
+            other => panic!("expected leveled task, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_generate_mvcc_gc_task_leveled_prefers_larger_sst_on_equal_score() {
+        let dir = tempdir().unwrap();
+        let options = LsmStorageOptions {
+            compaction_options: CompactionOptions::Leveled(LeveledCompactionOptions {
+                level_size_multiplier: 2,
+                level0_file_num_compaction_trigger: 8,
+                max_levels: 3,
+                base_level_size_mb: 128,
+            }),
+            ..LsmStorageOptions::default_for_test()
+        };
+        let storage = LsmStorageInner::open(&dir, options).unwrap();
+        storage.mvcc.as_ref().unwrap().update_commit_ts(10);
+
+        let small_sst = storage.next_sst_id();
+        let large_sst = storage.next_sst_id();
+        let small_obj = build_test_multi_version_sst(&storage, small_sst, b"a", &[4, 3]);
+        let large_obj = build_test_multi_version_sst(
+            &storage,
+            large_sst,
+            b"this-key-is-deliberately-long",
+            &[4, 3],
+        );
+
+        let mut snapshot = storage.state.load().as_ref().clone();
+        snapshot.levels[0].1.extend([small_sst, large_sst]);
+        snapshot.sstables.insert(small_sst, small_obj);
+        snapshot.sstables.insert(large_sst, large_obj);
+        storage.state.store(Arc::new(snapshot));
+
+        let task = storage
+            .generate_mvcc_gc_task(storage.state.load().as_ref())
+            .expect("expected GC task");
+        match task {
+            CompactionTask::Leveled(task) => {
+                assert_eq!(task.upper_level, Some(1));
+                assert_eq!(task.lower_level, 1);
+                assert_eq!(task.upper_level_sst_ids, vec![large_sst]);
+            }
+            other => panic!("expected leveled task, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_generate_mvcc_gc_task_leveled_prefers_expired_ttl_sst_without_size_pressure() {
+        let dir = tempdir().unwrap();
+        let options = LsmStorageOptions {
+            compaction_options: CompactionOptions::Leveled(LeveledCompactionOptions {
+                level_size_multiplier: 2,
+                level0_file_num_compaction_trigger: 8,
+                max_levels: 3,
+                base_level_size_mb: 128,
+            }),
+            ..LsmStorageOptions::default_for_test()
+        };
+        let storage = LsmStorageInner::open(&dir, options).unwrap();
+        storage.mvcc.as_ref().unwrap().update_commit_ts(10);
+        let expire_at_secs = crate::vlog::wall_clock_secs().saturating_sub(1);
+
+        let ttl_sst = storage.next_sst_id();
+        let plain_sst = storage.next_sst_id();
+        let ttl_obj = build_test_multi_ttl_sst(
+            &storage,
+            ttl_sst,
+            b"a",
+            &[(5, expire_at_secs), (4, expire_at_secs)],
+        );
+        let plain_obj = build_test_sst(&storage, plain_sst, b"b", 4);
+
+        let mut snapshot = storage.state.load().as_ref().clone();
+        snapshot.levels[0].1.extend([ttl_sst, plain_sst]);
+        snapshot.sstables.insert(ttl_sst, ttl_obj);
+        snapshot.sstables.insert(plain_sst, plain_obj);
+        storage.state.store(Arc::new(snapshot));
+
+        let task = storage
+            .generate_mvcc_gc_task(storage.state.load().as_ref())
+            .expect("expected GC task");
+        match task {
+            CompactionTask::Leveled(task) => {
+                assert_eq!(task.upper_level, Some(1));
+                assert_eq!(task.lower_level, 1);
+                assert_eq!(task.upper_level_sst_ids, vec![ttl_sst]);
+            }
+            other => panic!("expected leveled task, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_generate_mvcc_gc_task_leveled_accepts_partially_expired_ttl_sst() {
+        let dir = tempdir().unwrap();
+        let options = LsmStorageOptions {
+            compaction_options: CompactionOptions::Leveled(LeveledCompactionOptions {
+                level_size_multiplier: 2,
+                level0_file_num_compaction_trigger: 8,
+                max_levels: 3,
+                base_level_size_mb: 128,
+            }),
+            ..LsmStorageOptions::default_for_test()
+        };
+        let storage = LsmStorageInner::open(&dir, options).unwrap();
+        storage.mvcc.as_ref().unwrap().update_commit_ts(10);
+        let expired_at_secs = crate::vlog::wall_clock_secs().saturating_sub(1);
+        let future_at_secs = crate::vlog::wall_clock_secs().saturating_add(60);
+
+        let ttl_sst = storage.next_sst_id();
+        let plain_sst = storage.next_sst_id();
+        let mut ttl_builder = SsTableBuilder::new(storage.options.block_size);
+        ttl_builder
+            .add_with_ttl(
+                KeySlice::for_testing_from_slice_with_ts(b"a", 5).as_key_slice(),
+                &encode_ttl_value(KvKind::TtlInline, expired_at_secs, b"va"),
+            )
+            .unwrap();
+        ttl_builder
+            .add_with_ttl(
+                KeySlice::for_testing_from_slice_with_ts(b"b", 4).as_key_slice(),
+                &encode_ttl_value(KvKind::TtlInline, future_at_secs, b"vb"),
+            )
+            .unwrap();
+        let ttl_obj = Arc::new(
+            ttl_builder
+                .build(ttl_sst, None, storage.path_of_sst(ttl_sst))
+                .unwrap(),
+        );
+        let plain_obj = build_test_sst(&storage, plain_sst, b"c", 4);
+
+        let mut snapshot = storage.state.load().as_ref().clone();
+        snapshot.levels[0].1.extend([ttl_sst, plain_sst]);
+        snapshot.sstables.insert(ttl_sst, ttl_obj);
+        snapshot.sstables.insert(plain_sst, plain_obj);
+        storage.state.store(Arc::new(snapshot));
+
+        let task = storage
+            .generate_mvcc_gc_task(storage.state.load().as_ref())
+            .expect("expected GC task");
+        match task {
+            CompactionTask::Leveled(task) => {
+                assert_eq!(task.upper_level, Some(1));
+                assert_eq!(task.lower_level, 1);
+                assert_eq!(task.upper_level_sst_ids, vec![ttl_sst]);
+            }
+            other => panic!("expected leveled task, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_generate_mvcc_gc_task_leveled_accepts_range_only_bottom_level() {
+        let dir = tempdir().unwrap();
+        let options = LsmStorageOptions {
+            compaction_options: CompactionOptions::Leveled(LeveledCompactionOptions {
+                level_size_multiplier: 2,
+                level0_file_num_compaction_trigger: 8,
+                max_levels: 3,
+                base_level_size_mb: 128,
+            }),
+            ..LsmStorageOptions::default_for_test()
+        };
+        let storage = LsmStorageInner::open(&dir, options).unwrap();
+        storage.mvcc.as_ref().unwrap().update_commit_ts(10);
+
+        let sst_id = storage.next_sst_id();
+        let mut builder = SsTableBuilder::new(storage.options.block_size);
+        builder.add_range_tombstones(vec![crate::range_tombstone::RangeTombstoneFragment {
+            start: bytes::Bytes::from_static(b"a"),
+            end: bytes::Bytes::from_static(b"z"),
+            covering_ts: vec![3],
+        }]);
+        let sst = Arc::new(
+            builder
+                .build(sst_id, None, storage.path_of_sst(sst_id))
+                .unwrap(),
+        );
+
+        let mut snapshot = storage.state.load().as_ref().clone();
+        snapshot.range_only_ssts[0].1.push(sst_id);
+        snapshot.sstables.insert(sst_id, sst);
+        storage.state.store(Arc::new(snapshot));
+
+        let task = storage
+            .generate_mvcc_gc_task(storage.state.load().as_ref())
+            .expect("expected GC task");
+        match task {
+            CompactionTask::Leveled(task) => {
+                assert_eq!(task.upper_level, Some(1));
+                assert_eq!(task.upper_level_sst_ids, Vec::<usize>::new());
+                assert_eq!(task.lower_level, 1);
+                assert_eq!(task.lower_level_sst_ids, vec![sst_id]);
+            }
+            other => panic!("expected leveled task, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_tiered_compaction_tracks_generated_range_only_ssts() {
+        let dir = tempdir().unwrap();
+        let options = LsmStorageOptions {
+            compaction_options: CompactionOptions::Tiered(TieredCompactionOptions {
+                num_tiers: 3,
+                max_size_amplification_percent: 200,
+                size_ratio: 1,
+                min_merge_width: 2,
+                max_merge_width: None,
+            }),
+            manifest_snapshot_threshold_bytes: 1,
+            ..LsmStorageOptions::default_for_test()
+        };
+        let storage = LsmStorageInner::open(&dir, options).unwrap();
+        storage.mvcc.as_ref().unwrap().update_commit_ts(10);
+
+        let point_sst_id = storage.next_sst_id();
+        let range_only_sst_id = storage.next_sst_id();
+        let point_sst = build_test_sst(&storage, point_sst_id, b"m", 3);
+        let mut ro_builder = SsTableBuilder::new(storage.options.block_size);
+        ro_builder.add_range_tombstones(vec![crate::range_tombstone::RangeTombstoneFragment {
+            start: bytes::Bytes::from_static(b"a"),
+            end: bytes::Bytes::from_static(b"z"),
+            covering_ts: vec![5],
+        }]);
+        let range_only_sst = Arc::new(
+            ro_builder
+                .build(
+                    range_only_sst_id,
+                    None,
+                    storage.path_of_sst(range_only_sst_id),
+                )
+                .unwrap(),
+        );
+
+        let mut snapshot = storage.state.load().as_ref().clone();
+        snapshot.levels = vec![(7, vec![point_sst_id])];
+        snapshot.range_only_ssts = vec![(7, vec![range_only_sst_id])];
+        snapshot.sstables.insert(point_sst_id, point_sst);
+        snapshot.sstables.insert(range_only_sst_id, range_only_sst);
+        storage.state.store(Arc::new(snapshot));
+        let state = storage.state.load();
+        storage
+            .manifest
+            .as_ref()
+            .expect("manifest initialized")
+            .snapshot(crate::manifest::ManifestRecord::Snapshot {
+                l0_sstables: state.l0_sstables.clone(),
+                levels: state.levels.clone(),
+                range_only_ssts: state.range_only_ssts.clone(),
+                next_sst_id: storage.current_sst_id(),
+                vlog_references: vec![],
+                imm_memtable_ids: state.imm_memtables.iter().map(|m| m.id()).collect(),
+                active_compaction_filters: storage.snapshot_compaction_filters(),
+                next_compaction_filter_id: storage.snapshot_compaction_filter_next_id(),
+                format_version: crate::manifest::MANIFEST_FORMAT_VERSION,
+            })
+            .unwrap();
+        drop(state);
+
+        let task = CompactionTask::Tiered(TieredCompactionTask {
+            tiers: vec![(7, vec![point_sst_id])],
+            bottom_tier_included: true,
+        });
+        storage.publish_compaction_task(&task).unwrap();
+
+        let state = storage.state.load();
+        assert_eq!(state.levels.len(), 1);
+        let new_tier_id = state.levels[0].0;
+        assert!(
+            state.levels[0].1.is_empty(),
+            "all point entries should have been dropped under the covering range tombstone"
+        );
+        let ro_ids = state
+            .range_only_ssts
+            .iter()
+            .find(|(tier_id, _)| *tier_id == new_tier_id)
+            .map(|(_, ids)| ids.clone())
+            .expect("expected replacement range-only SSTs");
+        assert_eq!(ro_ids.len(), 1);
+        assert_ne!(ro_ids[0], range_only_sst_id);
+        assert!(state.sstables.contains_key(&ro_ids[0]));
+        assert!(!state.sstables.contains_key(&point_sst_id));
+        assert!(!state.sstables.contains_key(&range_only_sst_id));
+    }
+
+    #[test]
+    fn test_reopen_recovers_tiered_range_only_compaction_v3() {
+        let dir = tempdir().unwrap();
+        let options = LsmStorageOptions {
+            compaction_options: CompactionOptions::Tiered(TieredCompactionOptions {
+                num_tiers: 3,
+                max_size_amplification_percent: 200,
+                size_ratio: 1,
+                min_merge_width: 2,
+                max_merge_width: None,
+            }),
+            ..LsmStorageOptions::default_for_test()
+        };
+        let storage = LsmStorageInner::open(&dir, options.clone()).unwrap();
+        storage.mvcc.as_ref().unwrap().update_commit_ts(10);
+
+        let point_sst_id = storage.next_sst_id();
+        let range_only_sst_id = storage.next_sst_id();
+        let point_sst = build_test_sst(&storage, point_sst_id, b"m", 3);
+        let mut ro_builder = SsTableBuilder::new(storage.options.block_size);
+        ro_builder.add_range_tombstones(vec![crate::range_tombstone::RangeTombstoneFragment {
+            start: bytes::Bytes::from_static(b"a"),
+            end: bytes::Bytes::from_static(b"z"),
+            covering_ts: vec![5],
+        }]);
+        let range_only_sst = Arc::new(
+            ro_builder
+                .build(
+                    range_only_sst_id,
+                    None,
+                    storage.path_of_sst(range_only_sst_id),
+                )
+                .unwrap(),
+        );
+
+        let mut snapshot = storage.state.load().as_ref().clone();
+        snapshot.levels = vec![(7, vec![point_sst_id])];
+        snapshot.range_only_ssts = vec![(7, vec![range_only_sst_id])];
+        snapshot.sstables.insert(point_sst_id, point_sst);
+        snapshot.sstables.insert(range_only_sst_id, range_only_sst);
+        storage.state.store(Arc::new(snapshot));
+
+        let task = CompactionTask::Tiered(TieredCompactionTask {
+            tiers: vec![(7, vec![point_sst_id])],
+            bottom_tier_included: true,
+        });
+        storage.publish_compaction_task(&task).unwrap();
+        let expected = storage.state.load().as_ref().clone();
+        drop(storage);
+
+        let reopened = LsmStorageInner::open(&dir, options).unwrap();
+        let state = reopened.state.load();
+        assert_eq!(state.levels, expected.levels);
+        assert_eq!(state.range_only_ssts, expected.range_only_ssts);
+        assert_eq!(state.sstables.len(), expected.sstables.len());
+    }
+
+    #[test]
+    fn test_generate_mvcc_gc_task_tiered_accepts_range_only_bottom_tier() {
+        let dir = tempdir().unwrap();
+        let options = LsmStorageOptions {
+            compaction_options: CompactionOptions::Tiered(TieredCompactionOptions {
+                num_tiers: 3,
+                max_size_amplification_percent: 200,
+                size_ratio: 1,
+                min_merge_width: 2,
+                max_merge_width: None,
+            }),
+            ..LsmStorageOptions::default_for_test()
+        };
+        let storage = LsmStorageInner::open(&dir, options).unwrap();
+        storage.mvcc.as_ref().unwrap().update_commit_ts(10);
+
+        let sst_id = storage.next_sst_id();
+        let mut builder = SsTableBuilder::new(storage.options.block_size);
+        builder.add_range_tombstones(vec![crate::range_tombstone::RangeTombstoneFragment {
+            start: bytes::Bytes::from_static(b"a"),
+            end: bytes::Bytes::from_static(b"z"),
+            covering_ts: vec![3],
+        }]);
+        let sst = Arc::new(
+            builder
+                .build(sst_id, None, storage.path_of_sst(sst_id))
+                .unwrap(),
+        );
+
+        let mut snapshot = storage.state.load().as_ref().clone();
+        snapshot.levels = vec![(7, vec![])];
+        snapshot.range_only_ssts = vec![(7, vec![sst_id])];
+        snapshot.sstables.insert(sst_id, sst);
+        storage.state.store(Arc::new(snapshot));
+
+        let task = storage
+            .generate_mvcc_gc_task(storage.state.load().as_ref())
+            .expect("expected GC task");
+        match task {
+            CompactionTask::Tiered(task) => {
+                assert_eq!(task.tiers, vec![(7, vec![])]);
+                assert!(task.bottom_tier_included);
+            }
+            other => panic!("expected tiered task, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_trigger_compaction_prefers_ordinary_over_gc_when_both_exist() {
+        let dir = tempdir().unwrap();
+        let options = LsmStorageOptions {
+            compaction_options: CompactionOptions::Leveled(LeveledCompactionOptions {
+                level_size_multiplier: 2,
+                level0_file_num_compaction_trigger: 1,
+                max_levels: 3,
+                base_level_size_mb: 128,
+            }),
+            ..LsmStorageOptions::default_for_test()
+        };
+        let storage = LsmStorageInner::open(&dir, options).unwrap();
+        storage.mvcc.as_ref().unwrap().update_commit_ts(10);
+
+        let ordinary_sst = storage.next_sst_id();
+        let gc_sst = storage.next_sst_id();
+        let ordinary_obj = build_test_sst(&storage, ordinary_sst, b"l0", 5);
+        let gc_obj = build_test_multi_version_sst(&storage, gc_sst, b"gc", &[4, 3]);
+
+        let mut snapshot = storage.state.load().as_ref().clone();
+        snapshot.l0_sstables.push(ordinary_sst);
+        snapshot.levels[0].1.push(gc_sst);
+        snapshot.sstables.insert(ordinary_sst, ordinary_obj);
+        snapshot.sstables.insert(gc_sst, gc_obj);
+        storage.state.store(Arc::new(snapshot));
+
+        let snapshot = storage.state.load();
+        assert!(
+            storage
+                .compaction_controller
+                .generate_compaction_task(snapshot.as_ref())
+                .is_some(),
+            "ordinary compaction candidate should exist"
+        );
+        assert!(
+            storage.generate_mvcc_gc_task(snapshot.as_ref()).is_some(),
+            "MVCC GC candidate should coexist with ordinary compaction"
+        );
+
+        assert!(storage.try_reserve_ssts(&[ordinary_sst]));
+        assert_eq!(
+            storage.trigger_compaction().unwrap(),
+            CompactionTriggerOutcome::Deferred
+        );
+        assert_eq!(storage.state.load().l0_sstables, vec![ordinary_sst]);
+
+        storage.release_reserved_ssts(&[ordinary_sst]);
+        assert_eq!(
+            storage.trigger_compaction().unwrap(),
+            CompactionTriggerOutcome::Submitted
+        );
+        assert!(storage.state.load().l0_sstables.is_empty());
     }
 
     #[test]
@@ -1069,8 +1604,6 @@ impl LsmStorageInner {
             self.run_compaction_task(&state, task, &merged_fragments)?;
 
         // Build range-only SSTs for gap ranges not covered by point output SSTs.
-        // Skip for Tiered compaction: range_only_ssts are not tracked per-tier,
-        // so generated range-only SSTs would become permanently orphaned.
         // Note: merged_fragments retain full timestamps even at bottommost
         // compactions (GC is applied only to point SSTs in compact_from_iter).
         // This is intentional — range-only SSTs preserve tombstone coverage
@@ -1153,7 +1686,7 @@ impl LsmStorageInner {
             CompactionTask::Tiered(t) => {
                 let mut fragment_lists: Vec<&[crate::range_tombstone::RangeTombstoneFragment]> =
                     Vec::new();
-                for (_, sst_ids) in &t.tiers {
+                for (tier_id, sst_ids) in &t.tiers {
                     for id in sst_ids {
                         if let Some(sst) = state.sstables.get(id)
                             && let Some(frags) = sst.range_tombstone_fragments()
@@ -1162,13 +1695,27 @@ impl LsmStorageInner {
                             fragment_lists.push(frags);
                         }
                     }
+                    if let Some((_, ro_ids)) = state
+                        .range_only_ssts
+                        .iter()
+                        .find(|(lvl, _)| *lvl == *tier_id)
+                    {
+                        for id in ro_ids {
+                            if let Some(sst) = state.sstables.get(id)
+                                && let Some(frags) = sst.range_tombstone_fragments()
+                                && !frags.is_empty()
+                            {
+                                fragment_lists.push(frags);
+                            }
+                        }
+                    }
                 }
                 let frags = if fragment_lists.is_empty() {
                     Vec::new()
                 } else {
                     crate::range_tombstone::merge_fragment_lists(&fragment_lists)
                 };
-                (frags, None)
+                (frags, t.tiers.last().map(|(tier_id, _)| *tier_id))
             }
         }
     }
@@ -1459,47 +2006,7 @@ impl LsmStorageInner {
 
     fn sst_has_expired_ttl_entries(sst: &SsTable, now_secs: u64) -> bool {
         let ttl_meta = &sst.ttl_metadata;
-        ttl_meta.ttl_entry_count > 0 && ttl_meta.max_ttl_expire_ts <= now_secs
-    }
-
-    fn sst_has_reclaimable_mvcc_entries(sst: Arc<SsTable>, now_secs: u64) -> bool {
-        if sst.is_range_only() {
-            return false;
-        }
-
-        let mut iter = match SsTableIterator::create_and_seek_to_first(sst, CacheAdmission::Force) {
-            Ok(iter) => iter,
-            Err(_) => return false,
-        };
-        let mut prev_user_key = Vec::new();
-        let mut has_prev_user_key = false;
-
-        while iter.is_valid() {
-            let key = iter.key();
-            let user_key = key.encoded_user_key();
-            if has_prev_user_key && user_key == prev_user_key.as_slice() {
-                return true;
-            }
-            has_prev_user_key = true;
-            prev_user_key.clear();
-            prev_user_key.extend_from_slice(user_key);
-
-            let raw = iter.raw_value();
-            if crate::vlog::KvKind::is_tombstone_value(raw) {
-                return true;
-            }
-            if crate::vlog::TtlMetadata::parse(raw)
-                .is_some_and(|(meta, _)| now_secs >= meta.expire_at_secs)
-            {
-                return true;
-            }
-
-            if iter.next().is_err() {
-                return false;
-            }
-        }
-
-        false
+        ttl_meta.ttl_entry_count > 0 && ttl_meta.min_ttl_expire_ts <= now_secs
     }
 
     fn bottom_level_has_overlapping_user_ranges(
@@ -1541,26 +2048,47 @@ impl LsmStorageInner {
         target_level: Option<usize>,
         input_sst_ids: &[usize],
     ) -> Vec<usize> {
-        let Some(level) = target_level else {
-            return Vec::new();
-        };
-
         let state = self.state.load();
-        let Some((_, ro_ids)) = state.range_only_ssts.iter().find(|(lvl, _)| *lvl == level) else {
-            return Vec::new();
-        };
 
         match task {
             CompactionTask::Simple(_) => {
+                let Some(level) = target_level else {
+                    return Vec::new();
+                };
+                let Some((_, ro_ids)) = state.range_only_ssts.iter().find(|(lvl, _)| *lvl == level)
+                else {
+                    return Vec::new();
+                };
                 // Simple compaction compacts the whole level, so every range-only SST at the
                 // target level is part of the input set.
                 ro_ids.clone()
             }
-            _ => ro_ids
+            CompactionTask::Tiered(t) => t
+                .tiers
                 .iter()
-                .filter(|id| input_sst_ids.contains(id))
-                .copied()
+                .flat_map(|(tier_id, _)| {
+                    state
+                        .range_only_ssts
+                        .iter()
+                        .find(|(lvl, _)| *lvl == *tier_id)
+                        .into_iter()
+                        .flat_map(|(_, ids)| ids.iter().copied())
+                })
                 .collect(),
+            _ => {
+                let Some(level) = target_level else {
+                    return Vec::new();
+                };
+                let Some((_, ro_ids)) = state.range_only_ssts.iter().find(|(lvl, _)| *lvl == level)
+                else {
+                    return Vec::new();
+                };
+                ro_ids
+                    .iter()
+                    .filter(|id| input_sst_ids.contains(id))
+                    .copied()
+                    .collect()
+            }
         }
     }
 
@@ -1589,110 +2117,243 @@ impl LsmStorageInner {
         let cutoff = self.mvcc.as_ref().map(|mvcc| mvcc.watermark())?;
         let reserved = self.snapshot_reserved_ssts();
         let now_secs = crate::vlog::wall_clock_secs();
-        let (bottom_level_num, bottom_level_ids) = snapshot
+        let bottom_level_num = snapshot
             .levels
             .iter()
             .rev()
-            .find(|(_, ids)| !ids.is_empty())?;
-
-        match &self.options.compaction_options {
-            crate::compact::CompactionOptions::Leveled(_) => {
-                let best = bottom_level_ids
+            .find(|(_, ids)| !ids.is_empty())
+            .map(|(level, _)| *level)
+            .into_iter()
+            .chain(
+                snapshot
+                    .range_only_ssts
                     .iter()
-                    .filter(|id| !reserved.contains(id))
-                    .filter_map(|id| {
-                        let sst = snapshot.sstables.get(id)?;
-                        let ttl_meta = &sst.ttl_metadata;
-                        let fully_old = sst.max_ts() <= cutoff;
-                        let ttl_candidate = Self::sst_has_expired_ttl_entries(sst, now_secs);
-                        if !fully_old && !ttl_candidate {
-                            return None;
-                        }
-                        if fully_old
-                            && !ttl_candidate
-                            && !sst.has_range_tombstones()
-                            && !Self::sst_has_reclaimable_mvcc_entries(sst.clone(), now_secs)
-                        {
-                            return None;
-                        }
-                        let ttl_ratio = if ttl_meta.total_entry_count == 0 {
-                            0.0
-                        } else {
-                            ttl_meta.ttl_entry_count as f64 / ttl_meta.total_entry_count as f64
-                        };
-                        Some((*id, fully_old, ttl_candidate, ttl_ratio, sst.table_size()))
-                    })
-                    .max_by(|a, b| {
-                        a.1.cmp(&b.1)
-                            .then(a.2.cmp(&b.2))
-                            .then_with(|| a.3.total_cmp(&b.3))
-                            .then(a.4.cmp(&b.4))
-                    })?;
-                Some(CompactionTask::Leveled(LeveledCompactionTask {
-                    upper_level: Some(*bottom_level_num),
-                    upper_level_sst_ids: vec![best.0],
-                    lower_level: *bottom_level_num,
-                    lower_level_sst_ids: Vec::new(),
-                    is_lower_level_bottom_level: true,
-                }))
-            }
-            crate::compact::CompactionOptions::Simple(_) => {
-                if bottom_level_ids.iter().any(|id| reserved.contains(id)) {
-                    return None;
-                }
-                let has_expired_ttl = bottom_level_ids.iter().any(|id| {
-                    snapshot
-                        .sstables
-                        .get(id)
-                        .is_some_and(|sst| Self::sst_has_expired_ttl_entries(sst, now_secs))
-                });
-                let has_old_versions = bottom_level_ids.iter().any(|id| {
-                    snapshot
-                        .sstables
-                        .get(id)
-                        .is_some_and(|sst| sst.max_ts() <= cutoff)
-                });
-                let has_overlap =
-                    Self::bottom_level_has_overlapping_user_ranges(snapshot, bottom_level_ids);
-                if !has_expired_ttl && !(has_old_versions && has_overlap) {
-                    return None;
-                }
-                Some(CompactionTask::Simple(SimpleLeveledCompactionTask {
-                    upper_level: Some(*bottom_level_num),
-                    upper_level_sst_ids: bottom_level_ids.clone(),
-                    lower_level: *bottom_level_num,
-                    lower_level_sst_ids: Vec::new(),
-                    is_lower_level_bottom_level: true,
-                }))
-            }
-            crate::compact::CompactionOptions::Tiered(_) => {
-                if bottom_level_ids.iter().any(|id| reserved.contains(id)) {
-                    return None;
-                }
-                let has_expired_ttl = bottom_level_ids.iter().any(|id| {
-                    snapshot
-                        .sstables
-                        .get(id)
-                        .is_some_and(|sst| Self::sst_has_expired_ttl_entries(sst, now_secs))
-                });
-                let has_old_versions = bottom_level_ids.iter().any(|id| {
-                    snapshot
-                        .sstables
-                        .get(id)
-                        .is_some_and(|sst| sst.max_ts() <= cutoff)
-                });
-                let has_overlap =
-                    Self::bottom_level_has_overlapping_user_ranges(snapshot, bottom_level_ids);
-                if !has_expired_ttl && !(has_old_versions && has_overlap) {
-                    return None;
-                }
-                Some(CompactionTask::Tiered(TieredCompactionTask {
-                    tiers: vec![(*bottom_level_num, bottom_level_ids.clone())],
-                    bottom_tier_included: true,
-                }))
-            }
+                    .rev()
+                    .find(|(_, ids)| !ids.is_empty())
+                    .map(|(level, _)| *level),
+            )
+            .max()?;
+        let bottom_level_ids = snapshot
+            .levels
+            .iter()
+            .find(|(level, _)| *level == bottom_level_num)
+            .map(|(_, ids)| ids.as_slice())
+            .unwrap_or(&[]);
+        let bottom_range_only_ids = snapshot
+            .range_only_ssts
+            .iter()
+            .find(|(level, _)| *level == bottom_level_num)
+            .map(|(_, ids)| ids.as_slice())
+            .unwrap_or(&[]);
+
+        self.pick_mvcc_gc_task(
+            snapshot,
+            cutoff,
+            &reserved,
+            now_secs,
+            bottom_level_num,
+            bottom_level_ids,
+            bottom_range_only_ids,
+        )
+    }
+
+    fn pick_mvcc_gc_task(
+        &self,
+        snapshot: &LsmStorageState,
+        cutoff: u64,
+        reserved: &HashSet<usize>,
+        now_secs: u64,
+        bottom_level_num: usize,
+        bottom_level_ids: &[usize],
+        bottom_range_only_ids: &[usize],
+    ) -> Option<CompactionTask> {
+        match &self.options.compaction_options {
+            crate::compact::CompactionOptions::Leveled(_) => Self::pick_leveled_mvcc_gc_task(
+                snapshot,
+                cutoff,
+                reserved,
+                now_secs,
+                bottom_level_num,
+                bottom_level_ids,
+                bottom_range_only_ids,
+            ),
+            crate::compact::CompactionOptions::Simple(_) => Self::pick_simple_mvcc_gc_task(
+                snapshot,
+                cutoff,
+                reserved,
+                now_secs,
+                bottom_level_num,
+                bottom_level_ids,
+                bottom_range_only_ids,
+            ),
+            crate::compact::CompactionOptions::Tiered(_) => Self::pick_tiered_mvcc_gc_task(
+                snapshot,
+                cutoff,
+                reserved,
+                now_secs,
+                bottom_level_num,
+                bottom_level_ids,
+                bottom_range_only_ids,
+            ),
             crate::compact::CompactionOptions::NoCompaction => None,
         }
+    }
+
+    fn pick_leveled_mvcc_gc_task(
+        snapshot: &LsmStorageState,
+        cutoff: u64,
+        reserved: &HashSet<usize>,
+        now_secs: u64,
+        bottom_level_num: usize,
+        bottom_level_ids: &[usize],
+        bottom_range_only_ids: &[usize],
+    ) -> Option<CompactionTask> {
+        let best = bottom_level_ids
+            .iter()
+            .map(|id| (*id, false))
+            .chain(bottom_range_only_ids.iter().map(|id| (*id, true)))
+            .filter(|(id, _)| !reserved.contains(id))
+            .filter_map(|(id, is_range_only)| {
+                let sst = snapshot.sstables.get(&id)?;
+                let stats = Arc::clone(sst).mvcc_gc_stats().ok()?;
+                let fully_old = sst.max_ts() <= cutoff;
+                let ttl_candidate = Self::sst_has_expired_ttl_entries(sst, now_secs);
+                if !fully_old && !ttl_candidate {
+                    return None;
+                }
+                if fully_old
+                    && !ttl_candidate
+                    && stats.point_tombstone_count == 0
+                    && stats.range_tombstone_fragment_count == 0
+                    && stats.redundant_version_count == 0
+                {
+                    return None;
+                }
+                Some((
+                    id,
+                    is_range_only,
+                    (
+                        fully_old,
+                        ttl_candidate,
+                        stats.redundant_version_count,
+                        stats.point_tombstone_count,
+                        stats.range_tombstone_fragment_count,
+                        stats.ttl_entry_count,
+                        sst.table_size(),
+                    ),
+                ))
+            })
+            .max_by(|a, b| a.2.cmp(&b.2))?;
+        Some(CompactionTask::Leveled(if best.1 {
+            LeveledCompactionTask {
+                upper_level: Some(bottom_level_num),
+                upper_level_sst_ids: Vec::new(),
+                lower_level: bottom_level_num,
+                lower_level_sst_ids: vec![best.0],
+                is_lower_level_bottom_level: true,
+            }
+        } else {
+            LeveledCompactionTask {
+                upper_level: Some(bottom_level_num),
+                upper_level_sst_ids: vec![best.0],
+                lower_level: bottom_level_num,
+                lower_level_sst_ids: Vec::new(),
+                is_lower_level_bottom_level: true,
+            }
+        }))
+    }
+
+    fn pick_simple_mvcc_gc_task(
+        snapshot: &LsmStorageState,
+        cutoff: u64,
+        reserved: &HashSet<usize>,
+        now_secs: u64,
+        bottom_level_num: usize,
+        bottom_level_ids: &[usize],
+        bottom_range_only_ids: &[usize],
+    ) -> Option<CompactionTask> {
+        if bottom_level_ids
+            .iter()
+            .chain(bottom_range_only_ids.iter())
+            .any(|id| reserved.contains(id))
+        {
+            return None;
+        }
+        let has_expired_ttl = bottom_level_ids
+            .iter()
+            .chain(bottom_range_only_ids.iter())
+            .any(|id| {
+                snapshot
+                    .sstables
+                    .get(id)
+                    .is_some_and(|sst| Self::sst_has_expired_ttl_entries(sst, now_secs))
+            });
+        let has_old_versions = bottom_level_ids
+            .iter()
+            .chain(bottom_range_only_ids.iter())
+            .any(|id| {
+                snapshot
+                    .sstables
+                    .get(id)
+                    .is_some_and(|sst| sst.max_ts() <= cutoff)
+            });
+        let has_overlap =
+            Self::bottom_level_has_overlapping_user_ranges(snapshot, bottom_level_ids);
+        if !has_expired_ttl && !(has_old_versions && (has_overlap || bottom_level_ids.is_empty())) {
+            return None;
+        }
+        Some(CompactionTask::Simple(SimpleLeveledCompactionTask {
+            upper_level: Some(bottom_level_num),
+            upper_level_sst_ids: bottom_level_ids.to_vec(),
+            lower_level: bottom_level_num,
+            lower_level_sst_ids: Vec::new(),
+            is_lower_level_bottom_level: true,
+        }))
+    }
+
+    fn pick_tiered_mvcc_gc_task(
+        snapshot: &LsmStorageState,
+        cutoff: u64,
+        reserved: &HashSet<usize>,
+        now_secs: u64,
+        bottom_level_num: usize,
+        bottom_level_ids: &[usize],
+        bottom_range_only_ids: &[usize],
+    ) -> Option<CompactionTask> {
+        if bottom_level_ids
+            .iter()
+            .chain(bottom_range_only_ids.iter())
+            .any(|id| reserved.contains(id))
+        {
+            return None;
+        }
+        let has_expired_ttl = bottom_level_ids
+            .iter()
+            .chain(bottom_range_only_ids.iter())
+            .any(|id| {
+                snapshot
+                    .sstables
+                    .get(id)
+                    .is_some_and(|sst| Self::sst_has_expired_ttl_entries(sst, now_secs))
+            });
+        let has_old_versions = bottom_level_ids
+            .iter()
+            .chain(bottom_range_only_ids.iter())
+            .any(|id| {
+                snapshot
+                    .sstables
+                    .get(id)
+                    .is_some_and(|sst| sst.max_ts() <= cutoff)
+            });
+        let has_overlap =
+            Self::bottom_level_has_overlapping_user_ranges(snapshot, bottom_level_ids);
+        if !has_expired_ttl && !(has_old_versions && (has_overlap || bottom_level_ids.is_empty())) {
+            return None;
+        }
+        Some(CompactionTask::Tiered(TieredCompactionTask {
+            tiers: vec![(bottom_level_num, bottom_level_ids.to_vec())],
+            bottom_tier_included: true,
+        }))
     }
 
     fn remove_sst_files<I>(&self, sst_ids: I) -> Result<()>
@@ -1968,6 +2629,15 @@ impl LsmStorageInner {
         let new_sst_ids = new_ssts.iter().map(|x| x.sst_id()).collect::<Vec<_>>();
         let new_range_only_sst_ids: Vec<usize> =
             new_range_only_ssts.iter().map(|x| x.sst_id()).collect();
+        let controller_output_ids = if matches!(t, CompactionTask::Tiered(_)) {
+            new_sst_ids
+                .iter()
+                .copied()
+                .chain(new_range_only_sst_ids.iter().copied())
+                .collect::<Vec<_>>()
+        } else {
+            new_sst_ids.clone()
+        };
 
         // Collect input SST IDs for post-compaction GC
         let input_sst_ids = Self::collect_compaction_input_sst_ids(t);
@@ -2001,7 +2671,7 @@ impl LsmStorageInner {
             }
             let (snapshot_partial, rm_sst_ids) = self
                 .compaction_controller
-                .apply_compaction_result(&snapshot, t, new_sst_ids.as_slice());
+                .apply_compaction_result(&snapshot, t, controller_output_ids.as_slice());
 
             // Register vLog references for new point SSTs only.
             // Range-only SSTs have no point data and no vLog references,
@@ -2026,14 +2696,23 @@ impl LsmStorageInner {
             snapshot.levels = snapshot_partial.levels;
 
             // Add new range-only SSTs to the target level and remove old ones
-            if let Some(level) = target_level {
+            let range_only_target = target_level.or_else(|| {
+                if matches!(t, CompactionTask::Tiered(_)) {
+                    controller_output_ids.first().copied()
+                } else {
+                    None
+                }
+            });
+            for (_, ro_ids) in snapshot.range_only_ssts.iter_mut() {
+                ro_ids.retain(|id| !input_range_only_ids.contains(id));
+            }
+            snapshot.range_only_ssts.retain(|(_, ids)| !ids.is_empty());
+            if let Some(level) = range_only_target {
                 if let Some((_, ro_ids)) = snapshot
                     .range_only_ssts
                     .iter_mut()
                     .find(|(lvl, _)| *lvl == level)
                 {
-                    // Remove old range-only SSTs that were in the input
-                    ro_ids.retain(|id| !input_range_only_ids.contains(id));
                     // Add new range-only SSTs
                     for &id in &new_range_only_sst_ids {
                         ro_ids.push(id);
@@ -2098,28 +2777,38 @@ impl LsmStorageInner {
 
     /// Check whether any mixed SSTs have a high enough proportion of
     /// expired TTL entries to justify compaction.
-    pub(crate) fn trigger_compaction(&self) -> Result<()> {
+    pub(crate) fn trigger_compaction(&self) -> Result<CompactionTriggerOutcome> {
         // TTL background scan: drop fully-expired TTL-only SSTs at the
         // bottommost level. Mixed SSTs with expired entries are prioritized
         // by the compaction controller's generate_compaction_task.
         self.try_ttl_wholesale_drop()?;
 
         let snapshot = self.state.load_full();
+        let mut deferred = false;
         if let Some(task) = self
             .compaction_controller
             .generate_compaction_task(snapshot.as_ref())
-            && let Some(_reservation) = self.reserve_task_inputs(&task)
         {
-            return self.publish_compaction_task(&task);
+            if let Some(_reservation) = self.reserve_task_inputs(&task) {
+                self.publish_compaction_task(&task)?;
+                return Ok(CompactionTriggerOutcome::Submitted);
+            }
+            deferred = true;
         }
 
-        if let Some(task) = self.generate_mvcc_gc_task(snapshot.as_ref())
-            && let Some(_reservation) = self.reserve_task_inputs(&task)
-        {
-            return self.publish_compaction_task(&task);
+        if let Some(task) = self.generate_mvcc_gc_task(snapshot.as_ref()) {
+            if let Some(_reservation) = self.reserve_task_inputs(&task) {
+                self.publish_compaction_task(&task)?;
+                return Ok(CompactionTriggerOutcome::Submitted);
+            }
+            deferred = true;
         }
 
-        Ok(())
+        Ok(if deferred {
+            CompactionTriggerOutcome::Deferred
+        } else {
+            CompactionTriggerOutcome::Idle
+        })
     }
 
     pub(crate) fn trigger_flush(&self) -> Result<()> {

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -634,7 +634,7 @@ mod tests {
         );
 
         let mut snapshot = storage.state.load().as_ref().clone();
-        snapshot.range_only_ssts[0].1.push(sst_id);
+        snapshot.range_only_ssts = vec![(1, vec![sst_id])];
         snapshot.sstables.insert(sst_id, sst);
         storage.state.store(Arc::new(snapshot));
 

--- a/kv-engine/src/compact/tiered.rs
+++ b/kv-engine/src/compact/tiered.rs
@@ -28,6 +28,16 @@ impl TieredCompactionController {
         Self { options }
     }
 
+    fn tier_run_size(snapshot: &LsmStorageState, tier_id: usize, sst_ids: &[usize]) -> usize {
+        let range_only = snapshot
+            .range_only_ssts
+            .iter()
+            .find(|(level, _)| *level == tier_id)
+            .map(|(_, ids)| ids.len())
+            .unwrap_or(0);
+        sst_ids.len() + range_only
+    }
+
     pub fn generate_compaction_task(
         &self,
         snapshot: &LsmStorageState,
@@ -40,9 +50,11 @@ impl TieredCompactionController {
         // Triggered by Space Amplification Ratio
         let mut all_levels_but_last_size = 0;
         for l in 0..snapshot.levels.len() - 1 {
-            all_levels_but_last_size += &snapshot.levels[l].1.len();
+            all_levels_but_last_size +=
+                Self::tier_run_size(snapshot, snapshot.levels[l].0, &snapshot.levels[l].1);
         }
-        let last_size = snapshot.levels.last().unwrap().1.len();
+        let last_tier = snapshot.levels.last().unwrap();
+        let last_size = Self::tier_run_size(snapshot, last_tier.0, &last_tier.1);
 
         if all_levels_but_last_size as f64 / last_size as f64
             >= self.options.max_size_amplification_percent as f64 / 100_f64
@@ -56,8 +68,10 @@ impl TieredCompactionController {
         // Triggered by Size Ratio
         let mut pre_size = 0;
         for l in 0..snapshot.levels.len() - 1 {
-            pre_size += &snapshot.levels[l].1.len();
-            let ratio = pre_size as f64 / snapshot.levels[l + 1].1.len() as f64;
+            pre_size += Self::tier_run_size(snapshot, snapshot.levels[l].0, &snapshot.levels[l].1);
+            let next_tier = &snapshot.levels[l + 1];
+            let ratio =
+                pre_size as f64 / Self::tier_run_size(snapshot, next_tier.0, &next_tier.1) as f64;
 
             if l + 2 >= self.options.min_merge_width
                 && ratio >= (100_f64 + self.options.size_ratio as f64) / 100_f64
@@ -112,11 +126,33 @@ impl TieredCompactionController {
                 // middle of the LSM tree
                 new_tier_added = true;
                 // use the first output SST id as the level/tier id for new sorted run
-                levels.push((output[0], output.to_vec()));
+                let new_tier_id = output[0];
+                let point_output = output
+                    .iter()
+                    .copied()
+                    .filter(|id| {
+                        snapshot
+                            .sstables
+                            .get(id)
+                            .is_some_and(|sst| !sst.is_range_only())
+                    })
+                    .collect();
+                levels.push((new_tier_id, point_output));
             }
         }
-        if !tier_to_remove.is_empty() {
-            unreachable!("some tiers not found??");
+        if !tier_to_remove.is_empty() && !new_tier_added && !output.is_empty() {
+            let new_tier_id = output[0];
+            let point_output = output
+                .iter()
+                .copied()
+                .filter(|id| {
+                    snapshot
+                        .sstables
+                        .get(id)
+                        .is_some_and(|sst| !sst.is_range_only())
+                })
+                .collect();
+            levels.push((new_tier_id, point_output));
         }
         snapshot.levels = levels;
 

--- a/kv-engine/src/compact/tiered.rs
+++ b/kv-engine/src/compact/tiered.rs
@@ -127,7 +127,27 @@ impl TieredCompactionController {
                 new_tier_added = true;
                 // use the first output SST id as the level/tier id for new sorted run
                 let new_tier_id = output[0];
-                let point_output = output
+                let point_output = if output.iter().all(|id| snapshot.sstables.contains_key(id)) {
+                    output
+                        .iter()
+                        .copied()
+                        .filter(|id| {
+                            snapshot
+                                .sstables
+                                .get(id)
+                                .is_some_and(|sst| !sst.is_range_only())
+                        })
+                        .collect()
+                } else {
+                    output.to_vec()
+                };
+                levels.push((new_tier_id, point_output));
+            }
+        }
+        if !tier_to_remove.is_empty() && !new_tier_added && !output.is_empty() {
+            let new_tier_id = output[0];
+            let point_output = if output.iter().all(|id| snapshot.sstables.contains_key(id)) {
+                output
                     .iter()
                     .copied()
                     .filter(|id| {
@@ -136,22 +156,10 @@ impl TieredCompactionController {
                             .get(id)
                             .is_some_and(|sst| !sst.is_range_only())
                     })
-                    .collect();
-                levels.push((new_tier_id, point_output));
-            }
-        }
-        if !tier_to_remove.is_empty() && !new_tier_added && !output.is_empty() {
-            let new_tier_id = output[0];
-            let point_output = output
-                .iter()
-                .copied()
-                .filter(|id| {
-                    snapshot
-                        .sstables
-                        .get(id)
-                        .is_some_and(|sst| !sst.is_range_only())
-                })
-                .collect();
+                    .collect()
+            } else {
+                output.to_vec()
+            };
             levels.push((new_tier_id, point_output));
         }
         snapshot.levels = levels;

--- a/kv-engine/src/compact/tiered.rs
+++ b/kv-engine/src/compact/tiered.rs
@@ -128,21 +128,21 @@ impl TieredCompactionController {
                 if !output.is_empty() {
                     // use the first output SST id as the level/tier id for new sorted run
                     let new_tier_id = output[0];
-                    let point_output =
-                        if output.iter().all(|id| snapshot.sstables.contains_key(id)) {
-                            output
-                                .iter()
-                                .copied()
-                                .filter(|id| {
-                                    snapshot
-                                        .sstables
-                                        .get(id)
-                                        .map_or(true, |sst| !sst.is_range_only())
-                                })
-                                .collect()
-                        } else {
-                            output.to_vec()
-                        };
+                    let point_output = if output.iter().all(|id| snapshot.sstables.contains_key(id))
+                    {
+                        output
+                            .iter()
+                            .copied()
+                            .filter(|id| {
+                                snapshot
+                                    .sstables
+                                    .get(id)
+                                    .is_none_or(|sst| !sst.is_range_only())
+                            })
+                            .collect()
+                    } else {
+                        output.to_vec()
+                    };
                     levels.push((new_tier_id, point_output));
                 }
             }
@@ -157,7 +157,7 @@ impl TieredCompactionController {
                         snapshot
                             .sstables
                             .get(id)
-                            .map_or(true, |sst| !sst.is_range_only())
+                            .is_none_or(|sst| !sst.is_range_only())
                     })
                     .collect()
             } else {

--- a/kv-engine/src/compact/tiered.rs
+++ b/kv-engine/src/compact/tiered.rs
@@ -125,23 +125,26 @@ impl TieredCompactionController {
                 // tricky one, insert the new generated tier to the LSM tree, this may be in the
                 // middle of the LSM tree
                 new_tier_added = true;
-                // use the first output SST id as the level/tier id for new sorted run
-                let new_tier_id = output[0];
-                let point_output = if output.iter().all(|id| snapshot.sstables.contains_key(id)) {
-                    output
-                        .iter()
-                        .copied()
-                        .filter(|id| {
-                            snapshot
-                                .sstables
-                                .get(id)
-                                .is_some_and(|sst| !sst.is_range_only())
-                        })
-                        .collect()
-                } else {
-                    output.to_vec()
-                };
-                levels.push((new_tier_id, point_output));
+                if !output.is_empty() {
+                    // use the first output SST id as the level/tier id for new sorted run
+                    let new_tier_id = output[0];
+                    let point_output =
+                        if output.iter().all(|id| snapshot.sstables.contains_key(id)) {
+                            output
+                                .iter()
+                                .copied()
+                                .filter(|id| {
+                                    snapshot
+                                        .sstables
+                                        .get(id)
+                                        .map_or(true, |sst| !sst.is_range_only())
+                                })
+                                .collect()
+                        } else {
+                            output.to_vec()
+                        };
+                    levels.push((new_tier_id, point_output));
+                }
             }
         }
         if !tier_to_remove.is_empty() && !new_tier_added && !output.is_empty() {
@@ -154,7 +157,7 @@ impl TieredCompactionController {
                         snapshot
                             .sstables
                             .get(id)
-                            .is_some_and(|sst| !sst.is_range_only())
+                            .map_or(true, |sst| !sst.is_range_only())
                     })
                     .collect()
             } else {

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -32,7 +32,7 @@ use crate::{
     manifest::{Manifest, ManifestRecord},
     mem_table::{self, MemTable},
     mvcc::LsmMvccInner,
-    table::{FileObject, SsTable, SsTableBuilder, SsTableIterator},
+    table::{FileObject, SsTable, SsTableBuilder, SsTableIterator, SsTableMvccGcStats},
     vlog::{KvKind, ValueLog, ValuePointer, ValueSeparationOptions},
 };
 
@@ -332,23 +332,39 @@ impl ManifestRecoveryState<'_> {
         vlog_ids: Vec<u32>,
         ro_ids: Vec<usize>,
     ) -> Result<()> {
-        self.replay_compaction(task, &ids)?;
+        let replay_ids = if matches!(task, CompactionTask::Tiered(_)) {
+            ids.iter()
+                .copied()
+                .chain(ro_ids.iter().copied())
+                .collect::<Vec<_>>()
+        } else {
+            ids.clone()
+        };
+        self.replay_compaction(task, &replay_ids)?;
         if !vlog_ids.is_empty() {
             self.replay_vlog_refs(&ids, vlog_ids);
         }
         if let Some(&last_id) = ro_ids.last() {
             self.max_id = std::cmp::max(self.max_id, last_id);
         }
-        self.replay_range_only_ssts(task, ro_ids);
+        self.replay_range_only_ssts(task, &ids, ro_ids);
         Ok(())
     }
 
-    fn replay_range_only_ssts(&mut self, task: &CompactionTask, ro_ids: Vec<usize>) {
+    fn replay_range_only_ssts(
+        &mut self,
+        task: &CompactionTask,
+        output_point_ids: &[usize],
+        ro_ids: Vec<usize>,
+    ) {
         let target_level = match task {
             CompactionTask::Leveled(t) => Some(t.lower_level),
             CompactionTask::Simple(t) => Some(t.lower_level),
             CompactionTask::ForceFullCompaction { .. } => Some(1),
-            CompactionTask::Tiered(_) => None,
+            CompactionTask::Tiered(_) => output_point_ids
+                .first()
+                .copied()
+                .or_else(|| ro_ids.first().copied()),
         };
         let Some(level) = target_level else {
             return;
@@ -390,16 +406,31 @@ impl ManifestRecoveryState<'_> {
             CompactionTask::Tiered(t) => {
                 self.input_ids_buf
                     .extend(t.tiers.iter().flat_map(|(_, ids)| ids.iter().copied()));
+                for (tier_id, _) in &t.tiers {
+                    if let Some((_, ro_ids_in_state)) = self
+                        .state
+                        .range_only_ssts
+                        .iter()
+                        .find(|(lvl, _)| *lvl == *tier_id)
+                    {
+                        self.input_ids_buf.extend(ro_ids_in_state.iter().copied());
+                    }
+                }
             }
         };
 
+        for (_, existing) in self.state.range_only_ssts.iter_mut() {
+            existing.retain(|id| !self.input_ids_buf.contains(id));
+        }
+        self.state
+            .range_only_ssts
+            .retain(|(_, ids)| !ids.is_empty());
         if let Some((_, existing)) = self
             .state
             .range_only_ssts
             .iter_mut()
             .find(|(l, _)| *l == level)
         {
-            existing.retain(|id| !self.input_ids_buf.contains(id));
             existing.extend(ro_ids);
         } else if !ro_ids.is_empty() {
             self.state.range_only_ssts.push((level, ro_ids));
@@ -613,6 +644,23 @@ pub struct RangeTombstoneStats {
     pub covered_point_drops: u64,
     /// Number of range-tombstone fragments dropped by compaction (obsolete).
     pub tombstone_drops: u64,
+}
+
+/// MVCC GC candidate-scoring statistics for the storage engine.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct MvccGcStats {
+    /// Per-SST stats used for GC candidate scoring.
+    pub ssts: Vec<SsTableMvccGcStats>,
+    /// Total number of SSTs in the snapshot.
+    pub sst_count: u64,
+    /// Total point tombstones across all SSTs.
+    pub point_tombstone_count: u64,
+    /// Total range-tombstone fragments across all SSTs.
+    pub range_tombstone_fragment_count: u64,
+    /// Total range-tombstone metadata bytes across all SSTs.
+    pub range_tombstone_metadata_bytes: u64,
+    /// Total estimated redundant historical versions across all SSTs.
+    pub redundant_version_count: u64,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -1139,7 +1187,7 @@ impl BackgroundWorkers {
                                 compaction_shutdown,
                                 compaction_notify,
                                 "compaction",
-                                |inner| inner.trigger_compaction(),
+                                |inner| inner.trigger_compaction().map(|_| ()),
                             )
                             .await;
                         });
@@ -1593,6 +1641,53 @@ impl KvEngine {
             covered_point_drops,
             tombstone_drops,
         }
+    }
+
+    /// Snapshot MVCC-GC candidate-scoring stats for the current SST layout.
+    ///
+    /// This is intentionally non-hot-path and may touch SST data blocks.
+    pub fn mvcc_gc_stats(&self) -> Result<MvccGcStats> {
+        let state = self.inner.state.load();
+        let mut ssts = Vec::with_capacity(state.sstables.len());
+        let mut point_tombstone_count = 0u64;
+        let mut range_tombstone_fragment_count = 0u64;
+        let mut range_tombstone_metadata_bytes = 0u64;
+        let mut redundant_version_count = 0u64;
+        let mut push_stats = |sst_id: &usize, level: Option<usize>| -> Result<()> {
+            if let Some(sst) = state.sstables.get(sst_id) {
+                let mut stats = Arc::clone(sst).mvcc_gc_stats()?;
+                stats.level = level;
+                point_tombstone_count += stats.point_tombstone_count;
+                range_tombstone_fragment_count += stats.range_tombstone_fragment_count;
+                range_tombstone_metadata_bytes += stats.range_tombstone_metadata_bytes;
+                redundant_version_count += stats.redundant_version_count;
+                ssts.push(stats);
+            }
+            Ok(())
+        };
+
+        for sst_id in &state.l0_sstables {
+            push_stats(sst_id, Some(0))?;
+        }
+        for (level_num, level) in &state.levels {
+            for sst_id in level {
+                push_stats(sst_id, Some(*level_num))?;
+            }
+        }
+        for (level_num, range_only_ids) in &state.range_only_ssts {
+            for sst_id in range_only_ids {
+                push_stats(sst_id, Some(*level_num))?;
+            }
+        }
+
+        Ok(MvccGcStats {
+            ssts,
+            sst_count: state.sstables.len() as u64,
+            point_tombstone_count,
+            range_tombstone_fragment_count,
+            range_tombstone_metadata_bytes,
+            redundant_version_count,
+        })
     }
 
     /// Snapshot of cumulative write-path profiling counters for this engine.

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -170,6 +170,14 @@ impl LsmStorageState {
             sstables: Default::default(),
         }
     }
+
+    fn normalize_range_only_ssts(&mut self) {
+        for (_, ids) in &mut self.range_only_ssts {
+            ids.sort_unstable();
+            ids.dedup();
+        }
+        self.range_only_ssts.retain(|(_, ids)| !ids.is_empty());
+    }
 }
 
 /// Mutable state accumulated during manifest replay in `open()`.
@@ -432,6 +440,8 @@ impl ManifestRecoveryState<'_> {
             .find(|(l, _)| *l == level)
         {
             existing.extend(ro_ids);
+            existing.sort_unstable();
+            existing.dedup();
         } else if !ro_ids.is_empty() {
             self.state.range_only_ssts.push((level, ro_ids));
         }
@@ -441,6 +451,7 @@ impl ManifestRecoveryState<'_> {
         self.state.l0_sstables = snapshot.l0_sstables;
         self.state.levels = snapshot.levels;
         self.state.range_only_ssts = snapshot.range_only_ssts;
+        self.state.normalize_range_only_ssts();
         self.max_id = snapshot.next_sst_id.saturating_sub(1);
 
         self.recovered_vlog_refs.clear();
@@ -3146,6 +3157,8 @@ impl LsmStorageInner {
             };
             plan.manifest.snapshot(snapshot)?;
         }
+
+        plan.state.normalize_range_only_ssts();
 
         // Create the new active memtable on the recovery path.  Must happen
         // AFTER any snapshot upgrades so the NewMemtable record survives

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -13,6 +13,7 @@ pub use iterator::SsTableIterator;
 use self::bloom::Bloom;
 use crate::{
     block::Block,
+    iterators::StorageIterator,
     key::{Key, KeyBytes, KeySlice, TS_ENABLED},
     lsm_storage::{BlockCache, CacheAdmission},
 };
@@ -236,6 +237,35 @@ impl BlockMeta {
 /// A file object.
 #[derive(Debug)]
 pub struct FileObject(Option<File>, u64);
+
+/// Per-SST MVCC-GC candidate stats.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SsTableMvccGcStats {
+    /// SST id.
+    pub sst_id: usize,
+    /// SST level when reported through the engine stats API.
+    pub level: Option<usize>,
+    /// Maximum timestamp in the SST.
+    pub max_ts: u64,
+    /// Minimum TTL expiration timestamp in the SST.
+    pub min_ttl_expire_ts: u64,
+    /// Maximum TTL expiration timestamp in the SST.
+    pub max_ttl_expire_ts: u64,
+    /// Whether the SST contains non-TTL entries.
+    pub has_non_ttl_entries: bool,
+    /// Number of TTL entries in the SST.
+    pub ttl_entry_count: u64,
+    /// Total number of entries in the SST.
+    pub total_entry_count: u64,
+    /// Number of point tombstones in the SST.
+    pub point_tombstone_count: u64,
+    /// Number of range-tombstone fragments in the SST.
+    pub range_tombstone_fragment_count: u64,
+    /// Approximate bytes of range-tombstone metadata in the SST.
+    pub range_tombstone_metadata_bytes: u64,
+    /// Estimated redundant historical versions in the SST.
+    pub redundant_version_count: u64,
+}
 
 impl FileObject {
     pub fn read(&self, offset: u64, len: u64) -> Result<Vec<u8>> {
@@ -1260,6 +1290,65 @@ impl SsTable {
 
     pub fn max_ts(&self) -> u64 {
         self.max_ts
+    }
+
+    /// Snapshot candidate-scoring stats for this SST.
+    ///
+    /// This is intentionally non-hot-path and may touch SST data blocks.
+    pub fn mvcc_gc_stats(self: Arc<Self>) -> Result<SsTableMvccGcStats> {
+        let mut point_tombstone_count = 0u64;
+        let mut redundant_version_count = 0u64;
+        if !self.is_range_only() {
+            let mut iter =
+                SsTableIterator::create_and_seek_to_first(self.clone(), CacheAdmission::Bypass)?;
+            let mut prev_user_key: Option<Vec<u8>> = None;
+
+            while iter.is_valid() {
+                let key = iter.key();
+                let user_key = key.encoded_user_key();
+                if prev_user_key
+                    .as_ref()
+                    .is_some_and(|prev| prev.as_slice() == user_key)
+                {
+                    redundant_version_count += 1;
+                } else {
+                    prev_user_key = Some(user_key.to_vec());
+                }
+
+                if crate::vlog::KvKind::is_tombstone_value(iter.raw_value()) {
+                    point_tombstone_count += 1;
+                }
+
+                iter.next()?;
+            }
+        }
+
+        let range_tombstone_fragment_count = self
+            .range_tombstone_fragments()
+            .map_or(0, |frags| frags.len() as u64);
+        let range_tombstone_metadata_bytes = self.range_tombstone_fragments().map_or(0, |frags| {
+            frags
+                .iter()
+                .map(|f| {
+                    8 + f.start.len() as u64 + f.end.len() as u64 + f.covering_ts.len() as u64 * 8
+                })
+                .sum()
+        });
+
+        Ok(SsTableMvccGcStats {
+            sst_id: self.sst_id(),
+            level: None,
+            max_ts: self.max_ts(),
+            min_ttl_expire_ts: self.ttl_metadata.min_ttl_expire_ts,
+            max_ttl_expire_ts: self.ttl_metadata.max_ttl_expire_ts,
+            has_non_ttl_entries: self.ttl_metadata.has_non_ttl_entries,
+            ttl_entry_count: self.ttl_metadata.ttl_entry_count,
+            total_entry_count: self.ttl_metadata.total_entry_count,
+            point_tombstone_count,
+            range_tombstone_fragment_count,
+            range_tombstone_metadata_bytes,
+            redundant_version_count,
+        })
     }
 
     pub fn range_overlap(&self, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> bool {

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -3,6 +3,7 @@ mod builder;
 mod iterator;
 
 use std::os::unix::io::AsRawFd;
+use std::sync::OnceLock;
 use std::{fs::File, mem, ops::Bound, path::Path, sync::Arc};
 
 use anyhow::Result;
@@ -339,6 +340,10 @@ pub struct SsTable {
     /// Last block index hint for sorted batch lookups. When consecutive
     /// sorted keys land in the same block, this avoids a full binary search.
     last_block_hint: std::sync::atomic::AtomicUsize,
+    /// Cached MVCC GC stats computed on first access. An SST's stats cannot
+    /// change after construction, so caching avoids repeated full SST scans
+    /// in the background compaction loop.
+    mvcc_gc_stats_cache: OnceLock<SsTableMvccGcStats>,
 }
 
 impl SsTable {
@@ -702,6 +707,7 @@ impl SsTable {
             range_tombstones,
             ttl_metadata: ttl_meta,
             last_block_hint: std::sync::atomic::AtomicUsize::new(0),
+            mvcc_gc_stats_cache: OnceLock::new(),
         })
     }
 
@@ -862,6 +868,7 @@ impl SsTable {
             range_tombstones: None,
             ttl_metadata: SsTableTtlMetadata::NONE,
             last_block_hint: std::sync::atomic::AtomicUsize::new(0),
+            mvcc_gc_stats_cache: OnceLock::new(),
         }
     }
 
@@ -1296,6 +1303,10 @@ impl SsTable {
     ///
     /// This is intentionally non-hot-path and may touch SST data blocks.
     pub fn mvcc_gc_stats(self: Arc<Self>) -> Result<SsTableMvccGcStats> {
+        if let Some(cached) = self.mvcc_gc_stats_cache.get() {
+            return Ok(*cached);
+        }
+
         let mut point_tombstone_count = 0u64;
         let mut redundant_version_count = 0u64;
         if !self.is_range_only() {
@@ -1335,7 +1346,7 @@ impl SsTable {
                 .sum()
         });
 
-        Ok(SsTableMvccGcStats {
+        let stats = SsTableMvccGcStats {
             sst_id: self.sst_id(),
             level: None,
             max_ts: self.max_ts(),
@@ -1348,7 +1359,12 @@ impl SsTable {
             range_tombstone_fragment_count,
             range_tombstone_metadata_bytes,
             redundant_version_count,
-        })
+        };
+        // Cache the result. set() returns Err if already set; this is expected
+        // under concurrent access and we simply use the cached value.
+        let _ = self.mvcc_gc_stats_cache.set(stats);
+
+        Ok(stats)
     }
 
     pub fn range_overlap(&self, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> bool {

--- a/kv-engine/src/table/builder.rs
+++ b/kv-engine/src/table/builder.rs
@@ -655,6 +655,7 @@ impl SsTableBuilder {
             range_tombstones,
             ttl_metadata,
             last_block_hint: std::sync::atomic::AtomicUsize::new(0),
+            mvcc_gc_stats_cache: std::sync::OnceLock::new(),
         };
         Ok((sst, self.collected_blocks))
     }

--- a/kv-engine/src/tests/compaction.rs
+++ b/kv-engine/src/tests/compaction.rs
@@ -543,6 +543,122 @@ fn test_trigger_compaction_skips_reserved_mvcc_gc_candidate() {
 }
 
 #[test]
+fn test_trigger_compaction_defers_when_ordinary_candidate_is_reserved() {
+    use crate::compact::{CompactionOptions, CompactionTriggerOutcome, LeveledCompactionOptions};
+
+    let dir = tempdir().unwrap();
+    let options = LsmStorageOptions {
+        compaction_options: CompactionOptions::Leveled(LeveledCompactionOptions {
+            level_size_multiplier: 2,
+            level0_file_num_compaction_trigger: 1,
+            max_levels: 3,
+            base_level_size_mb: 128,
+        }),
+        num_memtable_limit: 2,
+        target_sst_size: 1 << 20,
+        ..LsmStorageOptions::default_for_test()
+    };
+    let storage = Arc::new(LsmStorageInner::open(&dir, options).unwrap());
+
+    storage.put(b"a", b"v1").unwrap();
+    sync(&storage);
+
+    let reserved_sst = storage.state.load().l0_sstables[0];
+    assert!(storage.try_reserve_ssts(&[reserved_sst]));
+
+    assert_eq!(
+        storage.trigger_compaction().unwrap(),
+        CompactionTriggerOutcome::Deferred
+    );
+    assert_eq!(storage.state.load().l0_sstables, vec![reserved_sst]);
+
+    storage.release_reserved_ssts(&[reserved_sst]);
+    assert_eq!(
+        storage.trigger_compaction().unwrap(),
+        CompactionTriggerOutcome::Submitted
+    );
+    assert!(storage.state.load().l0_sstables.is_empty());
+}
+
+#[test]
+fn test_trigger_compaction_runs_mvcc_gc_when_ordinary_candidate_is_reserved() {
+    use crate::compact::{CompactionOptions, CompactionTriggerOutcome, LeveledCompactionOptions};
+
+    let dir = tempdir().unwrap();
+    let options = LsmStorageOptions {
+        compaction_options: CompactionOptions::Leveled(LeveledCompactionOptions {
+            level_size_multiplier: 2,
+            level0_file_num_compaction_trigger: 1,
+            max_levels: 1,
+            base_level_size_mb: 128,
+        }),
+        num_memtable_limit: 2,
+        target_sst_size: 1 << 20,
+        ..LsmStorageOptions::default_for_test()
+    };
+    let storage = Arc::new(LsmStorageInner::open(&dir, options).unwrap());
+    storage.mvcc.as_ref().unwrap().update_commit_ts(10);
+
+    let ordinary_sst = storage.next_sst_id();
+    let mut ordinary_builder = SsTableBuilder::new(storage.options.block_size);
+    ordinary_builder
+        .add(
+            KeySlice::for_testing_from_slice_with_ts(b"l0", 5).as_key_slice(),
+            b"v5",
+        )
+        .unwrap();
+    let ordinary_obj = Arc::new(
+        ordinary_builder
+            .build(ordinary_sst, None, storage.path_of_sst(ordinary_sst))
+            .unwrap(),
+    );
+
+    let gc_sst = storage.next_sst_id();
+    let mut gc_builder = SsTableBuilder::new(storage.options.block_size);
+    gc_builder
+        .add(
+            KeySlice::for_testing_from_slice_with_ts(b"a", 3).as_key_slice(),
+            b"v3",
+        )
+        .unwrap();
+    gc_builder
+        .add(
+            KeySlice::for_testing_from_slice_with_ts(b"a", 2).as_key_slice(),
+            b"v2",
+        )
+        .unwrap();
+    let gc_obj = Arc::new(
+        gc_builder
+            .build(gc_sst, None, storage.path_of_sst(gc_sst))
+            .unwrap(),
+    );
+
+    let mut snapshot = storage.state.load().as_ref().clone();
+    snapshot.l0_sstables.push(ordinary_sst);
+    snapshot.levels[0].1.push(gc_sst);
+    snapshot.sstables.insert(ordinary_sst, ordinary_obj);
+    snapshot.sstables.insert(gc_sst, gc_obj);
+    storage.state.store(Arc::new(snapshot));
+
+    assert!(storage.try_reserve_ssts(&[ordinary_sst]));
+
+    assert_eq!(
+        storage.trigger_compaction().unwrap(),
+        CompactionTriggerOutcome::Submitted
+    );
+    assert_eq!(storage.state.load().l0_sstables, vec![ordinary_sst]);
+
+    let mut after_gc = construct_merge_iterator_over_storage(&storage.state.load());
+    check_iter_result_by_key(
+        &mut after_gc,
+        vec![
+            (Bytes::from_static(b"a"), Bytes::from_static(b"v3")),
+            (Bytes::from_static(b"l0"), Bytes::from_static(b"v5")),
+        ],
+    );
+}
+
+#[test]
 fn test_compaction_filter_respects_cutoff_ts() {
     let dir = tempdir().unwrap();
     let storage =

--- a/kv-engine/src/tests/lsm_storage_extra.rs
+++ b/kv-engine/src/tests/lsm_storage_extra.rs
@@ -231,7 +231,7 @@ fn test_mvcc_gc_stats_surface_handles_range_only_sst() {
     );
 
     let mut snapshot = engine.inner.state.load().as_ref().clone();
-    snapshot.range_only_ssts[0].1.push(sst_id);
+    snapshot.range_only_ssts = vec![(1, vec![sst_id])];
     snapshot.sstables.insert(sst_id, sst);
     engine.inner.state.store(Arc::new(snapshot));
 

--- a/kv-engine/src/tests/lsm_storage_extra.rs
+++ b/kv-engine/src/tests/lsm_storage_extra.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use bytes::Bytes;
 use tempfile::tempdir;
 
@@ -5,10 +7,14 @@ use super::harness::skip_if_io_uring_unavailable;
 use crate::{
     compact::CompactionOptions,
     iterators::StorageIterator,
+    key::KeySlice,
     lsm_storage::{
         CompactionFilterKind, CompactionFilterRequest, KvEngine, LsmStorageOptions,
         PrefixBloomOptions, WriteBatchRecord,
     },
+    range_tombstone::RangeTombstoneFragment,
+    table::SsTableBuilder,
+    vlog::KvKind,
     vlog::ValueSeparationOptions,
 };
 
@@ -128,6 +134,118 @@ fn test_compaction_filter_stats_track_drops() {
     assert!(stats.entries_eligible >= 2);
     assert_eq!(stats.entries_dropped, 1);
     assert!(stats.bytes_dropped > 0);
+}
+
+#[test]
+fn test_mvcc_gc_stats_surface_reports_sst_signals() {
+    let dir = tempdir().unwrap();
+    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let l0_sst_id = engine.inner.next_sst_id();
+    let level_sst_id = engine.inner.next_sst_id();
+
+    let mut builder = SsTableBuilder::new(engine.inner.options.block_size);
+    builder
+        .add(
+            KeySlice::for_testing_from_slice_with_ts(b"a", 3).as_key_slice(),
+            b"v3",
+        )
+        .unwrap();
+    builder
+        .add(
+            KeySlice::for_testing_from_slice_with_ts(b"a", 2).as_key_slice(),
+            &[KvKind::Tombstone as u8],
+        )
+        .unwrap();
+    builder
+        .add(
+            KeySlice::for_testing_from_slice_with_ts(b"b", 1).as_key_slice(),
+            b"vb",
+        )
+        .unwrap();
+    let l0_sst = Arc::new(
+        builder
+            .build(l0_sst_id, None, engine.inner.path_of_sst(l0_sst_id))
+            .unwrap(),
+    );
+
+    let mut level_builder = SsTableBuilder::new(engine.inner.options.block_size);
+    level_builder
+        .add(
+            KeySlice::for_testing_from_slice_with_ts(b"c", 4).as_key_slice(),
+            b"vc4",
+        )
+        .unwrap();
+    let level_sst = Arc::new(
+        level_builder
+            .build(level_sst_id, None, engine.inner.path_of_sst(level_sst_id))
+            .unwrap(),
+    );
+
+    let mut snapshot = engine.inner.state.load().as_ref().clone();
+    snapshot.l0_sstables.push(l0_sst_id);
+    snapshot.levels[0].1.push(level_sst_id);
+    snapshot.sstables.insert(l0_sst_id, l0_sst);
+    snapshot.sstables.insert(level_sst_id, level_sst);
+    engine.inner.state.store(Arc::new(snapshot));
+
+    let stats = engine.mvcc_gc_stats().unwrap();
+    assert_eq!(stats.sst_count, 2);
+    assert_eq!(stats.point_tombstone_count, 1);
+    assert_eq!(stats.range_tombstone_fragment_count, 0);
+    assert_eq!(stats.redundant_version_count, 1);
+    assert_eq!(stats.ssts.len(), 2);
+
+    let l0_stats = stats
+        .ssts
+        .iter()
+        .find(|sst| sst.sst_id == l0_sst_id)
+        .expect("expected L0 stats");
+    assert_eq!(l0_stats.level, Some(0));
+    assert_eq!(l0_stats.total_entry_count, 3);
+
+    let level_stats = stats
+        .ssts
+        .iter()
+        .find(|sst| sst.sst_id == level_sst_id)
+        .expect("expected level stats");
+    assert_eq!(level_stats.level, Some(1));
+    assert_eq!(level_stats.total_entry_count, 1);
+}
+
+#[test]
+fn test_mvcc_gc_stats_surface_handles_range_only_sst() {
+    let dir = tempdir().unwrap();
+    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+    let sst_id = engine.inner.next_sst_id();
+
+    let mut builder = SsTableBuilder::new(engine.inner.options.block_size);
+    builder.add_range_tombstones(vec![RangeTombstoneFragment {
+        start: Bytes::from_static(b"a"),
+        end: Bytes::from_static(b"z"),
+        covering_ts: vec![7],
+    }]);
+    let sst = Arc::new(
+        builder
+            .build(sst_id, None, engine.inner.path_of_sst(sst_id))
+            .unwrap(),
+    );
+
+    let mut snapshot = engine.inner.state.load().as_ref().clone();
+    snapshot.range_only_ssts[0].1.push(sst_id);
+    snapshot.sstables.insert(sst_id, sst);
+    engine.inner.state.store(Arc::new(snapshot));
+
+    let stats = engine.mvcc_gc_stats().unwrap();
+    let range_only_stats = stats
+        .ssts
+        .iter()
+        .find(|sst| sst.sst_id == sst_id)
+        .expect("expected range-only stats");
+    assert_eq!(range_only_stats.level, Some(1));
+    assert_eq!(range_only_stats.total_entry_count, 0);
+    assert_eq!(range_only_stats.point_tombstone_count, 0);
+    assert_eq!(range_only_stats.redundant_version_count, 0);
+    assert_eq!(range_only_stats.range_tombstone_fragment_count, 1);
 }
 
 #[test]

--- a/kv-engine/src/tests/vlog_integration_tests/gc.rs
+++ b/kv-engine/src/tests/vlog_integration_tests/gc.rs
@@ -385,6 +385,68 @@ fn test_vlog_gc_drops_unreferenced_old_version() {
 }
 
 #[test]
+fn test_mvcc_gc_unreferences_old_vlog_file_for_reclaim() {
+    use crate::compact::CompactionTriggerOutcome;
+
+    let dir = tempfile::tempdir().unwrap();
+    let mut options = options_with_vlog_and_compaction(256, 1 << 20);
+    if let crate::compact::CompactionOptions::Leveled(ref mut leveled) = options.compaction_options
+    {
+        leveled.max_levels = 1;
+    }
+    let storage = KvEngine::open(dir.path(), options).unwrap();
+
+    // Pin the watermark so the first version survives the full compaction.
+    let reader = storage.inner.new_txn().unwrap();
+
+    storage.put(b"foo", &[b'A'; 64]).unwrap();
+    force_flush(&storage.inner);
+    let old_vlog_file = 0u32;
+    assert!(
+        storage
+            .inner
+            .vlog
+            .as_ref()
+            .unwrap()
+            .get_ssts_referencing(old_vlog_file)
+            .is_some_and(|ssts| !ssts.is_empty())
+    );
+
+    storage.put(b"foo", &[b'B'; 64]).unwrap();
+    force_flush(&storage.inner);
+
+    storage.inner.force_full_compaction().unwrap();
+    assert!(
+        storage
+            .inner
+            .vlog
+            .as_ref()
+            .unwrap()
+            .get_ssts_referencing(old_vlog_file)
+            .is_some_and(|ssts| !ssts.is_empty()),
+        "old vLog file should still be referenced while the reader is active"
+    );
+
+    drop(reader);
+
+    assert_eq!(
+        storage.inner.trigger_compaction().unwrap(),
+        CompactionTriggerOutcome::Submitted
+    );
+
+    let vlog = storage.inner.vlog.as_ref().unwrap();
+    assert!(
+        vlog.get_ssts_referencing(old_vlog_file).is_none()
+            || vlog
+                .get_ssts_referencing(old_vlog_file)
+                .is_some_and(|ssts| ssts.is_empty()),
+        "MVCC GC should remove the old SST reference and make the file reclaimable"
+    );
+    let reclaimed = vlog.reclaim_pending_deletions().unwrap();
+    let _ = reclaimed;
+}
+
+#[test]
 fn test_vlog_entries_across_versions() {
     // Write multiple versions of the same key, all going to vLog.
     // Verify the newest version returns the correct value.

--- a/rfcs/017-mvcc-garbage-collection.md
+++ b/rfcs/017-mvcc-garbage-collection.md
@@ -180,8 +180,9 @@ Useful signals already present or naturally derivable in this engine include:
    - `has_non_ttl_entries`
    - `ttl_entry_count`
    - `total_entry_count`
-3. tombstone/range-tombstone density
-4. future redundant-version estimates per SST
+3. point tombstone count
+4. range-tombstone fragment count and metadata size
+5. estimated redundant-version count per SST
 
 ### What `max_ts` is good for
 
@@ -268,8 +269,10 @@ The standalone MVCC-GC scheduler should:
    work cannot overlap with in-flight ordinary compactions or other GC
    compactions,
 6. submit targeted compaction tasks for the reserved SSTs,
-7. if reservation or submission fails, release the reservation and retry on a
-   later wakeup rather than busy-resubmitting immediately,
+7. if reservation fails, return `Deferred` and retry on a later wakeup rather
+   than busy-resubmitting immediately; if submission fails after reservation,
+   release the reservation, surface the error, and let the periodic wakeup loop
+   retry on a later tick,
 8. when a submitted GC task completes, release its SST reservations only after
    the resulting state transition has either been durably published or
    abandoned.

--- a/todo.md
+++ b/todo.md
@@ -8,7 +8,7 @@
 ## RFC 017: Standalone MVCC GC Follow-up
 
 **RFC:** [rfcs/017-mvcc-garbage-collection.md](rfcs/017-mvcc-garbage-collection.md)
-**Status:** partially implemented on `feat/mvcc-gc-scheduler`
+**Status:** landed on `main` via PR #165 and follow-up commit `fc93578`
 
 ### Landed slice
 
@@ -18,40 +18,42 @@
 - [x] Candidate generation exists for leveled, simple, and tiered modes
 - [x] SST reservations prevent overlapping GC / compaction ownership
 - [x] TTL-aware bottom-level candidate picking exists
+- [x] Leveled MVCC GC skips no-op bottom SST rewrites without reclaimable MVCC
+  entries
+- [x] vLog reference unregister happens after publication succeeds
 - [x] Current compaction rewrite path remains the execution mechanism
 
 ### Remaining implementation work
 
-- [ ] Split RFC 017 candidate picking into a dedicated picker surface instead of
+- [x] Split RFC 017 candidate picking into a dedicated picker surface instead of
   keeping all policy embedded in `generate_mvcc_gc_task()`
-- [ ] Add the missing stats surfaces the RFC assumes for candidate scoring
+- [x] Add the missing stats surfaces the RFC assumes for candidate scoring
   Current code mostly uses `max_ts`, TTL metadata, overlap shape, and
   reservations. The RFC still calls out tombstone density,
   range-tombstone density, and redundant-version estimates.
-- [ ] Define the minimum viable GC scoring policy beyond `max_ts` / TTL
+- [x] Define the minimum viable GC scoring policy beyond `max_ts` / TTL
   metadata
-  Start with cheap metadata-only scoring, then layer in richer reclaim signals
-  only where they improve candidate quality measurably.
-- [ ] Tighten scheduler backpressure / retry semantics
-  Document and implement what happens when reservation succeeds but submission
-  cannot proceed, and make retry behavior explicit rather than implicit in the
-  periodic wakeup loop.
-- [ ] Add deterministic tests for ordinary-compaction vs GC-compaction
+  Candidate scoring now uses per-SST GC stats for redundant versions,
+  point tombstones, range-tombstone fragments, TTL counts, and size.
+- [x] Tighten scheduler backpressure / retry semantics
+  Reservation conflicts are surfaced as `CompactionTriggerOutcome::Deferred`.
+  Submission failures bubble out of the trigger path and are retried on the
+  next periodic wakeup after logging.
+- [x] Add deterministic tests for ordinary-compaction vs GC-compaction
   coexistence and reservation conflicts
-- [ ] Add deterministic tests for stats-driven candidate selection once those
+  Covered both candidate generators in one snapshot and verified the
+  reservation conflict returns `Deferred` before ordinary compaction is
+  submitted.
+- [x] Add deterministic tests for stats-driven candidate selection once those
   stats exist
-- [ ] Add tests showing TTL-heavy SSTs are selected without size-pressure
-- [ ] Add tests showing standalone MVCC GC improves later vLog reclaim
+  Covered leveled GC picking by redundant-version density and TTL-expired SSTs
+  without relying on size pressure.
+- [x] Add tests showing TTL-heavy SSTs are selected without size-pressure
+- [x] Add tests showing standalone MVCC GC improves later vLog reclaim
   opportunities by removing obsolete pointer-bearing versions
-- [ ] Reconcile RFC 017 wording with the actually shipped slice
-  If richer stats-driven scoring is deferred, keep the RFC explicit that it is
-  future work rather than already implemented behavior.
-
-### Current PR-loop blockers on `feat/mvcc-gc-scheduler`
-
-- [ ] Clear the remaining GitHub `sanitizers-unit` failure on the latest PR head
-- [ ] Keep the PR review loop running until CI is green or a concrete new
-  blocker appears
+- [x] Reconcile RFC 017 wording with the actually shipped slice
+  The RFC now names the implemented stats signals and the actual retry behavior
+  instead of leaving those pieces as future work.
 
 ---
 


### PR DESCRIPTION
## Summary

Finish the RFC 017 MVCC GC follow-up around range-only SST handling, scheduler behavior, and stats/reporting.

## Changes
- add MVCC GC stats surfaces for SST-level candidate scoring and fix them to cover L0 and range-only SSTs
- make standalone MVCC GC consider range-only bottom-level work in leveled, simple, and tiered modes
- track tiered range-only SST lifecycle through publication and manifest replay
- restore partially expired TTL candidate selection and larger-SST tie-breaking for leveled GC
- allow MVCC GC to run when an unrelated ordinary compaction candidate is reservation-blocked
- sync RFC 017 and todo notes to the shipped behavior

## Verification
- [x] cargo fmt --all
- [x] cargo test --package kv-engine test_generate_mvcc_gc_task_ -- --nocapture
- [x] cargo test --package kv-engine test_trigger_compaction_runs_mvcc_gc_when_ordinary_candidate_is_reserved -- --nocapture
- [x] cargo test --package kv-engine test_reopen_recovers_tiered_range_only_compaction_v3 -- --nocapture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MVCC-GC stats reporting to help observe candidate scoring signals at both engine and SST levels.
  * Improved compaction status reporting with explicit idle/deferred/submitted outcomes.
  * Enhanced tiered compaction handling for range-only data to improve sizing and candidate evaluation.
  * Added MVCC-aware vLog cleanup so older, unreferenced files become reclaimable sooner.

* **Bug Fixes**
  * Fixed compaction/recovery behavior for range-only and tiered layouts, including correctness around publication and state updates.

* **Documentation**
  * Updated MVCC garbage-collection documentation and status to reflect landed changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->