### PR TITLE
perf: avoid redundant scan helper checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,11 +247,11 @@ durable Fjall comparison, ToyKV wins 16 of 17 full-run rows; a focused
 workload correctly.
 
 The 2026-07-13 durable RocksDB comparison shows ToyKV ahead on point reads and
-large durable batch writes. A 2026-07-14 focused PR #170 scan rerun moved ToyKV
-ahead on four of five scan rows. The latest focused batch rerun keeps
-`batch_read_1000` ahead of RocksDB; after increasing the short `batch_read_100`
-row to 10,000 iterations, ToyKV also leads that row by 15.6%. The only remaining
-focused read gap is `select(*) limit(100)`, where RocksDB leads by 3.8%.
+large durable batch writes. Focused scan reruns now put ToyKV ahead on all five
+no-index scan watch rows, including the repeated `select(*) limit(100)` row
+from PR #173 where ToyKV leads RocksDB by 28.3%. The latest focused batch rerun
+keeps `batch_read_1000` ahead of RocksDB; after increasing the short
+`batch_read_100` row to 10,000 iterations, ToyKV also leads that row by 15.6%.
 
 See [ToyKV vs Fjall Benchmark Report](docs/bench-report-crud-bench-fjall.md)
 for the full numbers, caveats, and artifact names. See

--- a/docs/bench-report-crud-bench-rocksdb.md
+++ b/docs/bench-report-crud-bench-rocksdb.md
@@ -5,8 +5,8 @@ This report tracks ToyKV against the embedded RocksDB backend in a sibling
 
 ## Summary
 
-Run date: 2026-07-13 full durable run. Focused PR #170 scan and batch reruns:
-2026-07-14.
+Run date: 2026-07-13 full durable run. Focused scan and batch reruns:
+2026-07-14 to 2026-07-15.
 
 Configuration:
 
