### PR TITLE
perf: profile WAL group commit shape

### DIFF
--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -525,6 +525,8 @@ fn print_write_profile(engine: &KvEngine, label: &str) {
          wal_write:    {:>8.2} ms  ({:>5.1}%)\n  \
          wal_sync:     {:>8.2} ms  ({:>5.1}%)\n  \
          memtable:     {:>8.2} ms  ({:>5.1}%)\n  \
+         commit_groups: {:>7}  solo={:>7} ({:>5.1}%)  avg_bufs={:>5.2}  max_bufs={:>3}\n  \
+         commit_bytes:  avg={:>8.0} B  max={:>8} B\n  \
          total:        {:>8.2} ms",
         p.op_count,
         p.wal_write_ms(),
@@ -541,6 +543,13 @@ fn print_write_profile(engine: &KvEngine, label: &str) {
         } else {
             0.0
         },
+        p.wal_commit_groups,
+        p.wal_commit_solo_groups,
+        p.wal_commit_solo_pct(),
+        p.wal_commit_avg_buffers(),
+        p.wal_commit_max_buffers,
+        p.wal_commit_avg_bytes(),
+        p.wal_commit_max_bytes,
         total,
     );
 }

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -825,24 +825,23 @@ impl MemTable {
                 return Ok(());
             }
             #[cfg(feature = "bench")]
-            let t = Instant::now();
-            #[cfg(feature = "bench")]
-            let write_profile = self.write_profile.load();
-            #[cfg(feature = "bench")]
-            crate::profile_scope!(
-                "wal.submit_and_commit",
-                wal.submit_and_commit_profiled(watermark - 1, &write_profile)
-            )?;
+            {
+                let t = Instant::now();
+                let write_profile = self.write_profile.load();
+                crate::profile_scope!(
+                    "wal.submit_and_commit",
+                    wal.submit_and_commit_profiled(watermark - 1, &write_profile)
+                )?;
+                write_profile.wal_sync_ns.fetch_add(
+                    t.elapsed().as_nanos() as u64,
+                    std::sync::atomic::Ordering::Relaxed,
+                );
+            }
             #[cfg(not(feature = "bench"))]
             crate::profile_scope!(
                 "wal.submit_and_commit",
                 wal.submit_and_commit(watermark - 1)
             )?;
-            #[cfg(feature = "bench")]
-            write_profile.wal_sync_ns.fetch_add(
-                t.elapsed().as_nanos() as u64,
-                std::sync::atomic::Ordering::Relaxed,
-            );
         }
 
         Ok(())

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -46,6 +46,18 @@ pub struct WriteProfile {
     pub wal_sync_ns: AtomicU64,
     /// Time inserting into the SkipMap + bloom filter.
     pub memtable_insert_ns: AtomicU64,
+    /// Number of WAL commit groups that reached fdatasync.
+    pub wal_commit_groups: AtomicU64,
+    /// Number of WAL commit groups that only contained one pending buffer.
+    pub wal_commit_solo_groups: AtomicU64,
+    /// Total pending buffers drained across all WAL commit groups.
+    pub wal_commit_buffers: AtomicU64,
+    /// Total aligned bytes submitted across all WAL commit groups.
+    pub wal_commit_bytes: AtomicU64,
+    /// Maximum pending buffers drained by one WAL commit group.
+    pub wal_commit_max_buffers: AtomicU64,
+    /// Maximum aligned bytes submitted by one WAL commit group.
+    pub wal_commit_max_bytes: AtomicU64,
     /// Number of write operations profiled.
     pub op_count: AtomicU64,
 }
@@ -57,8 +69,27 @@ impl WriteProfile {
             wal_write_ns: self.wal_write_ns.load(o),
             wal_sync_ns: self.wal_sync_ns.load(o),
             memtable_insert_ns: self.memtable_insert_ns.load(o),
+            wal_commit_groups: self.wal_commit_groups.load(o),
+            wal_commit_solo_groups: self.wal_commit_solo_groups.load(o),
+            wal_commit_buffers: self.wal_commit_buffers.load(o),
+            wal_commit_bytes: self.wal_commit_bytes.load(o),
+            wal_commit_max_buffers: self.wal_commit_max_buffers.load(o),
+            wal_commit_max_bytes: self.wal_commit_max_bytes.load(o),
             op_count: self.op_count.load(o),
         }
