### PR TITLE
chore: guard hotpath profile in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -68,6 +68,32 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - run: cargo clippy --workspace --all-features --all-targets -- -D warnings
 
+  hotpath-profile:
+    runs-on: ubuntu-latest
+    name: hotpath-profile
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          submodules: true
+      - name: Install ${{ env.RUST_TOOLCHAIN }}
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+      - name: cargo check hotpath-profile
+        run: cargo check --locked -p kv-engine --features hotpath-profile --bin write-perf
+
   typos:
       runs-on: ubuntu-latest
       name: typos
@@ -102,4 +128,3 @@ jobs:
   #         toolchain: ${{ matrix.msrv }}
   #     - name: cargo +${{ matrix.msrv }} check
   #       run: cargo +${{ matrix.msrv }} check
-

--- a/kv-engine/Cargo.toml
+++ b/kv-engine/Cargo.toml
@@ -15,7 +15,7 @@ required-features = ["chaos-testing"]
 [features]
 bench = []
 chaos-testing = ["fail/failpoints"]
-hotpath-profile = ["dep:hotpath", "hotpath/hotpath"]
+hotpath-profile = ["dep:hotpath", "hotpath/hotpath", "hotpath/threads"]
 
 [dependencies]
 TinyUFO = "0.8"

--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -545,22 +545,27 @@ fn print_write_profile(engine: &KvEngine, label: &str) {
     );
 }
 