@@ -22,14 +22,15 @@ cargo run --release --no-default-features --features fjall,rocksdb,toykv -- \
 ```
 
 ToyKV is ahead of RocksDB on point reads and durable batch writes, including
-large batch create/update/delete rows. The PR #170 focused scan rerun flips four
-of the five previously RocksDB-winning scan rows: ToyKV now leads `count()`,
-`select(id) limit(100)`, and both `start(5000) limit(100)` scan rows. RocksDB
-still leads `select(*) limit(100)` by 3.8% over ToyKV. The focused
-`batch_read_100` row changed substantially across the default 250-iteration
-reruns, so it was repeated with a temporary 10,000-iteration batch-read config.
-That longer timed row puts ToyKV ahead by 15.6%. ToyKV also still leads
-`batch_read_1000`.
+large batch create/update/delete rows. The PR #170 focused scan rerun flipped
+four of the five previously RocksDB-winning scan rows. PR #173 repeated the
+remaining `select(*) limit(100)` gap and now puts ToyKV ahead on all five
+focused no-index scan watch rows. The repeated `select(*) limit(100)` row is
+646,130.69 OPS for ToyKV vs 503,709.26 OPS for RocksDB, a 28.3% ToyKV lead. The
+focused `batch_read_100` row changed substantially across the default
+250-iteration reruns, so it was repeated with a temporary 10,000-iteration
+batch-read config. That longer timed row puts ToyKV ahead by 15.6%. ToyKV also
+still leads `batch_read_1000`.
 
 Artifacts:
 
@@ -46,6 +47,8 @@ Artifacts:
 - `result-rocksdb_batch_confirm_pr170_sync_100k.{csv,json,html}`
 - `result-toykv_batch100_iter10000_pr170_sync_100k.{csv,json,html}`
 - `result-rocksdb_batch100_iter10000_pr170_sync_100k.{csv,json,html}`
+- `result-toykv_read_rerun_pr173_sync_100k.{csv,json,html}`
+- `result-rocksdb_read_rerun_pr173_sync_100k.{csv,json,html}`
 
 ## Durable 100k Results
 
@@ -68,22 +71,23 @@ All rows are OPS. Higher is better.
 
 ## Focused Scan Rerun
 
-These rows come from the 2026-07-14 focused PR #170 scan rerun on head
-`95c0811`. The command used `--skip-indexes --skip-batches` to isolate the
-read-only no-index scan rows after the scan iterator fast paths landed. Fjall
-was not rerun in this focused pass.
+These rows come from the 2026-07-15 focused PR #173 scan rerun on head
+`4bd002d`. The command used `--skip-indexes --skip-batches` to isolate the
+read-only no-index scan rows after the scan iterator fast paths landed and the
+remaining full-projection limit row was repeated. Fjall was not rerun in this
+focused pass.
 
 | Row | ToyKV | RocksDB | Result |
 |---|---:|---:|---|
-| count() | **626.90** | 378.79 | ToyKV +65.5% |
-| select(id) limit(100) | **518,545.76** | 487,420.34 | ToyKV +6.4% |
-| select(*) limit(100) | 544,404.19 | **564,861.78** | RocksDB +3.8% |
-| select(id) start(5000) limit(100) | **14,860.10** | 12,218.91 | ToyKV +21.6% |
-| select(*) start(5000) limit(100) | **14,914.80** | 12,308.01 | ToyKV +21.2% |
+| count() | **639.73** | 422.17 | ToyKV +51.5% |
+| select(id) limit(100) | **531,176.56** | 531,124.54 | ToyKV +0.01%, tie |
+| select(*) limit(100) | **646,130.69** | 503,709.26 | ToyKV +28.3% |
+| select(id) start(5000) limit(100) | **15,064.87** | 12,260.85 | ToyKV +22.9% |
+| select(*) start(5000) limit(100) | **14,969.44** | 12,209.65 | ToyKV +22.6% |
 
 The 2026-07-13 full durable run had RocksDB ahead on all five scan rows before
-the PR #170 scan work. Keep the full-run artifacts for historical comparison,
-but use this focused rerun as the current scan baseline.
+the PR #170 and PR #173 scan work. Keep the full-run artifacts for historical
+comparison, but use this focused rerun as the current scan baseline.
 
 ## Focused Batch Rerun
 
@@ -141,16 +145,15 @@ Keep the current durable batch-write path intact. ToyKV is substantially ahead
 on `batch_create_100`, `batch_update_100`, `batch_create_1000`,
 `batch_update_1000`, and `batch_delete_1000`.
 
-The remaining read-path target is narrow after PR #170:
+The focused read-path gap is closed after PR #173:
 
-- `select(*) limit(100)`: RocksDB +3.8% in the focused scan rerun.
+- `select(*) limit(100)`: ToyKV +28.3% in the focused scan rerun.
 
-Repeat `select(*) limit(100)` before deeper work because its current gap is
-below the 10% gate. If chasing that last scan row, inspect
-projection/materialization and value decode cost before broad iterator setup
-changes. Keep `batch_read_100`, `batch_read_1000`, `count()`,
-`select(id) limit(100)`, and the two `start(5000) limit(100)` rows as regression
-watch rows because ToyKV now leads them.
+Do not start deeper full-projection scan work from the old PR #170 gap unless a
+future repeat reproduces a stable RocksDB lead. Keep `batch_read_100`,
+`batch_read_1000`, `count()`, `select(id) limit(100)`, `select(*) limit(100)`,
+and the two `start(5000) limit(100)` rows as regression watch rows because
+ToyKV now leads or ties them.
 
 ## Gates
 
@@ -167,7 +170,7 @@ Use these gates before accepting performance-oriented ToyKV changes:
 
 Priority profiling rows:
 
-- `select(*) limit(100)` after a repeat run confirms a stable gap
+- None currently confirmed above the profiling gate.
 
 ## Reproduction
 
@@ -211,13 +214,13 @@ cargo run --release --no-default-features --features fjall,rocksdb,toykv -- \
   --color never
 ```
 
