### PR TITLE
perf: use cursor for WAL direct buffer encoding

### DIFF
--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -133,10 +133,6 @@ impl DirectBuf {
         unsafe { *self.ptr.add(pos) = value };
     }
 
-    fn write_u16_be_at(&mut self, pos: usize, value: u16) {
-        self.write_at(pos, &value.to_be_bytes());
-    }
-
     fn write_u32_be_at(&mut self, pos: usize, value: u32) {
         self.write_at(pos, &value.to_be_bytes());
     }
@@ -190,6 +186,36 @@ impl DirectBuf {
 impl Drop for DirectBuf {
     fn drop(&mut self) {
         unsafe { libc::free(self.ptr as *mut libc::c_void) };
+    }
+}
+
+struct DirectBufCursor<'a> {
+    buf: &'a mut DirectBuf,
+    pos: usize,
+}
+
+impl<'a> DirectBufCursor<'a> {
+    fn new(buf: &'a mut DirectBuf, pos: usize) -> Self {
+        Self { buf, pos }
+    }
+
+    fn position(&self) -> usize {
+        self.pos
+    }
+
+    fn write_u8(&mut self, value: u8) {
+        self.buf.write_u8_at(self.pos, value);
+        self.pos += 1;
+    }
+
+    fn write_u16_be(&mut self, value: u16) {
+        let bytes = value.to_be_bytes();
+        self.write(&bytes);
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        self.buf.write_at(self.pos, bytes);
+        self.pos += bytes.len();
     }
 }
 
