### PR TITLE
perf: split WAL write profile buckets

### DIFF
--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -534,6 +534,10 @@ fn print_write_profile(engine: &KvEngine, label: &str) {
     eprintln!(
         "\n--- write profile: {label} ({} ops) ---\n  \
          wal_write:    {:>8.2} ms  ({:>5.1}%)\n  \
+         wal_validate: {:>8.2} ms\n  \
+         wal_prepare:  {:>8.2} ms\n  \
+         wal_encode:   {:>8.2} ms\n  \
+         wal_enqueue:  {:>8.2} ms\n  \
          wal_sync:     {:>8.2} ms  ({:>5.1}%)\n  \
          wal_submit:   {:>8.2} ms\n  \
          fdatasync:    {:>8.2} ms\n  \
@@ -550,6 +554,10 @@ fn print_write_profile(engine: &KvEngine, label: &str) {
         } else {
             0.0
         },
+        p.wal_validate_ms(),
+        p.wal_prepare_ms(),
+        p.wal_encode_ms(),
+        p.wal_enqueue_ms(),
         p.wal_sync_ms(),
         p.wal_sync_pct(),
         p.wal_submit_ms(),

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -40,8 +40,16 @@ const BLOOM_FALSE_POSITIVE_RATE: f64 = 0.01;
 /// but the hot path has zero profiling overhead.
 #[derive(Debug, Default)]
 pub struct WriteProfile {
-    /// Time in `Wal::put_batch` (encode + BufWriter write).
+    /// Time in `Wal::put_batch` / `Wal::put_key_batch`.
     pub wal_write_ns: AtomicU64,
+    /// Time validating WAL batch entry lengths and computing encoded size.
+    pub wal_validate_ns: AtomicU64,
+    /// Time preparing WAL direct buffers before byte encoding.
+    pub wal_prepare_ns: AtomicU64,
+    /// Time encoding WAL batch bytes into an aligned direct buffer.
+    pub wal_encode_ns: AtomicU64,
+    /// Time enqueuing encoded WAL buffers for group commit.
+    pub wal_enqueue_ns: AtomicU64,
     /// Time in `Wal::sync` (BufWriter flush + `fsync`).
     pub wal_sync_ns: AtomicU64,
     /// Time submitting and waiting for WAL write SQEs.
@@ -79,6 +87,10 @@ impl WriteProfile {
         let o = std::sync::atomic::Ordering::Relaxed;
         WriteProfileSnapshot {
             wal_write_ns: self.wal_write_ns.load(o),
+            wal_validate_ns: self.wal_validate_ns.load(o),
+            wal_prepare_ns: self.wal_prepare_ns.load(o),
+            wal_encode_ns: self.wal_encode_ns.load(o),
+            wal_enqueue_ns: self.wal_enqueue_ns.load(o),
             wal_sync_ns: self.wal_sync_ns.load(o),
             wal_submit_ns: self.wal_submit_ns.load(o),
             wal_fdatasync_ns: self.wal_fdatasync_ns.load(o),
@@ -117,6 +129,30 @@ impl WriteProfile {
     }
 
     #[cfg(feature = "bench")]
+    pub(crate) fn record_wal_validate_ns(&self, nanos: u64) {
+        self.wal_validate_ns
+            .fetch_add(nanos, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    #[cfg(feature = "bench")]
+    pub(crate) fn record_wal_prepare_ns(&self, nanos: u64) {
+        self.wal_prepare_ns
+            .fetch_add(nanos, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    #[cfg(feature = "bench")]
+    pub(crate) fn record_wal_encode_ns(&self, nanos: u64) {
+        self.wal_encode_ns
+            .fetch_add(nanos, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    #[cfg(feature = "bench")]
+    pub(crate) fn record_wal_enqueue_ns(&self, nanos: u64) {
+        self.wal_enqueue_ns
+            .fetch_add(nanos, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    #[cfg(feature = "bench")]
     pub(crate) fn record_wal_fdatasync_ns(&self, nanos: u64) {
         self.wal_fdatasync_ns
             .fetch_add(nanos, std::sync::atomic::Ordering::Relaxed);
@@ -142,6 +178,10 @@ impl WriteProfile {
 #[derive(Debug, Clone, Copy)]
 pub struct WriteProfileSnapshot {
     pub wal_write_ns: u64,
+    pub wal_validate_ns: u64,
+    pub wal_prepare_ns: u64,
+    pub wal_encode_ns: u64,
+    pub wal_enqueue_ns: u64,
     pub wal_sync_ns: u64,
     pub wal_submit_ns: u64,
     pub wal_fdatasync_ns: u64,
@@ -162,6 +202,22 @@ pub struct WriteProfileSnapshot {
 impl WriteProfileSnapshot {
     pub fn wal_write_ms(&self) -> f64 {
         self.wal_write_ns as f64 / 1_000_000.0
+    }
+
+    pub fn wal_validate_ms(&self) -> f64 {
+        self.wal_validate_ns as f64 / 1_000_000.0
+    }
+
+    pub fn wal_prepare_ms(&self) -> f64 {
+        self.wal_prepare_ns as f64 / 1_000_000.0
+    }
+
+    pub fn wal_encode_ms(&self) -> f64 {
+        self.wal_encode_ns as f64 / 1_000_000.0
+    }
+
+    pub fn wal_enqueue_ms(&self) -> f64 {
+        self.wal_enqueue_ns as f64 / 1_000_000.0
     }
 
     pub fn wal_sync_ms(&self) -> f64 {
@@ -799,7 +855,13 @@ impl MemTable {
         );
         #[cfg(feature = "bench")]
         let t = Instant::now();
-        let ticket = crate::profile_scope!("wal.put_batch", wal.put_key_batch(data, commit_ts))?;
+        #[cfg(feature = "bench")]
+        let ticket = crate::profile_scope!(
+            "wal.put_batch",
+            wal.put_key_batch_profiled(data, commit_ts, &self.write_profile.load())
+        )?;
+        #[cfg(not(feature = "bench"))]
+        let ticket = wal.put_key_batch(data, commit_ts)?;
         self.last_ticket
             .fetch_max(ticket + 1, std::sync::atomic::Ordering::Release);
         #[cfg(feature = "bench")]

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -505,11 +505,18 @@ impl Wal {
         entries_size: usize,
         commit_ts: u64,
         entry_count: u32,
+        profile: Option<&crate::mem_table::WriteProfile>,
     ) -> Result<u64> {
+        #[cfg(not(feature = "bench"))]
+        let _ = profile;
+
         // Fail fast after I/O error — don't allocate or enqueue into `pending`.
         if self.poisoned.load(Ordering::Acquire) {
             anyhow::bail!("WAL is poisoned due to a previous I/O error");
         }
+
+        #[cfg(feature = "bench")]
+        let prepare_start = Instant::now();
 
         // Reject empty batches with commit_ts=0 — they produce an all-zero v4
         // header indistinguishable from preallocated (fallocate'd) space, which
@@ -543,7 +550,13 @@ impl Wal {
             None => DirectBuf::new(alloc_size),
         };
         buf.clear();
+        #[cfg(feature = "bench")]
+        if let Some(profile) = profile {
+            profile.record_wal_prepare_ns(prepare_start.elapsed().as_nanos() as u64);
+        }
 
+        #[cfg(feature = "bench")]
+        let encode_start = Instant::now();
         let slice = buf.as_mut_slice();
         // Reserve header space (filled later).
         let mut pos = V4_BATCH_HEADER_SIZE;
@@ -575,11 +588,21 @@ impl Wal {
         let aligned_len = DirectBuf::align_up(pos);
         slice[pos..aligned_len].fill(0);
         buf.set_len(aligned_len);
+        #[cfg(feature = "bench")]
+        if let Some(profile) = profile {
+            profile.record_wal_encode_ns(encode_start.elapsed().as_nanos() as u64);
+        }
 
+        #[cfg(feature = "bench")]
+        let enqueue_start = Instant::now();
         let mut pending = self.pending.lock();
         let ticket = self.next_ticket.fetch_add(1, Ordering::Release);
         pending.push(TicketedBuf { ticket, buf });
         drop(pending);
+        #[cfg(feature = "bench")]
+        if let Some(profile) = profile {
+            profile.record_wal_enqueue_ns(enqueue_start.elapsed().as_nanos() as u64);
+        }
 
         #[cfg(feature = "chaos-testing")]
         {
@@ -1296,15 +1319,35 @@ impl Wal {
         self.put_batch_entries(data, commit_ts)
     }
 
+    #[cfg(not(feature = "bench"))]
     pub(crate) fn put_key_batch(
         &self,
         data: &[(KeySlice<'_>, &[u8])],
         commit_ts: u64,
     ) -> Result<u64> {
-        self.put_batch_entries(data, commit_ts)
+        self.put_batch_entries_inner(data, commit_ts, None)
+    }
+
+    #[cfg(feature = "bench")]
+    pub(crate) fn put_key_batch_profiled(
+        &self,
+        data: &[(KeySlice<'_>, &[u8])],
+        commit_ts: u64,
+        profile: &crate::mem_table::WriteProfile,
+    ) -> Result<u64> {
+        self.put_batch_entries_inner(data, commit_ts, Some(profile))
     }
 
     fn put_batch_entries<T: WalPointEntry>(&self, data: &[T], commit_ts: u64) -> Result<u64> {
+        self.put_batch_entries_inner(data, commit_ts, None)
+    }
+
+    fn put_batch_entries_inner<T: WalPointEntry>(
+        &self,
+        data: &[T],
+        commit_ts: u64,
+        profile: Option<&crate::mem_table::WriteProfile>,
+    ) -> Result<u64> {
         for entry in data {
             let key = entry.key();
             let value = entry.value();
@@ -1347,6 +1390,8 @@ impl Wal {
         }
 
         // MVCC format: encode into a DirectBuf with v4 header, push to pending.
+        #[cfg(feature = "bench")]
+        let validate_start = Instant::now();
         let per_entry_overhead = if self.is_v3 { 5 } else { 4 };
         let mut validated = Vec::with_capacity(data.len());
         let mut entries_size = 0usize;
@@ -1360,8 +1405,19 @@ impl Wal {
                 .context("batch size overflow")?;
             validated.push((key_len, value_len));
         }
+        #[cfg(feature = "bench")]
+        if let Some(profile) = profile {
+            profile.record_wal_validate_ns(validate_start.elapsed().as_nanos() as u64);
+        }
 
-        self.encode_and_push_direct_buf(data, &validated, entries_size, commit_ts, entry_count)
+        self.encode_and_push_direct_buf(
+            data,
+            &validated,
+            entries_size,
+            commit_ts,
+            entry_count,
+            profile,
+        )
     }
 
     /// Write a batch of range tombstones as a single atomic WAL record.

--- a/todo.md
+++ b/todo.md
@@ -295,6 +295,11 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   `wal_concurrent` 92,929 → 91,484 OPS, `wal_sync` 1,798.27 → 1,831.11 ms, with the control commit-group shape at
   11.1% solo groups, 2.30 average buffers/group, and max 4 buffers / 16 KiB. Copying the aligned buffers costs more
   than the saved SQE/CQE work for this shape.
+  Follow-up instrumentation: `write-perf --bench wal_batch --num 100000 --threads 4 --value-size 1024 --profile`
+  now splits WAL write time into validate/prepare/encode/enqueue. The batch-size 100 profile still points at
+  sync/follower wait (`wal_sync` 270.51 ms, `follower_wait` 174.09 ms), while the batch-size 1000 profile shows
+  direct-buffer preparation dominating the WAL write bucket (`wal_prepare` 28.46 ms versus `wal_encode` 7.41 ms).
+  The next large-batch target should inspect direct-buffer pool sizing/reuse before more encoding-loop changes.
   Final PR-head sync/no-sync comparison artifacts:
   `result-toykv_pr174_final_sync_100k.csv` and `result-toykv_pr174_final_nosync_100k.csv`. Same command shape
   (`--samples 100000 --clients 4 --threads 4 --skip-indexes --skip-scans`) shows durable batch writes remain below


### PR DESCRIPTION
## Summary

Split the existing write-profile `wal_write` bucket into finer WAL batch stages so batch-write tuning can distinguish validation, direct-buffer preparation, byte encoding, and pending-queue enqueue cost.

## Changes

- Add write-profile counters for `wal_validate`, `wal_prepare`, `wal_encode`, and `wal_enqueue`.
- Route bench builds through a profiled `Wal::put_key_batch_profiled` entry point.
- Print the new counters in `write-perf --profile` output.
- Record the latest `wal_batch` profile signal in `todo.md`.

## Measurements

Outside-sandbox profiler runs from this branch:

- `cargo run --release --features bench --bin write-perf -- --bench wal_batch --num 100000 --threads 4 --value-size 1024 --wal-batch-size 100 --profile`
  - `concurrent_batch_100`: 160,811 ops/s
  - `wal_write`: 12.81 ms; `wal_validate`: 0.18 ms; `wal_prepare`: 0.12 ms; `wal_encode`: 11.86 ms; `wal_enqueue`: 0.20 ms
  - `wal_sync`: 270.51 ms; `follower_wait`: 174.09 ms
- `cargo run --release --features bench --bin write-perf -- --bench wal_batch --num 100000 --threads 4 --value-size 1024 --wal-batch-size 1000 --profile`
  - `concurrent_batch_1000`: 510,462 ops/s
  - `wal_write`: 36.16 ms; `wal_validate`: 0.17 ms; `wal_prepare`: 28.46 ms; `wal_encode`: 7.41 ms; `wal_enqueue`: 0.03 ms
  - `wal_sync`: 51.61 ms; `memtable`: 50.94 ms

## Verification

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo check --workspace --all-features`
- [x] `cargo test --package kv-engine --bin write-perf wal_batch`
- [x] `cargo nextest run --workspace --all-features wal` outside sandbox

Note: the same WAL nextest command fails inside the sandbox because io_uring creation returns `Operation not permitted`; it passes outside the sandbox.