-Run the focused PR #170 scan rerun:
+Run the focused PR #173 scan rerun:
 
 ```bash
 cd <crud-bench checkout>
 
 cargo run --release --no-default-features --features rocksdb,toykv -- \
-  --name toykv_read_rerun_pr170_sync_100k \
+  --name toykv_read_rerun_pr173_sync_100k \
   --database toykv \
   --samples 100000 \
   --clients 4 \
@@ -228,7 +231,7 @@ cargo run --release --no-default-features --features rocksdb,toykv -- \
   --color never
 
 cargo run --release --no-default-features --features rocksdb,toykv -- \
-  --name rocksdb_read_rerun_pr170_sync_100k \
+  --name rocksdb_read_rerun_pr173_sync_100k \
   --database rocksdb \
   --samples 100000 \
   --clients 4 \

--- a/docs/bench-report-crud-bench-rocksdb.md
+++ b/docs/bench-report-crud-bench-rocksdb.md
@@ -170,7 +170,10 @@ Use these gates before accepting performance-oriented ToyKV changes:
 
 Priority profiling rows:
 
-- None currently confirmed above the profiling gate.
+- None currently confirmed above the profiling gate. The durable
+  `batch_read_100` row still records the original 100k comparison result, but
+  the 10,000-iteration focused rerun supersedes it for current gating because
+  the default timed row was too short and unstable.
 
 ## Reproduction
 

--- a/kv-engine/src/lsm_iterator.rs
+++ b/kv-engine/src/lsm_iterator.rs
@@ -236,7 +236,7 @@ impl StorageIterator for LsmIterator {
     type KeyType<'a> = &'a [u8];
 
     fn is_valid(&self) -> bool {
-        self.inner.is_valid() & self.check_bound()
+        self.inner.is_valid() && self.check_bound()
     }
 
     fn key(&self) -> &[u8] {
@@ -402,7 +402,7 @@ impl ScanIterator {
     {
         let mut count = 0;
         while count < limit && self.iter.is_valid() {
-            visit(self.iter.key());
+            visit(self.iter.iter.key());
             count += 1;
             if count < limit {
                 self.iter.next()?;
@@ -420,7 +420,7 @@ impl ScanIterator {
     {
         let mut count = 0;
         while count < limit && self.iter.is_valid() {
-            visit(self.iter.value());
+            visit(self.iter.iter.value());
             count += 1;
             if count < limit {
                 self.iter.next()?;

--- a/kv-engine/src/lsm_iterator.rs
+++ b/kv-engine/src/lsm_iterator.rs
@@ -389,6 +389,11 @@ impl ScanIterator {
         Ok(())
     }
 
+    #[cfg(test)]
+    pub(crate) fn for_testing_mark_errored(&mut self) {
+        self.iter.has_errored = true;
+    }
+
     /// Advance over up to `n` visible entries and return the number skipped.
     ///
     /// This is equivalent to repeated `next()` calls, but lets callers express

--- a/kv-engine/src/lsm_iterator.rs
+++ b/kv-engine/src/lsm_iterator.rs
@@ -386,7 +386,10 @@ impl ScanIterator {
     /// offset handling without duplicating iterator-validity loops.
     pub fn skip_entries(&mut self, n: usize) -> Result<usize> {
         let mut skipped = 0;
-        while skipped < n && self.iter.is_valid() {
+        if self.iter.has_errored {
+            return Ok(skipped);
+        }
+        while skipped < n && self.iter.iter.is_valid() {
             self.iter.next()?;
             skipped += 1;
         }
@@ -401,7 +404,10 @@ impl ScanIterator {
         F: FnMut(&[u8]),
     {
         let mut count = 0;
-        while count < limit && self.iter.is_valid() {
+        if self.iter.has_errored {
+            return Ok(count);
+        }
+        while count < limit && self.iter.iter.is_valid() {
             visit(self.iter.iter.key());
             count += 1;
             if count < limit {
@@ -419,7 +425,10 @@ impl ScanIterator {
         F: FnMut(&[u8]),
     {
         let mut count = 0;
-        while count < limit && self.iter.is_valid() {
+        if self.iter.has_errored {
+            return Ok(count);
+        }
+        while count < limit && self.iter.iter.is_valid() {
             visit(self.iter.iter.value());
             count += 1;
             if count < limit {
@@ -434,7 +443,10 @@ impl ScanIterator {
     /// counted entry.
     pub fn count_entries(&mut self, limit: usize) -> Result<usize> {
         let mut count = 0;
-        while count < limit && self.iter.is_valid() {
+        if self.iter.has_errored {
+            return Ok(count);
+        }
+        while count < limit && self.iter.iter.is_valid() {
             count += 1;
             if count < limit {
                 self.iter.next()?;

--- a/kv-engine/src/lsm_iterator.rs
+++ b/kv-engine/src/lsm_iterator.rs
@@ -380,6 +380,15 @@ impl ScanIterator {
         self.iter
     }
 
+    fn next_inner(&mut self) -> Result<()> {
+        if let Err(e) = self.iter.iter.next() {
+            self.iter.has_errored = true;
+            return Err(e);
+        }
+
+        Ok(())
+    }
+
     /// Advance over up to `n` visible entries and return the number skipped.
     ///
     /// This is equivalent to repeated `next()` calls, but lets callers express
@@ -390,7 +399,7 @@ impl ScanIterator {
             return Ok(skipped);
         }
         while skipped < n && self.iter.iter.is_valid() {
-            self.iter.next()?;
+            self.next_inner()?;
             skipped += 1;
         }
 
@@ -411,7 +420,7 @@ impl ScanIterator {
             visit(self.iter.iter.key());
             count += 1;
             if count < limit {
-                self.iter.next()?;
+                self.next_inner()?;
             }
         }
 
@@ -432,7 +441,7 @@ impl ScanIterator {
             visit(self.iter.iter.value());
             count += 1;
             if count < limit {
-                self.iter.next()?;
+                self.next_inner()?;
             }
         }
 
@@ -449,7 +458,7 @@ impl ScanIterator {
         while count < limit && self.iter.iter.is_valid() {
             count += 1;
             if count < limit {
-                self.iter.next()?;
+                self.next_inner()?;
             }
         }
 

--- a/kv-engine/src/tests/iterators.rs
+++ b/kv-engine/src/tests/iterators.rs
@@ -316,6 +316,65 @@ fn test_task4_integration() {
 }
 
 #[test]
+fn test_scan_iterator_limited_helpers() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+
+    for (key, value) in [
+        (b"a".as_slice(), b"va".as_slice()),
+        (b"b".as_slice(), b"vb".as_slice()),
+        (b"c".as_slice(), b"vc".as_slice()),
+        (b"d".as_slice(), b"vd".as_slice()),
+    ] {
+        storage.put(key, value).unwrap();
+    }
+
+    let mut iter = storage.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    let mut keys = Vec::new();
+    assert_eq!(
+        iter.visit_keys(2, |key| keys.push(key.to_vec())).unwrap(),
+        2
+    );
+    assert_eq!(keys, vec![b"a".to_vec(), b"b".to_vec()]);
+    assert_eq!(iter.key(), b"b");
+    iter.next().unwrap();
+    assert_eq!(iter.key(), b"c");
+
+    let mut iter = storage.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    let mut values = Vec::new();
+    assert_eq!(
+        iter.visit_values(2, |value| values.push(value.to_vec()))
+            .unwrap(),
+        2
+    );
+    assert_eq!(values, vec![b"va".to_vec(), b"vb".to_vec()]);
+    assert_eq!(iter.key(), b"b");
+
+    let mut iter = storage.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    assert_eq!(iter.count_entries(3).unwrap(), 3);
+    assert_eq!(iter.key(), b"c");
+    iter.next().unwrap();
+    assert_eq!(iter.key(), b"d");
+
+    let mut iter = storage.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    assert_eq!(iter.skip_entries(2).unwrap(), 2);
+    assert_eq!(iter.key(), b"c");
+
+    let mut iter = storage.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    assert_eq!(iter.visit_keys(0, |_| unreachable!()).unwrap(), 0);
+    assert_eq!(iter.count_entries(0).unwrap(), 0);
+    assert_eq!(iter.key(), b"a");
+
+    let mut iter = storage.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    iter.for_testing_mark_errored();
+    assert_eq!(iter.skip_entries(2).unwrap(), 0);
+    assert_eq!(iter.visit_keys(2, |_| unreachable!()).unwrap(), 0);
+    assert_eq!(iter.visit_values(2, |_| unreachable!()).unwrap(), 0);
+    assert_eq!(iter.count_entries(2).unwrap(), 0);
+}
+
+#[test]
 fn test_storage_iterator_default_methods() {
     // Exercise raw_value() and num_active_iterators() default impls
     let iter = MockIterator::new(vec![

--- a/todo.md
+++ b/todo.md
@@ -221,9 +221,10 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   scan rows and `batch_read_100` in the initial full run; the PR #170 focused scan rerun moves ToyKV ahead on four of
   five scan rows, while a 10,000-iteration focused batch rerun moves `batch_read_100` back ahead and keeps
   `batch_read_1000` ahead of RocksDB.
-- [ ] **Repeat remaining focused read gap** — Repeat `select(*) limit(100)` before deeper work because the PR #170
-  focused scan rerun leaves RocksDB ahead by only 3.8%. Treat projection/materialization and value decode cost as the
-  first suspects; keep the now-winning scan rows plus `batch_read_100` and `batch_read_1000` as regression watch rows.
+- [x] **Repeat remaining focused read gap** — PR #173 repeated the remaining `select(*) limit(100)` gap with
+  `--sync --samples 100000 --clients 4 --threads 4 --skip-indexes --skip-batches`. ToyKV now leads RocksDB on all five
+  focused no-index scan watch rows; the repeated `select(*) limit(100)` row is 646,130.69 vs 503,709.26 OPS
+  (+28.3%). Keep the scan rows plus `batch_read_100` and `batch_read_1000` as regression watch rows.
 - [x] **Ticket-based group commit** — Replace CAS-based leader election with ticket/sequence design to eliminate
   O(N) leader-election cascade. Assign monotonic ticket on `put_batch`, leader drains queue + records max ticket,
   sets `durable_sequence` atomic after I/O. Followers check `durable_sequence >= my_ticket` and return immediately


### PR DESCRIPTION
## Summary
- short-circuit `LsmIterator::is_valid()` so upper-bound checks are skipped after the inner iterator is exhausted
- avoid redundant `FusedIterator` checks inside `ScanIterator` limited helpers
- keep `skip_entries`, `visit_keys`, `visit_values`, and `count_entries` on the already-owned inner iterator once the fused error state is known
- advance the owned inner iterator directly from those helpers while preserving fused error tainting

## Focused Benchmark
Temporary release microbenchmark comparing PR branch against `origin/main`:

```bash
cargo run --release -p kv-engine --features bench --bin tmp_visit_keys_bench -- \
  /tmp/toykv/visit 10000 100000 100
