### PR TITLE
docs: add RocksDB benchmark report

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,19 +240,27 @@ failpoint injection, and cross-process persistence behavior.
 
 ## Performance Notes
 
-The current benchmark report compares ToyKV with Fjall through `crud-bench`
-using matched LSM settings. In the latest 2026-07-13 durable comparison, ToyKV
-wins 16 of 17 full-run rows; a focused `batch_read_100` rerun puts ToyKV ahead
-by about 13.5% after seeding the batch workload correctly.
+The current benchmark reports compare ToyKV with Fjall and RocksDB through
+`crud-bench` using matched LSM settings. In the latest 2026-07-13 durable Fjall
+comparison, ToyKV wins 16 of 17 full-run rows; a focused `batch_read_100` rerun
+puts ToyKV ahead by about 13.5% after seeding the batch workload correctly.
+
+The 2026-07-13 durable RocksDB comparison shows ToyKV ahead on point reads and
+large durable batch writes. RocksDB is ahead on scan rows and `batch_read_100`,
+so the next performance target is profiling the scan and small batch-read paths
+before changing storage code.
 
 See [ToyKV vs Fjall Benchmark Report](docs/bench-report-crud-bench-fjall.md)
-for the full numbers, caveats, and artifact names.
+for the full numbers, caveats, and artifact names. See
+[ToyKV vs RocksDB Benchmark Report](docs/bench-report-crud-bench-rocksdb.md) for
+the RocksDB comparison numbers, parity notes, gates, and next target.
 
 ## Docs And RFCs
 
 ### Reports
 
 - [ToyKV vs Fjall Benchmark Report](docs/bench-report-crud-bench-fjall.md)
+- [ToyKV vs RocksDB Benchmark Report](docs/bench-report-crud-bench-rocksdb.md)
 - [vLog Benchmark Report](docs/bench-report-vlog.md)
 - [DeleteRange Benchmark Report](docs/bench-report-deleterange.md)
 - [io_uring Benchmark Notes](docs/io-uring-bench.md)

--- a/README.md
+++ b/README.md
@@ -241,9 +241,10 @@ failpoint injection, and cross-process persistence behavior.
 ## Performance Notes
 
 The current benchmark reports compare ToyKV with Fjall and RocksDB through
-`crud-bench` using matched LSM settings. In the latest 2026-07-13 durable Fjall
-comparison, ToyKV wins 16 of 17 full-run rows; a focused `batch_read_100` rerun
-puts ToyKV ahead by about 13.5% after seeding the batch workload correctly.
+`crud-bench` using roughly matched adapter settings. In the latest 2026-07-13
+durable Fjall comparison, ToyKV wins 16 of 17 full-run rows; a focused
+`batch_read_100` rerun puts ToyKV ahead by about 13.5% after seeding the batch
+workload correctly.
 
 The 2026-07-13 durable RocksDB comparison shows ToyKV ahead on point reads and
 large durable batch writes. RocksDB is ahead on scan rows and `batch_read_100`,

