### PR TITLE
perf: parameterize WAL batch profile size

### DIFF
--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -1158,10 +1158,10 @@ fn run_wal_batch_concurrent(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>
     let value = vec![b'x'; cfg.value_size];
     let num_keys = cfg.num;
     let writer_threads = cfg.threads;
-    let batch_size = cfg.wal_batch_size.min(num_keys.max(1));
     let baseline = collect_counters(&engine)?;
     let per_thread = num_keys / writer_threads;
     let remainder = num_keys % writer_threads;
+    let batch_size = effective_wal_batch_size(num_keys, writer_threads, cfg.wal_batch_size);
     let start = Instant::now();
     let mut handles = vec![];
     for t in 0..writer_threads {
@@ -1221,6 +1221,13 @@ fn run_wal_batch_concurrent(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>
         },
         counters,
     )])
+}
+
+fn effective_wal_batch_size(num_keys: usize, writer_threads: usize, requested: usize) -> usize {
+    let per_thread = num_keys / writer_threads;
+    let remainder = num_keys % writer_threads;
+    let max_thread_ops = per_thread + usize::from(remainder > 0);
+    requested.min(max_thread_ops.max(1))
 }
 
 fn run_vlog_gc(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
@@ -2542,6 +2549,13 @@ mod tests {
             Args::try_parse_from(["write-perf", "--wal-batch-size", "100"]).expect("parse args");
         let cfg = HarnessConfig::from_args(args);
         assert_eq!(cfg.wal_batch_size, 100);
+    }
+
+    #[test]
+    fn effective_wal_batch_size_uses_largest_writer_partition() {
+        assert_eq!(effective_wal_batch_size(100, 4, 100), 25);
+        assert_eq!(effective_wal_batch_size(101, 4, 100), 26);
+        assert_eq!(effective_wal_batch_size(1000, 4, 100), 100);
     }
 
     #[test]

--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -106,6 +106,8 @@ struct Args {
     parallel_scan_yield_every_rows: Option<usize>,
     #[arg(long)]
     parallel_scan_channel_capacity: Option<usize>,
+    #[arg(long)]
+    wal_batch_size: Option<usize>,
     /// Block cache admission policy for parallel scan: force, admit, bypass.
     #[arg(long)]
     parallel_scan_cache_admission: Option<String>,
@@ -144,6 +146,7 @@ struct HarnessConfig {
     parallel_scan_batch_bytes: usize,
     parallel_scan_yield_every_rows: usize,
     parallel_scan_channel_capacity: usize,
+    wal_batch_size: usize,
     parallel_scan_cache_admission: String,
     compaction: CompactionMode,
     wal_override: bool,
@@ -197,6 +200,7 @@ impl HarnessConfig {
             parallel_scan_batch_bytes: args.parallel_scan_batch_bytes.unwrap_or(256 * 1024),
             parallel_scan_yield_every_rows: args.parallel_scan_yield_every_rows.unwrap_or(1024),
             parallel_scan_channel_capacity: args.parallel_scan_channel_capacity.unwrap_or(4),
+            wal_batch_size: args.wal_batch_size.unwrap_or(1000),
             parallel_scan_cache_admission: args
                 .parallel_scan_cache_admission
                 .unwrap_or_else(|| "bypass".to_string()),
@@ -1154,7 +1158,7 @@ fn run_wal_batch_concurrent(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>
     let value = vec![b'x'; cfg.value_size];
     let num_keys = cfg.num;
     let writer_threads = cfg.threads;
-    let batch_size = 1000usize.min(num_keys.max(1));
+    let batch_size = cfg.wal_batch_size.min(num_keys.max(1));
     let baseline = collect_counters(&engine)?;
     let per_thread = num_keys / writer_threads;
     let remainder = num_keys % writer_threads;
@@ -1199,7 +1203,7 @@ fn run_wal_batch_concurrent(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>
     Ok(vec![make_measurement(
         cfg,
         workload,
-        "concurrent_batch_1000",
+        &format!("concurrent_batch_{batch_size}"),
         &options,
         MeasurementParams {
             num: Some(num_keys),
@@ -2500,6 +2504,7 @@ fn validate_config(cfg: &HarnessConfig) -> Result<()> {
     anyhow::ensure!(cfg.cache_capacity > 0, "--cache-capacity must be > 0");
     anyhow::ensure!(cfg.target_sst_size > 0, "--target-sst-size must be > 0");
     anyhow::ensure!(cfg.memtable_limit > 0, "--memtable-limit must be > 0");
+    anyhow::ensure!(cfg.wal_batch_size > 0, "--wal-batch-size must be > 0");
 
     Ok(())
 }
@@ -2529,6 +2534,14 @@ mod tests {
         let selected = select_workloads(Some("wal_batch")).expect("select workload");
         let names: Vec<_> = selected.iter().map(|w| w.name).collect();
         assert_eq!(names, vec!["wal_batch_concurrent"]);
+    }
+
+    #[test]
+    fn parse_wal_batch_size() {
+        let args =
+            Args::try_parse_from(["write-perf", "--wal-batch-size", "100"]).expect("parse args");
+        let cfg = HarnessConfig::from_args(args);
+        assert_eq!(cfg.wal_batch_size, 100);
     }
 
     #[test]
@@ -2563,6 +2576,7 @@ mod tests {
             parallel_scan_batch_bytes: 1,
             parallel_scan_yield_every_rows: 1,
             parallel_scan_channel_capacity: 1,
+            wal_batch_size: 1,
             parallel_scan_cache_admission: "bypass".to_string(),
             compaction: CompactionMode::None,
             wal_override: false,
@@ -2615,6 +2629,7 @@ mod tests {
             parallel_scan_batch_bytes: 1,
             parallel_scan_yield_every_rows: 1,
             parallel_scan_channel_capacity: 1,
+            wal_batch_size: 1,
             parallel_scan_cache_admission: "bypass".to_string(),
             compaction: CompactionMode::None,
             wal_override: false,
@@ -2624,5 +2639,14 @@ mod tests {
             profile: false,
         };
         assert!(validate_config(&cfg).is_err());
+    }
+
+    #[test]
+    fn reject_zero_wal_batch_size() {
+        let args =
+            Args::try_parse_from(["write-perf", "--wal-batch-size", "0"]).expect("parse args");
+        let cfg = HarnessConfig::from_args(args);
+        let err = validate_config(&cfg).expect_err("zero wal batch size should fail");
+        assert!(err.to_string().contains("--wal-batch-size"));
     }
 }

--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -1203,7 +1203,7 @@ fn run_wal_batch_concurrent(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>
     Ok(vec![make_measurement(
         cfg,
         workload,
-        &format!("concurrent_batch_{batch_size}"),
+        format!("concurrent_batch_{batch_size}"),
         &options,
         MeasurementParams {
             num: Some(num_keys),


### PR DESCRIPTION
## Summary

Add a `--wal-batch-size` flag to the `write-perf wal_batch` workload so the local WAL batch profiler can match CRUD batch widths instead of being fixed at 1000 rows.

## Changes

- Add `--wal-batch-size` with a default of 1000.
- Use the configured size in `wal_batch_concurrent` and reflect it in the measurement label.
- Validate the flag is nonzero.
- Add parser/validation unit coverage.

## Measurements

Outside-sandbox profiler runs from this branch:

- `cargo run --release --features bench --bin write-perf -- --bench wal_batch --num 100000 --threads 4 --value-size 1024 --wal-batch-size 100 --profile`
  - `wal_batch_concurrent/concurrent_batch_100`: 145,532 ops/s
  - `wal_sync`: 206.45 ms, `follower_wait`: 127.49 ms, commit groups 674, solo 70.8%, avg 1.48 buffers/group
- `cargo run --release --features bench --bin write-perf -- --bench wal_batch --num 100000 --threads 4 --value-size 1024 --wal-batch-size 1000 --profile`
  - `wal_batch_concurrent/concurrent_batch_1000`: 418,174 ops/s
  - `wal_write`: 39.38 ms, `wal_sync`: 51.23 ms, `memtable`: 58.61 ms, commit groups 98, solo 98.0%, avg 1.02 buffers/group

## Verification

- [x] `cargo fmt --all --check`
- [x] `cargo test --package kv-engine --bin write-perf wal_batch`
- [x] `cargo check --workspace --all-features`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--wal-batch-size` option to configure WAL write batch sizes for performance benchmarks.
  * The selected batch size is reflected in benchmark results and automatically limited by the number of keys.

* **Bug Fixes**
  * Invalid batch sizes, including zero or negative values, are now rejected during configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->