+    }
+
+    #[cfg(feature = "bench")]
+    pub(crate) fn record_wal_commit_group(&self, buffers: u64, bytes: u64) {
+        let o = std::sync::atomic::Ordering::Relaxed;
+        self.wal_commit_groups.fetch_add(1, o);
+        if buffers == 1 {
+            self.wal_commit_solo_groups.fetch_add(1, o);
+        }
+        self.wal_commit_buffers.fetch_add(buffers, o);
+        self.wal_commit_bytes.fetch_add(bytes, o);
+        self.wal_commit_max_buffers.fetch_max(buffers, o);
+        self.wal_commit_max_bytes.fetch_max(bytes, o);
     }
 }
 
@@ -67,6 +98,12 @@ pub struct WriteProfileSnapshot {
     pub wal_write_ns: u64,
     pub wal_sync_ns: u64,
     pub memtable_insert_ns: u64,
+    pub wal_commit_groups: u64,
+    pub wal_commit_solo_groups: u64,
+    pub wal_commit_buffers: u64,
+    pub wal_commit_bytes: u64,
+    pub wal_commit_max_buffers: u64,
+    pub wal_commit_max_bytes: u64,
     pub op_count: u64,
 }
 
@@ -93,6 +130,30 @@ impl WriteProfileSnapshot {
             0.0
         } else {
             self.wal_sync_ms() / total * 100.0
+        }
+    }
+
+    pub fn wal_commit_avg_buffers(&self) -> f64 {
+        if self.wal_commit_groups == 0 {
+            0.0
+        } else {
+            self.wal_commit_buffers as f64 / self.wal_commit_groups as f64
+        }
+    }
+
+    pub fn wal_commit_avg_bytes(&self) -> f64 {
+        if self.wal_commit_groups == 0 {
+            0.0
+        } else {
+            self.wal_commit_bytes as f64 / self.wal_commit_groups as f64
+        }
+    }
+
+    pub fn wal_commit_solo_pct(&self) -> f64 {
+        if self.wal_commit_groups == 0 {
+            0.0
+        } else {
+            self.wal_commit_solo_groups as f64 / self.wal_commit_groups as f64 * 100.0
         }
     }
 }
@@ -765,12 +826,20 @@ impl MemTable {
             }
             #[cfg(feature = "bench")]
             let t = Instant::now();
+            #[cfg(feature = "bench")]
+            let write_profile = self.write_profile.load();
+            #[cfg(feature = "bench")]
+            crate::profile_scope!(
+                "wal.submit_and_commit",
+                wal.submit_and_commit_profiled(watermark - 1, &write_profile)
+            )?;
+            #[cfg(not(feature = "bench"))]
             crate::profile_scope!(
                 "wal.submit_and_commit",
                 wal.submit_and_commit(watermark - 1)
             )?;
             #[cfg(feature = "bench")]
