### PR TITLE
perf: move MVCC batch entries into publish path

### DIFF
--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -4829,7 +4829,7 @@ impl LsmStorageInner {
     /// Write a batch through MVCC (used by transaction commit).
     pub(crate) fn mvcc_write_batch(
         &self,
-        entries: &[(bytes::Bytes, bytes::Bytes, crate::mvcc::BatchEntryKind)],
+        entries: Vec<(bytes::Bytes, bytes::Bytes, crate::mvcc::BatchEntryKind)>,
     ) -> Result<()> {
         let mvcc = self.mvcc.as_ref().expect("mvcc_write_batch requires MVCC");
         let (commit_ts, memtable, publish_data) = {
@@ -5155,7 +5155,7 @@ impl LsmStorageInner {
 
     pub(crate) fn mvcc_write_batch_inner(
         &self,
-        entries: &[(bytes::Bytes, bytes::Bytes, crate::mvcc::BatchEntryKind)],
+        entries: Vec<(bytes::Bytes, bytes::Bytes, crate::mvcc::BatchEntryKind)>,
     ) -> Result<u64> {
         let mvcc = self
             .mvcc
@@ -6021,7 +6021,7 @@ impl LsmStorageInner {
                 let (entries, dedup_indices) =
                     Self::build_unique_point_batch_entries_or_dedup(batch);
                 // WAL-only: do NOT publish to skiplist yet.
-                let (commit_ts, data) = mvcc.write_batch_wal_only(&entries, &state.memtable)?;
+                let (commit_ts, data) = mvcc.write_batch_wal_only(entries, &state.memtable)?;
                 mvcc_commit_ts = commit_ts;
                 // Defer record_committed_txn until after commit_wal succeeds
                 // so that failed WAL syncs don't poison serializable validation.

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -293,7 +293,7 @@ impl LsmMvccInner {
     #[allow(clippy::type_complexity)]
     pub(crate) fn write_batch_wal_only(
         &self,
-        entries: &[(bytes::Bytes, bytes::Bytes, BatchEntryKind)],
+        entries: Vec<(bytes::Bytes, bytes::Bytes, BatchEntryKind)>,
         memtable: &MemTable,
     ) -> Result<(u64, DeferredBatchPublish), anyhow::Error> {
         if entries.is_empty() {
@@ -302,22 +302,22 @@ impl LsmMvccInner {
         let _write_guard = self.write_lock.lock();
         let commit_ts = self.current_ts.load(Ordering::Acquire) + 1;
         let publish_data: Vec<(Bytes, Bytes)> = entries
-            .iter()
+            .into_iter()
             .map(|(key, value, kind)| match kind {
                 BatchEntryKind::Delete => (
-                    Bytes::from(encode_internal_key(key, commit_ts)),
+                    Bytes::from(encode_internal_key(key.as_ref(), commit_ts)),
                     Bytes::from_static(TOMBSTONE_VALUE),
                 ),
                 BatchEntryKind::PutPrefixed => (
-                    Bytes::from(encode_internal_key(key, commit_ts)),
-                    value.clone(),
+                    Bytes::from(encode_internal_key(key.as_ref(), commit_ts)),
+                    value,
                 ),
                 BatchEntryKind::PutRaw => {
                     let mut p = Vec::with_capacity(1 + value.len());
                     p.push(crate::vlog::KvKind::Inline as u8);
                     p.extend_from_slice(value.as_ref());
                     (
-                        Bytes::from(encode_internal_key(key, commit_ts)),
+                        Bytes::from(encode_internal_key(key.as_ref(), commit_ts)),
                         Bytes::from(p),
                     )
                 }

--- a/kv-engine/src/mvcc/txn.rs
+++ b/kv-engine/src/mvcc/txn.rs
@@ -447,11 +447,7 @@ impl Transaction {
                     }
                 }
                 // No conflict — write batch and record our write_set.
-                let owned: Vec<(bytes::Bytes, bytes::Bytes, crate::mvcc::BatchEntryKind)> = entries
-                    .iter()
-                    .map(|(k, v, t)| (k.clone(), v.clone(), *t))
-                    .collect();
-                let commit_ts = self.inner.mvcc_write_batch_inner(&owned)?;
+                let commit_ts = self.inner.mvcc_write_batch_inner(entries)?;
                 // Record our write_set in committed_txns.
                 mvcc.record_committed_txn(
                     commit_ts,
@@ -469,11 +465,7 @@ impl Transaction {
             }
         }
         // Non-serializable path (or read-only serializable).
-        let owned: Vec<(bytes::Bytes, bytes::Bytes, crate::mvcc::BatchEntryKind)> = entries
-            .iter()
-            .map(|(k, v, t)| (k.clone(), v.clone(), *t))
-            .collect();
-        if let Err(e) = self.inner.mvcc_write_batch(&owned) {
+        if let Err(e) = self.inner.mvcc_write_batch(entries) {
             // Revert committed flag so caller can retry.
             self.committed
                 .store(false, std::sync::atomic::Ordering::SeqCst);
@@ -599,11 +591,7 @@ impl Transaction {
                                     }
                                 }
                             }
-                            let owned_bytes: Vec<(bytes::Bytes, bytes::Bytes, crate::mvcc::BatchEntryKind)> = owned
-                                .iter()
-                                .map(|(k, v, t)| (k.clone(), v.clone(), *t))
-                                .collect();
-                            match inner1.mvcc_write_batch_inner(&owned_bytes) {
+                            match inner1.mvcc_write_batch_inner(owned) {
                                 Ok(commit_ts) => {
                                     mvcc_ref.record_committed_txn(
                                         commit_ts,
@@ -643,15 +631,7 @@ impl Transaction {
             let result: Result<WriteBatchStep> = blocking
                 .run_result(move || {
                     let read_guard = read_guard;
-                    let owned_bytes: Vec<(
-                        bytes::Bytes,
-                        bytes::Bytes,
-                        crate::mvcc::BatchEntryKind,
-                    )> = owned
-                        .iter()
-                        .map(|(k, v, t)| (k.clone(), v.clone(), *t))
-                        .collect();
-                    match inner.mvcc_write_batch(&owned_bytes) {
+                    match inner.mvcc_write_batch(owned) {
                         Ok(()) => Ok(WriteBatchStep::Committed),
                         Err(error) => Ok(WriteBatchStep::RestoreErr(error, read_guard)),
                     }

--- a/kv-engine/src/tests/wal.rs
+++ b/kv-engine/src/tests/wal.rs
@@ -1671,7 +1671,7 @@ fn test_mvcc_write_batch_ts_advances() {
 
     let ts_before = mvcc.read_ts();
     storage
-        .mvcc_write_batch(&[
+        .mvcc_write_batch(vec![
             (
                 bytes::Bytes::from_static(b"k1"),
                 bytes::Bytes::from_static(b"v1"),
@@ -1711,7 +1711,7 @@ fn test_mvcc_write_batch_inner_ts_advances() {
 
     let ts_before = mvcc.read_ts();
     let commit_ts = storage
-        .mvcc_write_batch_inner(&[
+        .mvcc_write_batch_inner(vec![
             (
                 bytes::Bytes::from_static(b"k1"),
                 bytes::Bytes::from_static(b"v1"),


### PR DESCRIPTION
## Summary

- Move owned MVCC point-batch entries into the WAL-only publish path.
- Avoid cloning prefixed values while building deferred publish data.
- Remove extra transaction commit clone vectors for sync and async MVCC batch commits.

## Verification

- cargo fmt --all --check
- git diff --check
- cargo test --package kv-engine test_mvcc_write_batch --all-features
- cargo test --package kv-engine write_batch --all-features
- cargo clippy --package kv-engine --all-features -- -D warnings
- cargo test --package kv-engine --lib --all-features (692 passed; remaining failures are local io_uring EPERM when creating rings)

## Benchmark Result

Rejected by outside-sandbox focused sync crud-bench A/B against origin/main (8e105f9) using:

cargo run --release --no-default-features --features toykv -- -d toykv -s 100000 -c 4 -t 4 --sync --skip-indexes --skip-scans --color never

Key OPS deltas:

| Row | origin/main | PR | Delta |
| --- | ---: | ---: | ---: |
| batch_create_100 | 13797.72 | 13634.77 | -1.18% |
| batch_read_100 | 32180.97 | 30756.42 | -4.43% |
| batch_update_100 | 12928.56 | 13795.53 | +6.71% |
| batch_delete_100 | 32223.05 | 31985.69 | -0.74% |
| batch_create_1000 | 1702.84 | 1706.70 | +0.23% |
| batch_read_1000 | 6703.26 | 6061.71 | -9.57% |
| batch_update_1000 | 1750.97 | 1867.54 | +6.66% |
| batch_delete_1000 | 7203.09 | 6631.52 | -7.94% |

This is not worth keeping as a performance PR.