### PR TITLE
perf: commit caller WAL ticket before publish

### DIFF
--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -4832,13 +4832,13 @@ impl LsmStorageInner {
         entries: &[(bytes::Bytes, bytes::Bytes, crate::mvcc::BatchEntryKind)],
     ) -> Result<()> {
         let mvcc = self.mvcc.as_ref().expect("mvcc_write_batch requires MVCC");
-        let (commit_ts, memtable, publish_data) = {
+        let (commit_ts, memtable, publish_data, ticket) = {
             let _read_guard = self.active_memtable_lock.read();
             let state = self.state.load();
-            let (commit_ts, data) = mvcc.write_batch_wal_only(entries, &state.memtable)?;
-            (commit_ts, state.memtable.clone(), data)
+            let (commit_ts, data, ticket) = mvcc.write_batch_wal_only(entries, &state.memtable)?;
+            (commit_ts, state.memtable.clone(), data, ticket)
         };
-        memtable.commit_wal()?;
+        memtable.commit_wal_ticket(ticket)?;
         if !publish_data.is_empty() {
             publish_data.with_borrowed_refs(|refs| memtable.publish_raw_batch(refs))?;
         }
@@ -4963,20 +4963,20 @@ impl LsmStorageInner {
             );
         }
 
-        let (memtable, rt_ts) = {
+        let (memtable, rt_ts, ticket) = {
             let _guard = self.active_memtable_lock.read();
             let state = self.state.load_full();
-            let ts = if let Some(ref mvcc) = self.mvcc {
+            let (ts, ticket) = if let Some(ref mvcc) = self.mvcc {
                 mvcc.write_range_batch_wal_only(&entries, &state.memtable)?
             } else {
-                state
+                let ticket = state
                     .memtable
                     .put_range_tombstone_batch_wal_only(&entries, 0, 0)?;
-                0
+                (0, ticket)
             };
-            (state.memtable.clone(), ts)
+            (state.memtable.clone(), ts, ticket)
         };
-        memtable.commit_wal()?;
+        memtable.commit_wal_ticket(ticket)?;
         memtable.publish_range_tombstones(&entries, rt_ts, 0)?;
         if rt_ts > 0
             && let Some(ref mvcc) = self.mvcc
@@ -5161,15 +5161,15 @@ impl LsmStorageInner {
             .mvcc
             .as_ref()
             .expect("mvcc_write_batch_inner requires MVCC");
-        let (commit_ts, memtable, publish_data) = {
+        let (commit_ts, memtable, publish_data, ticket) = {
             let _read_guard = self.active_memtable_lock.read();
             // L5: Use load() (borrow) instead of load_full() (Arc clone)
             // to avoid an unnecessary atomic increment.
             let guard = self.state.load();
-            let (commit_ts, data) = mvcc.write_batch_wal_only(entries, &guard.memtable)?;
-            (commit_ts, guard.memtable.clone(), data)
+            let (commit_ts, data, ticket) = mvcc.write_batch_wal_only(entries, &guard.memtable)?;
+            (commit_ts, guard.memtable.clone(), data, ticket)
         };
-        memtable.commit_wal()?;
+        memtable.commit_wal_ticket(ticket)?;
         if !publish_data.is_empty() {
             publish_data.with_borrowed_refs(|refs| memtable.publish_raw_batch(refs))?;
         }
@@ -5999,14 +5999,18 @@ impl LsmStorageInner {
             return self.range_batch_write(batch);
         }
 
-        // Defer serializable txn recording until after commit_wal succeeds.
+        // Defer serializable txn recording until after commit_wal_ticket succeeds.
         let mut txn_info: Option<(u64, std::collections::HashSet<bytes::Bytes>)> = None;
         // Track commit_ts for advancing current_ts after publish.
         let mut mvcc_commit_ts: u64 = 0;
 
         // M5: WAL-only writes under the lock. Publish to skiplist happens
-        // AFTER commit_wal succeeds, preventing ghost entries on sync failure.
-        let (memtable, publish_data): (Arc<MemTable>, crate::mvcc::DeferredBatchPublish) = {
+        // AFTER commit_wal_ticket succeeds, preventing ghost entries on sync failure.
+        let (memtable, publish_data, ticket): (
+            Arc<MemTable>,
+            crate::mvcc::DeferredBatchPublish,
+            Option<u64>,
+        ) = {
             let _commit_guard = self.mvcc.as_ref().and_then(|mvcc| {
                 if self.options.serializable {
                     Some(mvcc.commit_lock.lock())
@@ -6021,9 +6025,10 @@ impl LsmStorageInner {
                 let (entries, dedup_indices) =
                     Self::build_unique_point_batch_entries_or_dedup(batch);
                 // WAL-only: do NOT publish to skiplist yet.
-                let (commit_ts, data) = mvcc.write_batch_wal_only(&entries, &state.memtable)?;
+                let (commit_ts, data, ticket) =
+                    mvcc.write_batch_wal_only(&entries, &state.memtable)?;
                 mvcc_commit_ts = commit_ts;
-                // Defer record_committed_txn until after commit_wal succeeds
+                // Defer record_committed_txn until after commit_wal_ticket succeeds
                 // so that failed WAL syncs don't poison serializable validation.
                 if self.options.serializable && commit_ts > 0 {
                     txn_info = Some((
@@ -6031,19 +6036,19 @@ impl LsmStorageInner {
                         Self::build_serializable_write_set(batch, dedup_indices.as_deref()),
                     ));
                 }
-                (state.memtable.clone(), data)
+                (state.memtable.clone(), data, ticket)
             } else {
                 // Non-MVCC path: write raw user keys to WAL only.
                 let dedup_indices = Self::dedup_write_batch_indices(batch);
                 let data = Self::build_non_mvcc_batch_entries(batch, dedup_indices.as_deref());
                 let publish_data = crate::mvcc::DeferredBatchPublish::from_entries(data);
-                publish_data
+                let ticket = publish_data
                     .with_borrowed_refs(|refs| state.memtable.write_wal_batch_only(refs))?;
-                (state.memtable.clone(), publish_data)
+                (state.memtable.clone(), publish_data, ticket)
             }
         };
-        // Phase 2: After locks released, commit_wal() then publish to skiplist.
-        memtable.commit_wal()?;
+        // Phase 2: After locks released, commit_wal_ticket() then publish to skiplist.
+        memtable.commit_wal_ticket(ticket)?;
         // Publish to skiplist + bloom AFTER WAL sync succeeds.
         if !publish_data.is_empty() {
             publish_data.with_borrowed_refs(|refs| memtable.publish_raw_batch(refs))?;
@@ -6095,9 +6100,9 @@ impl LsmStorageInner {
         );
         Self::validate_key_size(key)?;
         // Phase 1: Under locks, write to WAL buffer only (no skiplist insert).
-        // Phase 2: After locks released, commit_wal() then publish to skiplist.
+        // Phase 2: After locks released, commit_wal_ticket() then publish to skiplist.
         // This ensures data is not visible to readers if the WAL sync fails.
-        let (memtable, publish_data) = {
+        let (memtable, publish_data, ticket) = {
             let _commit_guard = self.mvcc.as_ref().and_then(|mvcc| {
                 if self.options.serializable {
                     Some(mvcc.commit_lock.lock())
@@ -6108,26 +6113,31 @@ impl LsmStorageInner {
             let _guard = self.active_memtable_lock.read();
             let state = self.state.load_full();
             if let Some(ref mvcc) = self.mvcc {
-                let (commit_ts, encoded_key, prefixed_val) =
+                let (commit_ts, encoded_key, prefixed_val, ticket) =
                     mvcc.write_wal_only(key, value, &state.memtable)?;
                 (
                     state.memtable.clone(),
                     Some((commit_ts, encoded_key, prefixed_val)),
+                    ticket,
                 )
             } else {
                 // Non-MVCC path: write to WAL, publish after sync.
                 let mut prefixed = Vec::with_capacity(1 + value.len());
                 prefixed.push(crate::vlog::KvKind::Inline as u8);
                 prefixed.extend_from_slice(value);
-                state.memtable.write_wal_batch_only(&[(
+                let ticket = state.memtable.write_wal_batch_only(&[(
                     crate::key::KeySlice::from_slice(key),
                     prefixed.as_slice(),
                 )])?;
-                (state.memtable.clone(), Some((0, key.to_vec(), prefixed)))
+                (
+                    state.memtable.clone(),
+                    Some((0, key.to_vec(), prefixed)),
+                    ticket,
+                )
             }
         };
-        // M5: commit_wal() is called outside the active_memtable_lock.
-        memtable.commit_wal()?;
+        // M5: commit_wal_ticket() is called outside the active_memtable_lock.
+        memtable.commit_wal_ticket(ticket)?;
         // Publish to skiplist + bloom AFTER WAL sync succeeds.
         if let Some((commit_ts, encoded_key, prefixed_val)) = publish_data {
             memtable.publish_raw_batch(&[(
@@ -6166,28 +6176,33 @@ impl LsmStorageInner {
                 None
             }
         });
-        let (memtable, publish_data) = {
+        let (memtable, publish_data, ticket) = {
             let _guard = self.active_memtable_lock.read();
             let state = self.state.load_full();
             if let Some(ref mvcc) = self.mvcc {
-                let (commit_ts, encoded_key, prefixed_val) =
+                let (commit_ts, encoded_key, prefixed_val, ticket) =
                     mvcc.write_ttl_wal_only(key, value, ttl, &state.memtable)?;
                 (
                     state.memtable.clone(),
                     Some((commit_ts, encoded_key, prefixed_val)),
+                    ticket,
                 )
             } else {
                 let expire_at = crate::vlog::compute_expire_at(ttl);
                 let prefixed =
                     crate::vlog::encode_ttl_value(crate::vlog::KvKind::TtlInline, expire_at, value);
-                state.memtable.write_wal_batch_only(&[(
+                let ticket = state.memtable.write_wal_batch_only(&[(
                     crate::key::KeySlice::from_slice(key),
                     prefixed.as_slice(),
                 )])?;
-                (state.memtable.clone(), Some((0, key.to_vec(), prefixed)))
+                (
+                    state.memtable.clone(),
+                    Some((0, key.to_vec(), prefixed)),
+                    ticket,
+                )
             }
         };
-        memtable.commit_wal()?;
+        memtable.commit_wal_ticket(ticket)?;
         if let Some((commit_ts, encoded_key, prefixed_val)) = publish_data {
             memtable.publish_raw_batch(&[(
                 crate::key::KeySlice::from_slice(&encoded_key),
@@ -6220,30 +6235,32 @@ impl LsmStorageInner {
                 None
             }
         });
-        let (memtable, publish_data) = {
+        let (memtable, publish_data, ticket) = {
             let _guard = self.active_memtable_lock.read();
             let state = self.state.load_full();
             if let Some(ref mvcc) = self.mvcc {
-                let (commit_ts, encoded_key, tombstone_val) =
+                let (commit_ts, encoded_key, tombstone_val, ticket) =
                     mvcc.write_tombstone_wal_only(key, &state.memtable)?;
                 (
                     state.memtable.clone(),
                     Some((commit_ts, encoded_key, tombstone_val)),
+                    ticket,
                 )
             } else {
                 // Non-MVCC path: write to WAL, publish after sync.
                 let tombstone_val = vec![crate::vlog::KvKind::Tombstone as u8];
-                state.memtable.write_wal_batch_only(&[(
+                let ticket = state.memtable.write_wal_batch_only(&[(
                     crate::key::KeySlice::from_slice(key),
                     tombstone_val.as_slice(),
                 )])?;
                 (
                     state.memtable.clone(),
                     Some((0, key.to_vec(), tombstone_val)),
+                    ticket,
                 )
             }
         };
-        memtable.commit_wal()?;
+        memtable.commit_wal_ticket(ticket)?;
         if let Some((commit_ts, encoded_key, tombstone_val)) = publish_data {
             memtable.publish_raw_batch(&[(
                 crate::key::KeySlice::from_slice(&encoded_key),

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -6004,6 +6004,17 @@ impl LsmStorageInner {
         // Track commit_ts for advancing current_ts after publish.
         let mut mvcc_commit_ts: u64 = 0;
 
+        // Hold commit_lock through record_committed_txn to prevent concurrent
+        // serializable transactions from passing conflict checks before our
+        // write set is visible.
+        let _commit_guard = self.mvcc.as_ref().and_then(|mvcc| {
+            if self.options.serializable {
+                Some(mvcc.commit_lock.lock())
+            } else {
+                None
+            }
+        });
+
         // M5: WAL-only writes under the lock. Publish to skiplist happens
         // AFTER commit_wal_ticket succeeds, preventing ghost entries on sync failure.
         let (memtable, publish_data, ticket): (
@@ -6011,13 +6022,6 @@ impl LsmStorageInner {
             crate::mvcc::DeferredBatchPublish,
             Option<u64>,
         ) = {
-            let _commit_guard = self.mvcc.as_ref().and_then(|mvcc| {
-                if self.options.serializable {
-                    Some(mvcc.commit_lock.lock())
-                } else {
-                    None
-                }
-            });
             let _guard = self.active_memtable_lock.read();
             let state = self.state.load();
             if let Some(ref mvcc) = self.mvcc {
@@ -6067,6 +6071,7 @@ impl LsmStorageInner {
         {
             mvcc.record_committed_txn(commit_ts, write_set, 0);
         }
+        drop(_commit_guard);
         self.try_freeze_memtable()
     }
 
@@ -6102,14 +6107,16 @@ impl LsmStorageInner {
         // Phase 1: Under locks, write to WAL buffer only (no skiplist insert).
         // Phase 2: After locks released, commit_wal_ticket() then publish to skiplist.
         // This ensures data is not visible to readers if the WAL sync fails.
+        // Hold commit_lock through record_write to prevent concurrent serializable
+        // transactions from passing conflict checks before our write set is visible.
+        let _commit_guard = self.mvcc.as_ref().and_then(|mvcc| {
+            if self.options.serializable {
+                Some(mvcc.commit_lock.lock())
+            } else {
+                None
+            }
+        });
         let (memtable, publish_data, ticket) = {
-            let _commit_guard = self.mvcc.as_ref().and_then(|mvcc| {
-                if self.options.serializable {
-                    Some(mvcc.commit_lock.lock())
-                } else {
-                    None
-                }
-            });
             let _guard = self.active_memtable_lock.read();
             let state = self.state.load_full();
             if let Some(ref mvcc) = self.mvcc {
@@ -6157,6 +6164,7 @@ impl LsmStorageInner {
                 Self::record_write(mvcc, commit_ts, key);
             }
         }
+        drop(_commit_guard);
         self.try_freeze_memtable()
     }
 

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -816,32 +816,34 @@ impl MemTable {
         if data.is_empty() {
             return Ok(());
         }
-        self.write_wal_batch(data)?;
-        self.commit_wal()?;
+        let ticket = self.write_wal_batch(data)?;
+        self.commit_wal_ticket(ticket)?;
         self.publish_raw_batch(data)
     }
 
     /// Write a batch to the WAL buffer only (no skiplist insert, no sync).
     ///
+    /// Returns the WAL ticket assigned to this batch, if WAL is enabled.
+    ///
     /// The caller must subsequently call:
-    /// 1. [`commit_wal`] to durably sync the WAL.
+    /// 1. [`commit_wal_ticket`] with the returned ticket to durably sync the WAL.
     /// 2. [`publish_raw_batch`] to insert into the skiplist + bloom filter.
     ///
     /// This split ensures data is not visible to readers until the WAL sync
     /// succeeds, preventing ghost entries on fsync failure.
-    pub fn write_wal_batch_only(&self, data: &[(KeySlice, &[u8])]) -> Result<()> {
+    pub fn write_wal_batch_only(&self, data: &[(KeySlice, &[u8])]) -> Result<Option<u64>> {
         if data.is_empty() {
-            return Ok(());
+            return Ok(None);
         }
         self.write_wal_batch(data)
     }
 
-    fn write_wal_batch(&self, data: &[(KeySlice, &[u8])]) -> Result<()> {
+    fn write_wal_batch(&self, data: &[(KeySlice, &[u8])]) -> Result<Option<u64>> {
         if data.is_empty() {
-            return Ok(());
+            return Ok(None);
         }
         let Some(wal) = &self.wal else {
-            return Ok(());
+            return Ok(None);
         };
         let commit_ts = data
             .first()
@@ -870,7 +872,7 @@ impl MemTable {
             std::sync::atomic::Ordering::Relaxed,
         );
 
-        Ok(())
+        Ok(Some(ticket))
     }
 
     pub(crate) fn publish_raw_batch(&self, data: &[(KeySlice, &[u8])]) -> Result<()> {
@@ -940,7 +942,7 @@ impl MemTable {
         }
     }
 
-    /// Sync all pending WAL writes via group commit.
+    /// Sync all WAL writes up to the current memtable watermark via group commit.
     ///
     /// Call this AFTER releasing any write locks (e.g., the MVCC write lock)
     /// so that concurrent writers can batch their fsyncs together.
@@ -968,6 +970,33 @@ impl MemTable {
                 "wal.submit_and_commit",
                 wal.submit_and_commit(watermark - 1)
             )?;
+        }
+
+        Ok(())
+    }
+
+    /// Sync the caller's own WAL ticket. This avoids waiting for later tickets
+    /// that were enqueued by other writers after this write.
+    pub fn commit_wal_ticket(&self, ticket: Option<u64>) -> Result<()> {
+        let Some(ticket) = ticket else {
+            return Ok(());
+        };
+        if let Some(wal) = &self.wal {
+            #[cfg(feature = "bench")]
+            {
+                let t = Instant::now();
+                let write_profile = self.write_profile.load();
+                crate::profile_scope!(
+                    "wal.submit_and_commit",
+                    wal.submit_and_commit_profiled(ticket, &write_profile)
+                )?;
+                write_profile.wal_sync_ns.fetch_add(
+                    t.elapsed().as_nanos() as u64,
+                    std::sync::atomic::Ordering::Relaxed,
+                );
+            }
+            #[cfg(not(feature = "bench"))]
+            crate::profile_scope!("wal.submit_and_commit", wal.submit_and_commit(ticket))?;
         }
 
         Ok(())
@@ -1183,8 +1212,9 @@ impl MemTable {
     }
 
     /// Write a batch of range tombstones to the WAL buffer only (no skiplist
-    /// insert, no sync). The caller must subsequently call:
-    /// 1. [`commit_wal`] to durably sync the WAL.
+    /// insert, no sync). Returns the WAL ticket assigned to this batch, if WAL
+    /// is enabled. The caller must subsequently call:
+    /// 1. [`commit_wal_ticket`] with the returned ticket to durably sync the WAL.
     /// 2. [`publish_range_tombstones`] to insert into the in-memory set.
     ///
     /// This ensures tombstones are not visible to readers until the WAL sync
@@ -1194,9 +1224,9 @@ impl MemTable {
         tombstones: &[(&[u8], &[u8])],
         ts: u64,
         base_ordinal: u32,
-    ) -> Result<()> {
+    ) -> Result<Option<u64>> {
         if tombstones.is_empty() {
-            return Ok(());
+            return Ok(None);
         }
         let _ = base_ordinal
             .checked_add(u32::try_from(tombstones.len()).context("ordinal overflow")?)
@@ -1206,9 +1236,10 @@ impl MemTable {
             let ticket = wal.put_range_tombstone_batch(tombstones, ts)?;
             self.last_ticket
                 .fetch_max(ticket + 1, std::sync::atomic::Ordering::Release);
+            return Ok(Some(ticket));
         }
 
-        Ok(())
+        Ok(None)
     }
 
     /// Insert range tombstones into the in-memory set.

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 
 pub(crate) const TOMBSTONE_VALUE: &[u8] = &[crate::vlog::KvKind::Tombstone as u8];
+type WalPublish = (u64, Vec<u8>, Vec<u8>, Option<u64>);
 
 pub(crate) struct CommittedTxnData {
     pub(crate) write_set: HashSet<Bytes>,
@@ -148,9 +149,9 @@ impl LsmMvccInner {
     }
 
     /// Write to WAL only (no skiplist insert). Returns `(commit_ts, encoded_key,
-    /// prefixed_value)`. The caller must subsequently call
-    /// [`MemTable::commit_wal`] then [`MemTable::publish_raw_batch`] to make
-    /// the data visible to readers.
+    /// prefixed_value, wal_ticket)`. The caller must subsequently call
+    /// [`MemTable::commit_wal_ticket`] then [`MemTable::publish_raw_batch`] to
+    /// make the data visible to readers.
     ///
     /// This ensures data is not visible until the WAL sync succeeds.
     pub fn write_wal_only(
@@ -158,7 +159,7 @@ impl LsmMvccInner {
         user_key: &[u8],
         value: &[u8],
         memtable: &MemTable,
-    ) -> Result<(u64, Vec<u8>, Vec<u8>), anyhow::Error> {
+    ) -> Result<WalPublish, anyhow::Error> {
         anyhow::ensure!(
             !(value.len() == 1 && value[0] == crate::vlog::KvKind::Tombstone as u8),
             "value must not be the tombstone marker byte (0x02)"
@@ -169,41 +170,41 @@ impl LsmMvccInner {
         let mut prefixed = Vec::with_capacity(1 + value.len());
         prefixed.push(crate::vlog::KvKind::Inline as u8);
         prefixed.extend_from_slice(value);
-        memtable.write_wal_batch_only(&[(
+        let ticket = memtable.write_wal_batch_only(&[(
             crate::key::KeySlice::from_slice(&encoded_key),
             prefixed.as_slice(),
         )])?;
         // Do NOT advance current_ts here — readers would see the timestamp
         // before the data is published to the skiplist. The caller must
-        // advance current_ts after commit_wal + publish_raw_batch succeed.
+        // advance current_ts after commit_wal_ticket + publish_raw_batch succeed.
 
-        Ok((commit_ts, encoded_key, prefixed))
+        Ok((commit_ts, encoded_key, prefixed, ticket))
     }
 
-    /// Write a tombstone to WAL only. Returns `(commit_ts, encoded_key, tombstone_value)`.
-    /// The caller must subsequently call [`MemTable::commit_wal`] then
+    /// Write a tombstone to WAL only. Returns `(commit_ts, encoded_key, tombstone_value,
+    /// wal_ticket)`. The caller must subsequently call [`MemTable::commit_wal_ticket`] then
     /// [`MemTable::publish_raw_batch`].
     pub fn write_tombstone_wal_only(
         &self,
         user_key: &[u8],
         memtable: &MemTable,
-    ) -> Result<(u64, Vec<u8>, Vec<u8>), anyhow::Error> {
+    ) -> Result<WalPublish, anyhow::Error> {
         let _write_guard = self.write_lock.lock();
         let commit_ts = self.current_ts.load(Ordering::Acquire) + 1;
         let encoded_key = encode_internal_key(user_key, commit_ts);
         let tombstone_val = vec![crate::vlog::KvKind::Tombstone as u8];
-        memtable.write_wal_batch_only(&[(
+        let ticket = memtable.write_wal_batch_only(&[(
             crate::key::KeySlice::from_slice(&encoded_key),
             tombstone_val.as_slice(),
         )])?;
         // Do NOT advance current_ts here — see write_wal_only comment.
 
-        Ok((commit_ts, encoded_key, tombstone_val))
+        Ok((commit_ts, encoded_key, tombstone_val, ticket))
     }
 
     /// Write a TTL-prefixed key-value pair to WAL only.
-    /// Returns `(commit_ts, encoded_key, ttl_prefixed_value)`.
-    /// The caller must subsequently call [`MemTable::commit_wal`] then
+    /// Returns `(commit_ts, encoded_key, ttl_prefixed_value, wal_ticket)`.
+    /// The caller must subsequently call [`MemTable::commit_wal_ticket`] then
     /// [`MemTable::publish_raw_batch`].
     pub fn write_ttl_wal_only(
         &self,
@@ -211,7 +212,7 @@ impl LsmMvccInner {
         value: &[u8],
         ttl: std::time::Duration,
         memtable: &MemTable,
-    ) -> Result<(u64, Vec<u8>, Vec<u8>), anyhow::Error> {
+    ) -> Result<WalPublish, anyhow::Error> {
         anyhow::ensure!(
             !(value.len() == 1 && value[0] == crate::vlog::KvKind::Tombstone as u8),
             "value must not be the tombstone marker byte (0x02)"
@@ -222,12 +223,12 @@ impl LsmMvccInner {
         let expire_at = crate::vlog::compute_expire_at(ttl);
         let prefixed =
             crate::vlog::encode_ttl_value(crate::vlog::KvKind::TtlInline, expire_at, value);
-        memtable.write_wal_batch_only(&[(
+        let ticket = memtable.write_wal_batch_only(&[(
             crate::key::KeySlice::from_slice(&encoded_key),
             prefixed.as_slice(),
         )])?;
 
-        Ok((commit_ts, encoded_key, prefixed))
+        Ok((commit_ts, encoded_key, prefixed, ticket))
     }
 
     /// Write a range tombstone covering `[start, end)`.
@@ -247,17 +248,17 @@ impl LsmMvccInner {
     }
 
     /// Write a batch of range tombstones to WAL buffer only (no skiplist
-    /// insert, no sync). Returns `(commit_ts, base_ordinal)`.
+    /// insert, no sync). Returns `(commit_ts, wal_ticket)`.
     ///
-    /// The caller must subsequently call [`MemTable::commit_wal`] then
+    /// The caller must subsequently call [`MemTable::commit_wal_ticket`] then
     /// [`MemTable::publish_range_tombstones`] to make tombstones visible.
     pub fn write_range_batch_wal_only(
         &self,
         entries: &[(&[u8], &[u8])],
         memtable: &MemTable,
-    ) -> Result<u64, anyhow::Error> {
+    ) -> Result<(u64, Option<u64>), anyhow::Error> {
         if entries.is_empty() {
-            return Ok(0);
+            return Ok((0, None));
         }
         anyhow::ensure!(
             entries.len() <= u32::MAX as usize,
@@ -266,10 +267,10 @@ impl LsmMvccInner {
         );
         let _write_guard = self.write_lock.lock();
         let commit_ts = self.current_ts.load(Ordering::Acquire) + 1;
-        memtable.put_range_tombstone_batch_wal_only(entries, commit_ts, 0)?;
+        let ticket = memtable.put_range_tombstone_batch_wal_only(entries, commit_ts, 0)?;
         // Do NOT advance current_ts here — see write_wal_only comment.
 
-        Ok(commit_ts)
+        Ok((commit_ts, ticket))
     }
 
     /// Write a batch to the WAL buffer only — no skiplist insert, no sync.
@@ -278,12 +279,12 @@ impl LsmMvccInner {
     /// specifies whether the value is raw, already kind-prefixed, or a tombstone
     /// — no byte-sniffing.
     ///
-    /// Returns `(commit_ts, publish_data)` where `publish_data` owns the
+    /// Returns `(commit_ts, publish_data, wal_ticket)` where `publish_data` owns the
     /// encoded key-value pairs needed by `MemTable::publish_raw_batch` after
-    /// the caller confirms WAL sync via `commit_wal`.
+    /// the caller confirms WAL sync via `commit_wal_ticket`.
     ///
     /// The caller must subsequently:
-    /// 1. Call `memtable.commit_wal()` to durably sync the WAL.
+    /// 1. Call `memtable.commit_wal_ticket(ticket)` to durably sync this write's WAL ticket.
     /// 2. Call `memtable.publish_raw_batch(&publish_data)` to insert into the skiplist + bloom
     ///    filter.
     /// 3. Store `commit_ts` into `current_ts`.
@@ -295,9 +296,9 @@ impl LsmMvccInner {
         &self,
         entries: &[(bytes::Bytes, bytes::Bytes, BatchEntryKind)],
         memtable: &MemTable,
-    ) -> Result<(u64, DeferredBatchPublish), anyhow::Error> {
+    ) -> Result<(u64, DeferredBatchPublish, Option<u64>), anyhow::Error> {
         if entries.is_empty() {
-            return Ok((0, DeferredBatchPublish::from_entries(Vec::new())));
+            return Ok((0, DeferredBatchPublish::from_entries(Vec::new()), None));
         }
         let _write_guard = self.write_lock.lock();
         let commit_ts = self.current_ts.load(Ordering::Acquire) + 1;
@@ -325,10 +326,10 @@ impl LsmMvccInner {
             .collect();
         let publish_data = DeferredBatchPublish::from_entries(publish_data);
         // Write to WAL buffer only — do NOT publish to skiplist yet.
-        publish_data.with_refs(|refs| memtable.write_wal_batch_only(refs))?;
+        let ticket = publish_data.with_refs(|refs| memtable.write_wal_batch_only(refs))?;
         // Do NOT advance current_ts here — see write_wal_only comment.
 
-        Ok((commit_ts, publish_data))
+        Ok((commit_ts, publish_data, ticket))
     }
 
     /// Get a read timestamp (the latest committed ts).
@@ -473,8 +474,8 @@ mod tests {
         val: &[u8],
         memtable: &crate::mem_table::MemTable,
     ) -> anyhow::Result<u64> {
-        let (commit_ts, encoded_key, prefixed) = mvcc.write_wal_only(key, val, memtable)?;
-        memtable.commit_wal()?;
+        let (commit_ts, encoded_key, prefixed, ticket) = mvcc.write_wal_only(key, val, memtable)?;
+        memtable.commit_wal_ticket(ticket)?;
         memtable.publish_raw_batch(&[(
             crate::key::KeySlice::from_slice(&encoded_key),
             prefixed.as_slice(),

--- a/kv-engine/src/tests/memtable.rs
+++ b/kv-engine/src/tests/memtable.rs
@@ -5,6 +5,7 @@ use tempfile::tempdir;
 
 use crate::{
     iterators::StorageIterator,
+    key::KeySlice,
     lsm_storage::{KvEngine, LsmStorageInner, LsmStorageOptions},
     mem_table::MemTable,
 };
@@ -231,6 +232,28 @@ fn test_memtable_commit_wal_without_writes_is_noop() {
     let mt = crate::mem_table::MemTable::create_with_wal(0, false, &path).unwrap();
 
     mt.commit_wal().unwrap();
+}
+
+#[test]
+fn test_memtable_commit_wal_ticket_publishes_after_specific_ticket() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("ticket_memtable.wal");
+    let mt = crate::mem_table::MemTable::create_with_wal(0, false, &path).unwrap();
+    let key = crate::key::encode_internal_key(b"k", 1);
+    let value = [crate::vlog::KvKind::Inline as u8, b'v'];
+
+    let ticket = mt
+        .write_wal_batch_only(&[(KeySlice::from_slice(&key), value.as_slice())])
+        .unwrap();
+    assert!(ticket.is_some());
+    mt.commit_wal_ticket(ticket).unwrap();
+    mt.publish_raw_batch(&[(KeySlice::from_slice(&key), value.as_slice())])
+        .unwrap();
+
+    assert_eq!(
+        mt.get_raw_exact(&key),
+        Some(bytes::Bytes::copy_from_slice(&value))
+    );
 }
 
 #[test]

--- a/todo.md
+++ b/todo.md
@@ -360,6 +360,15 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   staging MVCC batch encoded keys in one temporary `BytesMut` slab reduced per-entry key allocations in theory, but the
   focused large-batch profile regressed to 747,154 OPS with higher WAL sync/submit time, so the shared-slab lifetime and
   extra staging work were not a win.
+  Accepted follow-up: hot write paths now commit the caller's own WAL ticket instead of the memtable's latest ticket,
+  so an earlier writer no longer waits for later tickets before publishing. Focused `write-perf` improved
+  `wal_batch_size=100` from 468,367 to 661,830 OPS and `wal_batch_size=1000` from 795,221 to 1,057,081 OPS in the
+  refreshed same-session profile, while `wal_concurrent` stayed effectively flat (161,309 -> 159,031 OPS). The
+  same-window CRUD sync gate was strongly positive: control `result-toykv_ticket_commit_control_sync_100k.csv` versus
+  candidate rerun `result-toykv_ticket_commit_pr193_sync_100k_rerun2.csv` moved `batch_create_100`
+  4,480.67 -> 7,845.61 OPS, `batch_update_100` 2,063.21 -> 8,060.23 OPS, `batch_delete_100`
+  3,658.38 -> 11,376.21 OPS, `batch_create_1000` 721.23 -> 1,385.87 OPS, `batch_update_1000`
+  612.92 -> 1,824.51 OPS, and `batch_delete_1000` 1,775.83 -> 5,994.75 OPS.
   Final PR-head sync/no-sync comparison artifacts:
   `result-toykv_pr174_final_sync_100k.csv` and `result-toykv_pr174_final_nosync_100k.csv`. Same command shape
   (`--samples 100000 --clients 4 --threads 4 --skip-indexes --skip-scans`) shows durable batch writes remain below


### PR DESCRIPTION
## Summary

Hot write paths now commit the caller's own WAL ticket before publishing to the memtable, instead of syncing to the memtable's latest WAL watermark. This keeps the durability-before-visibility ordering while avoiding waits for later tickets enqueued by other writers.

## Changes

- Return the assigned WAL ticket from WAL-only memtable and MVCC write paths.
- Add `MemTable::commit_wal_ticket` and route point, batch, TTL, delete, and range-tombstone publish paths through it.
- Keep `MemTable::commit_wal` for compatibility with callers that intentionally wait for the current watermark.
- Add memtable coverage for ticket-specific commit followed by publish.
- Record the focused write-perf and CRUD sync gate evidence in `todo.md`.

## Verification

- `cargo fmt --all --check`
- `cargo check --workspace --all-features`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo nextest run --workspace --all-features wal write_batch mvcc memtable_commit_wal_ticket` passed: 185 passed, 555 skipped.
- `git diff --check`
- `cargo nextest run --workspace --all-features --all-targets` reached 810 passed tests, then failed because 27 Criterion bench cases timed out under nextest's 30s test timeout.

## Performance

Focused `write-perf` profiles:

- `wal_batch_size=100`: 468,367 -> 661,830 ops/s
- `wal_batch_size=1000`: 795,221 -> 1,057,081 ops/s
- `wal_concurrent`: 161,309 -> 159,031 ops/s

Same-window CRUD sync gate, control `result-toykv_ticket_commit_control_sync_100k.csv` vs candidate rerun `result-toykv_ticket_commit_pr193_sync_100k_rerun2.csv`:

- `batch_create_100`: 4,480.67 -> 7,845.61 ops/s
- `batch_update_100`: 2,063.21 -> 8,060.23 ops/s
- `batch_delete_100`: 3,658.38 -> 11,376.21 ops/s
- `batch_create_1000`: 721.23 -> 1,385.87 ops/s
- `batch_update_1000`: 612.92 -> 1,824.51 ops/s
- `batch_delete_1000`: 1,775.83 -> 5,994.75 ops/s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved write-path durability synchronization, reducing unnecessary waiting during batches and individual writes.
  * Preserved data visibility only after the corresponding WAL data is successfully synchronized.

* **Bug Fixes**
  * Prevented failed WAL synchronization from affecting subsequent serializable validation.
  * Applied consistent durability handling across MVCC, non-MVCC, TTL, delete, and range-tombstone operations.

* **Tests**
  * Added coverage confirming data becomes readable only after its specific WAL operation is committed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->