@@ -584,25 +610,21 @@ impl Wal {
         #[cfg(feature = "bench")]
         let encode_start = Instant::now();
         // Reserve header space (filled later).
-        let mut pos = V4_BATCH_HEADER_SIZE;
+        let mut cursor = DirectBufCursor::new(&mut buf, V4_BATCH_HEADER_SIZE);
 
         for (entry, (kl, vl)) in data.iter().zip(validated.iter()) {
             let key = entry.key();
             let value = entry.value();
             if self.is_v3 {
-                buf.write_u8_at(pos, WalEntryKind::Put as u8);
-                pos += 1;
+                cursor.write_u8(WalEntryKind::Put as u8);
             }
-            buf.write_u16_be_at(pos, *kl);
-            pos += 2;
-            buf.write_at(pos, key);
-            pos += key.len();
-            buf.write_u16_be_at(pos, *vl);
-            pos += 2;
-            buf.write_at(pos, value);
-            pos += value.len();
+            cursor.write_u16_be(*kl);
+            cursor.write(key);
+            cursor.write_u16_be(*vl);
+            cursor.write(value);
         }
 
+        let pos = cursor.position();
         let crc = crc32fast::hash(buf.initialized_slice(V4_BATCH_HEADER_SIZE, pos));
         buf.write_u64_be_at(0, commit_ts);
         buf.write_u32_be_at(8, entry_count);
@@ -684,21 +706,17 @@ impl Wal {
         };
         buf.clear();
 
-        let mut pos = V4_BATCH_HEADER_SIZE;
+        let mut cursor = DirectBufCursor::new(&mut buf, V4_BATCH_HEADER_SIZE);
 
         for (start, end) in tombstones {
-            buf.write_u8_at(pos, WalEntryKind::RangeTombstone as u8);
-            pos += 1;
-            buf.write_u16_be_at(pos, start.len() as u16);
-            pos += 2;
-            buf.write_at(pos, start);
-            pos += start.len();
-            buf.write_u16_be_at(pos, end.len() as u16);
-            pos += 2;
-            buf.write_at(pos, end);
-            pos += end.len();
+            cursor.write_u8(WalEntryKind::RangeTombstone as u8);
+            cursor.write_u16_be(start.len() as u16);
+            cursor.write(start);
+            cursor.write_u16_be(end.len() as u16);
+            cursor.write(end);
         }
 
+        let pos = cursor.position();
         let crc = crc32fast::hash(buf.initialized_slice(V4_BATCH_HEADER_SIZE, pos));
         buf.write_u64_be_at(0, commit_ts);
         buf.write_u32_be_at(8, entry_count);

--- a/todo.md
+++ b/todo.md
@@ -329,15 +329,15 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   `batch_create_100` 7,667.52 OPS, `batch_update_100` 7,046.86 OPS, `batch_delete_100` 11,421.73 OPS,
   `batch_create_1000` 1,631.38 OPS, `batch_update_1000` 1,758.70 OPS, and `batch_delete_1000` 5,380.71 OPS, which is
   flat/slightly down against `result-toykv_raw_directbuf_encode_pr189_sync_100k.csv`.
-  Accepted follow-up: routing raw DirectBuf WAL payload encoding through a small cursor removed repeated manual
-  offset updates in the hot loop. Focused `write-perf` moved `wal_batch_size=1000` to 1,141,209 OPS,
-  `wal_batch_size=100` to 584,235 OPS, and `wal_concurrent` to 179,615 OPS. The first CRUD sync run
-  `result-toykv_directbuf_cursor_pr190_sync_100k.csv` was noisy (`batch_create_100` dipped to 3,429.86 OPS), but
-  rerun `result-toykv_directbuf_cursor_pr190_sync_100k_rerun2.csv` recovered targeted rows and beat the same-window
-  baseline `result-toykv_pr189_control_for_cursor_sync_100k.csv`: `batch_create_100` 6,932.80 / 1,229.78 OPS,
-  `batch_update_100` 7,641.12 / 1,233.78 OPS, `batch_delete_100` 12,559.98 / 2,797.77 OPS,
-  `batch_create_1000` 1,764.33 / 1,174.21 OPS, `batch_update_1000` 1,791.25 / 934.30 OPS, and
-  `batch_delete_1000` 3,851.35 / 2,184.58 OPS.
+  Kept follow-up: routing raw DirectBuf WAL payload encoding through a small cursor removed repeated manual offset
+  updates in the hot loop without changing the encoded bytes. Focused `write-perf` moved `wal_batch_size=1000` to
+  1,141,209 OPS, `wal_batch_size=100` to 584,235 OPS, and `wal_concurrent` to 179,615 OPS. The CRUD sync evidence was
+  mixed and noisy rather than a clean durable-gate win: rerun `result-toykv_directbuf_cursor_pr190_sync_100k_rerun2.csv`
+  recovered from an anomalous first run and beat the anomalously slow same-window baseline
+  `result-toykv_pr189_control_for_cursor_sync_100k.csv` (`batch_create_1000` 1,764.33 / 1,174.21 OPS,
+  `batch_update_1000` 1,791.25 / 934.30 OPS, `batch_delete_1000` 3,851.35 / 2,184.58 OPS), but remained mixed against
+  the accepted PR #189 artifact: `batch_create_100` 7,692.27 -> 6,932.80 OPS, `batch_update_1000`
+  1,829.53 -> 1,791.25 OPS, and `batch_delete_1000` 5,383.25 -> 3,851.35 OPS.
   Final PR-head sync/no-sync comparison artifacts:
   `result-toykv_pr174_final_sync_100k.csv` and `result-toykv_pr174_final_nosync_100k.csv`. Same command shape
   (`--samples 100000 --clients 4 --threads 4 --skip-indexes --skip-scans`) shows durable batch writes remain below

--- a/todo.md
+++ b/todo.md
@@ -322,6 +322,22 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   7,170.94 -> 7,305.25 OPS, `batch_delete_100` 10,679.07 -> 11,929.03 OPS, `batch_create_1000`
   1,245.03 -> 1,635.38 OPS, `batch_update_1000` 1,548.54 -> 1,829.53 OPS, and `batch_delete_1000`
   3,397.84 -> 5,383.25 OPS.
+  Rejected follow-up: computing CRC incrementally while encoding only for WAL payloads >=512 KiB improved the
+  `write-perf` large-batch microprofile (`wal_batch_size=1000` same-window control 736,265 OPS, candidate up to
+  1,009,827 OPS) and kept `wal_batch_size=100` near control, but did not improve the focused CRUD sync gate versus the
+  accepted PR #189 artifact. `result-toykv_inline_crc_pr190_sync_100k.csv` moved targeted rows to
+  `batch_create_100` 7,667.52 OPS, `batch_update_100` 7,046.86 OPS, `batch_delete_100` 11,421.73 OPS,
+  `batch_create_1000` 1,631.38 OPS, `batch_update_1000` 1,758.70 OPS, and `batch_delete_1000` 5,380.71 OPS, which is
+  flat/slightly down against `result-toykv_raw_directbuf_encode_pr189_sync_100k.csv`.
+  Accepted follow-up: routing raw DirectBuf WAL payload encoding through a small cursor removed repeated manual
+  offset updates in the hot loop. Focused `write-perf` moved `wal_batch_size=1000` to 1,141,209 OPS,
+  `wal_batch_size=100` to 584,235 OPS, and `wal_concurrent` to 179,615 OPS. The first CRUD sync run
+  `result-toykv_directbuf_cursor_pr190_sync_100k.csv` was noisy (`batch_create_100` dipped to 3,429.86 OPS), but
+  rerun `result-toykv_directbuf_cursor_pr190_sync_100k_rerun2.csv` recovered targeted rows and beat the same-window
+  baseline `result-toykv_pr189_control_for_cursor_sync_100k.csv`: `batch_create_100` 6,932.80 / 1,229.78 OPS,
+  `batch_update_100` 7,641.12 / 1,233.78 OPS, `batch_delete_100` 12,559.98 / 2,797.77 OPS,
+  `batch_create_1000` 1,764.33 / 1,174.21 OPS, `batch_update_1000` 1,791.25 / 934.30 OPS, and
+  `batch_delete_1000` 3,851.35 / 2,184.58 OPS.
   Final PR-head sync/no-sync comparison artifacts:
   `result-toykv_pr174_final_sync_100k.csv` and `result-toykv_pr174_final_nosync_100k.csv`. Same command shape
   (`--samples 100000 --clients 4 --threads 4 --skip-indexes --skip-scans`) shows durable batch writes remain below

--- a/todo.md
+++ b/todo.md
@@ -337,7 +337,11 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   `result-toykv_pr189_control_for_cursor_sync_100k.csv` (`batch_create_1000` 1,764.33 / 1,174.21 OPS,
   `batch_update_1000` 1,791.25 / 934.30 OPS, `batch_delete_1000` 3,851.35 / 2,184.58 OPS), but remained mixed against
   the accepted PR #189 artifact: `batch_create_100` 7,692.27 -> 6,932.80 OPS, `batch_update_1000`
-  1,829.53 -> 1,791.25 OPS, and `batch_delete_1000` 5,383.25 -> 3,851.35 OPS.
+  1,829.53 -> 1,791.25 OPS, and `batch_delete_1000` 5,383.25 -> 3,851.35 OPS. Fresh rerun
+  `result-toykv_directbuf_cursor_pr190_sync_100k_rerun3.csv` stayed mixed against PR #189: `batch_create_100`
+  7,692.27 -> 6,457.65 OPS, `batch_update_100` 7,305.25 -> 7,530.86 OPS, `batch_delete_100`
+  11,929.03 -> 12,492.57 OPS, `batch_create_1000` 1,635.38 -> 1,771.70 OPS, `batch_update_1000`
+  1,829.53 -> 1,360.18 OPS, and `batch_delete_1000` 5,383.25 -> 4,739.29 OPS.
   Final PR-head sync/no-sync comparison artifacts:
   `result-toykv_pr174_final_sync_100k.csv` and `result-toykv_pr174_final_nosync_100k.csv`. Same command shape
   (`--samples 100000 --clients 4 --threads 4 --skip-indexes --skip-scans`) shows durable batch writes remain below


### PR DESCRIPTION
## Summary

- Add a small DirectBufCursor for WAL payload encoding.
- Use it for point-entry and range-tombstone batch payloads to remove repeated manual offset arithmetic in the hot path.
- Record rejected inline-CRC and mixed cursor CRUD benchmark evidence in todo.md.

## Verification

- cargo fmt --all --check
- git diff --check
- cargo check --workspace --all-features
- cargo clippy --workspace --all-features --all-targets -- -D warnings
- cargo nextest run --workspace --all-features wal

## Benchmarks

Focused write-perf profiles on this branch:
- wal_batch_size=1000: 1,141,209 OPS
- wal_batch_size=100: 584,235 OPS
- wal_concurrent: 179,615 OPS

Latest CRUD sync gate artifact:
- result-toykv_directbuf_cursor_pr190_sync_100k_rerun3.csv

Latest rerun stayed mixed against PR #189: batch_create_1000 improved from 1,635.38 to 1,771.70 OPS, batch_update_100 improved from 7,305.25 to 7,530.86 OPS, and batch_delete_100 improved from 11,929.03 to 12,492.57 OPS, while batch_create_100, batch_update_1000, and batch_delete_1000 were lower.

Same-window control artifact used for noise context:
- result-toykv_pr189_control_for_cursor_sync_100k.csv