### PR TITLE
docs: point perf gate to crud-bench

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ When evaluating a write-path performance patch, run the
 against the previous and current CSV artifacts:
 
 ```bash
-cd crud-bench-checkout
+cd "$CRUD_BENCH_CHECKOUT"
 cargo run --release --bin perf-gate -- \
   --baseline-sync previous-toykv-sync.csv \
   --current-sync current-toykv-sync.csv \

--- a/README.md
+++ b/README.md
@@ -258,6 +258,22 @@ for the full numbers, caveats, and artifact names. See
 [ToyKV vs RocksDB Benchmark Report](docs/bench-report-crud-bench-rocksdb.md) for
 the RocksDB comparison numbers, parity notes, gates, and next target.
 
+When evaluating a write-path performance patch, run the `crud-bench`
+`perf-gate` checker against the previous and current CSV artifacts:
+
+```bash
+cd <crud-bench checkout>
+cargo run --bin perf-gate -- \
+  --baseline-sync <previous-toykv-sync.csv> \
+  --current-sync <current-toykv-sync.csv> \
+  --baseline-nosync <previous-toykv-nosync.csv> \
+  --current-nosync <current-toykv-nosync.csv> \
+  --fjall-sync <current-fjall-sync.csv>
+```
+
+Add `--baseline-latency-sync` and `--current-latency-sync` with single-client
+sync CSVs when checking p95/p99 latency.
+
 ## Docs And RFCs
 
 ### Reports

--- a/README.md
+++ b/README.md
@@ -263,13 +263,13 @@ When evaluating a write-path performance patch, run the
 against the previous and current CSV artifacts:
 
 ```bash
-cd <crud-bench checkout>
+cd crud-bench-checkout
 cargo run --release --bin perf-gate -- \
-  --baseline-sync <previous-toykv-sync.csv> \
-  --current-sync <current-toykv-sync.csv> \
-  --baseline-nosync <previous-toykv-nosync.csv> \
-  --current-nosync <current-toykv-nosync.csv> \
-  --fjall-sync <current-fjall-sync.csv>
+  --baseline-sync previous-toykv-sync.csv \
+  --current-sync current-toykv-sync.csv \
+  --baseline-nosync previous-toykv-nosync.csv \
+  --current-nosync current-toykv-nosync.csv \
+  --fjall-sync current-fjall-sync.csv
 ```
 
 Add `--baseline-latency-sync` and `--current-latency-sync` with single-client

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ against the previous and current CSV artifacts:
 
 ```bash
 cd <crud-bench checkout>
-cargo run --bin perf-gate -- \
+cargo run --release --bin perf-gate -- \
   --baseline-sync <previous-toykv-sync.csv> \
   --current-sync <current-toykv-sync.csv> \
   --baseline-nosync <previous-toykv-nosync.csv> \

--- a/README.md
+++ b/README.md
@@ -258,8 +258,9 @@ for the full numbers, caveats, and artifact names. See
 [ToyKV vs RocksDB Benchmark Report](docs/bench-report-crud-bench-rocksdb.md) for
 the RocksDB comparison numbers, parity notes, gates, and next target.
 
