### PR TITLE
perf: profile WAL follower wait events

### DIFF
--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -527,6 +527,7 @@ fn print_write_profile(engine: &KvEngine, label: &str) {
          wal_submit:   {:>8.2} ms\n  \
          fdatasync:    {:>8.2} ms\n  \
          follower_wait:{:>8.2} ms\n  \
+         follower_events: calls={:>7}  parks={:>7}  retries={:>7}\n  \
          memtable:     {:>8.2} ms  ({:>5.1}%)\n  \
          commit_groups: {:>7}  solo={:>7} ({:>5.1}%)  avg_bufs={:>5.2}  max_bufs={:>3}\n  \
          commit_bytes:  avg={:>8.0} B  max={:>8} B\n  \
@@ -543,6 +544,9 @@ fn print_write_profile(engine: &KvEngine, label: &str) {
         p.wal_submit_ms(),
         p.wal_fdatasync_ms(),
         p.wal_follower_wait_ms(),
+        p.wal_follower_wait_calls,
+        p.wal_follower_condvar_waits,
+        p.wal_follower_retry_loops,
         p.memtable_insert_ms(),
         if total > 0.0 {
             p.memtable_insert_ms() / total * 100.0

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -50,6 +50,12 @@ pub struct WriteProfile {
     pub wal_fdatasync_ns: AtomicU64,
     /// Time followers spend waiting for the leader to publish durability.
     pub wal_follower_wait_ns: AtomicU64,
+    /// Number of times a follower entered the WAL durability wait path.
+    pub wal_follower_wait_calls: AtomicU64,
+    /// Number of condvar waits performed by WAL followers.
+    pub wal_follower_condvar_waits: AtomicU64,
+    /// Number of follower wait attempts that had to retry leadership.
+    pub wal_follower_retry_loops: AtomicU64,
     /// Time inserting into the SkipMap + bloom filter.
     pub memtable_insert_ns: AtomicU64,
     /// Number of WAL commit groups that reached fdatasync.
@@ -77,6 +83,9 @@ impl WriteProfile {
             wal_submit_ns: self.wal_submit_ns.load(o),
             wal_fdatasync_ns: self.wal_fdatasync_ns.load(o),
             wal_follower_wait_ns: self.wal_follower_wait_ns.load(o),
+            wal_follower_wait_calls: self.wal_follower_wait_calls.load(o),
+            wal_follower_condvar_waits: self.wal_follower_condvar_waits.load(o),
+            wal_follower_retry_loops: self.wal_follower_retry_loops.load(o),
             memtable_insert_ns: self.memtable_insert_ns.load(o),
             wal_commit_groups: self.wal_commit_groups.load(o),
             wal_commit_solo_groups: self.wal_commit_solo_groups.load(o),
@@ -118,6 +127,16 @@ impl WriteProfile {
         self.wal_follower_wait_ns
             .fetch_add(nanos, std::sync::atomic::Ordering::Relaxed);
     }
+
+    #[cfg(feature = "bench")]
+    pub(crate) fn record_wal_follower_wait(&self, condvar_waits: u64, retried_leadership: bool) {
+        let o = std::sync::atomic::Ordering::Relaxed;
+        self.wal_follower_wait_calls.fetch_add(1, o);
+        self.wal_follower_condvar_waits.fetch_add(condvar_waits, o);
+        if retried_leadership {
+            self.wal_follower_retry_loops.fetch_add(1, o);
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -127,6 +146,9 @@ pub struct WriteProfileSnapshot {
     pub wal_submit_ns: u64,
     pub wal_fdatasync_ns: u64,
     pub wal_follower_wait_ns: u64,
+    pub wal_follower_wait_calls: u64,
+    pub wal_follower_condvar_waits: u64,
+    pub wal_follower_retry_loops: u64,
     pub memtable_insert_ns: u64,
     pub wal_commit_groups: u64,
     pub wal_commit_solo_groups: u64,

--- a/kv-engine/src/tests/wal.rs
+++ b/kv-engine/src/tests/wal.rs
@@ -10,6 +10,8 @@ use crossbeam_skiplist::SkipMap;
 use tempfile::tempdir;
 
 use super::harness::create_wal_or_skip;
+#[cfg(feature = "bench")]
+use crate::mem_table::WriteProfile;
 use crate::{
     lsm_storage::{LsmStorageInner, LsmStorageOptions},
     wal::Wal,
@@ -457,6 +459,53 @@ fn test_wal_group_commit_handles_late_arrival() {
     let (_wal, max_ts) = Wal::recover(&path, &skiplist).unwrap();
     assert_eq!(max_ts, 3);
     assert_eq!(skiplist.len(), 257);
+}
+
+#[cfg(feature = "bench")]
+#[test]
+fn test_wal_profiled_group_commit_records_follower_wait_events() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("profiled_group_commit.wal");
+    let Some(wal) = create_wal_or_skip(&path) else {
+        return;
+    };
+    let wal = Arc::new(wal);
+    let profile = Arc::new(WriteProfile::default());
+    let start = Arc::new(Barrier::new(5));
+
+    let mut handles = Vec::new();
+    for worker_id in 0..4u8 {
+        let wal = Arc::clone(&wal);
+        let profile = Arc::clone(&profile);
+        let start = Arc::clone(&start);
+        handles.push(thread::spawn(move || {
+            let mut keys = Vec::new();
+            let mut values = Vec::new();
+            for entry_idx in 0..256 {
+                keys.push(vec![worker_id, (entry_idx & 0xff) as u8]);
+                values.push(vec![worker_id; 1024]);
+            }
+            let refs: Vec<(&[u8], &[u8])> = keys
+                .iter()
+                .zip(values.iter())
+                .map(|(key, value)| (key.as_slice(), value.as_slice()))
+                .collect();
+
+            start.wait();
+            let ticket = wal.put_batch(&refs, worker_id as u64 + 1).unwrap();
+            wal.submit_and_commit_profiled(ticket, &profile).unwrap();
+        }));
+    }
+
+    start.wait();
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    let snapshot = profile.snapshot();
+    assert!(snapshot.wal_commit_groups > 0);
+    assert!(snapshot.wal_follower_wait_calls > 0);
+    assert!(snapshot.wal_follower_condvar_waits > 0);
 }
 
 #[test]

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -218,6 +218,11 @@ struct CompletionInner {
     last_error: Option<Arc<anyhow::Error>>,
 }
 
+#[derive(Debug, Default)]
+struct WaitForTicketStats {
+    condvar_waits: u64,
+}
+
 impl CompletionState {
     fn new() -> Self {
         Self {
@@ -1522,11 +1527,16 @@ impl Wal {
                 // Follower path: wait until the leader commits our ticket.
                 #[cfg(feature = "bench")]
                 let wait_start = Instant::now();
-                self.wait_for_ticket_durability(ticket)?;
+                let wait_stats = self.wait_for_ticket_durability(ticket)?;
                 #[cfg(feature = "bench")]
                 if let Some(profile) = profile {
                     profile.record_wal_follower_wait_ns(wait_start.elapsed().as_nanos() as u64);
+                    let retried_leadership =
+                        self.completion_state.durable_ticket.load(Ordering::Acquire) <= ticket;
+                    profile.record_wal_follower_wait(wait_stats.condvar_waits, retried_leadership);
                 }
+                #[cfg(not(feature = "bench"))]
+                let _ = wait_stats;
                 // Our ticket is durable — return success. Don't check
                 // last_error: a subsequent leader's failure should not
                 // affect data that was already committed.
@@ -1644,8 +1654,9 @@ impl Wal {
         self.completion_state.cond.notify_all();
     }
 
-    fn wait_for_ticket_durability(&self, ticket: u64) -> Result<()> {
+    fn wait_for_ticket_durability(&self, ticket: u64) -> Result<WaitForTicketStats> {
         let mut state = self.completion_state.mutex.lock();
+        let mut stats = WaitForTicketStats::default();
         while self.completion_state.durable_ticket.load(Ordering::Acquire) <= ticket {
             if let Some(ref e) = state.last_error {
                 return Err(anyhow::anyhow!("{e}"));
@@ -1653,10 +1664,11 @@ impl Wal {
             if !self.submitting.load(Ordering::Acquire) {
                 break;
             }
+            stats.condvar_waits += 1;
             self.completion_state.cond.wait(&mut state);
         }
 
-        Ok(())
+        Ok(stats)
     }
 
     /// Submit DirectBuf buffers as io_uring SQEs, poll CQEs for completion.


### PR DESCRIPTION
## Summary
- add bench-only WAL follower wait event counters to `WriteProfile`
- print follower wait calls, condvar parks, and retry loops in `write-perf --profile`
- keep the existing WAL timing and commit-group counters unchanged

## Measurement
Command run outside sandbox because io_uring is blocked there:

```text
cargo run --release --features bench --bin write-perf -- --bench wal_concurrent --num 100000 --threads 4 --value-size 1024 --profile
```

Result on this branch:

```text
wal_concurrent/concurrent num=100000 value=1024B measure=978.97ms ops=100000 ops/s=102148
follower_wait: 1141.05 ms
follower_events: calls=71653 parks=116756 retries=14658
commit_groups: 43003 solo=3664 (8.5%) avg_bufs=2.33 max_bufs=4
```

## Verification
- `cargo fmt --all --check`
- `cargo check --workspace --all-features`
- `cargo nextest run --workspace --all-features wal` (outside sandbox)
- `cargo run --release --features bench --bin write-perf -- --bench wal_concurrent --num 100000 --threads 4 --value-size 1024 --profile` (outside sandbox)

Note: the same targeted nextest command fails inside the sandbox because io_uring setup returns EPERM.
