### PR TITLE
feat: add optional Hotpath profiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +140,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +168,12 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "ciborium"
@@ -387,10 +405,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "either"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "endian-type"
@@ -444,6 +489,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +572,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "byteorder",
+ "num-traits",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +613,45 @@ checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "hotpath"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0772e97af6db4889a5894b3eddb7d6b8a75819fdf03fe89a07185ce651c66c85"
+dependencies = [
+ "arc-swap",
+ "cfg-if",
+ "crossbeam-channel",
+ "futures-util",
+ "hdrhistogram",
+ "hotpath-macros",
+ "libc",
+ "pin-project-lite",
+ "prettytable-rs",
+ "quanta",
+ "regex",
+ "serde",
+ "serde_json",
+ "tiny_http",
+]
+
+[[package]]
+name = "hotpath-macros"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1a3963a08af931247e0a560a8afd922d4a9f34b97be61306d286953e56fb96"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "io-uring"
@@ -629,6 +766,7 @@ dependencies = [
  "crossbeam-skiplist",
  "dashmap",
  "fail",
+ "hotpath",
  "io-uring",
  "libc",
  "log",
@@ -646,10 +784,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -944,6 +1097,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "prettytable-rs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
+dependencies = [
+ "encode_unicode",
+ "is-terminal",
+ "lazy_static",
+ "term",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,6 +1129,21 @@ dependencies = [
  "syn",
  "version_check",
  "yansi",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1021,6 +1202,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.12.1",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,6 +1237,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.12.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.14",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -1092,6 +1293,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
 name = "rustyline"
 version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,7 +1314,7 @@ dependencies = [
  "nix",
  "radix_trie",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
  "utf8parse",
  "windows-sys 0.61.2",
 ]
@@ -1181,6 +1388,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1222,12 +1435,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
 ]
 
 [[package]]
@@ -1272,6 +1528,12 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/docs/perf-profile.md
+++ b/docs/perf-profile.md
@@ -11,7 +11,35 @@
 `crossbeam_queue::ArrayQueue` (16 pre-allocated 64KB buffers) + lock-free `SegQueue`. Group commit via
 leader/follower condvar barrier amortizes fsync across concurrent writers. MVCC write-lock released before
 `commit_wal` to prevent deadlocks during memtable freezing. 4-thread WAL throughput: 177K → 451K (+155%).
-All profiling gated behind `#[cfg(feature = "bench")]` — zero overhead in production builds.
+All built-in write-path counters are gated behind `#[cfg(feature = "bench")]`
+and add zero timing overhead in production builds.
+
+## Optional Hotpath Profiling
+
+The engine also supports broad phase profiling through
+[hotpath-rs](https://hotpath.rs/profiling_overhead) behind the
+`hotpath-profile` Cargo feature. This is intended for exploratory profiling of
+coarse engine phases, not for replacing the stable `WriteProfile` counters used
+in benchmark reports.
+
+Hotpath scopes currently cover public engine operations (`kv.get`, `kv.put`,
+`kv.write_batch`, `kv.scan`, flush/compaction/vLog GC) plus write-path phases
+(`wal.put_batch`, `wal.submit_and_commit`, `memtable.publish_batch`). Normal
+builds do not include the dependency or runtime hooks.
+
+Example:
+
+```bash
+HOTPATH_METRICS_SERVER_OFF=true \
+HOTPATH_TIME_SAMPLING_RATE=0.1 \
+cargo run --release --features hotpath-profile --bin write-perf -- \
+  --profile --bench readrandom --num 100000 --reads 100000
+```
+
+Use time sampling for very hot workloads. The Hotpath overhead guide reports
+that disabled instrumentation compiles to no-op and enabled function timing is
+on the order of tens of nanoseconds per measured call; sampling avoids most
+clock reads while preserving exact call counts.
 
 **I/O is NOT the bottleneck.** The engine is CPU-bound across all workloads. Context switches: 0. I/O accounts for ~0-4% of CPU time.
 

--- a/kv-engine/Cargo.toml
+++ b/kv-engine/Cargo.toml
@@ -7,16 +7,21 @@ publish = false
 [package.metadata.cargo-machete]
 ignored = ["arc-swap", "crossbeam-epoch"]
 
+[[bin]]
+name = "chaos-child"
+path = "src/bin/chaos-child.rs"
+required-features = ["chaos-testing"]
+
 [features]
 bench = []
 chaos-testing = ["fail/failpoints"]
+hotpath-profile = ["dep:hotpath", "hotpath/hotpath"]
 
 [dependencies]
 TinyUFO = "0.8"
 ahash = "0.8"
 anyhow = "1"
 arc-swap = "1"
-fail = "0.5"
 bytes = "1"
 clap = { version = "4.4.17", features = ["derive"] }
 crc32fast = "1.3.2"
@@ -25,6 +30,8 @@ crossbeam-epoch = "0.9"
 crossbeam-queue = "0.3"
 crossbeam-skiplist = "0.1"
 dashmap = "6"
+fail = "0.5"
+hotpath = { version = "0.21.2", default-features = false, optional = true }
 
 io-uring = "0.6"
 libc = "0.2"
@@ -64,11 +71,6 @@ required-features = ["bench"]
 [[bench]]
 name = "wal_bench"
 harness = false
-
-[[bin]]
-name = "chaos-child"
-path = "src/bin/chaos-child.rs"
-required-features = ["chaos-testing"]
 
 [[test]]
 name = "chaos_failpoint"

--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -551,7 +551,7 @@ fn main() -> Result<()> {
     let cfg = HarnessConfig::from_args(args);
     validate_config(&cfg)?;
     let _hotpath_guard = if cfg.profile {
-        let guard = kv_engine::profiling::start_hotpath_profile();
+        let guard = kv_engine::profiling::start_hotpath_profile("write-perf");
         if guard.is_some() {
             eprintln!(
                 "hotpath-profile enabled; set HOTPATH_TIME_SAMPLING_RATE=0.1 to reduce timing overhead and HOTPATH_METRICS_SERVER_OFF=true in restricted environments"

--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -550,6 +550,17 @@ fn main() -> Result<()> {
     let bench_arg = args.bench.clone();
     let cfg = HarnessConfig::from_args(args);
     validate_config(&cfg)?;
+    let _hotpath_guard = if cfg.profile {
+        let guard = kv_engine::profiling::start_hotpath_profile();
+        if guard.is_some() {
+            eprintln!(
+                "hotpath-profile enabled; set HOTPATH_TIME_SAMPLING_RATE=0.1 to reduce timing overhead and HOTPATH_METRICS_SERVER_OFF=true in restricted environments"
+            );
+        }
+        guard
+    } else {
+        None
+    };
     let workloads = select_workloads(bench_arg.as_deref())?;
 
     let mut all_measurements = Vec::new();

--- a/kv-engine/src/cache.rs
+++ b/kv-engine/src/cache.rs
@@ -221,16 +221,19 @@ impl BlockCache {
         F: FnOnce() -> Result<Arc<Block>, E>,
     {
         let key = (sst_id, block_idx);
-        if let Some(v) = self.inner.get(&key) {
+        if let Some(v) = crate::profile_scope!("block_cache.lookup", self.inner.get(&key)) {
             self.hits.fetch_add(1, Ordering::Relaxed);
             return Ok(v);
         }
         self.misses.fetch_add(1, Ordering::Relaxed);
-        let block = f()?;
+        let block = crate::profile_scope!("block_cache.load_miss", f())?;
 
         match admission {
             CacheAdmission::Force => {
-                let evicted = self.inner.force_put(key, block.clone(), 1);
+                let evicted = crate::profile_scope!(
+                    "block_cache.admit_force",
+                    self.inner.force_put(key, block.clone(), 1)
+                );
                 self.admitted.fetch_add(1, Ordering::Relaxed);
                 self.evicted
                     .fetch_add(evicted.len() as u64, Ordering::Relaxed);
@@ -242,7 +245,10 @@ impl BlockCache {
                 self.count.fetch_add(1, Ordering::Relaxed);
             }
             CacheAdmission::Admit => {
-                let evicted = self.inner.put(key, block.clone(), 1);
+                let evicted = crate::profile_scope!(
+                    "block_cache.admit_tinyufo",
+                    self.inner.put(key, block.clone(), 1)
+                );
                 let rejected = evicted.iter().any(|kv| Arc::ptr_eq(&kv.data, &block));
                 if rejected {
                     self.rejected.fetch_add(1, Ordering::Relaxed);

--- a/kv-engine/src/lib.rs
+++ b/kv-engine/src/lib.rs
@@ -11,6 +11,7 @@ pub mod lsm_storage;
 pub mod manifest;
 pub mod mem_table;
 pub mod mvcc;
+pub mod profiling;
 pub mod range_tombstone;
 pub(crate) mod scan_trace;
 pub mod table;

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1426,11 +1426,11 @@ impl KvEngine {
     /// The transaction reads from a consistent snapshot at its creation
     /// timestamp. Writes are buffered locally until `commit()`.
     pub fn new_txn(&self) -> Result<Arc<crate::mvcc::txn::Transaction>> {
-        self.inner.new_txn()
+        crate::profile_scope!("kv.new_txn", self.inner.new_txn())
     }
 
     pub fn write_batch<T: AsRef<[u8]>>(&self, batch: &[WriteBatchRecord<T>]) -> Result<()> {
-        self.inner.write_batch(batch)
+        crate::profile_scope!("kv.write_batch", self.inner.write_batch(batch))
     }
 
     pub fn add_compaction_filter(&self, compaction_filter: CompactionFilterRequest) -> Result<u64> {
@@ -1459,7 +1459,7 @@ impl KvEngine {
     }
 
     pub fn get(&self, key: &[u8]) -> Result<Option<Bytes>> {
-        self.inner.get(key)
+        crate::profile_scope!("kv.get", self.inner.get(key))
     }
 
     /// Batch point-read for multiple keys.
@@ -1467,20 +1467,20 @@ impl KvEngine {
     /// Optimized for throughput when reading many keys at once. Results are
     /// returned in the same order as the input keys.
     pub fn batch_get(&self, keys: &[&[u8]]) -> Vec<Result<Option<Bytes>>> {
-        self.inner.batch_get(keys)
+        crate::profile_scope!("kv.batch_get", self.inner.batch_get(keys))
     }
 
     pub fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
-        self.inner.put(key, value)
+        crate::profile_scope!("kv.put", self.inner.put(key, value))
     }
 
     /// Write a key-value pair with a time-to-live duration.
     pub fn put_with_ttl(&self, key: &[u8], value: &[u8], ttl: std::time::Duration) -> Result<()> {
-        self.inner.put_with_ttl(key, value, ttl)
+        crate::profile_scope!("kv.put_with_ttl", self.inner.put_with_ttl(key, value, ttl))
     }
 
     pub fn delete(&self, key: &[u8]) -> Result<()> {
-        self.inner.delete(key)
+        crate::profile_scope!("kv.delete", self.inner.delete(key))
     }
 
     /// Delete all keys in the half-open range `[start, end)`.
@@ -1494,15 +1494,18 @@ impl KvEngine {
     /// key size, or if the engine is in serializable mode or has value
     /// separation enabled (not supported in the MVP).
     pub fn delete_range(&self, start: &[u8], end: &[u8]) -> Result<()> {
-        self.inner.delete_range_internal(start, end)
+        crate::profile_scope!(
+            "kv.delete_range",
+            self.inner.delete_range_internal(start, end)
+        )
     }
 
     pub fn sync(&self) -> Result<()> {
-        self.inner.sync()
+        crate::profile_scope!("kv.sync", self.inner.sync())
     }
 
     pub fn scan(&self, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> Result<ScanIterator> {
-        self.inner.scan(lower, upper)
+        crate::profile_scope!("kv.scan", self.inner.scan(lower, upper))
     }
 
     /// Return all visible keys whose user key starts with `prefix`, in sorted
@@ -1511,20 +1514,22 @@ impl KvEngine {
     /// When prefix bloom filters are enabled, irrelevant SSTs are skipped
     /// before creating iterators.
     pub fn prefix_scan(&self, prefix: &[u8]) -> Result<ScanIterator> {
-        self.inner.prefix_scan(prefix)
+        crate::profile_scope!("kv.prefix_scan", self.inner.prefix_scan(prefix))
     }
 
     /// Only call this in test cases due to race conditions
     pub fn force_flush(&self) -> Result<()> {
-        if !self.inner.state.load().memtable.is_empty() {
-            self.inner
-                .force_freeze_memtable(&self.inner.state_lock.lock())?;
-        }
-        if !self.inner.state.load().imm_memtables.is_empty() {
-            self.inner.force_flush_next_imm_memtable()?;
-        }
+        crate::profile_scope!("kv.force_flush", {
+            if !self.inner.state.load().memtable.is_empty() {
+                self.inner
+                    .force_freeze_memtable(&self.inner.state_lock.lock())?;
+            }
+            if !self.inner.state.load().imm_memtables.is_empty() {
+                self.inner.force_flush_next_imm_memtable()?;
+            }
 
-        Ok(())
+            Ok(())
+        })
     }
 
     /// Flush all memtables (current + all immutable) to SSTs.
@@ -1544,44 +1549,49 @@ impl KvEngine {
     }
 
     pub fn force_full_compaction(&self) -> Result<()> {
-        self.inner.force_full_compaction()
+        crate::profile_scope!(
+            "kv.force_full_compaction",
+            self.inner.force_full_compaction()
+        )
     }
 
     /// Trigger garbage collection on all vLog files.
     /// Returns the number of files that were GC'd.
     pub fn trigger_gc(&self) -> Result<usize> {
-        let Some(ref vlog) = self.inner.vlog else {
-            return Ok(0);
-        };
-        let gc = crate::vlog::gc::GarbageCollector::new(
-            vlog,
-            &self.inner,
-            vlog.options.gc_threshold_ratio,
-        );
-        let results = gc.gc_all()?;
-        let count = results.len();
+        crate::profile_scope!("kv.vlog_gc", {
+            let Some(ref vlog) = self.inner.vlog else {
+                return Ok(0);
+            };
+            let gc = crate::vlog::gc::GarbageCollector::new(
+                vlog,
+                &self.inner,
+                vlog.options.gc_threshold_ratio,
+            );
+            let results = gc.gc_all()?;
+            let count = results.len();
 
-        // Batch manifest records for GC operations into a single fsync.
-        if let Some(ref manifest) = self.inner.manifest
-            && !results.is_empty()
-        {
-            let records: Vec<ManifestRecord> = results
-                .iter()
-                .map(|r| {
-                    ManifestRecord::GcCompaction(r.old_file_id, r.new_file_id, r.keys_rewritten)
-                })
-                .collect();
-            let state_lock = self.inner.state_lock.lock();
-            manifest.add_records(&state_lock, &records)?;
-            self.inner.maybe_snapshot_manifest(&state_lock)?;
-        }
+            // Batch manifest records for GC operations into a single fsync.
+            if let Some(ref manifest) = self.inner.manifest
+                && !results.is_empty()
+            {
+                let records: Vec<ManifestRecord> = results
+                    .iter()
+                    .map(|r| {
+                        ManifestRecord::GcCompaction(r.old_file_id, r.new_file_id, r.keys_rewritten)
+                    })
+                    .collect();
+                let state_lock = self.inner.state_lock.lock();
+                manifest.add_records(&state_lock, &records)?;
+                self.inner.maybe_snapshot_manifest(&state_lock)?;
+            }
 
-        // Attempt to reclaim vLog files that are no longer referenced by any SST.
-        // Note: files with pending memtable CAS writes will still be referenced
-        // (via the SST that hasn't been re-flushed yet), so they won't be deleted.
-        let _ = vlog.reclaim_pending_deletions();
+            // Attempt to reclaim vLog files that are no longer referenced by any SST.
+            // Note: files with pending memtable CAS writes will still be referenced
+            // (via the SST that hasn't been re-flushed yet), so they won't be deleted.
+            let _ = vlog.reclaim_pending_deletions();
 
-        Ok(count)
+            Ok(count)
+        })
     }
 
     /// Get runtime statistics about the value log.
@@ -5041,11 +5051,15 @@ impl LsmStorageInner {
             key
         };
         let read_ts_for_range = mvcc_read_ts.unwrap_or(u64::MAX);
-        let memtable_range_ts = self.newest_memtable_range_ts(state, key, read_ts_for_range);
+        let memtable_range_ts = crate::profile_scope!(
+            "lookup.range_memtable",
+            self.newest_memtable_range_ts(state, key, read_ts_for_range)
+        );
         self.rt_stats.note_lookup();
-        if let Some((val, kind, _key, value_ts, expire_at)) =
-            self.lookup_memtable(state, key, bloom_hash, mvcc_read_ts)?
-        {
+        if let Some((val, kind, _key, value_ts, expire_at)) = crate::profile_scope!(
+            "lookup.memtable",
+            self.lookup_memtable(state, key, bloom_hash, mvcc_read_ts)
+        )? {
             if memtable_range_ts.is_some_and(|rt| value_ts <= rt) {
                 self.rt_stats.note_hit();
                 return Ok((None, KvKind::Inline, None));
@@ -5057,11 +5071,15 @@ impl LsmStorageInner {
         let range_ts = if memtable_range_ts.is_some_and(|ts| ts >= read_ts_for_range) {
             memtable_range_ts
         } else {
-            memtable_range_ts.max(self.newest_sst_range_ts(state, key, read_ts_for_range))
+            memtable_range_ts.max(crate::profile_scope!(
+                "lookup.range_sst",
+                self.newest_sst_range_ts(state, key, read_ts_for_range)
+            ))
         };
-        if let Some((val, kind, _key, value_ts, expire_at)) =
-            self.lookup_sst_raw(state, encoded, bloom_hash, mvcc_read_ts, None, None)?
-        {
+        if let Some((val, kind, _key, value_ts, expire_at)) = crate::profile_scope!(
+            "lookup.sst",
+            self.lookup_sst_raw(state, encoded, bloom_hash, mvcc_read_ts, None, None)
+        )? {
             if range_ts.is_some_and(|rt| value_ts <= rt) {
                 self.rt_stats.note_hit();
                 return Ok((None, KvKind::Inline, None));

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -665,7 +665,7 @@ impl MemTable {
         let entries: Vec<(&[u8], &[u8])> = data.iter().map(|(k, v)| (k.raw_ref(), *v)).collect();
         #[cfg(feature = "bench")]
         let t = Instant::now();
-        let ticket = wal.put_batch(&entries, commit_ts)?;
+        let ticket = crate::profile_scope!("wal.put_batch", wal.put_batch(&entries, commit_ts))?;
         self.last_ticket
             .fetch_max(ticket + 1, std::sync::atomic::Ordering::Release);
         #[cfg(feature = "bench")]
@@ -692,25 +692,27 @@ impl MemTable {
 
         #[cfg(feature = "bench")]
         let t = Instant::now();
-        let mut buf = Vec::new();
-        for (key, value) in data {
-            buf.clear();
-            key.decode_user_key_into(&mut buf);
-            self.bloom.push_hash(super::table::bloom::hash_key(&buf));
-            self.map.insert(
-                shared_bytes_from_slice(key.raw_ref()),
-                shared_bytes_from_slice(value),
-            );
+        crate::profile_scope!("memtable.publish_batch", {
+            let mut buf = Vec::new();
+            for (key, value) in data {
+                buf.clear();
+                key.decode_user_key_into(&mut buf);
+                self.bloom.push_hash(super::table::bloom::hash_key(&buf));
+                self.map.insert(
+                    shared_bytes_from_slice(key.raw_ref()),
+                    shared_bytes_from_slice(value),
+                );
 
-            // approximate_size is already approximate — Relaxed ordering
-            // is sufficient and avoids unnecessary fence overhead (L3).
-            // Use raw_ref().len() for key data size (size_of_val on KeySlice
-            // returns the struct size, not the data length).
-            self.approximate_size.fetch_add(
-                key.raw_ref().len() + value.len(),
-                std::sync::atomic::Ordering::Relaxed,
-            );
-        }
+                // approximate_size is already approximate — Relaxed ordering
+                // is sufficient and avoids unnecessary fence overhead (L3).
+                // Use raw_ref().len() for key data size (size_of_val on KeySlice
+                // returns the struct size, not the data length).
+                self.approximate_size.fetch_add(
+                    key.raw_ref().len() + value.len(),
+                    std::sync::atomic::Ordering::Relaxed,
+                );
+            }
+        });
         #[cfg(feature = "bench")]
         {
             let wp = self.write_profile.load();
@@ -737,7 +739,10 @@ impl MemTable {
             }
             #[cfg(feature = "bench")]
             let t = Instant::now();
-            wal.submit_and_commit(watermark - 1)?;
+            crate::profile_scope!(
+                "wal.submit_and_commit",
+                wal.submit_and_commit(watermark - 1)
+            )?;
             #[cfg(feature = "bench")]
             self.write_profile.load().wal_sync_ns.fetch_add(
                 t.elapsed().as_nanos() as u64,

--- a/kv-engine/src/profiling.rs
+++ b/kv-engine/src/profiling.rs
@@ -1,0 +1,46 @@
+//! Optional low-overhead profiling hooks.
+//!
+//! The `hotpath-profile` feature enables broad phase timing through hotpath-rs.
+//! Without that feature, `profile_scope!` evaluates its body directly and adds
+//! no runtime dependency or hot-path measurement cost.
+
+#[cfg(feature = "hotpath-profile")]
+pub use hotpath::HotpathGuard;
+
+#[cfg(not(feature = "hotpath-profile"))]
+pub struct HotpathGuard;
+
+#[cfg(feature = "hotpath-profile")]
+pub fn start_hotpath_profile() -> Option<HotpathGuard> {
+    Some(
+        hotpath::HotpathGuardBuilder::new("write-perf")
+            .percentiles(&[50.0, 95.0, 99.0])
+            .functions_limit(64)
+            .threads_limit(8)
+            .sections(vec![
+                hotpath::Section::FunctionsTiming,
+                hotpath::Section::Threads,
+            ])
+            .format(hotpath::Format::Table)
+            .build(),
+    )
+}
+
+#[cfg(not(feature = "hotpath-profile"))]
+pub fn start_hotpath_profile() -> Option<HotpathGuard> {
+    None
+}
+
+#[macro_export]
+macro_rules! profile_scope {
+    ($label:expr, $expr:expr) => {{
+        #[cfg(feature = "hotpath-profile")]
+        {
+            hotpath::measure_block!($label, $expr)
+        }
+        #[cfg(not(feature = "hotpath-profile"))]
+        {
+            $expr
+        }
+    }};
+}

--- a/kv-engine/src/profiling.rs
+++ b/kv-engine/src/profiling.rs
@@ -11,9 +11,9 @@ pub use hotpath::HotpathGuard;
 pub struct HotpathGuard;
 
 #[cfg(feature = "hotpath-profile")]
-pub fn start_hotpath_profile() -> Option<HotpathGuard> {
+pub fn start_hotpath_profile(app_name: &'static str) -> Option<HotpathGuard> {
     Some(
-        hotpath::HotpathGuardBuilder::new("write-perf")
+        hotpath::HotpathGuardBuilder::new(app_name)
             .percentiles(&[50.0, 95.0, 99.0])
             .functions_limit(64)
             .threads_limit(8)
@@ -27,7 +27,7 @@ pub fn start_hotpath_profile() -> Option<HotpathGuard> {
 }
 
 #[cfg(not(feature = "hotpath-profile"))]
-pub fn start_hotpath_profile() -> Option<HotpathGuard> {
+pub fn start_hotpath_profile(_app_name: &'static str) -> Option<HotpathGuard> {
     None
 }
 

--- a/kv-engine/src/table.rs
+++ b/kv-engine/src/table.rs
@@ -1055,16 +1055,26 @@ impl SsTable {
         bloom_hash: u32,
         read_ts: Option<u64>,
     ) -> Result<Option<(Bytes, Vec<u8>)>> {
-        if !self.should_probe_point_key(key, bloom_hash) {
+        if !crate::profile_scope!(
+            "sst.point_probe_filter",
+            self.should_probe_point_key(key, bloom_hash)
+        ) {
             return Ok(None);
         }
 
-        let (blk_idx, blk_iter) = self.seek_point_get_block_iter(key)?;
+        let (blk_idx, blk_iter) =
+            crate::profile_scope!("sst.point_seek_block", self.seek_point_get_block_iter(key))?;
         if TS_ENABLED {
-            return self.point_get_mvcc_match(key, read_ts, blk_idx, blk_iter);
+            return crate::profile_scope!(
+                "sst.point_match_mvcc",
+                self.point_get_mvcc_match(key, read_ts, blk_idx, blk_iter)
+            );
         }
 
-        if let Some(found) = Self::point_get_non_mvcc_match(key, &blk_iter) {
+        if let Some(found) = crate::profile_scope!(
+            "sst.point_match_non_mvcc",
+            Self::point_get_non_mvcc_match(key, &blk_iter)
+        ) {
             return Ok(Some(found));
         }
         Ok(None)
@@ -1158,10 +1168,11 @@ impl SsTable {
         blk_idx: usize,
         key: &[u8],
     ) -> Result<crate::block::BlockIterator> {
-        let block = self.read_block_cached(blk_idx)?;
-        Ok(crate::block::BlockIterator::create_and_seek_to_key(
-            block,
-            KeySlice::from_slice(key),
+        let block =
+            crate::profile_scope!("sst.read_block_cached", self.read_block_cached(blk_idx))?;
+        Ok(crate::profile_scope!(
+            "block.seek_key",
+            crate::block::BlockIterator::create_and_seek_to_key(block, KeySlice::from_slice(key))
         ))
     }
 

--- a/kv-engine/src/vlog/mod.rs
+++ b/kv-engine/src/vlog/mod.rs
@@ -662,31 +662,39 @@ impl ValueLog {
     /// `expected_key`. Returns from the value cache on hit; on miss, reads
     /// from disk and inserts into the cache.
     pub fn read(&self, ptr: &ValuePointer, expected_key: &[u8]) -> Result<Bytes> {
-        let cache_key = (ptr.file_id, ptr.offset);
+        crate::profile_scope!("vlog.read", {
+            let cache_key = (ptr.file_id, ptr.offset);
 
-        if let Some(ref cache) = self.value_cache {
-            if let Some(cached) = cache.get(&cache_key) {
-                self.cache_hits.fetch_add(1, Ordering::Relaxed);
-                return Ok(cached);
+            if let Some(ref cache) = self.value_cache {
+                if let Some(cached) =
+                    crate::profile_scope!("vlog.value_cache_lookup", cache.get(&cache_key))
+                {
+                    self.cache_hits.fetch_add(1, Ordering::Relaxed);
+                    return Ok(cached);
+                }
+                self.cache_misses.fetch_add(1, Ordering::Relaxed);
             }
-            self.cache_misses.fetch_add(1, Ordering::Relaxed);
-        }
 
-        let reader = self.get_reader(ptr.file_id)?;
-        let entry = reader.read_entry(ptr.offset, ptr.size)?;
-        if entry.key != expected_key {
-            return Err(anyhow!(
-                "vlog key mismatch: expected {:?}, got {:?}",
-                expected_key,
-                entry.key
-            ));
-        }
-        let value = Bytes::from(entry.value);
+            let reader = crate::profile_scope!("vlog.get_reader", self.get_reader(ptr.file_id))?;
+            let entry =
+                crate::profile_scope!("vlog.read_entry", reader.read_entry(ptr.offset, ptr.size))?;
+            if entry.key != expected_key {
+                return Err(anyhow!(
+                    "vlog key mismatch: expected {:?}, got {:?}",
+                    expected_key,
+                    entry.key
+                ));
+            }
+            let value = Bytes::from(entry.value);
 
-        if let Some(ref cache) = self.value_cache {
-            cache.insert(cache_key, value.clone());
-        }
-        Ok(value)
+            if let Some(ref cache) = self.value_cache {
+                crate::profile_scope!(
+                    "vlog.value_cache_insert",
+                    cache.insert(cache_key, value.clone())
+                );
+            }
+            Ok(value)
+        })
     }
 
     /// Read a full vLog entry (key, value) at the given pointer.


### PR DESCRIPTION
## Summary

Adds an optional Hotpath profiling integration behind the hotpath-profile feature for low-overhead runtime profiling of write-perf and core engine hot paths.

## Changes

- Add optional hotpath dependency and hotpath-profile feature gate.
- Add profiling helpers and no-op fallback when the feature is disabled.
- Instrument write-perf, public KV operations, memtable publish/WAL commit, SST point lookup, block cache, and vLog read paths.
- Document how to run Hotpath profiles and how to tune sampling/server settings.

## Verification

- cargo check --workspace
- cargo check -p kv-engine --features hotpath-profile
- HOTPATH_METRICS_SERVER_OFF=true HOTPATH_TIME_SAMPLING_RATE=0.1 cargo run --release --features hotpath-profile --bin write-perf -- --profile --path /tmp/toykv-hotpath-all-smoke --num 10000 --reads 10000 --scan-num 10000 --duration 2 --threads 2 --readers 2 --value-size 64
- HOTPATH_METRICS_SERVER_OFF=true HOTPATH_TIME_SAMPLING_RATE=0.2 cargo run --release --features hotpath-profile --bin write-perf -- --profile --bench fillseq,readrandom --path /tmp/toykv-hotpath-read-write-deep --num 100000 --reads 100000 --scan-num 10000 --duration 1 --threads 1 --readers 1 --value-size 64
- HOTPATH_METRICS_SERVER_OFF=true HOTPATH_TIME_SAMPLING_RATE=0.5 cargo run --release --features hotpath-profile --bin write-perf -- --profile --bench readrandom --vlog --path /tmp/toykv-hotpath-vlog-read-deep --num 50000 --reads 50000 --scan-num 10000 --duration 1 --threads 1 --readers 1 --value-size 4096
- cargo make check (passed outside sandbox: 729/729 tests passed; one nextest retry passed)

Note: cargo make check failed inside the sandbox because io_uring creation returns EPERM for WAL/chaos tests; the same command passed when run outside the sandbox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional hotpath profiling for write-performance analysis.
  * Added profiling coverage across cache, WAL, memtable, storage, table, and value-log operations.
  * Added guidance for enabling profiling, configuring environment variables, and understanding sampling overhead.

* **Performance**
  * Profiling remains disabled by default and adds no production overhead when unused.
  * Added informational guidance when profiling is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->