-When evaluating a write-path performance patch, run the `crud-bench`
-`perf-gate` checker against the previous and current CSV artifacts:
+When evaluating a write-path performance patch, run the
+[`crud-bench`](https://github.com/ben1009/crud-bench) `perf-gate` checker
+against the previous and current CSV artifacts:
 
 ```bash
 cd <crud-bench checkout>
@@ -272,7 +273,8 @@ cargo run --bin perf-gate -- \
 ```
 
 Add `--baseline-latency-sync` and `--current-latency-sync` with single-client
-sync CSVs when checking p95/p99 latency.
+sync CSVs to gate p95/p99 latency. The latency gate uses the same default rows,
+requires both p95 and p99 to pass, and allows at most 5% regression per metric.
 
 ## Docs And RFCs
 

--- a/docs/bench-report-crud-bench-rocksdb.md
+++ b/docs/bench-report-crud-bench-rocksdb.md
@@ -207,7 +207,7 @@ The repeatable gate checker lives in the
 
 ```bash
 cd <crud-bench checkout>
-cargo run --bin perf-gate -- \
+cargo run --release --bin perf-gate -- \
   --baseline-sync <previous-toykv-sync.csv> \
   --current-sync <current-toykv-sync.csv> \
   --baseline-nosync <previous-toykv-nosync.csv> \

--- a/docs/bench-report-crud-bench-rocksdb.md
+++ b/docs/bench-report-crud-bench-rocksdb.md
@@ -202,7 +202,8 @@ Use these gates before accepting performance-oriented ToyKV changes:
 - Do not accept buffered-only improvements that regress durable `--sync`
   workloads.
 
-The repeatable gate checker lives in the `crud-bench` checkout:
+The repeatable gate checker lives in the
+[`crud-bench`](https://github.com/ben1009/crud-bench) checkout:
 
 ```bash
 cd <crud-bench checkout>
@@ -218,8 +219,9 @@ The default rows are `put_c`, `batch_create_100`, `batch_create_1000`,
 `batch_delete_100`, and `batch_delete_1000`. The default sync/no-sync ratio
 gate requires improvement on at least two of `put_c`, `batch_create_1000`, and
 `batch_delete_1000`. Add `--baseline-latency-sync` and
-`--current-latency-sync` with single-client sync CSVs to enforce the p95/p99
-latency gate.
+`--current-latency-sync` with single-client sync CSVs to enforce the latency
+gate on the same default rows. Both p95 and p99 must pass, and each metric may
+regress by at most 5% versus the baseline latency CSV.
 
 Priority profiling rows:
 

--- a/docs/bench-report-crud-bench-rocksdb.md
+++ b/docs/bench-report-crud-bench-rocksdb.md
@@ -202,6 +202,25 @@ Use these gates before accepting performance-oriented ToyKV changes:
 - Do not accept buffered-only improvements that regress durable `--sync`
   workloads.
 
+The repeatable gate checker lives in the `crud-bench` checkout:
+
+```bash
+cd <crud-bench checkout>
+cargo run --bin perf-gate -- \
+  --baseline-sync <previous-toykv-sync.csv> \
+  --current-sync <current-toykv-sync.csv> \
+  --baseline-nosync <previous-toykv-nosync.csv> \
+  --current-nosync <current-toykv-nosync.csv> \
+  --fjall-sync <current-fjall-sync.csv>
+```
+
+The default rows are `put_c`, `batch_create_100`, `batch_create_1000`,
+`batch_delete_100`, and `batch_delete_1000`. The default sync/no-sync ratio
+gate requires improvement on at least two of `put_c`, `batch_create_1000`, and
+`batch_delete_1000`. Add `--baseline-latency-sync` and
+`--current-latency-sync` with single-client sync CSVs to enforce the p95/p99
+latency gate.
+
 Priority profiling rows:
 
 - None currently confirmed above the profiling gate. The durable

--- a/docs/bench-report-crud-bench-rocksdb.md
+++ b/docs/bench-report-crud-bench-rocksdb.md
@@ -206,13 +206,13 @@ The repeatable gate checker lives in the
 [`crud-bench`](https://github.com/ben1009/crud-bench) checkout:
 
 ```bash
-cd <crud-bench checkout>
+cd crud-bench-checkout
 cargo run --release --bin perf-gate -- \
-  --baseline-sync <previous-toykv-sync.csv> \
-  --current-sync <current-toykv-sync.csv> \
-  --baseline-nosync <previous-toykv-nosync.csv> \
-  --current-nosync <current-toykv-nosync.csv> \
-  --fjall-sync <current-fjall-sync.csv>
+  --baseline-sync previous-toykv-sync.csv \
+  --current-sync current-toykv-sync.csv \
+  --baseline-nosync previous-toykv-nosync.csv \
+  --current-nosync current-toykv-nosync.csv \
+  --fjall-sync current-fjall-sync.csv
 ```
 
 The default rows are `put_c`, `batch_create_100`, `batch_create_1000`,

--- a/docs/bench-report-crud-bench-rocksdb.md
+++ b/docs/bench-report-crud-bench-rocksdb.md
@@ -206,7 +206,7 @@ The repeatable gate checker lives in the
 [`crud-bench`](https://github.com/ben1009/crud-bench) checkout:
 
 ```bash
-cd crud-bench-checkout
+cd "$CRUD_BENCH_CHECKOUT"
 cargo run --release --bin perf-gate -- \
   --baseline-sync previous-toykv-sync.csv \
   --current-sync current-toykv-sync.csv \

--- a/todo.md
+++ b/todo.md
@@ -286,7 +286,7 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   sync/no-sync ratio for `put_c`, `batch_create_100`, `batch_create_1000`, `batch_delete_100`, and
   `batch_delete_1000`. Do not accept buffered-only improvements that regress sync production cases. Initial gates:
   no focused sync row regresses by more than 5%, sync/no-sync ratio improves for at least two of `put_c`,
-  `batch_create_1000`, and `batch_delete_1000`, and single-client sync p95/p99 latency on the same default rows each
+  `batch_create_1000`, and `batch_delete_1000`, and single-client sync p95/p99 latencies on the same default rows each
   regress by no more than 5%.
   Implemented in the sibling `crud-bench` checkout as `cargo run --release --bin perf-gate -- ...`, where the CSV
   schema is owned.

--- a/todo.md
+++ b/todo.md
@@ -282,11 +282,13 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   `batch_delete_100` 11,340.75 / 4,741.47 OPS (+139.2%), `batch_create_1000` 1,497.21 / 413.55 OPS (+262.0%),
   `batch_read_1000` 5,719.06 / 5,011.33 OPS (+14.1%), `batch_update_1000` 1,532.62 / 369.53 OPS (+314.7%), and
   `batch_delete_1000` 4,547.50 / 318.29 OPS (+1328.7%). RocksDB is slightly ahead only on single-op `Update`.
-- [ ] **Add sync perf gates to the comparison workflow** — Track both absolute Fjall-relative OPS and
+- [x] **Add sync perf gates to the comparison workflow** — Track both absolute Fjall-relative OPS and
   sync/no-sync ratio for `put_c`, `batch_create_100`, `batch_create_1000`, `batch_delete_100`, and
   `batch_delete_1000`. Do not accept buffered-only improvements that regress sync production cases. Initial gates:
   no focused sync row regresses by more than 5%, sync/no-sync ratio improves for at least two of `put_c`,
   `batch_create_1000`, and `batch_delete_1000`, and single-client sync p95/p99 latency does not materially regress.
+  Implemented in the sibling `crud-bench` checkout as `cargo run --bin perf-gate -- ...`, where the CSV schema is
+  owned.
 - [x] **Add durable RocksDB comparison** — Ran the existing `crud-bench` embedded RocksDB backend alongside ToyKV and
   Fjall with `--sync --samples 100000 --clients 4 --threads 4`, then filled in
   `docs/bench-report-crud-bench-rocksdb.md`. ToyKV wins point reads and large durable batch writes; RocksDB wins

--- a/todo.md
+++ b/todo.md
@@ -286,7 +286,8 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   sync/no-sync ratio for `put_c`, `batch_create_100`, `batch_create_1000`, `batch_delete_100`, and
   `batch_delete_1000`. Do not accept buffered-only improvements that regress sync production cases. Initial gates:
   no focused sync row regresses by more than 5%, sync/no-sync ratio improves for at least two of `put_c`,
-  `batch_create_1000`, and `batch_delete_1000`, and single-client sync p95/p99 latency does not materially regress.
+  `batch_create_1000`, and `batch_delete_1000`, and single-client sync p95/p99 latency on the same default rows each
+  regress by no more than 5%.
   Implemented in the sibling `crud-bench` checkout as `cargo run --bin perf-gate -- ...`, where the CSV schema is
   owned.
 - [x] **Add durable RocksDB comparison** — Ran the existing `crud-bench` embedded RocksDB backend alongside ToyKV and

--- a/todo.md
+++ b/todo.md
@@ -288,8 +288,8 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   no focused sync row regresses by more than 5%, sync/no-sync ratio improves for at least two of `put_c`,
   `batch_create_1000`, and `batch_delete_1000`, and single-client sync p95/p99 latency on the same default rows each
   regress by no more than 5%.
-  Implemented in the sibling `crud-bench` checkout as `cargo run --bin perf-gate -- ...`, where the CSV schema is
-  owned.
+  Implemented in the sibling `crud-bench` checkout as `cargo run --release --bin perf-gate -- ...`, where the CSV
+  schema is owned.
 - [x] **Add durable RocksDB comparison** — Ran the existing `crud-bench` embedded RocksDB backend alongside ToyKV and
   Fjall with `--sync --samples 100000 --clients 4 --threads 4`, then filled in
   `docs/bench-report-crud-bench-rocksdb.md`. ToyKV wins point reads and large durable batch writes; RocksDB wins

--- a/todo.md
+++ b/todo.md
@@ -288,8 +288,8 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   no focused sync row regresses by more than 5%, sync/no-sync ratio improves for at least two of `put_c`,
   `batch_create_1000`, and `batch_delete_1000`, and single-client sync p95/p99 latencies on the same default rows each
   regress by no more than 5%.
-  Implemented in the sibling `crud-bench` checkout as `cargo run --release --bin perf-gate -- ...`, where the CSV
-  schema is owned.
+  Implemented in the sibling `crud-bench` checkout using the `perf-gate` command; see `README.md` for the full
+  arguments. The CSV schema is owned there.
 - [x] **Add durable RocksDB comparison** — Ran the existing `crud-bench` embedded RocksDB backend alongside ToyKV and
   Fjall with `--sync --samples 100000 --clients 4 --threads 4`, then filled in
   `docs/bench-report-crud-bench-rocksdb.md`. ToyKV wins point reads and large durable batch writes; RocksDB wins


### PR DESCRIPTION
## Summary

Updates ToyKV docs to treat crud-bench as the owner of the perf-gate checker.

## Changes
- Point write-path perf validation docs at the crud-bench perf-gate command
- Update the RocksDB benchmark gate section with the external checker workflow
- Mark the sync perf gate TODO complete with the checker living in crud-bench

Related: surrealdb/crud-bench#273

## Verification
- cargo fmt --all
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions for evaluating write-path performance using repeatable benchmark comparisons.
  * Documented sync and no-sync workload inputs, Fjall comparisons, and supported benchmark scenarios.
  * Added guidance for checking p95 and p99 latency thresholds.
  * Marked sync performance gates as completed in the project checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->