--- a/docs/bench-report-crud-bench-rocksdb.md
+++ b/docs/bench-report-crud-bench-rocksdb.md
@@ -1,0 +1,180 @@
+# crud-bench: ToyKV vs RocksDB
+
+This report tracks ToyKV against the embedded RocksDB backend in
+`/home/liu/proj/crud-bench`.
+
+## Summary
+
+Run date: 2026-07-13.
+
+Configuration:
+
+```bash
+cd /home/liu/proj/crud-bench
+cargo run --release --no-default-features --features fjall,rocksdb,toykv -- \
+  --database <toykv|rocksdb|fjall> \
+  --samples 100000 \
+  --clients 4 \
+  --threads 4 \
+  --sync \
+  --color never
+```
+
+ToyKV is ahead of RocksDB on point reads and durable batch writes, including
+large batch create/update/delete rows. RocksDB is ahead on all measured scan
+rows and on `batch_read_100`. The next useful work is therefore not single-write
+optimization; it is profiling the scan and small batch-read paths where RocksDB
+wins by more than the 10% gate.
+
+Artifacts:
+
+- `/home/liu/proj/crud-bench/result-toykv_rocksdb_compare_toykv_sync_100k.{csv,json,html}`
+- `/home/liu/proj/crud-bench/result-toykv_rocksdb_compare_rocksdb_sync_100k.{csv,json,html}`
+- `/home/liu/proj/crud-bench/result-toykv_rocksdb_compare_fjall_sync_100k.{csv,json,html}`
+
+## Durable 100k Results
+
+All rows are OPS. Higher is better.
+
+| Row | ToyKV | RocksDB | Fjall | Result |
+|---|---:|---:|---:|---|
+| Create | 13,285 | **13,769** | 2,224 | RocksDB +3.6%, near tie |
+| Read | **4,024,724** | 1,576,567 | 2,002,965 | ToyKV +155.3% |
+| Update | 13,268 | **13,974** | 1,717 | RocksDB +5.3%, near tie |
+| Delete | 14,151 | **14,194** | 1,805 | RocksDB +0.3%, tie |
+| batch_create_100 | **6,642** | 1,580 | 645 | ToyKV +320.4% |
+| batch_read_100 | 36,283 | 48,411 | **48,467** | RocksDB +33.4% over ToyKV |
+| batch_update_100 | **6,499** | 2,167 | 667 | ToyKV +199.9% |
+| batch_delete_100 | **11,092** | 10,781 | 730 | ToyKV +2.9%, near tie |
+| batch_create_1000 | **1,562** | 481 | 318 | ToyKV +224.8% |
+| batch_read_1000 | **5,995** | 5,100 | 5,220 | ToyKV +17.6% over RocksDB |
+| batch_update_1000 | **1,643** | 459 | 204 | ToyKV +258.3% |
+| batch_delete_1000 | **4,693** | 393 | 299 | ToyKV +1,093.8% |
+
+## Scan Rows
+
+All scan rows are read-only, no-index rows from the same 100k run.
+
+| Row | ToyKV | RocksDB | Fjall | Result |
+|---|---:|---:|---:|---|
+| count() | 318 | **401** | 107 | RocksDB +25.9% |
+| select(id) limit(100) | 318,606 | **501,120** | 106,820 | RocksDB +57.3% |
+| select(*) limit(100) | 308,630 | **554,986** | 86,801 | RocksDB +79.8% |
+| select(id) start(5000) limit(100) | 9,656 | **12,144** | 2,105 | RocksDB +25.8% |
+| select(*) start(5000) limit(100) | 9,667 | **12,050** | 1,913 | RocksDB +24.7% |
+
+## Backend Parity Notes
+
+The current RocksDB adapter configures:
+
+- Level compaction.
+- 64 KiB data blocks.
+- 256 MiB write buffers.
+- Bloom filters.
+- Blob files enabled with `min_blob_size = 4 KiB`.
+- LZ4/Snappy dependencies available, with per-level compression configured.
+- `WriteOptions::set_sync(true)` for durable benchmark runs.
+
+The current ToyKV adapter configures:
+
+- Leveled compaction.
+- 64 KiB data blocks.
+- 256 MiB target SST size.
+- WAL enabled for `--sync`.
+- vLog value separation enabled at `min_value_size = 4 KiB`.
+- Large TinyUFO block cache and cache backfill.
+
+This is close enough for a first production-style comparison. Result claims must
+still state that RocksDB has many more mature tuning knobs and that this is a
+matched-adapter benchmark, not a universal RocksDB result.
+
+## Interpretation
+
+Do not prioritize single-write optimization from this run. RocksDB is only
+0.3%-5.3% ahead on create/update/delete, which is below the profiling gate and
+small enough to treat as a near tie until repeated.
+
+Keep the current durable batch-write path intact. ToyKV is substantially ahead
+on `batch_create_100`, `batch_update_100`, `batch_create_1000`,
+`batch_update_1000`, and `batch_delete_1000`.
+
+The next implementation target is scan and small batch-read performance:
+
+- `batch_read_100`: RocksDB +33.4%.
+- `count()`: RocksDB +25.9%.
+- `select(id) limit(100)`: RocksDB +57.3%.
+- `select(*) limit(100)`: RocksDB +79.8%.
+- `start(5000) limit(100)`: RocksDB +24.7%-25.8%.
+
+Profile those exact rows before changing storage code. The likely areas to
+inspect are iterator layering, block cache hit/miss behavior, vLog dereference
+cost, cache admission on scans, and block/value prefetch.
+
+## Gates
+
+Use these gates before accepting performance-oriented ToyKV changes:
+
+- No ToyKV row in the durable RocksDB comparison regresses by more than 5%
+  against the previous ToyKV baseline.
+- `hotpath-profile`, `clippy`, unit, integration, coverage, and sanitizer CI
+  remain green.
+- If RocksDB wins a workload by more than 10%, profile that exact workload
+  before choosing an implementation change.
+- Do not accept buffered-only improvements that regress durable `--sync`
+  workloads.
+
+Priority profiling rows:
+
+- `batch_read_100`
+- `count()`
+- `select(id) limit(100)`
+- `select(*) limit(100)`
+- `select(id) start(5000) limit(100)`
+- `select(*) start(5000) limit(100)`
+
+## Reproduction
+
+Build the narrow compare binary:
+
+```bash
+cd /home/liu/proj/crud-bench
+cargo build --release --no-default-features --features fjall,rocksdb,toykv
+```
+
+Run durable 100k-sample comparisons:
+
+```bash
+cd /home/liu/proj/crud-bench
+
+cargo run --release --no-default-features --features fjall,rocksdb,toykv -- \
+  --name toykv_rocksdb_compare_toykv_sync_100k \
+  --database toykv \
+  --samples 100000 \
+  --clients 4 \
+  --threads 4 \
+  --sync \
+  --color never
+
+cargo run --release --no-default-features --features fjall,rocksdb,toykv -- \
+  --name toykv_rocksdb_compare_rocksdb_sync_100k \
+  --database rocksdb \
+  --samples 100000 \
+  --clients 4 \
+  --threads 4 \
+  --sync \
+  --color never
+
+cargo run --release --no-default-features --features fjall,rocksdb,toykv -- \
+  --name toykv_rocksdb_compare_fjall_sync_100k \
+  --database fjall \
+  --samples 100000 \
+  --clients 4 \
+  --threads 4 \
+  --sync \
+  --color never
+```
+
+The release benchmark command shape was first smoke-validated with `--samples
+10000 --clients 1 --threads 1 --sync`. A smaller `--samples 100` smoke is
+invalid for this harness because the built-in `start(5000) limit(100)` scan
+expects at least 5100 rows.

