### PR TITLE
perf: skip empty range tombstone fragments in batch get

### DIFF
--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -3707,7 +3707,7 @@ impl LsmStorageInner {
                 && user_key < last.end.as_ref()
             {
                 best_ts = crate::range_tombstone::find_newest_covering_ts(
-                    &active_rt_frags,
+                    active_rt_frags,
                     user_key,
                     read_ts_for_range,
                 );

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -3650,8 +3650,13 @@ impl LsmStorageInner {
         // Pre-collect range tombstone fragments once to avoid per-key
         // discovery overhead. O(S) once instead of O(K×S) across the batch.
         // Cheap non-allocating checks first to short-circuit when no RTs exist.
-        let active_rt_frags = state.memtable.range_tombstones().cached_fragments();
-        let has_active_rt = !active_rt_frags.is_empty();
+        let active_rt = state.memtable.range_tombstones();
+        let has_active_rt = !active_rt.is_empty();
+        let active_rt_frags = if has_active_rt {
+            Some(active_rt.cached_fragments())
+        } else {
+            None
+        };
         let has_imm_rt = state
             .imm_memtables
             .iter()
@@ -3692,6 +3697,9 @@ impl LsmStorageInner {
             if !has_any_rt {
                 return None;
             }
+            let active_rt_frags = active_rt_frags
+                .as_ref()
+                .map_or(&[][..], |frags| frags.as_slice());
             let mut best_ts: Option<u64> = None;
             if has_active_rt
                 && let (Some(first), Some(last)) = (active_rt_frags.first(), active_rt_frags.last())
@@ -3893,8 +3901,13 @@ impl LsmStorageInner {
             .collect();
 
         // Check if memtable range tombstones exist (cheap check).
-        let active_rt_frags = state.memtable.range_tombstones().cached_fragments();
-        let has_active_rt = !active_rt_frags.is_empty();
+        let active_rt = state.memtable.range_tombstones();
+        let has_active_rt = !active_rt.is_empty();
+        let active_rt_frags = if has_active_rt {
+            Some(active_rt.cached_fragments())
+        } else {
+            None
+        };
         let has_imm_rt = state
             .imm_memtables
             .iter()
@@ -3936,7 +3949,9 @@ impl LsmStorageInner {
                     uk,
                     read_ts_for_range,
                     has_active_rt,
-                    &active_rt_frags,
+                    active_rt_frags
+                        .as_ref()
+                        .map_or(&[][..], |frags| frags.as_slice()),
                     has_imm_rt,
                 )
             } else {

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -3651,7 +3651,7 @@ impl LsmStorageInner {
         // discovery overhead. O(S) once instead of O(K×S) across the batch.
         // Cheap non-allocating checks first to short-circuit when no RTs exist.
         let active_rt = state.memtable.range_tombstones();
-        let has_active_rt = !active_rt.is_empty();
+        let has_active_rt = active_rt.has_tombstones();
         let active_rt_frags = if has_active_rt {
             Some(active_rt.cached_fragments())
         } else {
@@ -3902,7 +3902,7 @@ impl LsmStorageInner {
 
         // Check if memtable range tombstones exist (cheap check).
         let active_rt = state.memtable.range_tombstones();
-        let has_active_rt = !active_rt.is_empty();
+        let has_active_rt = active_rt.has_tombstones();
         let active_rt_frags = if has_active_rt {
             Some(active_rt.cached_fragments())
         } else {

--- a/kv-engine/src/range_tombstone.rs
+++ b/kv-engine/src/range_tombstone.rs
@@ -195,6 +195,11 @@ impl RangeTombstoneSet {
         self.raw.is_empty()
     }
 
+    /// Return `true` if the set contains at least one tombstone.
+    pub fn has_tombstones(&self) -> bool {
+        self.approximate_size.load(Ordering::Relaxed) != 0
+    }
+
     /// Return the number of tombstones in the set.
     pub fn len(&self) -> usize {
         self.raw.len()


### PR DESCRIPTION
## Summary

Skip active range-tombstone fragment cache loading in `batch_get` when the active memtable has no range tombstones.

This avoids an atomic `ArcSwap::load_full()` / lazy empty-fragment rebuild on the normal CRUD point-read path while preserving the existing fragment lookup when range tombstones are present.

## Benchmarks

Same-session full ToyKV CRUD skip-scan run:

```text
cargo run --release --bin crud-bench \
  --no-default-features \
  --features toykv -- \
  --database toykv \
  --samples 100000 \
  --clients 4 \
  --threads 4 \
  --sync \
  --skip-scans
```

Initial same-session target row:

```text
batch_read_100:
  baseline  30,597.54 OPS
  candidate 48,450.44 OPS
```

Other read row in the same pair was noisy/lower:

```text
batch_read_1000:
  baseline   6,299.85 OPS
  candidate  5,663.10 OPS
```

The change removes fixed empty-range-tombstone work and should not add per-key work, but the benchmark data is still noisy; review should treat this as a narrow hot-path cleanup with measured small-batch upside rather than a broad read-path win.

Confirmation rerun:

```text
batch_read_100:
  baseline  31,056.34 OPS
  candidate 37,380.39 OPS

batch_read_1000:
  baseline   6,276.16 OPS
  candidate  6,116.43 OPS
```

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo nextest run --workspace --all-features --lib batch_get`

Note: `cargo nextest run --workspace --all-features --lib` is blocked in this sandbox by existing `io_uring` EPERM failures in WAL/chaos tests.
