### PR TITLE
perf: split WAL sync profile phases

### DIFF
--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -524,6 +524,9 @@ fn print_write_profile(engine: &KvEngine, label: &str) {
         "\n--- write profile: {label} ({} ops) ---\n  \
          wal_write:    {:>8.2} ms  ({:>5.1}%)\n  \
          wal_sync:     {:>8.2} ms  ({:>5.1}%)\n  \
+         wal_submit:   {:>8.2} ms\n  \
+         fdatasync:    {:>8.2} ms\n  \
+         follower_wait:{:>8.2} ms\n  \
          memtable:     {:>8.2} ms  ({:>5.1}%)\n  \
          commit_groups: {:>7}  solo={:>7} ({:>5.1}%)  avg_bufs={:>5.2}  max_bufs={:>3}\n  \
          commit_bytes:  avg={:>8.0} B  max={:>8} B\n  \
@@ -537,6 +540,9 @@ fn print_write_profile(engine: &KvEngine, label: &str) {
         },
         p.wal_sync_ms(),
         p.wal_sync_pct(),
+        p.wal_submit_ms(),
+        p.wal_fdatasync_ms(),
+        p.wal_follower_wait_ms(),
         p.memtable_insert_ms(),
         if total > 0.0 {
             p.memtable_insert_ms() / total * 100.0

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -44,6 +44,12 @@ pub struct WriteProfile {
     pub wal_write_ns: AtomicU64,
     /// Time in `Wal::sync` (BufWriter flush + `fsync`).
     pub wal_sync_ns: AtomicU64,
+    /// Time submitting and waiting for WAL write SQEs.
+    pub wal_submit_ns: AtomicU64,
+    /// Time spent in the WAL fdatasync syscall.
+    pub wal_fdatasync_ns: AtomicU64,
+    /// Time followers spend waiting for the leader to publish durability.
+    pub wal_follower_wait_ns: AtomicU64,
     /// Time inserting into the SkipMap + bloom filter.
     pub memtable_insert_ns: AtomicU64,
     /// Number of WAL commit groups that reached fdatasync.
@@ -68,6 +74,9 @@ impl WriteProfile {
         WriteProfileSnapshot {
             wal_write_ns: self.wal_write_ns.load(o),
             wal_sync_ns: self.wal_sync_ns.load(o),
+            wal_submit_ns: self.wal_submit_ns.load(o),
+            wal_fdatasync_ns: self.wal_fdatasync_ns.load(o),
+            wal_follower_wait_ns: self.wal_follower_wait_ns.load(o),
             memtable_insert_ns: self.memtable_insert_ns.load(o),
             wal_commit_groups: self.wal_commit_groups.load(o),
             wal_commit_solo_groups: self.wal_commit_solo_groups.load(o),
@@ -91,12 +100,33 @@ impl WriteProfile {
         self.wal_commit_max_buffers.fetch_max(buffers, o);
         self.wal_commit_max_bytes.fetch_max(bytes, o);
     }
+
+    #[cfg(feature = "bench")]
+    pub(crate) fn record_wal_submit_ns(&self, nanos: u64) {
+        self.wal_submit_ns
+            .fetch_add(nanos, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    #[cfg(feature = "bench")]
+    pub(crate) fn record_wal_fdatasync_ns(&self, nanos: u64) {
+        self.wal_fdatasync_ns
+            .fetch_add(nanos, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    #[cfg(feature = "bench")]
+    pub(crate) fn record_wal_follower_wait_ns(&self, nanos: u64) {
+        self.wal_follower_wait_ns
+            .fetch_add(nanos, std::sync::atomic::Ordering::Relaxed);
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct WriteProfileSnapshot {
     pub wal_write_ns: u64,
     pub wal_sync_ns: u64,
+    pub wal_submit_ns: u64,
+    pub wal_fdatasync_ns: u64,
+    pub wal_follower_wait_ns: u64,
     pub memtable_insert_ns: u64,
     pub wal_commit_groups: u64,
     pub wal_commit_solo_groups: u64,
@@ -114,6 +144,18 @@ impl WriteProfileSnapshot {
 
     pub fn wal_sync_ms(&self) -> f64 {
         self.wal_sync_ns as f64 / 1_000_000.0
+    }
+
+    pub fn wal_submit_ms(&self) -> f64 {
+        self.wal_submit_ns as f64 / 1_000_000.0
+    }
+
+    pub fn wal_fdatasync_ms(&self) -> f64 {
+        self.wal_fdatasync_ns as f64 / 1_000_000.0
+    }
+
+    pub fn wal_follower_wait_ms(&self) -> f64 {
+        self.wal_follower_wait_ns as f64 / 1_000_000.0
     }
 
     pub fn memtable_insert_ms(&self) -> f64 {

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -1554,7 +1554,7 @@ impl Wal {
     fn submit_as_leader(
         &self,
         ticket: u64,
-        _profile: Option<&crate::mem_table::WriteProfile>,
+        profile: Option<&crate::mem_table::WriteProfile>,
     ) -> Result<()> {
         self.wait_for_group_commit_peers(ticket);
         let ticketed_bufs = self.drain_pending_ticketed_bufs();
@@ -1564,7 +1564,7 @@ impl Wal {
 
         let max_ticket = ticketed_bufs.last().unwrap().ticket;
         #[cfg(feature = "bench")]
-        if let Some(profile) = _profile {
+        if let Some(profile) = profile {
             let buffers = ticketed_bufs.len() as u64;
             let bytes = ticketed_bufs
                 .iter()
@@ -1572,7 +1572,7 @@ impl Wal {
                 .sum();
             profile.record_wal_commit_group(buffers, bytes);
         }
-        let result = self.submit_sqes_and_poll(ticketed_bufs, _profile);
+        let result = self.submit_sqes_and_poll(ticketed_bufs, profile);
 
         #[cfg(feature = "chaos-testing")]
         {
@@ -1666,8 +1666,11 @@ impl Wal {
     fn submit_sqes_and_poll(
         &self,
         bufs: Vec<TicketedBuf>,
-        _profile: Option<&crate::mem_table::WriteProfile>,
+        profile: Option<&crate::mem_table::WriteProfile>,
     ) -> Result<()> {
+        #[cfg(not(feature = "bench"))]
+        let _ = profile;
+
         // SAFETY: only called for MVCC WALs which always have a ring.
         let ring_ref = self.ring.as_ref().unwrap();
 
@@ -1797,7 +1800,7 @@ impl Wal {
         }
 
         #[cfg(feature = "bench")]
-        if let Some(profile) = _profile {
+        if let Some(profile) = profile {
             profile.record_wal_submit_ns(submit_start.elapsed().as_nanos() as u64);
         }
 
@@ -1825,7 +1828,7 @@ impl Wal {
                 break;
             }
             #[cfg(feature = "bench")]
-            if let Some(profile) = _profile {
+            if let Some(profile) = profile {
                 profile.record_wal_fdatasync_ns(fdatasync_start.elapsed().as_nanos() as u64);
             }
             if let Some(err) = fdatasync_err {

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -7,6 +7,9 @@ use std::{
     sync::atomic::{AtomicBool, AtomicU64, Ordering},
 };
 
+#[cfg(feature = "bench")]
+use std::time::Instant;
+
 use anyhow::{Context, Result};
 use bytes::{Buf, BufMut, Bytes};
 use crossbeam_queue::ArrayQueue;
@@ -1517,7 +1520,13 @@ impl Wal {
                 self.submit_as_leader(ticket, profile)?;
             } else {
                 // Follower path: wait until the leader commits our ticket.
+                #[cfg(feature = "bench")]
+                let wait_start = Instant::now();
                 self.wait_for_ticket_durability(ticket)?;
+                #[cfg(feature = "bench")]
+                if let Some(profile) = profile {
+                    profile.record_wal_follower_wait_ns(wait_start.elapsed().as_nanos() as u64);
+                }
                 // Our ticket is durable — return success. Don't check
                 // last_error: a subsequent leader's failure should not
                 // affect data that was already committed.
@@ -1563,7 +1572,7 @@ impl Wal {
                 .sum();
             profile.record_wal_commit_group(buffers, bytes);
         }
-        let result = self.submit_sqes_and_poll(ticketed_bufs);
+        let result = self.submit_sqes_and_poll(ticketed_bufs, _profile);
 
         #[cfg(feature = "chaos-testing")]
         {
@@ -1654,7 +1663,11 @@ impl Wal {
     ///
     /// Handles chunked submission when the batch exceeds ring capacity (64 SQEs).
     /// The entire drained set is one logical commit group.
-    fn submit_sqes_and_poll(&self, bufs: Vec<TicketedBuf>) -> Result<()> {
+    fn submit_sqes_and_poll(
+        &self,
+        bufs: Vec<TicketedBuf>,
+        _profile: Option<&crate::mem_table::WriteProfile>,
+    ) -> Result<()> {
         // SAFETY: only called for MVCC WALs which always have a ring.
         let ring_ref = self.ring.as_ref().unwrap();
 
@@ -1689,6 +1702,9 @@ impl Wal {
                 .map(|start| (start, (start + MAX_WRITES_PER_CHUNK).min(len)))
                 .collect()
         };
+
+        #[cfg(feature = "bench")]
+        let submit_start = Instant::now();
 
         for &(chunk_start, chunk_end) in &chunk_ranges {
             let chunk_len = chunk_end - chunk_start;
@@ -1780,6 +1796,11 @@ impl Wal {
             global_idx += chunk_len as u64;
         }
 
+        #[cfg(feature = "bench")]
+        if let Some(profile) = _profile {
+            profile.record_wal_submit_ns(submit_start.elapsed().as_nanos() as u64);
+        }
+
         // Single fdatasync after all chunks are written. Uses fdatasync(2)
         // directly instead of IORING_OP_FSYNC — lower per-call overhead since
         // it avoids the io_uring SQE/CQE round-trip for the fsync operation.
@@ -1789,6 +1810,8 @@ impl Wal {
             let direct_file = self.direct_file.as_ref().unwrap();
             let fd = direct_file.as_raw_fd();
             let mut fdatasync_err = None;
+            #[cfg(feature = "bench")]
+            let fdatasync_start = Instant::now();
             loop {
                 let ret = unsafe { libc::fdatasync(fd) };
                 if ret == 0 {
@@ -1800,6 +1823,10 @@ impl Wal {
                 }
                 fdatasync_err = Some(err);
                 break;
+            }
+            #[cfg(feature = "bench")]
+            if let Some(profile) = _profile {
+                profile.record_wal_fdatasync_ns(fdatasync_start.elapsed().as_nanos() as u64);
             }
             if let Some(err) = fdatasync_err {
                 // All CQEs reaped — kernel is done with buffers, safe to drop.

--- a/todo.md
+++ b/todo.md
@@ -277,6 +277,10 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   91.6% of profiled time, with 43,821 commit groups for 100,000 writes, 10.6% solo groups, 2.28 buffers per group on
   average, and a max group size of 4 buffers / 16 KiB. That points the next optimization away from blind solo-delay
   tuning and toward either larger effective commit groups or cheaper sync submission.
+  Follow-up instrumentation split `wal_sync` into leader write submission, fdatasync, and follower barrier wait. A
+  same-shape profile showed `wal_submit` at 312.39 ms, `fdatasync` at 8.41 ms, and `follower_wait` at 1,353.49 ms
+  cumulative. The next optimization should target follower wake/wait overhead or reduce leader cycles per durable
+  ticket group; fdatasync itself is not the bottleneck in this profile.
   Final PR-head sync/no-sync comparison artifacts:
   `result-toykv_pr174_final_sync_100k.csv` and `result-toykv_pr174_final_nosync_100k.csv`. Same command shape
   (`--samples 100000 --clients 4 --threads 4 --skip-indexes --skip-scans`) shows durable batch writes remain below


### PR DESCRIPTION
## Summary

Adds bench-only WAL sync phase counters so `write-perf --profile` can distinguish leader write submission, `fdatasync`, and follower barrier wait inside the existing `wal_sync` bucket.

## Findings

Latest same-shape profile command:

```bash
cargo run --release --features bench --bin write-perf -- --bench wal_concurrent --num 100000 --threads 4 --value-size 1024 --profile --output text
```

Observed output on this machine:

```text
wal_write:        60.10 ms
wal_sync:       1804.93 ms
wal_submit:      312.39 ms
fdatasync:         8.41 ms
follower_wait:  1353.49 ms
commit_groups: 42849 solo=3708 (8.7%) avg_bufs=2.33 max_bufs=4
```

This points the next optimization at follower wake/wait overhead or leader cycles per durable ticket group, not raw `fdatasync` cost for this profile shape.

## Changes

- Add `WriteProfile` counters for WAL submit, fdatasync, and follower wait time.
- Print the new counters in `write-perf --profile`.
- Record the profiling evidence and next target in `todo.md`.

## Verification

- [x] `cargo fmt --all --check`
- [x] `cargo check --workspace`
- [x] `cargo check --workspace --all-features`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace --all-features wal::test_wal_group_commit_multiple_writers`
- [x] `cargo run --release --features bench --bin write-perf -- --bench wal_concurrent --num 100000 --threads 4 --value-size 1024 --profile --output text`
