### PR TITLE
perf: publish large MVCC batches with owned bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,18 +240,20 @@ failpoint injection, and cross-process persistence behavior.
 
 ## Performance Notes
 
-The current benchmark reports compare ToyKV with Fjall and RocksDB through
-`crud-bench` using roughly matched adapter settings. In the latest 2026-07-13
-durable Fjall comparison, ToyKV wins 16 of 17 full-run rows; a focused
+The current benchmark reports compare ToyKV with Fjall, RocksDB, Redb, and
+SurrealKV through `crud-bench` using roughly matched embedded adapter settings.
+In the latest 2026-07-13 durable Fjall comparison, ToyKV wins 16 of 17 full-run rows; a focused
 `batch_read_100` rerun puts ToyKV ahead by about 13.5% after seeding the batch
 workload correctly.
 
-The 2026-07-13 durable RocksDB comparison shows ToyKV ahead on point reads and
-large durable batch writes. Focused scan reruns now put ToyKV ahead on all five
-no-index scan watch rows, including the repeated `select(*) limit(100)` row
-from PR #173 where ToyKV leads RocksDB by 28.3%. The latest focused batch rerun
-keeps `batch_read_1000` ahead of RocksDB; after increasing the short
-`batch_read_100` row to 10,000 iterations, ToyKV also leads that row by 15.6%.
+The latest 2026-07-23 embedded sync comparison for PR #194 shows ToyKV winning
+11 of 12 skip-scan rows across ToyKV, Fjall, RocksDB, Redb, and SurrealKV.
+ToyKV is roughly tied with RocksDB on point create/update/delete and leads every
+large durable batch write row; `batch_delete_1000` is 5.45x faster than
+SurrealKV, 16.69x faster than Fjall, and 19.10x faster than RocksDB in that
+run. Focused scan reruns still put ToyKV ahead on all five no-index scan watch
+rows, including the repeated `select(*) limit(100)` row from PR #173 where
+ToyKV leads RocksDB by 28.3%.
 
 See [ToyKV vs Fjall Benchmark Report](docs/bench-report-crud-bench-fjall.md)
 for the full numbers, caveats, and artifact names. See

--- a/docs/bench-report-crud-bench-rocksdb.md
+++ b/docs/bench-report-crud-bench-rocksdb.md
@@ -5,9 +5,9 @@ This report tracks ToyKV against the embedded RocksDB backend in a sibling
 
 ## Summary
 
-Run date: 2026-07-16 latest three-way durable rerun. The historical full
-durable run is 2026-07-13, with focused scan and batch reruns from 2026-07-14
-to 2026-07-15.
+Run date: 2026-07-23 latest PR #194 embedded durable rerun. Earlier durable
+RocksDB/Fjall runs are from 2026-07-13 to 2026-07-16, with focused scan and
+batch reruns from 2026-07-14 to 2026-07-15.
 
 Configuration:
 