--- a/docs/bench-report-crud-bench-rocksdb.md
+++ b/docs/bench-report-crud-bench-rocksdb.md
@@ -46,10 +46,10 @@ All rows are OPS. Higher is better.
 | batch_read_100 | 36,283 | 48,411 | **48,467** | RocksDB +33.4% over ToyKV |
 | batch_update_100 | **6,499** | 2,167 | 667 | ToyKV +199.9% |
 | batch_delete_100 | **11,092** | 10,781 | 730 | ToyKV +2.9%, near tie |
-| batch_create_1000 | **1,562** | 481 | 318 | ToyKV +224.8% |
-| batch_read_1000 | **5,995** | 5,100 | 5,220 | ToyKV +17.6% over RocksDB |
-| batch_update_1000 | **1,643** | 459 | 204 | ToyKV +258.3% |
-| batch_delete_1000 | **4,693** | 393 | 299 | ToyKV +1,093.8% |
+| batch_create_1000 | **1,562** | 481 | 318 | ToyKV +224.7% |
+| batch_read_1000 | **5,995** | 5,100 | 5,220 | ToyKV +17.5% over RocksDB |
+| batch_update_1000 | **1,643** | 459 | 204 | ToyKV +258.0% |
+| batch_delete_1000 | **4,693** | 393 | 299 | ToyKV +1,094.1% |
 
 ## Scan Rows
 