+fn start_hotpath_profile(enabled: bool) -> Option<kv_engine::profiling::HotpathGuard> {
+    if !enabled {
+        return None;
+    }
+
+    let guard = kv_engine::profiling::start_hotpath_profile("write-perf");
+    if guard.is_some() {
+        eprintln!(
+            "hotpath-profile enabled; set HOTPATH_TIME_SAMPLING_RATE=0.1 to reduce timing overhead and HOTPATH_METRICS_SERVER_OFF=true in restricted environments"
+        );
+    }
+
+    guard
+}
+
 fn main() -> Result<()> {
     let args = Args::parse();
     let bench_arg = args.bench.clone();
     let cfg = HarnessConfig::from_args(args);
     validate_config(&cfg)?;
-    let _hotpath_guard = if cfg.profile {
-        let guard = kv_engine::profiling::start_hotpath_profile("write-perf");
-        if guard.is_some() {
-            eprintln!(
-                "hotpath-profile enabled; set HOTPATH_TIME_SAMPLING_RATE=0.1 to reduce timing overhead and HOTPATH_METRICS_SERVER_OFF=true in restricted environments"
-            );
-        }
-        guard
-    } else {
-        None
-    };
+    let _hotpath_guard = start_hotpath_profile(cfg.profile);
     let workloads = select_workloads(bench_arg.as_deref())?;
 
     let mut all_measurements = Vec::new();

--- a/kv-engine/src/vlog/mod.rs
+++ b/kv-engine/src/vlog/mod.rs
@@ -662,39 +662,42 @@ impl ValueLog {
     /// `expected_key`. Returns from the value cache on hit; on miss, reads
     /// from disk and inserts into the cache.
     pub fn read(&self, ptr: &ValuePointer, expected_key: &[u8]) -> Result<Bytes> {
-        crate::profile_scope!("vlog.read", {
-            let cache_key = (ptr.file_id, ptr.offset);
+        crate::profile_scope!("vlog.read", self.read_inner(ptr, expected_key))
+    }
 
-            if let Some(ref cache) = self.value_cache {
-                if let Some(cached) =
-                    crate::profile_scope!("vlog.value_cache_lookup", cache.get(&cache_key))
-                {
-                    self.cache_hits.fetch_add(1, Ordering::Relaxed);
-                    return Ok(cached);
-                }
-                self.cache_misses.fetch_add(1, Ordering::Relaxed);
-            }
+    fn read_inner(&self, ptr: &ValuePointer, expected_key: &[u8]) -> Result<Bytes> {
+        let cache_key = (ptr.file_id, ptr.offset);
 
-            let reader = crate::profile_scope!("vlog.get_reader", self.get_reader(ptr.file_id))?;
-            let entry =
-                crate::profile_scope!("vlog.read_entry", reader.read_entry(ptr.offset, ptr.size))?;
-            if entry.key != expected_key {
-                return Err(anyhow!(
-                    "vlog key mismatch: expected {:?}, got {:?}",
-                    expected_key,
-                    entry.key
-                ));
+        if let Some(ref cache) = self.value_cache {
+            if let Some(cached) =
+                crate::profile_scope!("vlog.value_cache_lookup", cache.get(&cache_key))
+            {
+                self.cache_hits.fetch_add(1, Ordering::Relaxed);
+                return Ok(cached);
             }
-            let value = Bytes::from(entry.value);
+            self.cache_misses.fetch_add(1, Ordering::Relaxed);
+        }
 
-            if let Some(ref cache) = self.value_cache {
-                crate::profile_scope!(
-                    "vlog.value_cache_insert",
-                    cache.insert(cache_key, value.clone())
-                );
-            }
-            Ok(value)
-        })
+        let reader = crate::profile_scope!("vlog.get_reader", self.get_reader(ptr.file_id))?;
+        let entry =
+            crate::profile_scope!("vlog.read_entry", reader.read_entry(ptr.offset, ptr.size))?;
+        if entry.key != expected_key {
+            return Err(anyhow!(
+                "vlog key mismatch: expected {:?}, got {:?}",
+                expected_key,
+                entry.key
+            ));
+        }
+        let value = Bytes::from(entry.value);
+
+        if let Some(ref cache) = self.value_cache {
+            crate::profile_scope!(
+                "vlog.value_cache_insert",
+                cache.insert(cache_key, value.clone())
+            );
+        }
+
+        Ok(value)
     }
 
     /// Read a full vLog entry (key, value) at the given pointer.

--- a/kv-engine/src/vlog/reader.rs
+++ b/kv-engine/src/vlog/reader.rs
@@ -157,6 +157,13 @@ fn validate_entry_read_bounds(offset: u64, size: u32) -> Result<usize> {
 }
 
 fn decode_entry_buffer(buf: &[u8], size: usize) -> Result<DecodedEntry> {
+    anyhow::ensure!(
+        buf.len() >= HEADER_SIZE,
+        "buffer length {} is smaller than header size {}",
+        buf.len(),
+        HEADER_SIZE
+    );
+
     let mut hdr_bytes = &buf[..HEADER_SIZE];
     let header_crc32 = hdr_bytes.get_u32_le();
     let value_crc32 = hdr_bytes.get_u32_le();

--- a/kv-engine/src/vlog/reader.rs
+++ b/kv-engine/src/vlog/reader.rs
@@ -33,6 +33,12 @@ pub struct ValueLogReader {
     file_id: u32,
 }
 
+struct DecodedEntry {
+    header: VlogEntryHeader,
+    key: Vec<u8>,
+    value: Vec<u8>,
+}
+
 impl ValueLogReader {
     /// Open a vLog file and validate its file header.
     /// Reads and verifies the 16-byte `VlogFileHeader` at offset 0.
@@ -63,35 +69,25 @@ impl ValueLogReader {
     /// - Parses the 24-byte `VlogEntryHeader`, then key and value
     /// - Validates `header_crc32` and `value_crc32`
     /// - Returns a `VlogEntry` with ptr, key, value, size
-    #[allow(clippy::manual_is_multiple_of)]
     pub fn read_entry(&self, offset: u64, size: u32) -> Result<VlogEntry> {
-        let size = size as usize;
-        anyhow::ensure!(
-            offset >= VlogFileHeader::SIZE as u64,
-            "offset {} is within the file header region",
-            offset
-        );
-        anyhow::ensure!(
-            offset % super::ALIGNMENT as u64 == 0,
-            "offset {} is not aligned to {} bytes",
-            offset,
-            super::ALIGNMENT
-        );
-        anyhow::ensure!(
-            size >= HEADER_SIZE,
-            "entry size {} is smaller than header size {}",
-            size,
-            HEADER_SIZE
-        );
+        let size = validate_entry_read_bounds(offset, size)?;
+        let buf = self.read_entry_buffer(offset, size)?;
+        let decoded = decode_entry_buffer(&buf, size)?;
+        validate_entry_crcs(&decoded.header, &decoded.key, &decoded.value, offset)?;
 
-        // Guard against OOM from corrupted pointers before allocating.
-        const MAX_ENTRY_SIZE: usize = 512 * 1024 * 1024;
-        anyhow::ensure!(
-            size <= MAX_ENTRY_SIZE,
-            "entry size {} exceeds maximum allowed size ({})",
+        Ok(VlogEntry {
+            ptr: ValuePointer {
+                file_id: self.file_id,
+                offset,
+                size: size as u32,
+            },
+            key: decoded.key,
+            value: decoded.value,
             size,
-            MAX_ENTRY_SIZE
-        );
+        })
+    }
+
+    fn read_entry_buffer(&self, offset: u64, size: usize) -> Result<Vec<u8>> {
         // Read the entire entry in a single system call to minimize I/O overhead.
         // If the entry is past EOF, `read_exact_at` will fail with UnexpectedEof.
         let mut buf = vec![0u8; size];
@@ -105,69 +101,7 @@ impl ValueLogReader {
             )
         })?;
 
-        let mut hdr_bytes = &buf[..HEADER_SIZE];
-        let header_crc32 = hdr_bytes.get_u32_le();
-        let value_crc32 = hdr_bytes.get_u32_le();
-        let value_len = hdr_bytes.get_u32_le() as usize;
-        let key_len = hdr_bytes.get_u16_le() as usize;
-        let flags = hdr_bytes.get_u16_le();
-        let mut padding = [0u8; 8];
-        hdr_bytes.copy_to_slice(&mut padding);
-
-        // Validate that the caller-supplied size matches the expected aligned entry size
-        let expected_size = VlogEntryHeader::compute_entry_size(key_len, value_len)
-            .ok_or_else(|| anyhow!("entry size overflow"))?;
-        anyhow::ensure!(
-            size == expected_size,
-            "entry size mismatch: expected {}, got {}",
-            expected_size,
-            size
-        );
-
-        let key_start = HEADER_SIZE;
-        let key_end = key_start + key_len;
-        let value_end = key_end + value_len;
-        let key = buf[key_start..key_end].to_vec();
-        let value = buf[key_end..value_end].to_vec();
-
-        // Validate header CRC32: covers value_crc32 + value_len + key_len + flags + padding + key
-        let entry_header = VlogEntryHeader {
-            header_crc32,
-            value_crc32,
-            value_len: value_len as u32,
-            key_len: key_len as u16,
-            flags,
-            _padding: padding,
-        };
-        let computed_header_crc = entry_header.compute_header_crc(&key);
-        anyhow::ensure!(
-            computed_header_crc == header_crc32,
-            "header CRC32 mismatch: computed 0x{:08X}, stored 0x{:08X} at offset {}",
-            computed_header_crc,
-            header_crc32,
-            offset
-        );
-
-        // Validate value CRC32
-        let computed_value_crc = crc32fast::hash(&value);
-        anyhow::ensure!(
-            computed_value_crc == value_crc32,
-            "value CRC32 mismatch: computed 0x{:08X}, stored 0x{:08X} at offset {}",
-            computed_value_crc,
-            value_crc32,
-            offset
-        );
-
-        Ok(VlogEntry {
-            ptr: ValuePointer {
-                file_id: self.file_id,
-                offset,
-                size: size as u32,
-            },
-            key,
-            value,
-            size,
-        })
+        Ok(buf)
     }
 
     /// Return an iterator that yields `VlogEntryMeta` for each entry,
@@ -179,6 +113,7 @@ impl ValueLogReader {
         let mut file = File::open(&self.path)?;
         file.seek(SeekFrom::Start(VlogFileHeader::SIZE as u64))?;
         let file_size = file.metadata()?.len();
+
         Ok(VlogHeaderIterator {
             reader: BufReader::new(file),
             offset: VlogFileHeader::SIZE as u64,
@@ -186,6 +121,109 @@ impl ValueLogReader {
             file_id: self.file_id,
         })
     }
+}
+
+#[allow(clippy::manual_is_multiple_of)]
+fn validate_entry_read_bounds(offset: u64, size: u32) -> Result<usize> {
+    let size = size as usize;
+    // Guard against OOM from corrupted pointers before allocating.
+    const MAX_ENTRY_SIZE: usize = 512 * 1024 * 1024;
+
+    anyhow::ensure!(
+        offset >= VlogFileHeader::SIZE as u64,
+        "offset {} is within the file header region",
+        offset
+    );
+    anyhow::ensure!(
+        offset % super::ALIGNMENT as u64 == 0,
+        "offset {} is not aligned to {} bytes",
+        offset,
+        super::ALIGNMENT
+    );
+    anyhow::ensure!(
+        size >= HEADER_SIZE,
+        "entry size {} is smaller than header size {}",
+        size,
+        HEADER_SIZE
+    );
+    anyhow::ensure!(
+        size <= MAX_ENTRY_SIZE,
+        "entry size {} exceeds maximum allowed size ({})",
+        size,
+        MAX_ENTRY_SIZE
+    );
+
+    Ok(size)
+}
+
+fn decode_entry_buffer(buf: &[u8], size: usize) -> Result<DecodedEntry> {
+    let mut hdr_bytes = &buf[..HEADER_SIZE];
+    let header_crc32 = hdr_bytes.get_u32_le();
+    let value_crc32 = hdr_bytes.get_u32_le();
+    let value_len = hdr_bytes.get_u32_le() as usize;
+    let key_len = hdr_bytes.get_u16_le() as usize;
+    let flags = hdr_bytes.get_u16_le();
+    let mut padding = [0u8; 8];
+    hdr_bytes.copy_to_slice(&mut padding);
+
+    let expected_size = VlogEntryHeader::compute_entry_size(key_len, value_len)
+        .ok_or_else(|| anyhow!("entry size overflow"))?;
+    anyhow::ensure!(
+        size == expected_size,
+        "entry size mismatch: expected {}, got {}",
+        expected_size,
+        size
+    );
+
+    let key_start = HEADER_SIZE;
+    let key_end = key_start + key_len;
+    let value_end = key_end + value_len;
+    anyhow::ensure!(
+        value_end <= buf.len(),
+        "entry payload out of bounds: value end {}, len {}",
+        value_end,
+        buf.len()
+    );
+
+    Ok(DecodedEntry {
+        header: VlogEntryHeader {
+            header_crc32,
+            value_crc32,
+            value_len: value_len as u32,
+            key_len: key_len as u16,
+            flags,
+            _padding: padding,
+        },
+        key: buf[key_start..key_end].to_vec(),
+        value: buf[key_end..value_end].to_vec(),
+    })
+}
+
+fn validate_entry_crcs(
+    header: &VlogEntryHeader,
+    key: &[u8],
+    value: &[u8],
+    offset: u64,
+) -> Result<()> {
+    let computed_header_crc = header.compute_header_crc(key);
+    anyhow::ensure!(
+        computed_header_crc == header.header_crc32,
+        "header CRC32 mismatch: computed 0x{:08X}, stored 0x{:08X} at offset {}",
+        computed_header_crc,
+        header.header_crc32,
+        offset
+    );
+
+    let computed_value_crc = crc32fast::hash(value);
+    anyhow::ensure!(
+        computed_value_crc == header.value_crc32,
+        "value CRC32 mismatch: computed 0x{:08X}, stored 0x{:08X} at offset {}",
+        computed_value_crc,
+        header.value_crc32,
+        offset
+    );
+
+    Ok(())
 }
 
 /// Header-only iterator for GC analysis.


### PR DESCRIPTION
## Summary

Adds CI coverage for the optional Hotpath profiling path and cleans up the touched Rust code for readability.

## Changes

- Add a dedicated `hotpath-profile` GitHub Actions job that runs `cargo check --locked -p kv-engine --features hotpath-profile --bin write-perf`.
- Explicitly enable `hotpath/threads` in the `hotpath-profile` feature so `Section::Threads` remains covered when Hotpath defaults are disabled.
- Refactor Hotpath startup and vLog read/decode paths into smaller Rust-skill-style helpers.

## Verification

- `/home/liu/go/bin/actionlint`
- `cargo check --locked -p kv-engine --features hotpath-profile --bin write-perf`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `cargo make check-dep-sort`
- `git diff --check`
- `cargo nextest run -p kv-engine vlog::tests vlog::index::tests tests::vlog_integration_tests`