```

Shape: populate 100,000 rows, then run 10,000 bounded scans over 100 keys and call `visit_keys(limit=100)`.

| Revision | ns/scan samples | median ns/scan | scans/s median |
| --- | ---: | ---: | ---: |
| origin/main | 7179.7 / 7171.4 / 7323.7 | 7179.7 | 139,281 |
| PR branch | 6023.4 / 6005.9 / 7595.1 / 5573.7 / 5724.1 | 6005.9 | 166,503 |

Median limited-scan helper throughput improves by ~16.4% in this microbenchmark.

## Full Write-Perf Rerun
Ran the full `write-perf` workload list outside the sandbox after clearing `/tmp`, comparing PR `4ac7eec` against `origin/main` `39a9421`. Workloads were run one process at a time with JSON output.

`seekrandomwhilewriting` was killed with status 137 on both revisions and is excluded from the comparison table.

| Workload | Measurement | Metric | origin/main | PR | Delta |
| --- | --- | ---: | ---: | ---: | ---: |
| compact | full_compaction | ms | 376.20 | 519.92 | -27.6% |
| concurrent_rw_no_wal | mixed | reads/s | 120,927 | 178,647 | +47.7% |
| concurrent_rw_wal | mixed | reads/s | 239,867 | 337,929 | +40.9% |
| deleterandom | delete | ops/s | 777,601 | 650,664 | -16.3% |
| fillrandom | write | ops/s | 1,133,890 | 1,145,140 | +1.0% |
| fillseq | write | ops/s | 1,338,490 | 1,354,150 | +1.2% |
| overwrite | update | ops/s | 994,468 | 975,106 | -2.0% |
| parallel_scan | parallel_chunk_full_scan | entries/s | 2,586,900 | 2,628,570 | +1.6% |
| parallel_scan | sync_full_scan | entries/s | 1,289,960 | 1,394,350 | +8.1% |
| readmissing | negative_point_get | ops/s | 486,508 | 488,770 | +0.5% |
| readrandom | point_get | ops/s | 165,888 | 166,786 | +0.5% |
| readrandomwriterandom | mixed | reads/s | 244,801 | 246,408 | +0.7% |
| readseq | forward_scan | entries/s | 1,043,140 | 1,000,970 | -4.0% |
| readseq_validate_order | forward_placeholder | entries/s | 1,000,590 | 1,058,320 | +5.8% |
| readwhilewriting | mixed | reads/s | 250,623 | 249,861 | -0.3% |
| scan | full_scan | entries/s | 1,243,990 | 1,237,080 | -0.6% |
| scan | scan_10pct | entries/s | 758,500 | 1,433,860 | +89.0% |
| seekrandom | seek | ops/s | 30,197 | 30,658 | +1.5% |
| vlog_concurrent_gc | mixed | reads/s | 173,186 | 179,094 | +3.4% |
| vlog_gc | round_1 | writes/s | 1,443,480 | 1,462,070 | +1.3% |
| vlog_gc | round_2 | writes/s | 1,371,990 | 1,435,780 | +4.7% |
| vlog_gc | round_3 | writes/s | 1,427,770 | 1,388,620 | -2.7% |
| wal_concurrent | concurrent | ops/s | 99,409 | 105,761 | +6.4% |
| wal_throughput | seq_256b | ops/s | 153,016 | 157,663 | +3.0% |
| wal_throughput | seq_4096b | ops/s | 40,750 | 42,183 | +3.5% |

The relevant scan rows are neutral to positive overall: `scan_10pct` improves in this run, while full scan is effectively flat. Larger swings in unrelated mixed/compaction/delete workloads should be treated as noisy full-suite signal rather than direct evidence for this iterator helper change.

## Validation
- `cargo fmt --check`
- `cargo test -p kv-engine --features bench iterators`
- `cargo test -p kv-engine --features bench visit`
- `cargo clippy -p kv-engine --features bench --all-targets -- -D warnings`

Note: broad `cargo test -p kv-engine --features bench scan` was attempted earlier, but that filter includes WAL-GC tests that fail in this sandbox with `failed to create io_uring ring: Operation not permitted`. The scan/iterator tests reached before those WAL-GC cases passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan iterator error handling to stop further work after an iterator error.
  * Updated iterator validity and bound checks to ensure consistent, correct iteration behavior.
  * Enhanced limited scan helpers (keys, values, count, and skipping), including correct handling of zero-limit requests.
* **Tests**
  * Added integration coverage for limited scan helper behavior, iterator positioning, and outcomes after marking the iterator as errored.
* **Documentation**
  * Refreshed benchmark narratives, reproduction commands, and related performance notes to reflect the latest scan rerun results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->