### PR TITLE
perf: tune WAL solo group-commit spin

### DIFF
--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -76,7 +76,7 @@ const MAX_WRITES_PER_CHUNK: usize = RING_SIZE;
 const PREALLOC_BLOCK: u64 = 1 << 20;
 /// Briefly spin before a solo leader drains the WAL queue so peer writers can
 /// join the same fdatasync.
-const GROUP_COMMIT_SOLO_SPINS: usize = 8;
+const GROUP_COMMIT_SOLO_SPINS: usize = 4;
 /// Only delay solo leaders for larger batches where one extra peer can amortize
 /// a meaningful fdatasync cost.
 const GROUP_COMMIT_MIN_SOLO_BYTES: usize = 512 * 1024;

--- a/todo.md
+++ b/todo.md
@@ -266,7 +266,12 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   latency. Same-window sync A/B moved `batch_create_100` 3,085.46 → 6,738.57 OPS, `batch_update_100`
   2,220.15 → 5,991.32 OPS, `batch_delete_100` 3,789.87 → 11,160.01 OPS, `batch_create_1000`
   1,008.80 → 1,593.44 OPS, `batch_update_1000` 886.57 → 1,657.93 OPS, and `batch_delete_1000`
-  2,039.08 → 4,079.75 OPS.
+  2,039.08 → 4,079.75 OPS. Follow-up after merging the `crud-bench` ToyKV adapter: shortening the solo
+  leader spin window from 8 to 4 iterations kept the same 512 KiB gate and improved the fresh focused sync run
+  (`--samples 100000 --clients 4 --threads 4 --sync --skip-indexes --skip-scans`) from `batch_create_1000`
+  1,661.72 to 1,679.79 OPS, `batch_update_1000` 1,582.71 to 1,593.73 OPS, and `batch_delete_1000`
+  4,458.76 to 5,376.32 OPS. Increasing the spin window to 16 was rejected: the same run shape regressed
+  `batch_create_1000` to 1,197.35 OPS and `batch_update_1000` to 1,551.00 OPS.
   Final PR-head sync/no-sync comparison artifacts:
   `result-toykv_pr174_final_sync_100k.csv` and `result-toykv_pr174_final_nosync_100k.csv`. Same command shape
   (`--samples 100000 --clients 4 --threads 4 --skip-indexes --skip-scans`) shows durable batch writes remain below

--- a/todo.md
+++ b/todo.md
@@ -251,7 +251,11 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   `batch_create_1000` 1,074.83 → 1,565.98 OPS in a noisy baseline window, but regressed `batch_update_1000`
   1,587.33 → 1,563.96 OPS and `batch_delete_1000` 5,078.36 → 4,752.27 OPS. Increasing WAL fallocate granularity
   from 1 MiB to 16 MiB was a hard reject: same-window sync A/B moved `batch_create_1000` 1,726.79 → 983.89 OPS,
-  `batch_update_1000` 1,674.46 → 629.46 OPS, and `batch_delete_1000` 4,989.86 → 1,481.66 OPS.
+  `batch_update_1000` 1,674.46 → 629.46 OPS, and `batch_delete_1000` 4,989.86 → 1,481.66 OPS. Splitting
+  `WriteBatchRecord` into separate key/value generic types so the `crud-bench` ToyKV adapter could use stack `[u8; 4]`
+  integer keys was also rejected: three outside-sandbox focused sync A/B samples averaged `batch_create_1000`
+  1,788.90 → 1,732.37 OPS (-3.2%) and `batch_delete_1000` 6,601.51 → 5,950.58 OPS (-9.9%), despite
+  `batch_update_1000` moving 1,874.72 → 1,922.31 OPS (+2.5%).
   Kept sync-side follow-up: group-commit leaders now briefly delay only for solo WAL buffers at least 512 KiB, giving
   peer writers a chance to join the same `fdatasync` without taxing smaller writes. Same-window sync A/B moved
   `batch_create_100` 7,119.76 → 6,992.20 OPS, `batch_update_100` 7,041.70 → 7,878.78 OPS,


### PR DESCRIPTION
## Summary

- record the rejected split-key WriteBatchRecord experiment in the performance TODO
- shorten the WAL solo group-commit spin window from 8 to 4 iterations
- document the accepted 4-spin result and rejected 16-spin result from focused crud-bench runs

## Benchmark

Focused ToyKV sync run via merged crud-bench adapter:

```bash
cargo run --release --bin crud-bench --no-default-features --features toykv --   -d toykv -s 100000 -c 4 -t 4 --sync --skip-indexes --skip-scans --color never
```

Baseline 8 spins -> candidate 4 spins:

- batch_create_1000: 1661.72 -> 1679.79 OPS
- batch_update_1000: 1582.71 -> 1593.73 OPS
- batch_delete_1000: 4458.76 -> 5376.32 OPS

Rejected 16-spin candidate:

- batch_create_1000 regressed to 1197.35 OPS
- batch_update_1000 regressed to 1551.00 OPS

## Verification

- `cargo fmt --all --check`
- `cargo check --workspace --all-features`
- `cargo nextest run --workspace --all-features wal::test_wal_group_commit_multiple_writers`
- focused crud-bench ToyKV sync benchmark outside sandbox