@@ -22,12 +22,63 @@ cargo run --release --no-default-features --features fjall,rocksdb,toykv -- \
   --color never
 ```
 
+Latest PR #194 embedded comparison command shape:
+
+```bash
+cd <crud-bench checkout>
+cargo run --release --bin crud-bench \
+  --no-default-features \
+  --features toykv,fjall,rocksdb,redb,surrealkv -- \
+  --database <toykv|fjall|rocksdb|redb|surrealkv> \
+  --samples 100000 \
+  --clients 4 \
+  --threads 4 \
+  --sync \
+  --skip-scans
+```
+
 RocksDB backend version: `surrealdb-rocksdb 0.24.0-surreal.5` maps to
 `surrealdb-librocksdb-sys 0.18.3+11.0.0-4`, whose vendored
 `rocksdb/version.h` reports raw RocksDB `11.0.0`. The latest upstream raw
 RocksDB release checked on 2026-07-16 is `11.1.2`, so these results are against
 the latest available SurrealDB Rust binding but not the latest upstream RocksDB
 source.
+
+## Latest PR #194 Embedded Sync Comparison
+
+Artifacts:
+
+- `result-compare_embedded_sync_100k_toykv_pr194.{csv,json,html}`
+- `result-compare_embedded_sync_100k_fjall.{csv,json,html}`
+- `result-compare_embedded_sync_100k_rocksdb.{csv,json,html}`
+- `result-compare_embedded_sync_100k_redb.{csv,json,html}`
+- `result-compare_embedded_sync_100k_surrealkv.{csv,json,html}`
+
+All rows are OPS. Higher is better. This pass skipped scan rows to focus on the
+write path affected by PR #194.
+
+| Row | ToyKV | Fjall | RocksDB | Redb | SurrealKV | Winner |
+|---|---:|---:|---:|---:|---:|---|
+| Create | **13,217.74** | 2,231.21 | 12,793.72 | 1,600.00 | 1,689.85 | ToyKV, near tie with RocksDB |
+| Read | **3,607,177.24** | 1,671,018.11 | 1,610,136.21 | 459,820.62 | 1,357,430.66 | ToyKV |
+| Update | **13,233.50** | 1,706.49 | 13,090.03 | 1,669.70 | 1,694.87 | ToyKV, near tie with RocksDB |
+| Delete | **14,225.56** | 1,809.39 | 13,605.36 | 1,871.66 | 1,738.64 | ToyKV, near tie with RocksDB |
+| batch_create_100 | **7,607.83** | 829.68 | 648.83 | 277.76 | 1,228.24 | ToyKV |
+| batch_read_100 | 33,510.64 | 30,455.86 | 29,860.19 | 24,174.78 | **34,113.49** | SurrealKV, near tie with ToyKV |
+| batch_update_100 | **6,476.86** | 703.36 | 655.22 | 264.29 | 1,362.95 | ToyKV |
+| batch_delete_100 | **10,675.25** | 852.99 | 3,954.19 | 277.42 | 1,676.95 | ToyKV |
+| batch_create_1000 | **1,750.44** | 440.72 | 249.12 | 72.29 | 487.72 | ToyKV |
+| batch_read_1000 | **6,655.78** | 5,193.24 | 5,043.51 | 3,737.96 | 3,315.66 | ToyKV |
+| batch_update_1000 | **1,403.24** | 235.77 | 406.97 | 71.78 | 546.16 | ToyKV |
+| batch_delete_1000 | **6,026.26** | 361.09 | 315.56 | 81.73 | 1,106.60 | ToyKV |
+
+ToyKV wins 11 of 12 rows. The only peer lead is `batch_read_100`, where
+SurrealKV is ahead by about 1.8%, which is within the noise range seen in prior
+short batch-read reruns. On point create/update/delete, ToyKV and RocksDB are
+near ties. The meaningful PR #194 signal is the large durable batch write set:
+ToyKV is ahead of every peer on `batch_create_1000`, `batch_update_1000`, and
+`batch_delete_1000`. `batch_delete_1000` is 5.45x faster than SurrealKV, 16.69x
+faster than Fjall, and 19.10x faster than RocksDB in this run.
 
 Latest three-way rerun:
 

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -5027,10 +5027,11 @@ impl LsmStorageInner {
             WriteBatchRecord::PutWithTtl(key, value, ttl_secs) => {
                 let expire_at =
                     crate::vlog::compute_expire_at(std::time::Duration::from_secs(*ttl_secs));
-                let p = crate::vlog::encode_ttl_value(
+                let p = Self::encode_ttl_value_for_batch(
                     crate::vlog::KvKind::TtlInline,
                     expire_at,
                     value.as_ref(),
+                    shared_value_bytes,
                 );
                 data.push((
                     bytes::Bytes::copy_from_slice(key.as_ref()),
@@ -5818,6 +5819,20 @@ impl LsmStorageInner {
     fn encode_kind_value_for_batch(kind: KvKind, value: &[u8], shared_bytes: bool) -> Vec<u8> {
         let mut buf = Vec::with_capacity(1 + value.len() + usize::from(shared_bytes));
         buf.push(kind as u8);
+        buf.extend_from_slice(value);
+        buf
+    }
+
+    fn encode_ttl_value_for_batch(
+        kind: KvKind,
+        expire_at_secs: u64,
+        value: &[u8],
+        shared_bytes: bool,
+    ) -> Vec<u8> {
+        debug_assert!(kind.is_ttl());
+        let mut buf = Vec::with_capacity(9 + value.len() + usize::from(shared_bytes));
+        buf.push(kind as u8);
+        buf.extend_from_slice(&expire_at_secs.to_be_bytes());
         buf.extend_from_slice(value);
         buf
     }

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -4826,6 +4826,23 @@ impl LsmStorageInner {
         Some(rt_iter)
     }
 
+    /// Publish deferred MVCC batch entries after their WAL ticket has committed.
+    fn publish_deferred_batch(
+        memtable: &MemTable,
+        publish_data: crate::mvcc::DeferredBatchPublish,
+    ) -> Result<()> {
+        if Self::use_owned_batch_publish(publish_data.len()) {
+            memtable.publish_raw_batch_owned(publish_data.into_entries())
+        } else {
+            publish_data.with_borrowed_refs(|refs| memtable.publish_raw_batch(refs))
+        }
+    }
+
+    fn use_owned_batch_publish(entries: usize) -> bool {
+        const OWNED_PUBLISH_MIN_BATCH: usize = 512;
+        entries >= OWNED_PUBLISH_MIN_BATCH
+    }
+
     /// Write a batch through MVCC (used by transaction commit).
     pub(crate) fn mvcc_write_batch(
         &self,
@@ -4835,12 +4852,16 @@ impl LsmStorageInner {
         let (commit_ts, memtable, publish_data, ticket) = {
             let _read_guard = self.active_memtable_lock.read();
             let state = self.state.load();
-            let (commit_ts, data, ticket) = mvcc.write_batch_wal_only(entries, &state.memtable)?;
+            let (commit_ts, data, ticket) = mvcc.write_batch_wal_only(
+                entries,
+                &state.memtable,
+                Self::use_owned_batch_publish(entries.len()),
+            )?;
             (commit_ts, state.memtable.clone(), data, ticket)
         };
         memtable.commit_wal_ticket(ticket)?;
         if !publish_data.is_empty() {
-            publish_data.with_borrowed_refs(|refs| memtable.publish_raw_batch(refs))?;
+            Self::publish_deferred_batch(&memtable, publish_data)?;
         }
         // Advance current_ts AFTER publish.
         if commit_ts > 0 {
@@ -4989,12 +5010,17 @@ impl LsmStorageInner {
     fn push_point_batch_entry<T: AsRef<[u8]>>(
         data: &mut Vec<PointBatchEntry>,
         record: &WriteBatchRecord<T>,
+        shared_value_bytes: bool,
     ) {
         match record {
             WriteBatchRecord::Put(key, value) => {
                 data.push((
                     bytes::Bytes::copy_from_slice(key.as_ref()),
-                    bytes::Bytes::from(Self::encode_kind_value(KvKind::Inline, value.as_ref())),
+                    bytes::Bytes::from(Self::encode_kind_value_for_batch(
+                        KvKind::Inline,
+                        value.as_ref(),
+                        shared_value_bytes,
+                    )),
                     crate::mvcc::BatchEntryKind::PutPrefixed,
                 ));
             }
@@ -5026,17 +5052,18 @@ impl LsmStorageInner {
     fn build_point_batch_entries<T: AsRef<[u8]>>(
         batch: &[WriteBatchRecord<T>],
         dedup_indices: Option<&[usize]>,
+        shared_value_bytes: bool,
     ) -> Vec<PointBatchEntry> {
         let mut data = Vec::with_capacity(dedup_indices.map_or(batch.len(), <[usize]>::len));
         match dedup_indices {
             Some(indices) => {
                 for &idx in indices {
-                    Self::push_point_batch_entry(&mut data, &batch[idx]);
+                    Self::push_point_batch_entry(&mut data, &batch[idx], shared_value_bytes);
                 }
             }
             None => {
                 for record in batch {
-                    Self::push_point_batch_entry(&mut data, record);
+                    Self::push_point_batch_entry(&mut data, record, shared_value_bytes);
                 }
             }
         }
@@ -5045,9 +5072,13 @@ impl LsmStorageInner {
 
     fn build_unique_point_batch_entries_or_dedup<T: AsRef<[u8]>>(
         batch: &[WriteBatchRecord<T>],
+        shared_value_bytes: bool,
     ) -> PointBatchBuild {
         if batch.len() <= 1 {
-            return (Self::build_point_batch_entries(batch, None), None);
+            return (
+                Self::build_point_batch_entries(batch, None, shared_value_bytes),
+                None,
+            );
         }
 
         let mut seen = AHashSet::with_capacity(batch.len());
@@ -5059,7 +5090,7 @@ impl LsmStorageInner {
                 let mut dedup_indices = Vec::with_capacity(batch.len());
                 for (idx, record) in batch.iter().enumerate().rev() {
                     if seen.insert(Self::write_batch_key(record)) {
-                        Self::push_point_batch_entry(&mut dedup_data, record);
+                        Self::push_point_batch_entry(&mut dedup_data, record, shared_value_bytes);
                         dedup_indices.push(idx);
                     }
                 }
@@ -5069,7 +5100,7 @@ impl LsmStorageInner {
 
                 return (dedup_data, Some(dedup_indices));
             }
-            Self::push_point_batch_entry(&mut data, record);
+            Self::push_point_batch_entry(&mut data, record, shared_value_bytes);
         }
 
         (data, None)
@@ -5166,12 +5197,16 @@ impl LsmStorageInner {
             // L5: Use load() (borrow) instead of load_full() (Arc clone)
             // to avoid an unnecessary atomic increment.
             let guard = self.state.load();
-            let (commit_ts, data, ticket) = mvcc.write_batch_wal_only(entries, &guard.memtable)?;
+            let (commit_ts, data, ticket) = mvcc.write_batch_wal_only(
+                entries,
+                &guard.memtable,
+                Self::use_owned_batch_publish(entries.len()),
+            )?;
             (commit_ts, guard.memtable.clone(), data, ticket)
         };
         memtable.commit_wal_ticket(ticket)?;
         if !publish_data.is_empty() {
-            publish_data.with_borrowed_refs(|refs| memtable.publish_raw_batch(refs))?;
+            Self::publish_deferred_batch(&memtable, publish_data)?;
         }
         // Advance current_ts AFTER publish.
         if commit_ts > 0 {
@@ -5777,7 +5812,11 @@ impl LsmStorageInner {
 
     /// Encode a value with its kind byte prefix: `[kind_byte, value...]`.
     fn encode_kind_value(kind: KvKind, value: &[u8]) -> Vec<u8> {
-        let mut buf = Vec::with_capacity(1 + value.len());
+        Self::encode_kind_value_for_batch(kind, value, false)
+    }
+
+    fn encode_kind_value_for_batch(kind: KvKind, value: &[u8], shared_bytes: bool) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(1 + value.len() + usize::from(shared_bytes));
         buf.push(kind as u8);
         buf.extend_from_slice(value);
         buf
@@ -6026,11 +6065,12 @@ impl LsmStorageInner {
             let state = self.state.load();
             if let Some(ref mvcc) = self.mvcc {
                 // MVCC path: allocate a single commit_ts for the entire batch.
+                let shared_publish_bytes = Self::use_owned_batch_publish(batch.len());
                 let (entries, dedup_indices) =
-                    Self::build_unique_point_batch_entries_or_dedup(batch);
+                    Self::build_unique_point_batch_entries_or_dedup(batch, shared_publish_bytes);
                 // WAL-only: do NOT publish to skiplist yet.
                 let (commit_ts, data, ticket) =
-                    mvcc.write_batch_wal_only(&entries, &state.memtable)?;
+                    mvcc.write_batch_wal_only(&entries, &state.memtable, shared_publish_bytes)?;
                 mvcc_commit_ts = commit_ts;
                 // Defer record_committed_txn until after commit_wal_ticket succeeds
                 // so that failed WAL syncs don't poison serializable validation.
@@ -6055,7 +6095,7 @@ impl LsmStorageInner {
         memtable.commit_wal_ticket(ticket)?;
         // Publish to skiplist + bloom AFTER WAL sync succeeds.
         if !publish_data.is_empty() {
-            publish_data.with_borrowed_refs(|refs| memtable.publish_raw_batch(refs))?;
+            Self::publish_deferred_batch(&memtable, publish_data)?;
         }
         // Advance current_ts AFTER publish — readers must not see the
         // timestamp before data is visible in the skiplist.

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -933,6 +933,58 @@ impl MemTable {
         Ok(())
     }
 
+    pub(crate) fn publish_raw_batch_owned(&self, entries: Vec<(Bytes, Bytes)>) -> Result<()> {
+        struct AbortOnPanic;
+        impl Drop for AbortOnPanic {
+            fn drop(&mut self) {
+                if std::thread::panicking() {
+                    log::error!(
+                        "panic during memtable publication — aborting to prevent WAL/memtable divergence"
+                    );
+                    std::process::abort();
+                }
+            }
+        }
+        let _abort_guard = AbortOnPanic;
+
+        #[cfg(feature = "bench")]
+        let t = Instant::now();
+        thread_local! {
+            static PUBLISH_USER_KEY_BUF: std::cell::RefCell<Vec<u8>> =
+                const { std::cell::RefCell::new(Vec::new()) };
+        }
+        #[cfg(feature = "bench")]
+        let entry_count = entries.len();
+        PUBLISH_USER_KEY_BUF.with(|buf| {
+            let mut buf = buf.borrow_mut();
+            let mut approximate_size_delta = 0usize;
+            crate::profile_scope!("memtable.publish_batch", {
+                for (key, value) in entries {
+                    Self::maybe_note_ttl_value(&self.has_ttl_entries, &value);
+                    buf.clear();
+                    KeySlice::from_slice(key.as_ref()).decode_user_key_into(&mut buf);
+                    self.bloom.push_hash(super::table::bloom::hash_key(&buf));
+                    approximate_size_delta += key.len() + value.len();
+                    self.map.insert(key, value);
+                }
+                self.approximate_size
+                    .fetch_add(approximate_size_delta, std::sync::atomic::Ordering::Relaxed);
+            });
+        });
+        #[cfg(feature = "bench")]
+        {
+            let wp = self.write_profile.load();
+            wp.memtable_insert_ns.fetch_add(
+                t.elapsed().as_nanos() as u64,
+                std::sync::atomic::Ordering::Relaxed,
+            );
+            wp.op_count
+                .fetch_add(entry_count as u64, std::sync::atomic::Ordering::Relaxed);
+        }
+
+        Ok(())
+    }
+
     fn maybe_note_ttl_value(flag: &AtomicBool, value: &[u8]) {
         if value.first().is_some_and(|kind| {
             *kind == crate::vlog::KvKind::TtlInline as u8

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -1586,3 +1586,30 @@ impl MemTableIterator {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+
+    use super::MemTable;
+
+    #[test]
+    fn publish_raw_batch_owned_inserts_entries() {
+        let mt = MemTable::create(0, false);
+        let key1 = crate::key::encode_internal_key(b"k1", 10);
+        let key2 = crate::key::encode_internal_key(b"k2", 10);
+        let value1 = Bytes::from_static(&[crate::vlog::KvKind::Inline as u8, b'v', b'1']);
+        let value2 = Bytes::from_static(&[crate::vlog::KvKind::Inline as u8, b'v', b'2']);
+        let expected_size = key1.len() + key2.len() + value1.len() + value2.len();
+
+        mt.publish_raw_batch_owned(vec![
+            (Bytes::from(key1.clone()), value1.clone()),
+            (Bytes::from(key2.clone()), value2.clone()),
+        ])
+        .unwrap();
+
+        assert_eq!(mt.get_raw_exact(&key1), Some(value1));
+        assert_eq!(mt.get_raw_exact(&key2), Some(value2));
+        assert_eq!(mt.approximate_size(), expected_size);
+    }
+}

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -15,7 +15,7 @@ use parking_lot::{Mutex, RwLock};
 
 use self::{txn::Transaction, watermark::Watermark};
 use crate::{
-    key::{KeySlice, encode_internal_key},
+    key::{KeySlice, encode_internal_key, encode_internal_key_to_buf, encoded_internal_key_len},
     lsm_storage::LsmStorageInner,
     mem_table::MemTable,
 };
@@ -59,8 +59,16 @@ impl DeferredBatchPublish {
         self.borrow_entries().is_empty()
     }
 
+    pub(crate) fn len(&self) -> usize {
+        self.borrow_entries().len()
+    }
+
     pub(crate) fn with_borrowed_refs<R>(&self, f: impl FnOnce(&[(KeySlice<'_>, &[u8])]) -> R) -> R {
         self.with_refs(|refs| f(refs.as_slice()))
+    }
+
+    pub(crate) fn into_entries(self) -> Vec<(Bytes, Bytes)> {
+        self.into_heads().entries
     }
 }
 
@@ -86,6 +94,16 @@ pub(crate) enum BatchEntryKind {
 }
 
 impl LsmMvccInner {
+    fn encode_internal_key_bytes(user_key: &[u8], ts: u64, shared: bool) -> Bytes {
+        if shared {
+            let mut buf = Vec::with_capacity(encoded_internal_key_len(user_key.len()) + 1);
+            encode_internal_key_to_buf(&mut buf, user_key, ts);
+            Bytes::from(buf)
+        } else {
+            Bytes::from(encode_internal_key(user_key, ts))
+        }
+    }
+
     pub fn new(initial_ts: u64) -> Self {
         Self {
             write_lock: Mutex::new(()),
@@ -296,6 +314,7 @@ impl LsmMvccInner {
         &self,
         entries: &[(bytes::Bytes, bytes::Bytes, BatchEntryKind)],
         memtable: &MemTable,
+        shared_publish_bytes: bool,
     ) -> Result<(u64, DeferredBatchPublish, Option<u64>), anyhow::Error> {
         if entries.is_empty() {
             return Ok((0, DeferredBatchPublish::from_entries(Vec::new()), None));
@@ -306,19 +325,20 @@ impl LsmMvccInner {
             .iter()
             .map(|(key, value, kind)| match kind {
                 BatchEntryKind::Delete => (
-                    Bytes::from(encode_internal_key(key, commit_ts)),
+                    Self::encode_internal_key_bytes(key, commit_ts, shared_publish_bytes),
                     Bytes::from_static(TOMBSTONE_VALUE),
                 ),
                 BatchEntryKind::PutPrefixed => (
-                    Bytes::from(encode_internal_key(key, commit_ts)),
+                    Self::encode_internal_key_bytes(key, commit_ts, shared_publish_bytes),
                     value.clone(),
                 ),
                 BatchEntryKind::PutRaw => {
-                    let mut p = Vec::with_capacity(1 + value.len());
+                    let mut p =
+                        Vec::with_capacity(1 + value.len() + usize::from(shared_publish_bytes));
                     p.push(crate::vlog::KvKind::Inline as u8);
                     p.extend_from_slice(value.as_ref());
                     (
-                        Bytes::from(encode_internal_key(key, commit_ts)),
+                        Self::encode_internal_key_bytes(key, commit_ts, shared_publish_bytes),
                         Bytes::from(p),
                     )
                 }

--- a/kv-engine/src/tests/memtable.rs
+++ b/kv-engine/src/tests/memtable.rs
@@ -257,26 +257,6 @@ fn test_memtable_commit_wal_ticket_publishes_after_specific_ticket() {
 }
 
 #[test]
-fn test_memtable_publish_raw_batch_owned() {
-    let mt = crate::mem_table::MemTable::create(0, false);
-    let key1 = crate::key::encode_internal_key(b"k1", 10);
-    let key2 = crate::key::encode_internal_key(b"k2", 10);
-    let value1 = bytes::Bytes::from_static(&[crate::vlog::KvKind::Inline as u8, b'v', b'1']);
-    let value2 = bytes::Bytes::from_static(&[crate::vlog::KvKind::Inline as u8, b'v', b'2']);
-    let expected_size = key1.len() + key2.len() + value1.len() + value2.len();
-
-    mt.publish_raw_batch_owned(vec![
-        (bytes::Bytes::from(key1.clone()), value1.clone()),
-        (bytes::Bytes::from(key2.clone()), value2.clone()),
-    ])
-    .unwrap();
-
-    assert_eq!(mt.get_raw_exact(&key1), Some(value1));
-    assert_eq!(mt.get_raw_exact(&key2), Some(value2));
-    assert_eq!(mt.approximate_size(), expected_size);
-}
-
-#[test]
 fn test_memtable_range_overlap_containment() {
     // Query range [a, z] fully contains memtable keys [m, p].
     let dir = tempfile::tempdir().unwrap();

--- a/kv-engine/src/tests/memtable.rs
+++ b/kv-engine/src/tests/memtable.rs
@@ -257,6 +257,26 @@ fn test_memtable_commit_wal_ticket_publishes_after_specific_ticket() {
 }
 
 #[test]
+fn test_memtable_publish_raw_batch_owned() {
+    let mt = crate::mem_table::MemTable::create(0, false);
+    let key1 = crate::key::encode_internal_key(b"k1", 10);
+    let key2 = crate::key::encode_internal_key(b"k2", 10);
+    let value1 = bytes::Bytes::from_static(&[crate::vlog::KvKind::Inline as u8, b'v', b'1']);
+    let value2 = bytes::Bytes::from_static(&[crate::vlog::KvKind::Inline as u8, b'v', b'2']);
+    let expected_size = key1.len() + key2.len() + value1.len() + value2.len();
+
+    mt.publish_raw_batch_owned(vec![
+        (bytes::Bytes::from(key1.clone()), value1.clone()),
+        (bytes::Bytes::from(key2.clone()), value2.clone()),
+    ])
+    .unwrap();
+
+    assert_eq!(mt.get_raw_exact(&key1), Some(value1));
+    assert_eq!(mt.get_raw_exact(&key2), Some(value2));
+    assert_eq!(mt.approximate_size(), expected_size);
+}
+
+#[test]
 fn test_memtable_range_overlap_containment() {
     // Query range [a, z] fully contains memtable keys [m, p].
     let dir = tempfile::tempdir().unwrap();

--- a/kv-engine/src/tests/memtable.rs
+++ b/kv-engine/src/tests/memtable.rs
@@ -666,6 +666,32 @@ fn test_write_batch_dedup() {
 }
 
 #[test]
+fn test_write_batch_large_mvcc_publish() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+    let batch: Vec<_> = (0..520)
+        .map(|idx| {
+            crate::lsm_storage::WriteBatchRecord::Put(
+                format!("k{idx:04}").into_bytes(),
+                format!("v{idx:04}").into_bytes(),
+            )
+        })
+        .collect();
+
+    storage.write_batch(&batch).unwrap();
+
+    for idx in [0, 1, 255, 511, 519] {
+        let key = format!("k{idx:04}");
+        let value = format!("v{idx:04}");
+        assert_eq!(
+            storage.get(key.as_bytes()).unwrap().as_deref(),
+            Some(value.as_bytes())
+        );
+    }
+}
+
+#[test]
 fn test_storage_put_get_delete() {
     let dir = tempfile::tempdir().unwrap();
     let storage =


### PR DESCRIPTION
## Summary

Optimize large MVCC batch publication by moving owned `Bytes` entries directly into the memtable when the deferred publish batch has at least 512 entries.

## Changes

- Add an owned memtable batch publish path that inserts `(Bytes, Bytes)` without rebuilding borrowed publish references.
- Keep small batches on the existing borrowed publish path.
- Use shared-friendly key/value buffer construction only for large batches that will use owned publish.
- Apply the same large-batch capacity treatment to TTL batch values.
- Add direct owned-publish coverage plus an end-to-end public `write_batch` regression test above the 512-entry threshold.

## Benchmarks

CRUD skip-scans, sync, 100k samples, 4 clients, 4 threads.

### Candidate vs baseline

- Point create/update/delete stayed effectively flat across candidate reruns.
- `batch_delete_1000` stayed consistently faster across three candidate runs:
  - `+55.0%`
  - `+53.5%`
  - `+46.9%`
- Latest candidate rerun also showed:
  - `batch_create_1000`: `+3.5%`
  - `batch_update_1000`: `+33.0%`
  - `batch_delete_100`: `+1.6%`

### Embedded database comparison

Latest comparison run used the PR head with these embedded engines: ToyKV, Fjall, RocksDB, Redb, and SurrealKV.

| Test | ToyKV | Fjall | RocksDB | Redb | SurrealKV |
|---|---:|---:|---:|---:|---:|
| create | 13,217.74 | 2,231.21 | 12,793.72 | 1,600.00 | 1,689.85 |
| read | 3,607,177.24 | 1,671,018.11 | 1,610,136.21 | 459,820.62 | 1,357,430.66 |
| update | 13,233.50 | 1,706.49 | 13,090.03 | 1,669.70 | 1,694.87 |
| delete | 14,225.56 | 1,809.39 | 13,605.36 | 1,871.66 | 1,738.64 |
| batch_create_1000 | 1,750.44 | 440.72 | 249.12 | 72.29 | 487.72 |
| batch_update_1000 | 1,403.24 | 235.77 | 406.97 | 71.78 | 546.16 |
| batch_delete_1000 | 6,026.26 | 361.09 | 315.56 | 81.73 | 1,106.60 |

ToyKV was roughly tied with RocksDB on point create/update/delete and ahead on every batch write row. `batch_delete_1000` was `5.45x` faster than SurrealKV, `16.69x` faster than Fjall, and `19.10x` faster than RocksDB in this run.

Result artifacts:

- `crud-bench/result-compare_embedded_sync_100k_toykv_pr194.csv`
- `crud-bench/result-compare_embedded_sync_100k_fjall.csv`
- `crud-bench/result-compare_embedded_sync_100k_rocksdb.csv`
- `crud-bench/result-compare_embedded_sync_100k_redb.csv`
- `crud-bench/result-compare_embedded_sync_100k_surrealkv.csv`

## Verification

- [x] `cargo fmt --all --check`
- [x] `cargo check --workspace --all-features`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-features publish_raw_batch_owned_inserts_entries`
- [x] `cargo test --workspace --all-features test_write_batch_large_mvcc_publish`
- [x] CRUD ToyKV rerun: `toykv_owned_publish_threshold_local_candidate_sync_100k_rerun3`
- [x] CRUD embedded database comparison: `compare_embedded_sync_100k_*`

Note: local `cargo nextest run --workspace --all-features --lib` reached 693 passing tests before stopping on an environment failure creating an `io_uring` ring (`Operation not permitted`). CI completed successfully.
