### PR TITLE
perf: reduce sync write-batch overhead

### DIFF
--- a/docs/bench-report-crud-bench-rocksdb.md
+++ b/docs/bench-report-crud-bench-rocksdb.md
@@ -21,6 +21,13 @@ cargo run --release --no-default-features --features fjall,rocksdb,toykv -- \
   --color never
 ```
 
+RocksDB backend version: `surrealdb-rocksdb 0.24.0-surreal.5` maps to
+`surrealdb-librocksdb-sys 0.18.3+11.0.0-4`, whose vendored
+`rocksdb/version.h` reports raw RocksDB `11.0.0`. The latest upstream raw
+RocksDB release checked on 2026-07-16 is `11.1.2`, so these results are against
+the latest available SurrealDB Rust binding but not the latest upstream RocksDB
+source.
+
 ToyKV is ahead of RocksDB on point reads and durable batch writes, including
 large batch create/update/delete rows. The PR #170 focused scan rerun flipped
 four of the five previously RocksDB-winning scan rows. PR #173 repeated the

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -4887,11 +4887,11 @@ impl LsmStorageInner {
                     has_range = true;
                 }
             }
-            anyhow::ensure!(
-                !(has_point && has_range),
-                "mixed point/range batches are not supported in the MVP"
-            );
         }
+        anyhow::ensure!(
+            !(has_point && has_range),
+            "mixed point/range batches are not supported in the MVP"
+        );
 
         Ok(has_range)
     }
@@ -5054,8 +5054,14 @@ impl LsmStorageInner {
         let mut data = Vec::with_capacity(batch.len());
         for record in batch {
             if !seen.insert(Self::write_batch_key(record)) {
-                let dedup_indices =
-                    Self::dedup_write_batch_indices(batch).expect("duplicate key was observed");
+                let mut last_op = AHashMap::with_capacity(batch.len());
+                for (idx, record) in batch.iter().enumerate() {
+                    last_op.insert(Self::write_batch_key(record), idx);
+                }
+
+                let mut dedup_indices: Vec<_> = last_op.values().copied().collect();
+                dedup_indices.sort_unstable();
+
                 let data = Self::build_point_batch_entries(batch, Some(&dedup_indices));
                 return (data, Some(dedup_indices));
             }

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -5087,12 +5087,9 @@ impl LsmStorageInner {
                 ));
             }
             WriteBatchRecord::Put(key, value) => {
-                let mut p = Vec::with_capacity(1 + value.as_ref().len());
-                p.push(crate::vlog::KvKind::Inline as u8);
-                p.extend_from_slice(value.as_ref());
                 data.push((
                     bytes::Bytes::copy_from_slice(key.as_ref()),
-                    bytes::Bytes::from(p),
+                    bytes::Bytes::from(Self::encode_kind_value(KvKind::Inline, value.as_ref())),
                 ));
             }
             WriteBatchRecord::PutWithTtl(key, value, ttl_secs) => {

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -5054,16 +5054,20 @@ impl LsmStorageInner {
         let mut data = Vec::with_capacity(batch.len());
         for record in batch {
             if !seen.insert(Self::write_batch_key(record)) {
-                let mut last_op = AHashMap::with_capacity(batch.len());
-                for (idx, record) in batch.iter().enumerate() {
-                    last_op.insert(Self::write_batch_key(record), idx);
+                seen.clear();
+                let mut dedup_data = Vec::with_capacity(batch.len());
+                let mut dedup_indices = Vec::with_capacity(batch.len());
+                for (idx, record) in batch.iter().enumerate().rev() {
+                    if seen.insert(Self::write_batch_key(record)) {
+                        Self::push_point_batch_entry(&mut dedup_data, record);
+                        dedup_indices.push(idx);
+                    }
                 }
 
-                let mut dedup_indices: Vec<_> = last_op.values().copied().collect();
-                dedup_indices.sort_unstable();
+                dedup_data.reverse();
+                dedup_indices.reverse();
 
-                let data = Self::build_point_batch_entries(batch, Some(&dedup_indices));
-                return (data, Some(dedup_indices));
+                return (dedup_data, Some(dedup_indices));
             }
             Self::push_point_batch_entry(&mut data, record);
         }

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -10,6 +10,7 @@ use std::{
     time::Duration,
 };
 
+use ahash::{AHashMap, AHashSet};
 use anyhow::{Context, Result, anyhow};
 use arc_swap::ArcSwap;
 use bytes::Bytes;
@@ -150,6 +151,9 @@ pub enum WriteBatchRecord<T: AsRef<[u8]>> {
     /// MVP: range-only batches only (no mixed point/range batches).
     DelRange(T, T),
 }
+
+type PointBatchEntry = (bytes::Bytes, bytes::Bytes, crate::mvcc::BatchEntryKind);
+type PointBatchBuild = (Vec<PointBatchEntry>, Option<Vec<usize>>);
 
 impl LsmStorageState {
     fn create(options: &LsmStorageOptions, vlog_enabled: bool) -> Self {
@@ -4830,7 +4834,7 @@ impl LsmStorageInner {
         let mvcc = self.mvcc.as_ref().expect("mvcc_write_batch requires MVCC");
         let (commit_ts, memtable, publish_data) = {
             let _read_guard = self.active_memtable_lock.read();
-            let state = self.state.load_full();
+            let state = self.state.load();
             let (commit_ts, data) = mvcc.write_batch_wal_only(entries, &state.memtable)?;
             (commit_ts, state.memtable.clone(), data)
         };
@@ -4866,12 +4870,30 @@ impl LsmStorageInner {
         }
     }
 
-    fn validate_write_batch_keys<T: AsRef<[u8]>>(batch: &[WriteBatchRecord<T>]) -> Result<()> {
+    fn validate_and_classify_write_batch<T: AsRef<[u8]>>(
+        batch: &[WriteBatchRecord<T>],
+    ) -> Result<bool> {
+        let mut has_point = false;
+        let mut has_range = false;
         for record in batch {
-            Self::validate_key_size(Self::write_batch_key(record))?;
+            match record {
+                WriteBatchRecord::Put(key, _)
+                | WriteBatchRecord::PutWithTtl(key, _, _)
+                | WriteBatchRecord::Del(key) => {
+                    has_point = true;
+                    Self::validate_key_size(key.as_ref())?;
+                }
+                WriteBatchRecord::DelRange(_, _) => {
+                    has_range = true;
+                }
+            }
+            anyhow::ensure!(
+                !(has_point && has_range),
+                "mixed point/range batches are not supported in the MVP"
+            );
         }
 
-        Ok(())
+        Ok(has_range)
     }
 
     fn dedup_write_batch_indices<T: AsRef<[u8]>>(
@@ -4881,7 +4903,7 @@ impl LsmStorageInner {
             return None;
         }
 
-        let mut seen = std::collections::HashSet::with_capacity(batch.len());
+        let mut seen = AHashSet::with_capacity(batch.len());
         let mut has_duplicate_keys = false;
         for record in batch {
             if !seen.insert(Self::write_batch_key(record)) {
@@ -4893,7 +4915,7 @@ impl LsmStorageInner {
             return None;
         }
 
-        let mut last_op = std::collections::HashMap::with_capacity(batch.len());
+        let mut last_op = AHashMap::with_capacity(batch.len());
         for (idx, record) in batch.iter().enumerate() {
             last_op.insert(Self::write_batch_key(record), idx);
         }
@@ -4964,86 +4986,83 @@ impl LsmStorageInner {
         self.try_freeze_memtable()
     }
 
+    fn push_point_batch_entry<T: AsRef<[u8]>>(
+        data: &mut Vec<PointBatchEntry>,
+        record: &WriteBatchRecord<T>,
+    ) {
+        match record {
+            WriteBatchRecord::Put(key, value) => {
+                data.push((
+                    bytes::Bytes::copy_from_slice(key.as_ref()),
+                    bytes::Bytes::from(Self::encode_kind_value(KvKind::Inline, value.as_ref())),
+                    crate::mvcc::BatchEntryKind::PutPrefixed,
+                ));
+            }
+            WriteBatchRecord::PutWithTtl(key, value, ttl_secs) => {
+                let expire_at =
+                    crate::vlog::compute_expire_at(std::time::Duration::from_secs(*ttl_secs));
+                let p = crate::vlog::encode_ttl_value(
+                    crate::vlog::KvKind::TtlInline,
+                    expire_at,
+                    value.as_ref(),
+                );
+                data.push((
+                    bytes::Bytes::copy_from_slice(key.as_ref()),
+                    bytes::Bytes::from(p),
+                    crate::mvcc::BatchEntryKind::PutPrefixed,
+                ));
+            }
+            WriteBatchRecord::Del(key) => {
+                data.push((
+                    bytes::Bytes::copy_from_slice(key.as_ref()),
+                    bytes::Bytes::new(),
+                    crate::mvcc::BatchEntryKind::Delete,
+                ));
+            }
+            WriteBatchRecord::DelRange(_, _) => unreachable!(),
+        }
+    }
+
     fn build_point_batch_entries<T: AsRef<[u8]>>(
         batch: &[WriteBatchRecord<T>],
         dedup_indices: Option<&[usize]>,
-    ) -> Vec<(bytes::Bytes, bytes::Bytes, crate::mvcc::BatchEntryKind)> {
+    ) -> Vec<PointBatchEntry> {
         let mut data = Vec::with_capacity(dedup_indices.map_or(batch.len(), <[usize]>::len));
         match dedup_indices {
             Some(indices) => {
                 for &idx in indices {
-                    match &batch[idx] {
-                        WriteBatchRecord::Put(key, value) => {
-                            data.push((
-                                bytes::Bytes::copy_from_slice(key.as_ref()),
-                                bytes::Bytes::copy_from_slice(value.as_ref()),
-                                crate::mvcc::BatchEntryKind::Put,
-                            ));
-                        }
-                        WriteBatchRecord::PutWithTtl(key, value, ttl_secs) => {
-                            let expire_at = crate::vlog::compute_expire_at(
-                                std::time::Duration::from_secs(*ttl_secs),
-                            );
-                            let p = crate::vlog::encode_ttl_value(
-                                crate::vlog::KvKind::TtlInline,
-                                expire_at,
-                                value.as_ref(),
-                            );
-                            data.push((
-                                bytes::Bytes::copy_from_slice(key.as_ref()),
-                                bytes::Bytes::from(p),
-                                crate::mvcc::BatchEntryKind::PutTtl,
-                            ));
-                        }
-                        WriteBatchRecord::Del(key) => {
-                            data.push((
-                                bytes::Bytes::copy_from_slice(key.as_ref()),
-                                bytes::Bytes::new(),
-                                crate::mvcc::BatchEntryKind::Delete,
-                            ));
-                        }
-                        WriteBatchRecord::DelRange(_, _) => unreachable!(),
-                    }
+                    Self::push_point_batch_entry(&mut data, &batch[idx]);
                 }
             }
             None => {
                 for record in batch {
-                    match record {
-                        WriteBatchRecord::Put(key, value) => {
-                            data.push((
-                                bytes::Bytes::copy_from_slice(key.as_ref()),
-                                bytes::Bytes::copy_from_slice(value.as_ref()),
-                                crate::mvcc::BatchEntryKind::Put,
-                            ));
-                        }
-                        WriteBatchRecord::PutWithTtl(key, value, ttl_secs) => {
-                            let expire_at = crate::vlog::compute_expire_at(
-                                std::time::Duration::from_secs(*ttl_secs),
-                            );
-                            let p = crate::vlog::encode_ttl_value(
-                                crate::vlog::KvKind::TtlInline,
-                                expire_at,
-                                value.as_ref(),
-                            );
-                            data.push((
-                                bytes::Bytes::copy_from_slice(key.as_ref()),
-                                bytes::Bytes::from(p),
-                                crate::mvcc::BatchEntryKind::PutTtl,
-                            ));
-                        }
-                        WriteBatchRecord::Del(key) => {
-                            data.push((
-                                bytes::Bytes::copy_from_slice(key.as_ref()),
-                                bytes::Bytes::new(),
-                                crate::mvcc::BatchEntryKind::Delete,
-                            ));
-                        }
-                        WriteBatchRecord::DelRange(_, _) => unreachable!(),
-                    }
+                    Self::push_point_batch_entry(&mut data, record);
                 }
             }
         }
         data
+    }
+
+    fn build_unique_point_batch_entries_or_dedup<T: AsRef<[u8]>>(
+        batch: &[WriteBatchRecord<T>],
+    ) -> PointBatchBuild {
+        if batch.len() <= 1 {
+            return (Self::build_point_batch_entries(batch, None), None);
+        }
+
+        let mut seen = AHashSet::with_capacity(batch.len());
+        let mut data = Vec::with_capacity(batch.len());
+        for record in batch {
+            if !seen.insert(Self::write_batch_key(record)) {
+                let dedup_indices =
+                    Self::dedup_write_batch_indices(batch).expect("duplicate key was observed");
+                let data = Self::build_point_batch_entries(batch, Some(&dedup_indices));
+                return (data, Some(dedup_indices));
+            }
+            Self::push_point_batch_entry(&mut data, record);
+        }
+
+        (data, None)
     }
 
     fn build_non_mvcc_batch_entries<T: AsRef<[u8]>>(
@@ -5992,29 +6011,11 @@ impl LsmStorageInner {
     /// commit timestamp.
     #[allow(clippy::type_complexity)]
     pub fn write_batch<T: AsRef<[u8]>>(&self, batch: &[WriteBatchRecord<T>]) -> Result<()> {
-        // MVP: reject mixed batches containing both point and range operations.
-        let has_point = batch.iter().any(|r| {
-            matches!(
-                r,
-                WriteBatchRecord::Put(..)
-                    | WriteBatchRecord::PutWithTtl(..)
-                    | WriteBatchRecord::Del(_)
-            )
-        });
-        let has_range = batch
-            .iter()
-            .any(|r| matches!(r, WriteBatchRecord::DelRange(..)));
-        anyhow::ensure!(
-            !(has_point && has_range),
-            "mixed point/range batches are not supported in the MVP"
-        );
+        let has_range = Self::validate_and_classify_write_batch(batch)?;
 
         if has_range {
             return self.range_batch_write(batch);
         }
-
-        Self::validate_write_batch_keys(batch)?;
-        let dedup_indices = Self::dedup_write_batch_indices(batch);
 
         // Defer serializable txn recording until after commit_wal succeeds.
         let mut txn_info: Option<(u64, std::collections::HashSet<bytes::Bytes>)> = None;
@@ -6032,10 +6033,11 @@ impl LsmStorageInner {
                 }
             });
             let _guard = self.active_memtable_lock.read();
-            let state = self.state.load_full();
+            let state = self.state.load();
             if let Some(ref mvcc) = self.mvcc {
                 // MVCC path: allocate a single commit_ts for the entire batch.
-                let entries = Self::build_point_batch_entries(batch, dedup_indices.as_deref());
+                let (entries, dedup_indices) =
+                    Self::build_unique_point_batch_entries_or_dedup(batch);
                 // WAL-only: do NOT publish to skiplist yet.
                 let (commit_ts, data) = mvcc.write_batch_wal_only(&entries, &state.memtable)?;
                 mvcc_commit_ts = commit_ts;
@@ -6050,6 +6052,7 @@ impl LsmStorageInner {
                 (state.memtable.clone(), data)
             } else {
                 // Non-MVCC path: write raw user keys to WAL only.
+                let dedup_indices = Self::dedup_write_batch_indices(batch);
                 let data = Self::build_non_mvcc_batch_entries(batch, dedup_indices.as_deref());
                 let publish_data = crate::mvcc::DeferredBatchPublish::from_entries(data);
                 publish_data

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -5071,6 +5071,43 @@ impl LsmStorageInner {
         (data, None)
     }
 
+    fn push_non_mvcc_batch_entry<T: AsRef<[u8]>>(
+        data: &mut Vec<(bytes::Bytes, bytes::Bytes)>,
+        record: &WriteBatchRecord<T>,
+    ) {
+        match record {
+            WriteBatchRecord::Del(key) => {
+                data.push((
+                    bytes::Bytes::copy_from_slice(key.as_ref()),
+                    bytes::Bytes::from_static(crate::mvcc::TOMBSTONE_VALUE),
+                ));
+            }
+            WriteBatchRecord::Put(key, value) => {
+                let mut p = Vec::with_capacity(1 + value.as_ref().len());
+                p.push(crate::vlog::KvKind::Inline as u8);
+                p.extend_from_slice(value.as_ref());
+                data.push((
+                    bytes::Bytes::copy_from_slice(key.as_ref()),
+                    bytes::Bytes::from(p),
+                ));
+            }
+            WriteBatchRecord::PutWithTtl(key, value, ttl_secs) => {
+                let expire_at =
+                    crate::vlog::compute_expire_at(std::time::Duration::from_secs(*ttl_secs));
+                let p = crate::vlog::encode_ttl_value(
+                    crate::vlog::KvKind::TtlInline,
+                    expire_at,
+                    value.as_ref(),
+                );
+                data.push((
+                    bytes::Bytes::copy_from_slice(key.as_ref()),
+                    bytes::Bytes::from(p),
+                ));
+            }
+            WriteBatchRecord::DelRange(_, _) => unreachable!(),
+        }
+    }
+
     fn build_non_mvcc_batch_entries<T: AsRef<[u8]>>(
         batch: &[WriteBatchRecord<T>],
         dedup_indices: Option<&[usize]>,
@@ -5079,74 +5116,12 @@ impl LsmStorageInner {
         match dedup_indices {
             Some(indices) => {
                 for &idx in indices {
-                    match &batch[idx] {
-                        WriteBatchRecord::Del(key) => {
-                            data.push((
-                                bytes::Bytes::copy_from_slice(key.as_ref()),
-                                bytes::Bytes::from_static(crate::mvcc::TOMBSTONE_VALUE),
-                            ));
-                        }
-                        WriteBatchRecord::Put(key, value) => {
-                            let mut p = Vec::with_capacity(1 + value.as_ref().len());
-                            p.push(crate::vlog::KvKind::Inline as u8);
-                            p.extend_from_slice(value.as_ref());
-                            data.push((
-                                bytes::Bytes::copy_from_slice(key.as_ref()),
-                                bytes::Bytes::from(p),
-                            ));
-                        }
-                        WriteBatchRecord::PutWithTtl(key, value, ttl_secs) => {
-                            let expire_at = crate::vlog::compute_expire_at(
-                                std::time::Duration::from_secs(*ttl_secs),
-                            );
-                            let p = crate::vlog::encode_ttl_value(
-                                crate::vlog::KvKind::TtlInline,
-                                expire_at,
-                                value.as_ref(),
-                            );
-                            data.push((
-                                bytes::Bytes::copy_from_slice(key.as_ref()),
-                                bytes::Bytes::from(p),
-                            ));
-                        }
-                        WriteBatchRecord::DelRange(_, _) => unreachable!(),
-                    }
+                    Self::push_non_mvcc_batch_entry(&mut data, &batch[idx]);
                 }
             }
             None => {
                 for record in batch {
-                    match record {
-                        WriteBatchRecord::Del(key) => {
-                            data.push((
-                                bytes::Bytes::copy_from_slice(key.as_ref()),
-                                bytes::Bytes::from_static(crate::mvcc::TOMBSTONE_VALUE),
-                            ));
-                        }
-                        WriteBatchRecord::Put(key, value) => {
-                            let mut p = Vec::with_capacity(1 + value.as_ref().len());
-                            p.push(crate::vlog::KvKind::Inline as u8);
-                            p.extend_from_slice(value.as_ref());
-                            data.push((
-                                bytes::Bytes::copy_from_slice(key.as_ref()),
-                                bytes::Bytes::from(p),
-                            ));
-                        }
-                        WriteBatchRecord::PutWithTtl(key, value, ttl_secs) => {
-                            let expire_at = crate::vlog::compute_expire_at(
-                                std::time::Duration::from_secs(*ttl_secs),
-                            );
-                            let p = crate::vlog::encode_ttl_value(
-                                crate::vlog::KvKind::TtlInline,
-                                expire_at,
-                                value.as_ref(),
-                            );
-                            data.push((
-                                bytes::Bytes::copy_from_slice(key.as_ref()),
-                                bytes::Bytes::from(p),
-                            ));
-                        }
-                        WriteBatchRecord::DelRange(_, _) => unreachable!(),
-                    }
+                    Self::push_non_mvcc_batch_entry(&mut data, record);
                 }
             }
         }

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -702,27 +702,33 @@ impl MemTable {
 
         #[cfg(feature = "bench")]
         let t = Instant::now();
-        crate::profile_scope!("memtable.publish_batch", {
-            let mut buf = Vec::new();
-            for (key, value) in data {
-                Self::maybe_note_ttl_value(&self.has_ttl_entries, value);
-                buf.clear();
-                key.decode_user_key_into(&mut buf);
-                self.bloom.push_hash(super::table::bloom::hash_key(&buf));
-                self.map.insert(
-                    shared_bytes_from_slice(key.raw_ref()),
-                    shared_bytes_from_slice(value),
-                );
+        thread_local! {
+            static PUBLISH_USER_KEY_BUF: std::cell::RefCell<Vec<u8>> =
+                const { std::cell::RefCell::new(Vec::new()) };
+        }
+        PUBLISH_USER_KEY_BUF.with(|buf| {
+            let mut buf = buf.borrow_mut();
+            let mut approximate_size_delta = 0usize;
+            crate::profile_scope!("memtable.publish_batch", {
+                for (key, value) in data {
+                    Self::maybe_note_ttl_value(&self.has_ttl_entries, value);
+                    buf.clear();
+                    key.decode_user_key_into(&mut buf);
+                    self.bloom.push_hash(super::table::bloom::hash_key(&buf));
+                    self.map.insert(
+                        shared_bytes_from_slice(key.raw_ref()),
+                        shared_bytes_from_slice(value),
+                    );
 
-                // approximate_size is already approximate — Relaxed ordering
-                // is sufficient and avoids unnecessary fence overhead (L3).
-                // Use raw_ref().len() for key data size (size_of_val on KeySlice
-                // returns the struct size, not the data length).
-                self.approximate_size.fetch_add(
-                    key.raw_ref().len() + value.len(),
-                    std::sync::atomic::Ordering::Relaxed,
-                );
-            }
+                    // approximate_size is already approximate — Relaxed ordering
+                    // is sufficient and avoids unnecessary fence overhead (L3).
+                    // Use raw_ref().len() for key data size (size_of_val on KeySlice
+                    // returns the struct size, not the data length).
+                    approximate_size_delta += key.raw_ref().len() + value.len();
+                }
+                self.approximate_size
+                    .fetch_add(approximate_size_delta, std::sync::atomic::Ordering::Relaxed);
+            });
         });
         #[cfg(feature = "bench")]
         {

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -75,13 +75,13 @@ pub(crate) struct LsmMvccInner {
 /// Explicit entry kind for [`LsmMvccInner::write_batch_wal_only`].
 ///
 /// Replaces the previous `bool` (`is_tombstone`) + byte-sniffing heuristic
-/// so callers unambiguously tell the write path whether a value is a plain
-/// put, already TTL-prefixed, or a tombstone.
+/// so callers unambiguously tell the write path whether a value is raw,
+/// already kind-prefixed, or a tombstone.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum BatchEntryKind {
-    Put,
     Delete,
-    PutTtl,
+    PutRaw,
+    PutPrefixed,
 }
 
 impl LsmMvccInner {
@@ -275,7 +275,7 @@ impl LsmMvccInner {
     /// Write a batch to the WAL buffer only — no skiplist insert, no sync.
     ///
     /// Each entry carries a [`BatchEntryKind`] so the caller unambiguously
-    /// specifies whether the value is a plain put, TTL-prefixed, or a tombstone
+    /// specifies whether the value is raw, already kind-prefixed, or a tombstone
     /// — no byte-sniffing.
     ///
     /// Returns `(commit_ts, publish_data)` where `publish_data` owns the
@@ -308,15 +308,11 @@ impl LsmMvccInner {
                     Bytes::from(encode_internal_key(key, commit_ts)),
                     Bytes::from_static(TOMBSTONE_VALUE),
                 ),
-                BatchEntryKind::PutTtl => {
-                    // Value is already TTL-prefixed by build_point_batch_entries;
-                    // pass through without wrapping in another KvKind prefix.
-                    (
-                        Bytes::from(encode_internal_key(key, commit_ts)),
-                        value.clone(),
-                    )
-                }
-                BatchEntryKind::Put => {
+                BatchEntryKind::PutPrefixed => (
+                    Bytes::from(encode_internal_key(key, commit_ts)),
+                    value.clone(),
+                ),
+                BatchEntryKind::PutRaw => {
                     let mut p = Vec::with_capacity(1 + value.len());
                     p.push(crate::vlog::KvKind::Inline as u8);
                     p.extend_from_slice(value.as_ref());

--- a/kv-engine/src/mvcc/txn.rs
+++ b/kv-engine/src/mvcc/txn.rs
@@ -391,7 +391,7 @@ impl Transaction {
                 let kind = if crate::vlog::KvKind::is_tombstone_value(val) {
                     crate::mvcc::BatchEntryKind::Delete
                 } else {
-                    crate::mvcc::BatchEntryKind::Put
+                    crate::mvcc::BatchEntryKind::PutRaw
                 };
                 (e.key().clone(), val.clone(), kind)
             })
@@ -510,7 +510,7 @@ impl Transaction {
                 let kind = if crate::vlog::KvKind::is_tombstone_value(val) {
                     crate::mvcc::BatchEntryKind::Delete
                 } else {
-                    crate::mvcc::BatchEntryKind::Put
+                    crate::mvcc::BatchEntryKind::PutRaw
                 };
                 (e.key().clone(), val.clone(), kind)
             })

--- a/kv-engine/src/tests/wal.rs
+++ b/kv-engine/src/tests/wal.rs
@@ -1675,12 +1675,12 @@ fn test_mvcc_write_batch_ts_advances() {
             (
                 bytes::Bytes::from_static(b"k1"),
                 bytes::Bytes::from_static(b"v1"),
-                crate::mvcc::BatchEntryKind::Put,
+                crate::mvcc::BatchEntryKind::PutRaw,
             ),
             (
                 bytes::Bytes::from_static(b"k2"),
                 bytes::Bytes::from_static(b"v2"),
-                crate::mvcc::BatchEntryKind::Put,
+                crate::mvcc::BatchEntryKind::PutRaw,
             ),
         ])
         .unwrap();
@@ -1715,12 +1715,12 @@ fn test_mvcc_write_batch_inner_ts_advances() {
             (
                 bytes::Bytes::from_static(b"k1"),
                 bytes::Bytes::from_static(b"v1"),
-                crate::mvcc::BatchEntryKind::Put,
+                crate::mvcc::BatchEntryKind::PutRaw,
             ),
             (
                 bytes::Bytes::from_static(b"k2"),
                 bytes::Bytes::from_static(b"v2"),
-                crate::mvcc::BatchEntryKind::Put,
+                crate::mvcc::BatchEntryKind::PutRaw,
             ),
         ])
         .unwrap();

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -74,6 +74,12 @@ const RING_SIZE: usize = 256;
 const MAX_WRITES_PER_CHUNK: usize = RING_SIZE;
 /// Preallocation block size (1 MiB).
 const PREALLOC_BLOCK: u64 = 1 << 20;
+/// Briefly yield before a solo leader drains the WAL queue so peer writers can
+/// join the same fdatasync.
+const GROUP_COMMIT_SOLO_YIELDS: usize = 8;
+/// Only delay solo leaders for larger batches where one extra peer can amortize
+/// a meaningful fdatasync cost.
+const GROUP_COMMIT_MIN_SOLO_BYTES: usize = 512 * 1024;
 
 // ── DirectBuf: page-aligned buffer for O_DIRECT I/O ───────────────────────
 
@@ -1520,6 +1526,7 @@ impl Wal {
     }
 
     fn submit_as_leader(&self, ticket: u64) -> Result<()> {
+        self.wait_for_group_commit_peers(ticket);
         let ticketed_bufs = self.drain_pending_ticketed_bufs();
         if ticketed_bufs.is_empty() {
             return self.fail_empty_leader_drain(ticket);
@@ -1535,6 +1542,28 @@ impl Wal {
 
         self.publish_submit_result(max_ticket, &result);
         result
+    }
+
+    fn wait_for_group_commit_peers(&self, ticket: u64) {
+        {
+            let pending = self.pending.lock();
+            if pending.len() != 1
+                || pending.last().is_none_or(|buf| {
+                    buf.ticket != ticket || buf.buf.len() < GROUP_COMMIT_MIN_SOLO_BYTES
+                })
+            {
+                return;
+            }
+        }
+
+        for _ in 0..GROUP_COMMIT_SOLO_YIELDS {
+            if self.completion_state.durable_ticket.load(Ordering::Acquire) > ticket
+                || self.next_ticket.load(Ordering::Acquire) > ticket + 1
+            {
+                break;
+            }
+            std::thread::yield_now();
+        }
     }
 
     fn drain_pending_ticketed_bufs(&self) -> Vec<TicketedBuf> {

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -1547,11 +1547,11 @@ impl Wal {
     fn wait_for_group_commit_peers(&self, ticket: u64) {
         {
             let pending = self.pending.lock();
-            if pending.len() != 1
-                || pending.last().is_none_or(|buf| {
-                    buf.ticket != ticket || buf.buf.len() < GROUP_COMMIT_MIN_SOLO_BYTES
-                })
-            {
+            if pending.len() != 1 {
+                return;
+            }
+            let buf = pending.last().unwrap();
+            if buf.ticket != ticket || buf.buf.len() < GROUP_COMMIT_MIN_SOLO_BYTES {
                 return;
             }
         }

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -74,9 +74,9 @@ const RING_SIZE: usize = 256;
 const MAX_WRITES_PER_CHUNK: usize = RING_SIZE;
 /// Preallocation block size (1 MiB).
 const PREALLOC_BLOCK: u64 = 1 << 20;
-/// Briefly yield before a solo leader drains the WAL queue so peer writers can
+/// Briefly spin before a solo leader drains the WAL queue so peer writers can
 /// join the same fdatasync.
-const GROUP_COMMIT_SOLO_YIELDS: usize = 8;
+const GROUP_COMMIT_SOLO_SPINS: usize = 8;
 /// Only delay solo leaders for larger batches where one extra peer can amortize
 /// a meaningful fdatasync cost.
 const GROUP_COMMIT_MIN_SOLO_BYTES: usize = 512 * 1024;
@@ -1556,7 +1556,7 @@ impl Wal {
             }
         }
 
-        for _ in 0..GROUP_COMMIT_SOLO_YIELDS {
+        for _ in 0..GROUP_COMMIT_SOLO_SPINS {
             if self.completion_state.durable_ticket.load(Ordering::Acquire) > ticket
                 || self.next_ticket.load(Ordering::Acquire) > ticket + 1
             {

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -1562,7 +1562,7 @@ impl Wal {
             {
                 break;
             }
-            std::thread::yield_now();
+            std::hint::spin_loop();
         }
     }
 

--- a/todo.md
+++ b/todo.md
@@ -257,7 +257,12 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   `batch_create_100` 7,119.76 → 6,992.20 OPS, `batch_update_100` 7,041.70 → 7,878.78 OPS,
   `batch_delete_100` 10,356.25 → 11,011.69 OPS, `batch_create_1000` 1,609.98 → 1,695.84 OPS,
   `batch_update_1000` 1,174.04 → 1,198.38 OPS, and `batch_delete_1000` 4,000.73 → 4,630.94 OPS. A lower 128 KiB gate
-  improved large batches more, but regressed `batch_update_100`, so it was rejected.
+  improved large batches more, but regressed `batch_update_100`, so it was rejected. Follow-up: switching the solo
+  leader wait from `yield_now()` to `spin_loop()` kept the same durability semantics while avoiding scheduler handoff
+  latency. Same-window sync A/B moved `batch_create_100` 3,085.46 → 6,738.57 OPS, `batch_update_100`
+  2,220.15 → 5,991.32 OPS, `batch_delete_100` 3,789.87 → 11,160.01 OPS, `batch_create_1000`
+  1,008.80 → 1,593.44 OPS, `batch_update_1000` 886.57 → 1,657.93 OPS, and `batch_delete_1000`
+  2,039.08 → 4,079.75 OPS.
 - [ ] **Add sync perf gates to the comparison workflow** — Track both absolute Fjall-relative OPS and
   sync/no-sync ratio for `put_c`, `batch_create_100`, `batch_create_1000`, `batch_delete_100`, and
   `batch_delete_1000`. Do not accept buffered-only improvements that regress sync production cases. Initial gates:

--- a/todo.md
+++ b/todo.md
@@ -252,7 +252,7 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   1,587.33 → 1,563.96 OPS and `batch_delete_1000` 5,078.36 → 4,752.27 OPS. Increasing WAL fallocate granularity
   from 1 MiB to 16 MiB was a hard reject: same-window sync A/B moved `batch_create_1000` 1,726.79 → 983.89 OPS,
   `batch_update_1000` 1,674.46 → 629.46 OPS, and `batch_delete_1000` 4,989.86 → 1,481.66 OPS.
-  Kept sync-side follow-up: group-commit leaders now briefly yield only for solo WAL buffers at least 512 KiB, giving
+  Kept sync-side follow-up: group-commit leaders now briefly delay only for solo WAL buffers at least 512 KiB, giving
   peer writers a chance to join the same `fdatasync` without taxing smaller writes. Same-window sync A/B moved
   `batch_create_100` 7,119.76 → 6,992.20 OPS, `batch_update_100` 7,041.70 → 7,878.78 OPS,
   `batch_delete_100` 10,356.25 → 11,011.69 OPS, `batch_create_1000` 1,609.98 → 1,695.84 OPS,

--- a/todo.md
+++ b/todo.md
@@ -246,7 +246,18 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   sync batch rows (`batch_create_1000` 1,090.00 OPS, `batch_update_1000` 1,085.67 OPS, `batch_delete_1000` 2,097.61
   OPS), so it was reverted. Removing the WAL point-batch validated length vector was also rejected: same-window
   outside-sandbox sync A/B on 2026-07-15 moved `batch_create_1000` 1,682.54 → 1,682.08 OPS, but regressed
-  `batch_update_1000` 1,724.53 → 1,162.76 OPS and `batch_delete_1000` 5,716.15 → 4,862.19 OPS.
+  `batch_update_1000` 1,724.53 → 1,162.76 OPS and `batch_delete_1000` 5,716.15 → 4,862.19 OPS. Replacing WAL
+  submission chunk-range collection with a direct index loop was also rejected: same-window sync A/B moved
+  `batch_create_1000` 1,074.83 → 1,565.98 OPS in a noisy baseline window, but regressed `batch_update_1000`
+  1,587.33 → 1,563.96 OPS and `batch_delete_1000` 5,078.36 → 4,752.27 OPS. Increasing WAL fallocate granularity
+  from 1 MiB to 16 MiB was a hard reject: same-window sync A/B moved `batch_create_1000` 1,726.79 → 983.89 OPS,
+  `batch_update_1000` 1,674.46 → 629.46 OPS, and `batch_delete_1000` 4,989.86 → 1,481.66 OPS.
+  Kept sync-side follow-up: group-commit leaders now briefly yield only for solo WAL buffers at least 512 KiB, giving
+  peer writers a chance to join the same `fdatasync` without taxing smaller writes. Same-window sync A/B moved
+  `batch_create_100` 7,119.76 → 6,992.20 OPS, `batch_update_100` 7,041.70 → 7,878.78 OPS,
+  `batch_delete_100` 10,356.25 → 11,011.69 OPS, `batch_create_1000` 1,609.98 → 1,695.84 OPS,
+  `batch_update_1000` 1,174.04 → 1,198.38 OPS, and `batch_delete_1000` 4,000.73 → 4,630.94 OPS. A lower 128 KiB gate
+  improved large batches more, but regressed `batch_update_100`, so it was rejected.
 - [ ] **Add sync perf gates to the comparison workflow** — Track both absolute Fjall-relative OPS and
   sync/no-sync ratio for `put_c`, `batch_create_100`, `batch_create_1000`, `batch_delete_100`, and
   `batch_delete_1000`. Do not accept buffered-only improvements that regress sync production cases. Initial gates:

--- a/todo.md
+++ b/todo.md
@@ -263,6 +263,25 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   2,220.15 → 5,991.32 OPS, `batch_delete_100` 3,789.87 → 11,160.01 OPS, `batch_create_1000`
   1,008.80 → 1,593.44 OPS, `batch_update_1000` 886.57 → 1,657.93 OPS, and `batch_delete_1000`
   2,039.08 → 4,079.75 OPS.
+  Final PR-head sync/no-sync comparison artifacts:
+  `result-toykv_pr174_final_sync_100k.csv` and `result-toykv_pr174_final_nosync_100k.csv`. Same command shape
+  (`--samples 100000 --clients 4 --threads 4 --skip-indexes --skip-scans`) shows durable batch writes remain below
+  buffered mode: `batch_create_100` 6,583.98 / 18,522.37 OPS (35.5%), `batch_update_100` 7,170.94 / 25,770.59 OPS
+  (27.8%), `batch_delete_100` 10,679.07 / 31,217.23 OPS (34.2%), `batch_create_1000` 1,245.03 / 2,534.93 OPS
+  (49.1%), `batch_update_1000` 1,548.54 / 2,550.96 OPS (60.7%), and `batch_delete_1000` 3,397.84 / 7,703.75 OPS
+  (44.1%). Read rows are effectively tied or better under sync: `batch_read_100` 48,687.01 / 49,568.01 OPS and
+  `batch_read_1000` 6,618.30 / 5,590.60 OPS.
+  Fair RocksDB sync rerun used the same `rocksdb,toykv` feature set for both binaries. Artifacts:
+  `result-toykv_pr174_fair_sync_100k.csv` and `result-rocksdb_pr174_fair_sync_100k.csv`. The RocksDB adapter used
+  `surrealdb-rocksdb 0.24.0-surreal.5`, mapping to raw RocksDB `11.0.0` through
+  `surrealdb-librocksdb-sys 0.18.3+11.0.0-4`; latest upstream raw RocksDB was `11.1.2` when checked on 2026-07-16.
+  Under the same sync command, ToyKV wins 11 of
+  12 rows versus RocksDB: `Create` 13,350.01 / 13,275.94 OPS (+0.6%), `Read` 3,515,416.56 / 1,495,393.47 OPS
+  (+135.1%), `Delete` 14,223.39 / 13,806.87 OPS (+3.0%), `batch_create_100` 5,564.77 / 1,710.81 OPS (+225.3%),
+  `batch_read_100` 36,685.90 / 27,777.33 OPS (+32.1%), `batch_update_100` 5,653.76 / 1,590.98 OPS (+255.4%),
+  `batch_delete_100` 11,340.75 / 4,741.47 OPS (+139.2%), `batch_create_1000` 1,497.21 / 413.55 OPS (+262.0%),
+  `batch_read_1000` 5,719.06 / 5,011.33 OPS (+14.1%), `batch_update_1000` 1,532.62 / 369.53 OPS (+314.7%), and
+  `batch_delete_1000` 4,547.50 / 318.29 OPS (+1328.7%). RocksDB is slightly ahead only on single-op `Update`.
 - [ ] **Add sync perf gates to the comparison workflow** — Track both absolute Fjall-relative OPS and
   sync/no-sync ratio for `put_c`, `batch_create_100`, `batch_create_1000`, `batch_delete_100`, and
   `batch_delete_1000`. Do not accept buffered-only improvements that regress sync production cases. Initial gates:

--- a/todo.md
+++ b/todo.md
@@ -210,6 +210,41 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
 - [ ] **Reduce sync batch overhead before fsync** — Audit `Wal::put_batch`, `MemTable::put_raw_batch_inner`, and MVCC
   `write_batch` allocation paths for avoidable per-record buffers/copies. The next useful target is making durable
   `batch_create_1000` closer to the no-sync path without hurting duplicate-key last-op-wins semantics.
+  First slice: public MVCC `write_batch` now builds publish-ready kind-prefixed values once, while transaction commits
+  still mark raw values explicitly. Same-machine `crud-bench` A/B on 2026-07-15 (`--samples 100000 --clients 4
+  --threads 4 --skip-indexes --skip-scans`) moved sync `batch_create_1000` 1,653.63 → 1,735.30 OPS (+4.9%) and
+  sync `batch_delete_1000` 4,111.07 → 4,961.03 OPS (+20.7%). Sync/no-sync ratio improved for `put_c` and
+  `batch_delete_1000`, but not yet for `batch_create_1000`.
+  Follow-up same-window A/B: collapsing public `write_batch` classify/validate scans and swapping the batch state read
+  to `ArcSwap::load()` moved sync `batch_create_1000` 1,301.73 → 1,588.21 OPS (+22.0%) versus the immediate control,
+  with `batch_delete_1000` trading down 4,912.19 → 4,591.15 OPS (-6.5%) while still staying above the original
+  baseline.
+  Next slice: MVCC point batches now build entries while proving uniqueness and only fall back to the full last-op-wins
+  dedup path after observing a duplicate. Same command moved `batch_create_1000` essentially flat at 1,588.00 OPS and
+  improved `batch_delete_1000` to 5,453.39 OPS.
+  Follow-up: write-batch duplicate detection now uses in-memory `AHashSet`/`AHashMap` instead of the default hasher.
+  Focused sync rerun moved `batch_create_1000` to 1,678.16 OPS and kept `batch_delete_1000` near flat at 5,414.47 OPS.
+  Follow-up: `MemTable::publish_raw_batch` now batches `approximate_size` accounting into one relaxed atomic add per
+  publish. Immediate outside-sandbox rerun moved `batch_create_1000` 1,554.01 → 1,675.39 OPS, `batch_update_1000`
+  1,132.67 → 1,744.71 OPS, and `batch_delete_1000` 5,062.92 → 5,341.41 OPS. Follow-up: publish now reuses a
+  thread-local user-key decode buffer instead of allocating one per publish call. Same-window sync A/B moved
+  `batch_create_1000` 1,608.03 → 1,767.15 OPS, `batch_update_1000` 1,675.26 → 1,729.03 OPS, and
+  `batch_delete_1000` 4,828.19 → 4,983.64 OPS. Current no-sync comparison before these publish slices:
+  `batch_create_1000` 1,678.16 / 2,660.18 OPS (63.1%), and `batch_delete_1000` 5,414.47 / 7,408.65 OPS (73.1%).
+  The next remaining gap is still durable `batch_create_1000`.
+  Rejected follow-ups: consuming the prepared entry vector in MVCC WAL staging regressed `batch_delete_1000`, and fusing
+  point key validation into entry construction was too noisy/regressive in rerun (`batch_create_1000` fell to 1,099.95
+  OPS). Carrying precomputed user-key bloom hashes through deferred publish also regressed sync `batch_create_1000`
+  (1,182.16 OPS) and `batch_delete_1000` (3,932.22 OPS). Borrowing user keys through MVCC WAL staging also regressed the
+  current kept sync patch (`batch_create_1000` 1,636.52 OPS versus 1,678.16 OPS, and `batch_delete_100` 11,023.76 OPS
+  versus 13,477.38 OPS). Replacing hash-based uniqueness with a strictly-ordered-key fast path also regressed
+  `batch_create_1000` to 1,648.14 OPS and `batch_delete_1000` to 4,793.31 OPS. Replacing MVCC publish-data iterator
+  construction with an explicit preallocated loop improved `batch_delete_1000` but regressed `batch_create_1000` to
+  1,029.54 OPS, so it was reverted. Replacing `DeferredBatchPublish` refs-builder collection with an explicit
+  preallocated loop also regressed `batch_create_1000` to 1,573.97 OPS and `batch_update_1000` to 1,602.41 OPS.
+  Skipping `try_freeze_memtable()`'s state load when the just-written memtable was below threshold also regressed the
+  sync batch rows (`batch_create_1000` 1,090.00 OPS, `batch_update_1000` 1,085.67 OPS, `batch_delete_1000` 2,097.61
+  OPS), so it was reverted.
 - [ ] **Add sync perf gates to the comparison workflow** — Track both absolute Fjall-relative OPS and
   sync/no-sync ratio for `put_c`, `batch_create_100`, `batch_create_1000`, `batch_delete_100`, and
   `batch_delete_1000`. Do not accept buffered-only improvements that regress sync production cases. Initial gates:

--- a/todo.md
+++ b/todo.md
@@ -244,7 +244,9 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   preallocated loop also regressed `batch_create_1000` to 1,573.97 OPS and `batch_update_1000` to 1,602.41 OPS.
   Skipping `try_freeze_memtable()`'s state load when the just-written memtable was below threshold also regressed the
   sync batch rows (`batch_create_1000` 1,090.00 OPS, `batch_update_1000` 1,085.67 OPS, `batch_delete_1000` 2,097.61
-  OPS), so it was reverted.
+  OPS), so it was reverted. Removing the WAL point-batch validated length vector was also rejected: same-window
+  outside-sandbox sync A/B on 2026-07-15 moved `batch_create_1000` 1,682.54 → 1,682.08 OPS, but regressed
+  `batch_update_1000` 1,724.53 → 1,162.76 OPS and `batch_delete_1000` 5,716.15 → 4,862.19 OPS.
 - [ ] **Add sync perf gates to the comparison workflow** — Track both absolute Fjall-relative OPS and
   sync/no-sync ratio for `put_c`, `batch_create_100`, `batch_create_1000`, `batch_delete_100`, and
   `batch_delete_1000`. Do not accept buffered-only improvements that regress sync production cases. Initial gates:


### PR DESCRIPTION
## Summary

Reduce durable write-batch overhead in the ToyKV write path.

## Changes

- Build MVCC write-batch publish data once with explicit raw vs prefixed entry kinds.
- Fast-path unique point batches before falling back to duplicate-key last-op-wins dedup.
- Batch memtable approximate-size accounting during publish.
- Reuse a thread-local user-key decode buffer during publish.
- Add a size-gated WAL group-commit spin wait for large solo batches so peer writers can join the same fdatasync.
- Record rejected WAL/disk experiments and benchmark decisions in todo.md.

## Benchmark

Fresh same-window confirmation, pre-spin baseline 92f5648 -> spin candidate ad19469:

- batch_create_100: 5,566.34 -> 7,288.64 OPS (+30.9%)
- batch_update_100: 5,287.60 -> 6,360.90 OPS (+20.3%)
- batch_delete_100: 12,059.83 -> 11,360.21 OPS (-5.8%)
- batch_create_1000: 1,497.92 -> 1,633.43 OPS (+9.0%)
- batch_update_1000: 1,098.52 -> 1,533.26 OPS (+39.6%)
- batch_delete_1000: 2,908.38 -> 5,163.55 OPS (+77.5%)

Earlier same-window runs for the publish-path slices are recorded in todo.md.

## Verification

- cargo fmt --all --check
- git diff --check
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- cargo nextest run --workspace --all-features test_ttl_write_batch_put_with_ttl test_write_batch test_mvcc_write_batch_ts_advances test_mvcc_write_batch_inner_ts_advances test_serializable_write_batch wal
- Subagent review of the full branch diff found no correctness, durability, concurrency, MVCC/write_batch semantic, or WAL ordering regressions after the wording fix in b98d64b.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved write-batch efficiency via faster deduplication and reduced per-entry allocations during batch publication.
  * Enhanced MVCC WAL durability throughput by improving solo-leader group-commit waiting behavior.
* **Reliability**
  * Added stricter validation to reject mixed point+range batches (where not supported) and improved MVCC write classification for raw vs prefixed values and tombstones.
* **Tests**
  * Updated MVCC WAL write-batch tests to match the new batch value-kind semantics.
* **Documentation**
  * Expanded sync-performance notes with additional benchmark results and updated RocksDB backend version mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->