### PR TITLE
perf: add WAL batch write profile workload

### DIFF
--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -21,6 +21,7 @@ use kv_engine_wrapper::{
     iterators::StorageIterator,
     lsm_storage::{
         CacheAdmission, KvEngine, LsmStorageOptions, ParallelScanOptions, PrefixBloomOptions,
+        WriteBatchRecord,
     },
     vlog::ValueSeparationOptions,
 };
@@ -328,6 +329,11 @@ const WORKLOADS: &[WorkloadSpec] = &[
         run: run_wal_concurrent,
     },
     WorkloadSpec {
+        name: "wal_batch_concurrent",
+        aliases: &["wal_batch"],
+        run: run_wal_batch_concurrent,
+    },
+    WorkloadSpec {
         name: "vlog_gc",
         aliases: &[],
         run: run_vlog_gc,
@@ -440,6 +446,7 @@ struct MeasurementParams {
     num: Option<usize>,
     reads: Option<usize>,
     value_size: Option<usize>,
+    batch_size: Option<usize>,
     duration_secs: Option<u64>,
     threads: Option<usize>,
     readers: Option<usize>,
@@ -1125,6 +1132,79 @@ fn run_wal_concurrent(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
         MeasurementParams {
             num: Some(num_keys),
             value_size: Some(cfg.value_size),
+            threads: Some(writer_threads),
+            seed: Some(cfg.seed),
+            ..MeasurementParams::default()
+        },
+        MeasurementResult {
+            measure_elapsed_ms: ms(elapsed),
+            ops: Some(num_keys as u64),
+            ops_per_sec: Some(rate(num_keys as u64, elapsed)),
+            ..MeasurementResult::default()
+        },
+        counters,
+    )])
+}
+
+fn run_wal_batch_concurrent(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    let workload = "wal_batch_concurrent";
+    let path = prepare_path(cfg, workload)?;
+    let options = cfg.build_options(true, false);
+    let engine = KvEngine::open(&path, options.clone())?;
+    let value = vec![b'x'; cfg.value_size];
+    let num_keys = cfg.num;
+    let writer_threads = cfg.threads;
+    let batch_size = 1000usize.min(num_keys.max(1));
+    let baseline = collect_counters(&engine)?;
+    let per_thread = num_keys / writer_threads;
+    let remainder = num_keys % writer_threads;
+    let start = Instant::now();
+    let mut handles = vec![];
+    for t in 0..writer_threads {
+        let eng = engine.clone();
+        let val = value.clone();
+        handles.push(std::thread::spawn(move || {
+            let thread_ops = per_thread + usize::from(t < remainder);
+            let start_idx = t * per_thread + remainder.min(t);
+            let mut next = 0usize;
+            while next < thread_ops {
+                let current_batch = (thread_ops - next).min(batch_size);
+                let mut keys = Vec::with_capacity(current_batch);
+                for i in 0..current_batch {
+                    keys.push(format!("key{:08}", start_idx + next + i).into_bytes());
+                }
+                let batch: Vec<_> = keys
+                    .iter()
+                    .map(|key| WriteBatchRecord::Put(key.as_slice(), val.as_slice()))
+                    .collect();
+                eng.write_batch(&batch).expect("write_batch failed");
+                next += current_batch;
+            }
+        }));
+    }
+    for handle in handles {
+        handle
+            .join()
+            .map_err(|_| anyhow!("writer thread panicked"))?;
+    }
+    let elapsed = start.elapsed();
+    if cfg.profile {
+        print_write_profile(&engine, workload);
+    }
+    engine.drain_flush()?;
+    let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
+    engine.close()?;
+    finalize_path(cfg, &path)?;
+
+    Ok(vec![make_measurement(
+        cfg,
+        workload,
+        "concurrent_batch_1000",
+        &options,
+        MeasurementParams {
+            num: Some(num_keys),
+            value_size: Some(cfg.value_size),
+            batch_size: Some(batch_size),
             threads: Some(writer_threads),
             seed: Some(cfg.seed),
             ..MeasurementParams::default()
@@ -2442,6 +2522,13 @@ mod tests {
             select_workloads(Some("fillseq,readseq_validate_order")).expect("select workloads");
         let names: Vec<_> = selected.iter().map(|w| w.name).collect();
         assert_eq!(names, vec!["fillseq", "readseq_validate_order"]);
+    }
+
+    #[test]
+    fn parse_wal_batch_alias() {
+        let selected = select_workloads(Some("wal_batch")).expect("select workload");
+        let names: Vec<_> = selected.iter().map(|w| w.name).collect();
+        assert_eq!(names, vec!["wal_batch_concurrent"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a `wal_batch_concurrent` write-perf workload with `wal_batch` alias
- exercise concurrent public `KvEngine::write_batch` calls with 1,000-row batches
- include `batch_size` in emitted measurement parameters

## Measurement
Command run outside sandbox because the WAL path uses io_uring:

```text
cargo run --release --features bench --bin write-perf -- --bench wal_batch --num 100000 --threads 4 --value-size 1024 --profile
```

Result:

```text
wal_batch_concurrent/concurrent_batch_1000 num=100000 value=1024B measure=245.10ms ops=100000 ops/s=408000
wal_write: 42.28 ms
wal_sync: 73.77 ms
wal_submit: 26.88 ms
fdatasync: 0.05 ms
follower_wait: 20.61 ms
follower_events: calls=53 parks=60 retries=43
commit_groups: 90 solo=82 (91.1%) avg_bufs=1.11 max_bufs=3
commit_bytes: avg=1174187 B max=3170304 B
```

This gives a local profiler for the `crud-bench` large batch-write shape, where follower wait is much smaller than WAL encode/write plus memtable publish.

## Verification
- `cargo fmt --all --check`
- `cargo check --workspace --all-features`
- `cargo test --package kv-engine --bin write-perf parse_wal_batch_alias`
- `cargo run --release --features bench --bin write-perf -- --bench wal_batch --num 100000 --threads 4 --value-size 1024 --profile` (outside sandbox)