-            self.write_profile.load().wal_sync_ns.fetch_add(
+            write_profile.wal_sync_ns.fetch_add(
                 t.elapsed().as_nanos() as u64,
                 std::sync::atomic::Ordering::Relaxed,
             );

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -1464,6 +1464,7 @@ impl Wal {
         self.submit_and_commit_inner(ticket, None)
     }
 
+    #[cfg(feature = "bench")]
     pub(crate) fn submit_and_commit_profiled(
         &self,
         ticket: u64,
@@ -1544,7 +1545,7 @@ impl Wal {
     fn submit_as_leader(
         &self,
         ticket: u64,
-        profile: Option<&crate::mem_table::WriteProfile>,
+        _profile: Option<&crate::mem_table::WriteProfile>,
     ) -> Result<()> {
         self.wait_for_group_commit_peers(ticket);
         let ticketed_bufs = self.drain_pending_ticketed_bufs();
@@ -1554,7 +1555,7 @@ impl Wal {
 
         let max_ticket = ticketed_bufs.last().unwrap().ticket;
         #[cfg(feature = "bench")]
-        if let Some(profile) = profile {
+        if let Some(profile) = _profile {
             let buffers = ticketed_bufs.len() as u64;
             let bytes = ticketed_bufs
                 .iter()

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -1461,6 +1461,22 @@ impl Wal {
     /// is still not durable (late arrival after leader drained), it re-enters
     /// the CAS loop to become the leader itself.
     pub fn submit_and_commit(&self, ticket: u64) -> Result<()> {
+        self.submit_and_commit_inner(ticket, None)
+    }
+
+    pub(crate) fn submit_and_commit_profiled(
+        &self,
+        ticket: u64,
+        profile: &crate::mem_table::WriteProfile,
+    ) -> Result<()> {
+        self.submit_and_commit_inner(ticket, Some(profile))
+    }
+
+    fn submit_and_commit_inner(
+        &self,
+        ticket: u64,
+        profile: Option<&crate::mem_table::WriteProfile>,
+    ) -> Result<()> {
         if !self.mvcc_format {
             return self.flush_legacy_wal();
         }
@@ -1497,7 +1513,7 @@ impl Wal {
                 .is_ok();
 
             if is_leader {
-                self.submit_as_leader(ticket)?;
+                self.submit_as_leader(ticket, profile)?;
             } else {
                 // Follower path: wait until the leader commits our ticket.
                 self.wait_for_ticket_durability(ticket)?;
@@ -1525,7 +1541,11 @@ impl Wal {
         Ok(())
     }
 
-    fn submit_as_leader(&self, ticket: u64) -> Result<()> {
+    fn submit_as_leader(
+        &self,
+        ticket: u64,
+        profile: Option<&crate::mem_table::WriteProfile>,
+    ) -> Result<()> {
         self.wait_for_group_commit_peers(ticket);
         let ticketed_bufs = self.drain_pending_ticketed_bufs();
         if ticketed_bufs.is_empty() {
@@ -1533,6 +1553,15 @@ impl Wal {
         }
 
         let max_ticket = ticketed_bufs.last().unwrap().ticket;
+        #[cfg(feature = "bench")]
+        if let Some(profile) = profile {
+            let buffers = ticketed_bufs.len() as u64;
+            let bytes = ticketed_bufs
+                .iter()
+                .map(|buf| DirectBuf::align_up(buf.buf.len()) as u64)
+                .sum();
+            profile.record_wal_commit_group(buffers, bytes);
+        }
         let result = self.submit_sqes_and_poll(ticketed_bufs);
 
         #[cfg(feature = "chaos-testing")]

--- a/todo.md
+++ b/todo.md
@@ -272,6 +272,11 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   1,661.72 to 1,679.79 OPS, `batch_update_1000` 1,582.71 to 1,593.73 OPS, and `batch_delete_1000`
   4,458.76 to 5,376.32 OPS. Increasing the spin window to 16 was rejected: the same run shape regressed
   `batch_create_1000` to 1,197.35 OPS and `batch_update_1000` to 1,551.00 OPS.
+  Follow-up instrumentation: `write-perf --bench wal_concurrent --num 100000 --threads 4 --value-size 1024
+  --profile --features bench` now reports WAL commit-group shape. The first profile showed `wal_sync` still at
+  91.6% of profiled time, with 43,821 commit groups for 100,000 writes, 10.6% solo groups, 2.28 buffers per group on
+  average, and a max group size of 4 buffers / 16 KiB. That points the next optimization away from blind solo-delay
+  tuning and toward either larger effective commit groups or cheaper sync submission.
   Final PR-head sync/no-sync comparison artifacts:
   `result-toykv_pr174_final_sync_100k.csv` and `result-toykv_pr174_final_nosync_100k.csv`. Same command shape
   (`--samples 100000 --clients 4 --threads 4 --skip-indexes --skip-scans`) shows durable batch writes remain below


### PR DESCRIPTION
## Summary

- add bench-feature write profile counters for WAL commit-group shape
- report commit groups, solo percentage, average/max buffers, and average/max bytes in write-perf profiles
- record the first profiling result in the performance TODO

## Profiling Result

Command:

```bash
cargo run --release --features bench --bin write-perf --   --bench wal_concurrent --num 100000 --threads 4 --value-size 1024 --profile --output text
```

Result excerpt:

- wal_sync: 1660.80 ms (91.6%)
- commit_groups: 43821
- solo groups: 4645 (10.6%)
- avg buffers/group: 2.28
- max buffers/group: 4
- avg bytes/group: 9347 B
- max bytes/group: 16384 B

This points the next optimization away from blind solo-delay tuning and toward either larger effective commit groups or cheaper sync submission.

## Verification

- `cargo fmt --all --check`
- `cargo check --workspace --all-features`
- `cargo nextest run --workspace --all-features wal::test_wal_group_commit_multiple_writers`
- profiled `write-perf` run above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WAL commit-group profiling, including group counts, solo-group percentages, buffer usage, commit sizes, and maximums.
  * Added average WAL commit buffer and byte metrics to profiling snapshots.
  * Enhanced write performance output with the new WAL statistics.

* **Documentation**
  * Added follow-up findings on WAL concurrent profiling and potential performance optimization areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->