@@ -57,7 +57,7 @@ All scan rows are read-only, no-index rows from the same 100k run.
 
 | Row | ToyKV | RocksDB | Fjall | Result |
 |---|---:|---:|---:|---|
-| count() | 318 | **401** | 107 | RocksDB +25.9% |
+| count() | 318 | **401** | 107 | RocksDB +26.1% |
 | select(id) limit(100) | 318,606 | **501,120** | 106,820 | RocksDB +57.3% |
 | select(*) limit(100) | 308,630 | **554,986** | 86,801 | RocksDB +79.8% |
 | select(id) start(5000) limit(100) | 9,656 | **12,144** | 2,105 | RocksDB +25.8% |
@@ -101,7 +101,7 @@ on `batch_create_100`, `batch_update_100`, `batch_create_1000`,
 The next implementation target is scan and small batch-read performance:
 
 - `batch_read_100`: RocksDB +33.4%.
-- `count()`: RocksDB +25.9%.
+- `count()`: RocksDB +26.1%.
 - `select(id) limit(100)`: RocksDB +57.3%.
 - `select(*) limit(100)`: RocksDB +79.8%.
 - `start(5000) limit(100)`: RocksDB +24.7%-25.8%.

--- a/docs/bench-report-crud-bench-rocksdb.md
+++ b/docs/bench-report-crud-bench-rocksdb.md
@@ -1,7 +1,7 @@
 # crud-bench: ToyKV vs RocksDB
 
-This report tracks ToyKV against the embedded RocksDB backend in
-`/home/liu/proj/crud-bench`.
+This report tracks ToyKV against the embedded RocksDB backend in a sibling
+`crud-bench` checkout.
 
 ## Summary
 
@@ -10,7 +10,7 @@ Run date: 2026-07-13.
 Configuration:
 
 ```bash
-cd /home/liu/proj/crud-bench
+cd <crud-bench checkout>
 cargo run --release --no-default-features --features fjall,rocksdb,toykv -- \
   --database <toykv|rocksdb|fjall> \
   --samples 100000 \
@@ -28,9 +28,9 @@ wins by more than the 10% gate.
 
 Artifacts:
 
-- `/home/liu/proj/crud-bench/result-toykv_rocksdb_compare_toykv_sync_100k.{csv,json,html}`
-- `/home/liu/proj/crud-bench/result-toykv_rocksdb_compare_rocksdb_sync_100k.{csv,json,html}`
-- `/home/liu/proj/crud-bench/result-toykv_rocksdb_compare_fjall_sync_100k.{csv,json,html}`
+- `result-toykv_rocksdb_compare_toykv_sync_100k.{csv,json,html}`
+- `result-toykv_rocksdb_compare_rocksdb_sync_100k.{csv,json,html}`
+- `result-toykv_rocksdb_compare_fjall_sync_100k.{csv,json,html}`
 
 ## Durable 100k Results
 
@@ -137,14 +137,14 @@ Priority profiling rows:
 Build the narrow compare binary:
 
 ```bash
-cd /home/liu/proj/crud-bench
+cd <crud-bench checkout>
 cargo build --release --no-default-features --features fjall,rocksdb,toykv
 ```
 
 Run durable 100k-sample comparisons:
 
 ```bash
-cd /home/liu/proj/crud-bench
+cd <crud-bench checkout>
 
 cargo run --release --no-default-features --features fjall,rocksdb,toykv -- \
   --name toykv_rocksdb_compare_toykv_sync_100k \

