### PR TITLE
perf: skip WAL direct buffer preclear

### DIFF
--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -116,10 +116,6 @@ impl DirectBuf {
         let ret = unsafe { libc::posix_memalign(&mut ptr, 4096, cap) };
         // posix_memalign failure is OOM — recovery is impossible at this point.
         assert_eq!(ret, 0, "posix_memalign failed (OOM)");
-        // Zero-initialize: creating a &mut [u8] over uninitialized memory is UB.
-        // Also prevents stale data leakage if the buffer is read before being
-        // fully written.
-        unsafe { std::ptr::write_bytes(ptr as *mut u8, 0, cap) };
         Self {
             ptr: ptr as *mut u8,
             len: 0,
@@ -132,12 +128,42 @@ impl DirectBuf {
         (size + 4095) & !4095
     }
 
-    /// Returns a mutable slice over the full allocation (capacity, not length).
-    /// Used for encoding batch data and zero-padding the alignment gap.
-    /// Callers must not write beyond the intended region (header + entries +
-    /// padding) — the cap is 4KB-aligned to prevent io_uring out-of-bounds reads.
-    fn as_mut_slice(&mut self) -> &mut [u8] {
-        unsafe { std::slice::from_raw_parts_mut(self.ptr, self.cap) }
+    fn write_u8_at(&mut self, pos: usize, value: u8) {
+        debug_assert!(pos < self.cap);
+        unsafe { *self.ptr.add(pos) = value };
+    }
+
+    fn write_u16_be_at(&mut self, pos: usize, value: u16) {
+        self.write_at(pos, &value.to_be_bytes());
+    }
+
+    fn write_u32_be_at(&mut self, pos: usize, value: u32) {
+        self.write_at(pos, &value.to_be_bytes());
+    }
+
+    fn write_u64_be_at(&mut self, pos: usize, value: u64) {
+        self.write_at(pos, &value.to_be_bytes());
+    }
+
+    fn write_at(&mut self, pos: usize, bytes: &[u8]) {
+        debug_assert!(pos + bytes.len() <= self.cap);
+        unsafe {
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), self.ptr.add(pos), bytes.len());
+        }
+    }
+
+    fn zero_range(&mut self, start: usize, end: usize) {
+        debug_assert!(start <= end);
+        debug_assert!(end <= self.cap);
+        unsafe {
+            std::ptr::write_bytes(self.ptr.add(start), 0, end - start);
+        }
+    }
+
+    fn initialized_slice(&self, start: usize, end: usize) -> &[u8] {
+        debug_assert!(start <= end);
+        debug_assert!(end <= self.cap);
+        unsafe { std::slice::from_raw_parts(self.ptr.add(start), end - start) }
     }
 
     fn as_ptr(&self) -> *const u8 {
@@ -557,7 +583,6 @@ impl Wal {
 
         #[cfg(feature = "bench")]
         let encode_start = Instant::now();
-        let slice = buf.as_mut_slice();
         // Reserve header space (filled later).
         let mut pos = V4_BATCH_HEADER_SIZE;
 
@@ -565,28 +590,28 @@ impl Wal {
             let key = entry.key();
             let value = entry.value();
             if self.is_v3 {
-                slice[pos] = WalEntryKind::Put as u8;
+                buf.write_u8_at(pos, WalEntryKind::Put as u8);
                 pos += 1;
             }
-            slice[pos..pos + 2].copy_from_slice(&kl.to_be_bytes());
+            buf.write_u16_be_at(pos, *kl);
             pos += 2;
-            slice[pos..pos + key.len()].copy_from_slice(key);
+            buf.write_at(pos, key);
             pos += key.len();
-            slice[pos..pos + 2].copy_from_slice(&vl.to_be_bytes());
+            buf.write_u16_be_at(pos, *vl);
             pos += 2;
-            slice[pos..pos + value.len()].copy_from_slice(value);
+            buf.write_at(pos, value);
             pos += value.len();
         }
 
-        let crc = crc32fast::hash(&slice[V4_BATCH_HEADER_SIZE..pos]);
-        slice[0..8].copy_from_slice(&commit_ts.to_be_bytes());
-        slice[8..12].copy_from_slice(&entry_count.to_be_bytes());
-        slice[12..16].copy_from_slice(&crc.to_be_bytes());
-        slice[16..20].copy_from_slice(&(entries_size as u32).to_be_bytes());
+        let crc = crc32fast::hash(buf.initialized_slice(V4_BATCH_HEADER_SIZE, pos));
+        buf.write_u64_be_at(0, commit_ts);
+        buf.write_u32_be_at(8, entry_count);
+        buf.write_u32_be_at(12, crc);
+        buf.write_u32_be_at(16, entries_size as u32);
 
         // Zero-pad to 4KB alignment (O_DIRECT requirement).
         let aligned_len = DirectBuf::align_up(pos);
-        slice[pos..aligned_len].fill(0);
+        buf.zero_range(pos, aligned_len);
         buf.set_len(aligned_len);
         #[cfg(feature = "bench")]
         if let Some(profile) = profile {
@@ -659,30 +684,29 @@ impl Wal {
         };
         buf.clear();
 
-        let slice = buf.as_mut_slice();
         let mut pos = V4_BATCH_HEADER_SIZE;
 
         for (start, end) in tombstones {
-            slice[pos] = WalEntryKind::RangeTombstone as u8;
+            buf.write_u8_at(pos, WalEntryKind::RangeTombstone as u8);
             pos += 1;
-            slice[pos..pos + 2].copy_from_slice(&(start.len() as u16).to_be_bytes());
+            buf.write_u16_be_at(pos, start.len() as u16);
             pos += 2;
-            slice[pos..pos + start.len()].copy_from_slice(start);
+            buf.write_at(pos, start);
             pos += start.len();
-            slice[pos..pos + 2].copy_from_slice(&(end.len() as u16).to_be_bytes());
+            buf.write_u16_be_at(pos, end.len() as u16);
             pos += 2;
-            slice[pos..pos + end.len()].copy_from_slice(end);
+            buf.write_at(pos, end);
             pos += end.len();
         }
 
-        let crc = crc32fast::hash(&slice[V4_BATCH_HEADER_SIZE..pos]);
-        slice[0..8].copy_from_slice(&commit_ts.to_be_bytes());
-        slice[8..12].copy_from_slice(&entry_count.to_be_bytes());
-        slice[12..16].copy_from_slice(&crc.to_be_bytes());
-        slice[16..20].copy_from_slice(&(entries_size as u32).to_be_bytes());
+        let crc = crc32fast::hash(buf.initialized_slice(V4_BATCH_HEADER_SIZE, pos));
+        buf.write_u64_be_at(0, commit_ts);
+        buf.write_u32_be_at(8, entry_count);
+        buf.write_u32_be_at(12, crc);
+        buf.write_u32_be_at(16, entries_size as u32);
 
         let aligned_len = DirectBuf::align_up(pos);
-        slice[pos..aligned_len].fill(0);
+        buf.zero_range(pos, aligned_len);
         buf.set_len(aligned_len);
 
         let mut pending = self.pending.lock();

--- a/todo.md
+++ b/todo.md
@@ -304,6 +304,13 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   256 KiB pool entries did not reduce large-batch prepare time and regressed `wal_batch_size=1000` to 468,984 OPS.
   Prefilling the pool with 2 MiB buffers removed `wal_prepare` but was a hard reject: the same profile collapsed to
   124,450 OPS, with `wal_sync`/`follower_wait` increasing despite lower write preparation time.
+  Rejected follow-up: publishing `DeferredBatchPublish` by cloning its owned `Bytes` handles into the memtable instead
+  of copying borrowed payloads cut profiled memtable time but was mixed end-to-end: same-window profile moved
+  `wal_batch_size=1000` 405,409 → 460,487 OPS, but regressed `wal_batch_size=100` 169,555 → 140,555 OPS.
+  Rejected follow-up: adding a separate, non-prefilled large DirectBuf pool for 512 KiB-2 MiB buffers reduced
+  profiled `wal_prepare` on one large-batch run, but same-window control was faster: candidate `wal_batch_size=1000`
+  445,582 OPS versus control 502,948 OPS. The small-batch case was neutral in the same window (candidate
+  154,243-156,297 OPS versus control 154,749 OPS), so the reject is the large-batch throughput loss.
   Final PR-head sync/no-sync comparison artifacts:
   `result-toykv_pr174_final_sync_100k.csv` and `result-toykv_pr174_final_nosync_100k.csv`. Same command shape
   (`--samples 100000 --clients 4 --threads 4 --skip-indexes --skip-scans`) shows durable batch writes remain below

--- a/todo.md
+++ b/todo.md
@@ -300,6 +300,10 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   sync/follower wait (`wal_sync` 270.51 ms, `follower_wait` 174.09 ms), while the batch-size 1000 profile shows
   direct-buffer preparation dominating the WAL write bucket (`wal_prepare` 28.46 ms versus `wal_encode` 7.41 ms).
   The next large-batch target should inspect direct-buffer pool sizing/reuse before more encoding-loop changes.
+  Rejected follow-up: retaining up to 2 MiB direct buffers while letting oversized allocations replace undersized
+  256 KiB pool entries did not reduce large-batch prepare time and regressed `wal_batch_size=1000` to 468,984 OPS.
+  Prefilling the pool with 2 MiB buffers removed `wal_prepare` but was a hard reject: the same profile collapsed to
+  124,450 OPS, with `wal_sync`/`follower_wait` increasing despite lower write preparation time.
   Final PR-head sync/no-sync comparison artifacts:
   `result-toykv_pr174_final_sync_100k.csv` and `result-toykv_pr174_final_nosync_100k.csv`. Same command shape
   (`--samples 100000 --clients 4 --threads 4 --skip-indexes --skip-scans`) shows durable batch writes remain below

--- a/todo.md
+++ b/todo.md
@@ -314,6 +314,14 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   Rejected follow-up: lowering `GROUP_COMMIT_MIN_SOLO_BYTES` from 512 KiB to 128 KiB to include
   `wal_batch_size=100` in the solo-leader spin path regressed the focused profile to 143,988 OPS and raised solo
   groups to 70.7%, so spinning smaller batches did not improve group formation.
+  Accepted follow-up: raw DirectBuf encoding now skips full-buffer memset on allocation and initializes only the WAL
+  header, encoded entries, and O_DIRECT padding. Focused `write-perf` improved `wal_batch_size=1000` to 1,175,368
+  OPS with `wal_prepare` down to 0.52 ms, and `wal_batch_size=100` to 494,581 OPS. The focused CRUD sync gate
+  `result-toykv_raw_directbuf_encode_pr189_sync_100k.csv` improved targeted durable batch write/delete rows versus
+  `result-toykv_pr174_final_sync_100k.csv`: `batch_create_100` 6,583.98 -> 7,692.27 OPS, `batch_update_100`
+  7,170.94 -> 7,305.25 OPS, `batch_delete_100` 10,679.07 -> 11,929.03 OPS, `batch_create_1000`
+  1,245.03 -> 1,635.38 OPS, `batch_update_1000` 1,548.54 -> 1,829.53 OPS, and `batch_delete_1000`
+  3,397.84 -> 5,383.25 OPS.
   Final PR-head sync/no-sync comparison artifacts:
   `result-toykv_pr174_final_sync_100k.csv` and `result-toykv_pr174_final_nosync_100k.csv`. Same command shape
   (`--samples 100000 --clients 4 --threads 4 --skip-indexes --skip-scans`) shows durable batch writes remain below

--- a/todo.md
+++ b/todo.md
@@ -311,6 +311,9 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   profiled `wal_prepare` on one large-batch run, but same-window control was faster: candidate `wal_batch_size=1000`
   445,582 OPS versus control 502,948 OPS. The small-batch case was neutral in the same window (candidate
   154,243-156,297 OPS versus control 154,749 OPS), so the reject is the large-batch throughput loss.
+  Rejected follow-up: lowering `GROUP_COMMIT_MIN_SOLO_BYTES` from 512 KiB to 128 KiB to include
+  `wal_batch_size=100` in the solo-leader spin path regressed the focused profile to 143,988 OPS and raised solo
+  groups to 70.7%, so spinning smaller batches did not improve group formation.
   Final PR-head sync/no-sync comparison artifacts:
   `result-toykv_pr174_final_sync_100k.csv` and `result-toykv_pr174_final_nosync_100k.csv`. Same command shape
   (`--samples 100000 --clients 4 --threads 4 --skip-indexes --skip-scans`) shows durable batch writes remain below


### PR DESCRIPTION
## Summary

Skip full-capacity memset when allocating WAL DirectBuf buffers. The WAL encoders now initialize only the submitted bytes: v4 header, entry payload, and O_DIRECT padding.

## Details

- Replace full-buffer mutable-slice encoding with bounded raw writes into the page-aligned DirectBuf allocation.
- Keep CRC computation over initialized entry bytes only.
- Preserve zero-padding of the aligned write range before io_uring submission.
- Record rejected buffer-pool, owned-publish, and group-commit threshold experiments in todo.md.

## Performance

- write-perf wal_batch 1000: 1,175,368 OPS, with wal_prepare down to 0.52 ms.
- write-perf wal_batch 100: 494,581 OPS.
- CRUD sync gate improved targeted durable batch write/delete rows versus result-toykv_pr174_final_sync_100k.csv:
  - batch_create_100: 6,583.98 -> 7,692.27 OPS
  - batch_update_100: 7,170.94 -> 7,305.25 OPS
  - batch_delete_100: 10,679.07 -> 11,929.03 OPS
  - batch_create_1000: 1,245.03 -> 1,635.38 OPS
  - batch_update_1000: 1,548.54 -> 1,829.53 OPS
  - batch_delete_1000: 3,397.84 -> 5,383.25 OPS

## Verification

- [x] cargo fmt --all --check
- [x] cargo check --workspace --all-features
- [x] cargo clippy --workspace --all-features --all-targets -- -D warnings
- [x] cargo test --package kv-engine --bin write-perf wal_batch
- [x] cargo nextest run --workspace --all-features wal (outside sandbox)
- [x] cargo run --release --features bench --bin write-perf -- --bench wal_batch --num 100000 --threads 4 --value-size 1024 --wal-batch-size 1000 --profile (outside sandbox)
- [x] cargo run --release --features bench --bin write-perf -- --bench wal_batch --num 100000 --threads 4 --value-size 1024 --wal-batch-size 100 --profile (outside sandbox)
- [x] cargo run --release --no-default-features --features toykv --bin crud-bench -- --database toykv --samples 100000 --clients 4 --threads 4 --sync --skip-indexes --skip-scans --name toykv_raw_directbuf_encode_pr189_sync_100k (outside sandbox, crud-bench)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved write-ahead logging performance by avoiding unnecessary buffer initialization.
  * Reduced overhead when encoding and writing batches, including point updates and range deletions.
  * Preserved data integrity through targeted padding and checksum handling.

* **Documentation**
  * Updated production synchronization performance notes with experiment results and benchmark outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->