--- a/todo.md
+++ b/todo.md
@@ -215,6 +215,14 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   `batch_delete_1000`. Do not accept buffered-only improvements that regress sync production cases. Initial gates:
   no focused sync row regresses by more than 5%, sync/no-sync ratio improves for at least two of `put_c`,
   `batch_create_1000`, and `batch_delete_1000`, and single-client sync p95/p99 latency does not materially regress.
+- [x] **Add durable RocksDB comparison** — Ran the existing `crud-bench` embedded RocksDB backend alongside ToyKV and
+  Fjall with `--sync --samples 100000 --clients 4 --threads 4`, then filled in
+  `docs/bench-report-crud-bench-rocksdb.md`. ToyKV wins point reads and large durable batch writes; RocksDB wins
+  scan rows and `batch_read_100`.
+- [ ] **Profile RocksDB-winning read rows** — Use Hotpath/perf on ToyKV `batch_read_100`, `count()`,
+  `select(id) limit(100)`, `select(*) limit(100)`, and `start(5000) limit(100)` rows from the durable RocksDB
+  comparison. Treat iterator layering, block cache hit/miss behavior, vLog dereference cost, scan cache admission,
+  and block/value prefetch as the first suspects.
 - [x] **Ticket-based group commit** — Replace CAS-based leader election with ticket/sequence design to eliminate
   O(N) leader-election cascade. Assign monotonic ticket on `put_batch`, leader drains queue + records max ticket,
   sets `durable_sequence` atomic after I/O. Followers check `durable_sequence >= my_ticket` and return immediately

--- a/todo.md
+++ b/todo.md
@@ -220,9 +220,9 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   `docs/bench-report-crud-bench-rocksdb.md`. ToyKV wins point reads and large durable batch writes; RocksDB wins
   scan rows and `batch_read_100`.
 - [ ] **Profile RocksDB-winning read rows** — Use Hotpath/perf on ToyKV `batch_read_100`, `count()`,
-  `select(id) limit(100)`, `select(*) limit(100)`, and `start(5000) limit(100)` rows from the durable RocksDB
-  comparison. Treat iterator layering, block cache hit/miss behavior, vLog dereference cost, scan cache admission,
-  and block/value prefetch as the first suspects.
+  `select(id) limit(100)`, `select(*) limit(100)`, `select(id) start(5000) limit(100)`, and
+  `select(*) start(5000) limit(100)` rows from the durable RocksDB comparison. Treat iterator layering, block cache
+  hit/miss behavior, vLog dereference cost, scan cache admission, and block/value prefetch as the first suspects.
 - [x] **Ticket-based group commit** — Replace CAS-based leader election with ticket/sequence design to eliminate
   O(N) leader-election cascade. Assign monotonic ticket on `put_batch`, leader drains queue + records max ticket,
   sets `durable_sequence` atomic after I/O. Followers check `durable_sequence >= my_ticket` and return immediately


### PR DESCRIPTION
## Summary

Adds the completed durable RocksDB comparison report for crud-bench and updates the README/todo to point at the measured next target.

## Changes

- Add ToyKV vs RocksDB/Fjall durable 100k OPS tables and scan rows.
- Document benchmark artifacts, backend parity notes, gates, and reproduction commands.
- Mark the RocksDB comparison done in todo and add the follow-up profiling target for scan and small batch-read rows.

## Verification

- cargo make check (outside sandbox): 729 passed; nextest reported 1 flaky retry that passed
- git diff --check
- cargo make check-typos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded performance benchmarking notes with ToyKV comparisons against Fjall and RocksDB.
  * Added a detailed RocksDB benchmark report, including results, methodology, reproduction steps, and performance criteria.
  * Updated the reports index to include both benchmark reports.
* **Chores**
  * Documented the completed RocksDB durability comparison.
  * Added follow-up profiling tasks for read performance and identified areas for investigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->