### PR TITLE
chore: add write-path profiling counters

### DIFF
--- a/kv-engine/Cargo.toml
+++ b/kv-engine/Cargo.toml
@@ -12,6 +12,10 @@ name = "chaos-child"
 path = "src/bin/chaos-child.rs"
 required-features = ["chaos-testing"]
 
+[[bin]]
+name = "write-perf"
+path = "src/bin/write-perf.rs"
+
 [features]
 bench = []
 chaos-testing = ["fail/failpoints"]

--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -1258,6 +1258,7 @@ fn run_wal_batch_delete_concurrent(cfg: &HarnessConfig) -> Result<Vec<BenchMeasu
     let options = cfg.build_options(true, false);
     let engine = KvEngine::open(&path, options.clone())?;
     populate_fixed_value(&engine, cfg.num, &vec![b'x'; cfg.value_size])?;
+    #[cfg(feature = "bench")]
     if cfg.profile {
         engine.reset_write_profile();
     }

--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -538,6 +538,8 @@ fn print_write_profile(engine: &KvEngine, label: &str) {
     let total = p.total_ms();
     eprintln!(
         "\n--- write profile: {label} ({} ops) ---\n  \
+         batch_build:  {:>8.2} ms\n  \
+         mvcc_wal_only:{:>8.2} ms\n  \
          wal_write:    {:>8.2} ms  ({:>5.1}%)\n  \
          wal_validate: {:>8.2} ms\n  \
          wal_prepare:  {:>8.2} ms\n  \
@@ -553,8 +555,10 @@ fn print_write_profile(engine: &KvEngine, label: &str) {
          publish_map:   copy={:>7.2} ms  skipmap={:>7.2} ms\n  \
          commit_groups: {:>7}  solo={:>7} ({:>5.1}%)  avg_bufs={:>5.2}  max_bufs={:>3}\n  \
          commit_bytes:  avg={:>8.0} B  max={:>8} B\n  \
-         total:        {:>8.2} ms",
+        total:        {:>8.2} ms",
         p.op_count,
+        p.batch_build_ms(),
+        p.mvcc_wal_only_ms(),
         p.wal_write_ms(),
         if total > 0.0 {
             p.wal_write_ms() / total * 100.0

--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -544,6 +544,7 @@ fn print_write_profile(engine: &KvEngine, label: &str) {
          wal_validate: {:>8.2} ms\n  \
          wal_prepare:  {:>8.2} ms\n  \
          wal_encode:   {:>8.2} ms\n  \
+         encode_parts: entries={:>7.2} ms  crc_header={:>7.2} ms  finish={:>7.2} ms\n  \
          wal_enqueue:  {:>8.2} ms\n  \
          wal_sync:     {:>8.2} ms  ({:>5.1}%)\n  \
          wal_submit:   {:>8.2} ms\n  \
@@ -568,6 +569,9 @@ fn print_write_profile(engine: &KvEngine, label: &str) {
         p.wal_validate_ms(),
         p.wal_prepare_ms(),
         p.wal_encode_ms(),
+        p.wal_encode_entries_ms(),
+        p.wal_encode_crc_header_ms(),
+        p.wal_encode_finish_ms(),
         p.wal_enqueue_ms(),
         p.wal_sync_ms(),
         p.wal_sync_pct(),

--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -544,6 +544,8 @@ fn print_write_profile(engine: &KvEngine, label: &str) {
          follower_wait:{:>8.2} ms\n  \
          follower_events: calls={:>7}  parks={:>7}  retries={:>7}\n  \
          memtable:     {:>8.2} ms  ({:>5.1}%)\n  \
+         publish_parts: ttl={:>7.2} ms  decode={:>7.2} ms  bloom={:>7.2} ms  map={:>7.2} ms\n  \
+         publish_map:   copy={:>7.2} ms  skipmap={:>7.2} ms\n  \
          commit_groups: {:>7}  solo={:>7} ({:>5.1}%)  avg_bufs={:>5.2}  max_bufs={:>3}\n  \
          commit_bytes:  avg={:>8.0} B  max={:>8} B\n  \
          total:        {:>8.2} ms",
@@ -572,6 +574,12 @@ fn print_write_profile(engine: &KvEngine, label: &str) {
         } else {
             0.0
         },
+        p.memtable_publish_ttl_check_ms(),
+        p.memtable_publish_decode_ms(),
+        p.memtable_publish_bloom_ms(),
+        p.memtable_publish_map_ms(),
+        p.memtable_publish_copy_ms(),
+        p.memtable_publish_skipmap_ms(),
         p.wal_commit_groups,
         p.wal_commit_solo_groups,
         p.wal_commit_solo_pct(),

--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -338,6 +338,11 @@ const WORKLOADS: &[WorkloadSpec] = &[
         run: run_wal_batch_concurrent,
     },
     WorkloadSpec {
+        name: "wal_batch_delete_concurrent",
+        aliases: &["wal_batch_delete"],
+        run: run_wal_batch_delete_concurrent,
+    },
+    WorkloadSpec {
         name: "vlog_gc",
         aliases: &[],
         run: run_vlog_gc,
@@ -1220,6 +1225,82 @@ fn run_wal_batch_concurrent(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>
         cfg,
         workload,
         format!("concurrent_batch_{batch_size}"),
+        &options,
+        MeasurementParams {
+            num: Some(num_keys),
+            value_size: Some(cfg.value_size),
+            batch_size: Some(batch_size),
+            threads: Some(writer_threads),
+            seed: Some(cfg.seed),
+            ..MeasurementParams::default()
+        },
+        MeasurementResult {
+            measure_elapsed_ms: ms(elapsed),
+            ops: Some(num_keys as u64),
+            ops_per_sec: Some(rate(num_keys as u64, elapsed)),
+            ..MeasurementResult::default()
+        },
+        counters,
+    )])
+}
+
+fn run_wal_batch_delete_concurrent(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    let workload = "wal_batch_delete_concurrent";
+    let path = prepare_path(cfg, workload)?;
+    let options = cfg.build_options(true, false);
+    let engine = KvEngine::open(&path, options.clone())?;
+    populate_fixed_value(&engine, cfg.num, &vec![b'x'; cfg.value_size])?;
+    if cfg.profile {
+        engine.reset_write_profile();
+    }
+
+    let num_keys = cfg.num;
+    let writer_threads = cfg.threads;
+    let baseline = collect_counters(&engine)?;
+    let per_thread = num_keys / writer_threads;
+    let remainder = num_keys % writer_threads;
+    let batch_size = effective_wal_batch_size(num_keys, writer_threads, cfg.wal_batch_size);
+    let start = Instant::now();
+    let mut handles = vec![];
+    for t in 0..writer_threads {
+        let eng = engine.clone();
+        handles.push(std::thread::spawn(move || {
+            let thread_ops = per_thread + usize::from(t < remainder);
+            let start_idx = t * per_thread + remainder.min(t);
+            let mut next = 0usize;
+            while next < thread_ops {
+                let current_batch = (thread_ops - next).min(batch_size);
+                let mut keys = Vec::with_capacity(current_batch);
+                for i in 0..current_batch {
+                    keys.push(format!("key{:08}", start_idx + next + i).into_bytes());
+                }
+                let batch: Vec<_> = keys
+                    .iter()
+                    .map(|key| WriteBatchRecord::Del(key.as_slice()))
+                    .collect();
+                eng.write_batch(&batch).expect("write_batch delete failed");
+                next += current_batch;
+            }
+        }));
+    }
+    for handle in handles {
+        handle
+            .join()
+            .map_err(|_| anyhow!("writer thread panicked"))?;
+    }
+    let elapsed = start.elapsed();
+    if cfg.profile {
+        print_write_profile(&engine, workload);
+    }
+    engine.drain_flush()?;
+    let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
+    engine.close()?;
+    finalize_path(cfg, &path)?;
+
+    Ok(vec![make_measurement(
+        cfg,
+        workload,
+        format!("concurrent_delete_batch_{batch_size}"),
         &options,
         MeasurementParams {
             num: Some(num_keys),
@@ -2557,6 +2638,13 @@ mod tests {
         let selected = select_workloads(Some("wal_batch")).expect("select workload");
         let names: Vec<_> = selected.iter().map(|w| w.name).collect();
         assert_eq!(names, vec!["wal_batch_concurrent"]);
+    }
+
+    #[test]
+    fn parse_wal_batch_delete_alias() {
+        let selected = select_workloads(Some("wal_batch_delete")).expect("select workload");
+        let names: Vec<_> = selected.iter().map(|w| w.name).collect();
+        assert_eq!(names, vec!["wal_batch_delete_concurrent"]);
     }
 
     #[test]

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1774,6 +1774,11 @@ impl KvEngine {
         self.inner.write_profile.snapshot()
     }
 
+    #[cfg(feature = "bench")]
+    pub fn reset_write_profile(&self) {
+        self.inner.write_profile.reset();
+    }
+
     pub fn parallel_scan_stats(&self) -> ParallelScanStats {
         self.inner.parallel_scan_stats.snapshot()
     }

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -6101,11 +6101,21 @@ impl LsmStorageInner {
             if let Some(ref mvcc) = self.mvcc {
                 // MVCC path: allocate a single commit_ts for the entire batch.
                 let shared_publish_bytes = Self::use_owned_batch_publish(batch.len());
+                #[cfg(feature = "bench")]
+                let build_start = std::time::Instant::now();
                 let (entries, dedup_indices) =
                     Self::build_unique_point_batch_entries_or_dedup(batch, shared_publish_bytes);
+                #[cfg(feature = "bench")]
+                self.write_profile
+                    .record_batch_build_ns(build_start.elapsed().as_nanos() as u64);
                 // WAL-only: do NOT publish to skiplist yet.
+                #[cfg(feature = "bench")]
+                let wal_only_start = std::time::Instant::now();
                 let (commit_ts, data, ticket) =
                     mvcc.write_batch_wal_only(&entries, &state.memtable, shared_publish_bytes)?;
+                #[cfg(feature = "bench")]
+                self.write_profile
+                    .record_mvcc_wal_only_ns(wal_only_start.elapsed().as_nanos() as u64);
                 mvcc_commit_ts = commit_ts;
                 // Defer record_committed_txn until after commit_wal_ticket succeeds
                 // so that failed WAL syncs don't poison serializable validation.

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -52,6 +52,12 @@ pub struct WriteProfile {
     pub wal_prepare_ns: AtomicU64,
     /// Time encoding WAL batch bytes into an aligned direct buffer.
     pub wal_encode_ns: AtomicU64,
+    /// Time writing WAL batch entries into the direct buffer.
+    pub wal_encode_entries_ns: AtomicU64,
+    /// Time computing WAL batch CRC and writing the header.
+    pub wal_encode_crc_header_ns: AtomicU64,
+    /// Time padding and finalizing the encoded WAL direct buffer.
+    pub wal_encode_finish_ns: AtomicU64,
     /// Time enqueuing encoded WAL buffers for group commit.
     pub wal_enqueue_ns: AtomicU64,
     /// Time in `Wal::sync` (BufWriter flush + `fsync`).
@@ -108,6 +114,9 @@ impl WriteProfile {
         self.wal_validate_ns.store(0, o);
         self.wal_prepare_ns.store(0, o);
         self.wal_encode_ns.store(0, o);
+        self.wal_encode_entries_ns.store(0, o);
+        self.wal_encode_crc_header_ns.store(0, o);
+        self.wal_encode_finish_ns.store(0, o);
         self.wal_enqueue_ns.store(0, o);
         self.wal_sync_ns.store(0, o);
         self.wal_submit_ns.store(0, o);
@@ -141,6 +150,9 @@ impl WriteProfile {
             wal_validate_ns: self.wal_validate_ns.load(o),
             wal_prepare_ns: self.wal_prepare_ns.load(o),
             wal_encode_ns: self.wal_encode_ns.load(o),
+            wal_encode_entries_ns: self.wal_encode_entries_ns.load(o),
+            wal_encode_crc_header_ns: self.wal_encode_crc_header_ns.load(o),
+            wal_encode_finish_ns: self.wal_encode_finish_ns.load(o),
             wal_enqueue_ns: self.wal_enqueue_ns.load(o),
             wal_sync_ns: self.wal_sync_ns.load(o),
             wal_submit_ns: self.wal_submit_ns.load(o),
@@ -216,6 +228,19 @@ impl WriteProfile {
     }
 
     #[cfg(feature = "bench")]
+    pub(crate) fn record_wal_encode_parts_ns(
+        &self,
+        entries_ns: u64,
+        crc_header_ns: u64,
+        finish_ns: u64,
+    ) {
+        let o = std::sync::atomic::Ordering::Relaxed;
+        self.wal_encode_entries_ns.fetch_add(entries_ns, o);
+        self.wal_encode_crc_header_ns.fetch_add(crc_header_ns, o);
+        self.wal_encode_finish_ns.fetch_add(finish_ns, o);
+    }
+
+    #[cfg(feature = "bench")]
     pub(crate) fn record_wal_enqueue_ns(&self, nanos: u64) {
         self.wal_enqueue_ns
             .fetch_add(nanos, std::sync::atomic::Ordering::Relaxed);
@@ -272,6 +297,9 @@ pub struct WriteProfileSnapshot {
     pub wal_validate_ns: u64,
     pub wal_prepare_ns: u64,
     pub wal_encode_ns: u64,
+    pub wal_encode_entries_ns: u64,
+    pub wal_encode_crc_header_ns: u64,
+    pub wal_encode_finish_ns: u64,
     pub wal_enqueue_ns: u64,
     pub wal_sync_ns: u64,
     pub wal_submit_ns: u64,
@@ -319,6 +347,18 @@ impl WriteProfileSnapshot {
 
     pub fn wal_encode_ms(&self) -> f64 {
         self.wal_encode_ns as f64 / 1_000_000.0
+    }
+
+    pub fn wal_encode_entries_ms(&self) -> f64 {
+        self.wal_encode_entries_ns as f64 / 1_000_000.0
+    }
+
+    pub fn wal_encode_crc_header_ms(&self) -> f64 {
+        self.wal_encode_crc_header_ns as f64 / 1_000_000.0
+    }
+
+    pub fn wal_encode_finish_ms(&self) -> f64 {
+        self.wal_encode_finish_ns as f64 / 1_000_000.0
     }
 
     pub fn wal_enqueue_ms(&self) -> f64 {

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -411,7 +411,7 @@ impl WriteProfileSnapshot {
 
     pub fn total_ms(&self) -> f64 {
         self.batch_build_ms()
-            + self.mvcc_wal_only_ms()
+            + self.mvcc_wal_only_ms().max(self.wal_write_ms())
             + self.wal_sync_ms()
             + self.memtable_insert_ms()
     }

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -1125,105 +1125,49 @@ impl MemTable {
             #[cfg(feature = "bench")]
             let mut skipmap_ns = 0u64;
             crate::profile_scope!("memtable.publish_batch", {
-                if entries.len() >= 512
-                    && entries
-                        .iter()
-                        .all(|(_, value)| Self::is_tombstone_value(value))
-                {
-                    let mut key_hashes = Vec::with_capacity(entries.len());
-                    for (key, value) in &entries {
-                        #[cfg(feature = "bench")]
-                        let part_start = Instant::now();
-                        Self::maybe_note_ttl_value(&self.has_ttl_entries, value);
-                        #[cfg(feature = "bench")]
-                        {
-                            ttl_check_ns += part_start.elapsed().as_nanos() as u64;
-                        }
-
-                        #[cfg(feature = "bench")]
-                        let part_start = Instant::now();
-                        buf.clear();
-                        KeySlice::from_slice(key.as_ref()).decode_user_key_into(&mut buf);
-                        #[cfg(feature = "bench")]
-                        {
-                            decode_ns += part_start.elapsed().as_nanos() as u64;
-                        }
-
-                        key_hashes.push(super::table::bloom::hash_key(&buf));
+                for (key, value) in entries {
+                    #[cfg(feature = "bench")]
+                    let part_start = Instant::now();
+                    Self::maybe_note_ttl_value(&self.has_ttl_entries, &value);
+                    #[cfg(feature = "bench")]
+                    {
+                        ttl_check_ns += part_start.elapsed().as_nanos() as u64;
                     }
 
                     #[cfg(feature = "bench")]
                     let part_start = Instant::now();
-                    self.bloom.push_hashes(&key_hashes);
+                    buf.clear();
+                    KeySlice::from_slice(key.as_ref()).decode_user_key_into(&mut buf);
+                    #[cfg(feature = "bench")]
+                    {
+                        decode_ns += part_start.elapsed().as_nanos() as u64;
+                    }
+
+                    #[cfg(feature = "bench")]
+                    let part_start = Instant::now();
+                    self.bloom.push_hash(super::table::bloom::hash_key(&buf));
                     #[cfg(feature = "bench")]
                     {
                         bloom_ns += part_start.elapsed().as_nanos() as u64;
                     }
-                    for (key, value) in entries {
-                        #[cfg(feature = "bench")]
-                        let part_start = Instant::now();
-                        approximate_size_delta += key.len() + value.len();
-                        let map_key = key;
-                        let map_value = value;
-                        #[cfg(feature = "bench")]
-                        {
-                            copy_ns += part_start.elapsed().as_nanos() as u64;
-                        }
 
-                        #[cfg(feature = "bench")]
-                        let insert_start = Instant::now();
-                        self.map.insert(map_key, map_value);
-                        #[cfg(feature = "bench")]
-                        {
-                            skipmap_ns += insert_start.elapsed().as_nanos() as u64;
-                            map_ns += part_start.elapsed().as_nanos() as u64;
-                        }
+                    #[cfg(feature = "bench")]
+                    let part_start = Instant::now();
+                    approximate_size_delta += key.len() + value.len();
+                    let map_key = key;
+                    let map_value = value;
+                    #[cfg(feature = "bench")]
+                    {
+                        copy_ns += part_start.elapsed().as_nanos() as u64;
                     }
-                } else {
-                    for (key, value) in entries {
-                        #[cfg(feature = "bench")]
-                        let part_start = Instant::now();
-                        Self::maybe_note_ttl_value(&self.has_ttl_entries, &value);
-                        #[cfg(feature = "bench")]
-                        {
-                            ttl_check_ns += part_start.elapsed().as_nanos() as u64;
-                        }
 
-                        #[cfg(feature = "bench")]
-                        let part_start = Instant::now();
-                        buf.clear();
-                        KeySlice::from_slice(key.as_ref()).decode_user_key_into(&mut buf);
-                        #[cfg(feature = "bench")]
-                        {
-                            decode_ns += part_start.elapsed().as_nanos() as u64;
-                        }
-
-                        #[cfg(feature = "bench")]
-                        let part_start = Instant::now();
-                        self.bloom.push_hash(super::table::bloom::hash_key(&buf));
-                        #[cfg(feature = "bench")]
-                        {
-                            bloom_ns += part_start.elapsed().as_nanos() as u64;
-                        }
-
-                        #[cfg(feature = "bench")]
-                        let part_start = Instant::now();
-                        approximate_size_delta += key.len() + value.len();
-                        let map_key = key;
-                        let map_value = value;
-                        #[cfg(feature = "bench")]
-                        {
-                            copy_ns += part_start.elapsed().as_nanos() as u64;
-                        }
-
-                        #[cfg(feature = "bench")]
-                        let insert_start = Instant::now();
-                        self.map.insert(map_key, map_value);
-                        #[cfg(feature = "bench")]
-                        {
-                            skipmap_ns += insert_start.elapsed().as_nanos() as u64;
-                            map_ns += part_start.elapsed().as_nanos() as u64;
-                        }
+                    #[cfg(feature = "bench")]
+                    let insert_start = Instant::now();
+                    self.map.insert(map_key, map_value);
+                    #[cfg(feature = "bench")]
+                    {
+                        skipmap_ns += insert_start.elapsed().as_nanos() as u64;
+                        map_ns += part_start.elapsed().as_nanos() as u64;
                     }
                 }
                 self.approximate_size
@@ -1260,10 +1204,6 @@ impl MemTable {
         }) {
             flag.store(true, std::sync::atomic::Ordering::Relaxed);
         }
-    }
-
-    fn is_tombstone_value(value: &[u8]) -> bool {
-        value == [crate::vlog::KvKind::Tombstone as u8]
     }
 
     /// Sync all WAL writes up to the current memtable watermark via group commit.

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -1125,49 +1125,105 @@ impl MemTable {
             #[cfg(feature = "bench")]
             let mut skipmap_ns = 0u64;
             crate::profile_scope!("memtable.publish_batch", {
-                for (key, value) in entries {
-                    #[cfg(feature = "bench")]
-                    let part_start = Instant::now();
-                    Self::maybe_note_ttl_value(&self.has_ttl_entries, &value);
-                    #[cfg(feature = "bench")]
-                    {
-                        ttl_check_ns += part_start.elapsed().as_nanos() as u64;
+                if entries.len() >= 512
+                    && entries
+                        .iter()
+                        .all(|(_, value)| Self::is_tombstone_value(value))
+                {
+                    let mut key_hashes = Vec::with_capacity(entries.len());
+                    for (key, value) in &entries {
+                        #[cfg(feature = "bench")]
+                        let part_start = Instant::now();
+                        Self::maybe_note_ttl_value(&self.has_ttl_entries, value);
+                        #[cfg(feature = "bench")]
+                        {
+                            ttl_check_ns += part_start.elapsed().as_nanos() as u64;
+                        }
+
+                        #[cfg(feature = "bench")]
+                        let part_start = Instant::now();
+                        buf.clear();
+                        KeySlice::from_slice(key.as_ref()).decode_user_key_into(&mut buf);
+                        #[cfg(feature = "bench")]
+                        {
+                            decode_ns += part_start.elapsed().as_nanos() as u64;
+                        }
+
+                        key_hashes.push(super::table::bloom::hash_key(&buf));
                     }
 
                     #[cfg(feature = "bench")]
                     let part_start = Instant::now();
-                    buf.clear();
-                    KeySlice::from_slice(key.as_ref()).decode_user_key_into(&mut buf);
-                    #[cfg(feature = "bench")]
-                    {
-                        decode_ns += part_start.elapsed().as_nanos() as u64;
-                    }
-
-                    #[cfg(feature = "bench")]
-                    let part_start = Instant::now();
-                    self.bloom.push_hash(super::table::bloom::hash_key(&buf));
+                    self.bloom.push_hashes(&key_hashes);
                     #[cfg(feature = "bench")]
                     {
                         bloom_ns += part_start.elapsed().as_nanos() as u64;
                     }
+                    for (key, value) in entries {
+                        #[cfg(feature = "bench")]
+                        let part_start = Instant::now();
+                        approximate_size_delta += key.len() + value.len();
+                        let map_key = key;
+                        let map_value = value;
+                        #[cfg(feature = "bench")]
+                        {
+                            copy_ns += part_start.elapsed().as_nanos() as u64;
+                        }
 
-                    #[cfg(feature = "bench")]
-                    let part_start = Instant::now();
-                    approximate_size_delta += key.len() + value.len();
-                    let map_key = key;
-                    let map_value = value;
-                    #[cfg(feature = "bench")]
-                    {
-                        copy_ns += part_start.elapsed().as_nanos() as u64;
+                        #[cfg(feature = "bench")]
+                        let insert_start = Instant::now();
+                        self.map.insert(map_key, map_value);
+                        #[cfg(feature = "bench")]
+                        {
+                            skipmap_ns += insert_start.elapsed().as_nanos() as u64;
+                            map_ns += part_start.elapsed().as_nanos() as u64;
+                        }
                     }
+                } else {
+                    for (key, value) in entries {
+                        #[cfg(feature = "bench")]
+                        let part_start = Instant::now();
+                        Self::maybe_note_ttl_value(&self.has_ttl_entries, &value);
+                        #[cfg(feature = "bench")]
+                        {
+                            ttl_check_ns += part_start.elapsed().as_nanos() as u64;
+                        }
 
-                    #[cfg(feature = "bench")]
-                    let insert_start = Instant::now();
-                    self.map.insert(map_key, map_value);
-                    #[cfg(feature = "bench")]
-                    {
-                        skipmap_ns += insert_start.elapsed().as_nanos() as u64;
-                        map_ns += part_start.elapsed().as_nanos() as u64;
+                        #[cfg(feature = "bench")]
+                        let part_start = Instant::now();
+                        buf.clear();
+                        KeySlice::from_slice(key.as_ref()).decode_user_key_into(&mut buf);
+                        #[cfg(feature = "bench")]
+                        {
+                            decode_ns += part_start.elapsed().as_nanos() as u64;
+                        }
+
+                        #[cfg(feature = "bench")]
+                        let part_start = Instant::now();
+                        self.bloom.push_hash(super::table::bloom::hash_key(&buf));
+                        #[cfg(feature = "bench")]
+                        {
+                            bloom_ns += part_start.elapsed().as_nanos() as u64;
+                        }
+
+                        #[cfg(feature = "bench")]
+                        let part_start = Instant::now();
+                        approximate_size_delta += key.len() + value.len();
+                        let map_key = key;
+                        let map_value = value;
+                        #[cfg(feature = "bench")]
+                        {
+                            copy_ns += part_start.elapsed().as_nanos() as u64;
+                        }
+
+                        #[cfg(feature = "bench")]
+                        let insert_start = Instant::now();
+                        self.map.insert(map_key, map_value);
+                        #[cfg(feature = "bench")]
+                        {
+                            skipmap_ns += insert_start.elapsed().as_nanos() as u64;
+                            map_ns += part_start.elapsed().as_nanos() as u64;
+                        }
                     }
                 }
                 self.approximate_size
@@ -1204,6 +1260,10 @@ impl MemTable {
         }) {
             flag.store(true, std::sync::atomic::Ordering::Relaxed);
         }
+    }
+
+    fn is_tombstone_value(value: &[u8]) -> bool {
+        value == [crate::vlog::KvKind::Tombstone as u8]
     }
 
     /// Sync all WAL writes up to the current memtable watermark via group commit.

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -40,6 +40,10 @@ const BLOOM_FALSE_POSITIVE_RATE: f64 = 0.01;
 /// but the hot path has zero profiling overhead.
 #[derive(Debug, Default)]
 pub struct WriteProfile {
+    /// Time building point-batch entries before the MVCC/WAL phase.
+    pub batch_build_ns: AtomicU64,
+    /// Time in MVCC `write_batch_wal_only`, including internal-key encoding and WAL append.
+    pub mvcc_wal_only_ns: AtomicU64,
     /// Time in `Wal::put_batch` / `Wal::put_key_batch`.
     pub wal_write_ns: AtomicU64,
     /// Time validating WAL batch entry lengths and computing encoded size.
@@ -98,6 +102,8 @@ impl WriteProfile {
     #[cfg(feature = "bench")]
     pub(crate) fn reset(&self) {
         let o = std::sync::atomic::Ordering::Relaxed;
+        self.batch_build_ns.store(0, o);
+        self.mvcc_wal_only_ns.store(0, o);
         self.wal_write_ns.store(0, o);
         self.wal_validate_ns.store(0, o);
         self.wal_prepare_ns.store(0, o);
@@ -129,6 +135,8 @@ impl WriteProfile {
     pub fn snapshot(&self) -> WriteProfileSnapshot {
         let o = std::sync::atomic::Ordering::Relaxed;
         WriteProfileSnapshot {
+            batch_build_ns: self.batch_build_ns.load(o),
+            mvcc_wal_only_ns: self.mvcc_wal_only_ns.load(o),
             wal_write_ns: self.wal_write_ns.load(o),
             wal_validate_ns: self.wal_validate_ns.load(o),
             wal_prepare_ns: self.wal_prepare_ns.load(o),
@@ -169,6 +177,18 @@ impl WriteProfile {
         self.wal_commit_bytes.fetch_add(bytes, o);
         self.wal_commit_max_buffers.fetch_max(buffers, o);
         self.wal_commit_max_bytes.fetch_max(bytes, o);
+    }
+
+    #[cfg(feature = "bench")]
+    pub(crate) fn record_batch_build_ns(&self, nanos: u64) {
+        self.batch_build_ns
+            .fetch_add(nanos, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    #[cfg(feature = "bench")]
+    pub(crate) fn record_mvcc_wal_only_ns(&self, nanos: u64) {
+        self.mvcc_wal_only_ns
+            .fetch_add(nanos, std::sync::atomic::Ordering::Relaxed);
     }
 
     #[cfg(feature = "bench")]
@@ -246,6 +266,8 @@ impl WriteProfile {
 
 #[derive(Debug, Clone, Copy)]
 pub struct WriteProfileSnapshot {
+    pub batch_build_ns: u64,
+    pub mvcc_wal_only_ns: u64,
     pub wal_write_ns: u64,
     pub wal_validate_ns: u64,
     pub wal_prepare_ns: u64,
@@ -275,6 +297,14 @@ pub struct WriteProfileSnapshot {
 }
 
 impl WriteProfileSnapshot {
+    pub fn batch_build_ms(&self) -> f64 {
+        self.batch_build_ns as f64 / 1_000_000.0
+    }
+
+    pub fn mvcc_wal_only_ms(&self) -> f64 {
+        self.mvcc_wal_only_ns as f64 / 1_000_000.0
+    }
+
     pub fn wal_write_ms(&self) -> f64 {
         self.wal_write_ns as f64 / 1_000_000.0
     }
@@ -340,7 +370,10 @@ impl WriteProfileSnapshot {
     }
 
     pub fn total_ms(&self) -> f64 {
-        self.wal_write_ms() + self.wal_sync_ms() + self.memtable_insert_ms()
+        self.batch_build_ms()
+            + self.mvcc_wal_only_ms()
+            + self.wal_sync_ms()
+            + self.memtable_insert_ms()
     }
 
     pub fn wal_sync_pct(&self) -> f64 {

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -95,6 +95,37 @@ pub struct WriteProfile {
 }
 
 impl WriteProfile {
+    #[cfg(feature = "bench")]
+    pub(crate) fn reset(&self) {
+        let o = std::sync::atomic::Ordering::Relaxed;
+        self.wal_write_ns.store(0, o);
+        self.wal_validate_ns.store(0, o);
+        self.wal_prepare_ns.store(0, o);
+        self.wal_encode_ns.store(0, o);
+        self.wal_enqueue_ns.store(0, o);
+        self.wal_sync_ns.store(0, o);
+        self.wal_submit_ns.store(0, o);
+        self.wal_fdatasync_ns.store(0, o);
+        self.wal_follower_wait_ns.store(0, o);
+        self.wal_follower_wait_calls.store(0, o);
+        self.wal_follower_condvar_waits.store(0, o);
+        self.wal_follower_retry_loops.store(0, o);
+        self.memtable_insert_ns.store(0, o);
+        self.memtable_publish_ttl_check_ns.store(0, o);
+        self.memtable_publish_decode_ns.store(0, o);
+        self.memtable_publish_bloom_ns.store(0, o);
+        self.memtable_publish_map_ns.store(0, o);
+        self.memtable_publish_copy_ns.store(0, o);
+        self.memtable_publish_skipmap_ns.store(0, o);
+        self.wal_commit_groups.store(0, o);
+        self.wal_commit_solo_groups.store(0, o);
+        self.wal_commit_buffers.store(0, o);
+        self.wal_commit_bytes.store(0, o);
+        self.wal_commit_max_buffers.store(0, o);
+        self.wal_commit_max_bytes.store(0, o);
+        self.op_count.store(0, o);
+    }
+
     pub fn snapshot(&self) -> WriteProfileSnapshot {
         let o = std::sync::atomic::Ordering::Relaxed;
         WriteProfileSnapshot {

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -66,6 +66,18 @@ pub struct WriteProfile {
     pub wal_follower_retry_loops: AtomicU64,
     /// Time inserting into the SkipMap + bloom filter.
     pub memtable_insert_ns: AtomicU64,
+    /// Time checking value kind metadata while publishing to the memtable.
+    pub memtable_publish_ttl_check_ns: AtomicU64,
+    /// Time decoding internal keys back to user keys for bloom hashing.
+    pub memtable_publish_decode_ns: AtomicU64,
+    /// Time hashing and inserting published keys into the memtable bloom filter.
+    pub memtable_publish_bloom_ns: AtomicU64,
+    /// Time copying/inserting published key-value entries into the SkipMap.
+    pub memtable_publish_map_ns: AtomicU64,
+    /// Time preparing owned key-value bytes before SkipMap insertion.
+    pub memtable_publish_copy_ns: AtomicU64,
+    /// Time inside SkipMap insertion after owned bytes are ready.
+    pub memtable_publish_skipmap_ns: AtomicU64,
     /// Number of WAL commit groups that reached fdatasync.
     pub wal_commit_groups: AtomicU64,
     /// Number of WAL commit groups that only contained one pending buffer.
@@ -99,6 +111,12 @@ impl WriteProfile {
             wal_follower_condvar_waits: self.wal_follower_condvar_waits.load(o),
             wal_follower_retry_loops: self.wal_follower_retry_loops.load(o),
             memtable_insert_ns: self.memtable_insert_ns.load(o),
+            memtable_publish_ttl_check_ns: self.memtable_publish_ttl_check_ns.load(o),
+            memtable_publish_decode_ns: self.memtable_publish_decode_ns.load(o),
+            memtable_publish_bloom_ns: self.memtable_publish_bloom_ns.load(o),
+            memtable_publish_map_ns: self.memtable_publish_map_ns.load(o),
+            memtable_publish_copy_ns: self.memtable_publish_copy_ns.load(o),
+            memtable_publish_skipmap_ns: self.memtable_publish_skipmap_ns.load(o),
             wal_commit_groups: self.wal_commit_groups.load(o),
             wal_commit_solo_groups: self.wal_commit_solo_groups.load(o),
             wal_commit_buffers: self.wal_commit_buffers.load(o),
@@ -173,6 +191,26 @@ impl WriteProfile {
             self.wal_follower_retry_loops.fetch_add(1, o);
         }
     }
+
+    #[cfg(feature = "bench")]
+    pub(crate) fn record_memtable_publish_parts(
+        &self,
+        ttl_check_ns: u64,
+        decode_ns: u64,
+        bloom_ns: u64,
+        map_ns: u64,
+        copy_ns: u64,
+        skipmap_ns: u64,
+    ) {
+        let o = std::sync::atomic::Ordering::Relaxed;
+        self.memtable_publish_ttl_check_ns
+            .fetch_add(ttl_check_ns, o);
+        self.memtable_publish_decode_ns.fetch_add(decode_ns, o);
+        self.memtable_publish_bloom_ns.fetch_add(bloom_ns, o);
+        self.memtable_publish_map_ns.fetch_add(map_ns, o);
+        self.memtable_publish_copy_ns.fetch_add(copy_ns, o);
+        self.memtable_publish_skipmap_ns.fetch_add(skipmap_ns, o);
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -190,6 +228,12 @@ pub struct WriteProfileSnapshot {
     pub wal_follower_condvar_waits: u64,
     pub wal_follower_retry_loops: u64,
     pub memtable_insert_ns: u64,
+    pub memtable_publish_ttl_check_ns: u64,
+    pub memtable_publish_decode_ns: u64,
+    pub memtable_publish_bloom_ns: u64,
+    pub memtable_publish_map_ns: u64,
+    pub memtable_publish_copy_ns: u64,
+    pub memtable_publish_skipmap_ns: u64,
     pub wal_commit_groups: u64,
     pub wal_commit_solo_groups: u64,
     pub wal_commit_buffers: u64,
@@ -238,6 +282,30 @@ impl WriteProfileSnapshot {
 
     pub fn memtable_insert_ms(&self) -> f64 {
         self.memtable_insert_ns as f64 / 1_000_000.0
+    }
+
+    pub fn memtable_publish_ttl_check_ms(&self) -> f64 {
+        self.memtable_publish_ttl_check_ns as f64 / 1_000_000.0
+    }
+
+    pub fn memtable_publish_decode_ms(&self) -> f64 {
+        self.memtable_publish_decode_ns as f64 / 1_000_000.0
+    }
+
+    pub fn memtable_publish_bloom_ms(&self) -> f64 {
+        self.memtable_publish_bloom_ns as f64 / 1_000_000.0
+    }
+
+    pub fn memtable_publish_map_ms(&self) -> f64 {
+        self.memtable_publish_map_ns as f64 / 1_000_000.0
+    }
+
+    pub fn memtable_publish_copy_ms(&self) -> f64 {
+        self.memtable_publish_copy_ns as f64 / 1_000_000.0
+    }
+
+    pub fn memtable_publish_skipmap_ms(&self) -> f64 {
+        self.memtable_publish_skipmap_ns as f64 / 1_000_000.0
     }
 
     pub fn total_ms(&self) -> f64 {
@@ -898,16 +966,62 @@ impl MemTable {
         PUBLISH_USER_KEY_BUF.with(|buf| {
             let mut buf = buf.borrow_mut();
             let mut approximate_size_delta = 0usize;
+            #[cfg(feature = "bench")]
+            let mut ttl_check_ns = 0u64;
+            #[cfg(feature = "bench")]
+            let mut decode_ns = 0u64;
+            #[cfg(feature = "bench")]
+            let mut bloom_ns = 0u64;
+            #[cfg(feature = "bench")]
+            let mut map_ns = 0u64;
+            #[cfg(feature = "bench")]
+            let mut copy_ns = 0u64;
+            #[cfg(feature = "bench")]
+            let mut skipmap_ns = 0u64;
             crate::profile_scope!("memtable.publish_batch", {
                 for (key, value) in data {
+                    #[cfg(feature = "bench")]
+                    let part_start = Instant::now();
                     Self::maybe_note_ttl_value(&self.has_ttl_entries, value);
+                    #[cfg(feature = "bench")]
+                    {
+                        ttl_check_ns += part_start.elapsed().as_nanos() as u64;
+                    }
+
+                    #[cfg(feature = "bench")]
+                    let part_start = Instant::now();
                     buf.clear();
                     key.decode_user_key_into(&mut buf);
+                    #[cfg(feature = "bench")]
+                    {
+                        decode_ns += part_start.elapsed().as_nanos() as u64;
+                    }
+
+                    #[cfg(feature = "bench")]
+                    let part_start = Instant::now();
                     self.bloom.push_hash(super::table::bloom::hash_key(&buf));
-                    self.map.insert(
-                        shared_bytes_from_slice(key.raw_ref()),
-                        shared_bytes_from_slice(value),
-                    );
+                    #[cfg(feature = "bench")]
+                    {
+                        bloom_ns += part_start.elapsed().as_nanos() as u64;
+                    }
+
+                    #[cfg(feature = "bench")]
+                    let part_start = Instant::now();
+                    let map_key = shared_bytes_from_slice(key.raw_ref());
+                    let map_value = shared_bytes_from_slice(value);
+                    #[cfg(feature = "bench")]
+                    {
+                        copy_ns += part_start.elapsed().as_nanos() as u64;
+                    }
+
+                    #[cfg(feature = "bench")]
+                    let insert_start = Instant::now();
+                    self.map.insert(map_key, map_value);
+                    #[cfg(feature = "bench")]
+                    {
+                        skipmap_ns += insert_start.elapsed().as_nanos() as u64;
+                        map_ns += part_start.elapsed().as_nanos() as u64;
+                    }
 
                     // approximate_size is already approximate — Relaxed ordering
                     // is sufficient and avoids unnecessary fence overhead (L3).
@@ -918,6 +1032,15 @@ impl MemTable {
                 self.approximate_size
                     .fetch_add(approximate_size_delta, std::sync::atomic::Ordering::Relaxed);
             });
+            #[cfg(feature = "bench")]
+            self.write_profile.load().record_memtable_publish_parts(
+                ttl_check_ns,
+                decode_ns,
+                bloom_ns,
+                map_ns,
+                copy_ns,
+                skipmap_ns,
+            );
         });
         #[cfg(feature = "bench")]
         {
@@ -958,18 +1081,76 @@ impl MemTable {
         PUBLISH_USER_KEY_BUF.with(|buf| {
             let mut buf = buf.borrow_mut();
             let mut approximate_size_delta = 0usize;
+            #[cfg(feature = "bench")]
+            let mut ttl_check_ns = 0u64;
+            #[cfg(feature = "bench")]
+            let mut decode_ns = 0u64;
+            #[cfg(feature = "bench")]
+            let mut bloom_ns = 0u64;
+            #[cfg(feature = "bench")]
+            let mut map_ns = 0u64;
+            #[cfg(feature = "bench")]
+            let mut copy_ns = 0u64;
+            #[cfg(feature = "bench")]
+            let mut skipmap_ns = 0u64;
             crate::profile_scope!("memtable.publish_batch", {
                 for (key, value) in entries {
+                    #[cfg(feature = "bench")]
+                    let part_start = Instant::now();
                     Self::maybe_note_ttl_value(&self.has_ttl_entries, &value);
+                    #[cfg(feature = "bench")]
+                    {
+                        ttl_check_ns += part_start.elapsed().as_nanos() as u64;
+                    }
+
+                    #[cfg(feature = "bench")]
+                    let part_start = Instant::now();
                     buf.clear();
                     KeySlice::from_slice(key.as_ref()).decode_user_key_into(&mut buf);
+                    #[cfg(feature = "bench")]
+                    {
+                        decode_ns += part_start.elapsed().as_nanos() as u64;
+                    }
+
+                    #[cfg(feature = "bench")]
+                    let part_start = Instant::now();
                     self.bloom.push_hash(super::table::bloom::hash_key(&buf));
+                    #[cfg(feature = "bench")]
+                    {
+                        bloom_ns += part_start.elapsed().as_nanos() as u64;
+                    }
+
+                    #[cfg(feature = "bench")]
+                    let part_start = Instant::now();
                     approximate_size_delta += key.len() + value.len();
-                    self.map.insert(key, value);
+                    let map_key = key;
+                    let map_value = value;
+                    #[cfg(feature = "bench")]
+                    {
+                        copy_ns += part_start.elapsed().as_nanos() as u64;
+                    }
+
+                    #[cfg(feature = "bench")]
+                    let insert_start = Instant::now();
+                    self.map.insert(map_key, map_value);
+                    #[cfg(feature = "bench")]
+                    {
+                        skipmap_ns += insert_start.elapsed().as_nanos() as u64;
+                        map_ns += part_start.elapsed().as_nanos() as u64;
+                    }
                 }
                 self.approximate_size
                     .fetch_add(approximate_size_delta, std::sync::atomic::Ordering::Relaxed);
             });
+            #[cfg(feature = "bench")]
+            self.write_profile.load().record_memtable_publish_parts(
+                ttl_check_ns,
+                decode_ns,
+                bloom_ns,
+                map_ns,
+                copy_ns,
+                skipmap_ns,
+            );
         });
         #[cfg(feature = "bench")]
         {

--- a/kv-engine/src/table/bloom.rs
+++ b/kv-engine/src/table/bloom.rs
@@ -182,53 +182,6 @@ impl IncrementalBloom {
         }
     }
 
-    /// Add multiple key hashes to the bloom filter.
-    ///
-    /// This batches bit updates into a thread-local byte buffer, so multiple
-    /// keys that touch the same bloom byte usually need only one atomic
-    /// `fetch_or`.
-    pub fn push_hashes(&self, hashes: &[u32]) {
-        if hashes.len() <= 1 {
-            if let Some(&h) = hashes.first() {
-                self.push_hash(h);
-            }
-            return;
-        }
-
-        thread_local! {
-            static BLOOM_BATCH_BITS: std::cell::RefCell<Vec<u8>> =
-                const { std::cell::RefCell::new(Vec::new()) };
-        }
-
-        BLOOM_BATCH_BITS.with(|bits| {
-            let mut bits = bits.borrow_mut();
-            let nbytes = self.filter.len();
-            if bits.len() < nbytes {
-                bits.resize(nbytes, 0);
-            }
-
-            for &hash in hashes {
-                let mut h = hash;
-                let delta = h.rotate_left(15);
-                for _ in 0..self.k {
-                    let idx = (h as usize) % self.nbits;
-                    let pos = idx / 8;
-                    let offset = idx % 8;
-                    bits[pos] |= 1 << offset;
-                    h = h.wrapping_add(delta);
-                }
-            }
-
-            for (pos, byte) in bits[..nbytes].iter_mut().enumerate() {
-                let mask = *byte;
-                if mask != 0 {
-                    self.filter[pos].fetch_or(mask, std::sync::atomic::Ordering::Release);
-                    *byte = 0;
-                }
-            }
-        });
-    }
-
     /// Check if the bloom filter may contain this hash.
     /// Uses `load(Acquire)` — safe to call concurrently with `push_hash`.
     /// Acquire/Release ensures that if a reader sees any bit set by `push_hash`,

--- a/kv-engine/src/table/bloom.rs
+++ b/kv-engine/src/table/bloom.rs
@@ -182,6 +182,53 @@ impl IncrementalBloom {
         }
     }
 
+    /// Add multiple key hashes to the bloom filter.
+    ///
+    /// This batches bit updates into a thread-local byte buffer, so multiple
+    /// keys that touch the same bloom byte usually need only one atomic
+    /// `fetch_or`.
+    pub fn push_hashes(&self, hashes: &[u32]) {
+        if hashes.len() <= 1 {
+            if let Some(&h) = hashes.first() {
+                self.push_hash(h);
+            }
+            return;
+        }
+
+        thread_local! {
+            static BLOOM_BATCH_BITS: std::cell::RefCell<Vec<u8>> =
+                const { std::cell::RefCell::new(Vec::new()) };
+        }
+
+        BLOOM_BATCH_BITS.with(|bits| {
+            let mut bits = bits.borrow_mut();
+            let nbytes = self.filter.len();
+            if bits.len() < nbytes {
+                bits.resize(nbytes, 0);
+            }
+
+            for &hash in hashes {
+                let mut h = hash;
+                let delta = h.rotate_left(15);
+                for _ in 0..self.k {
+                    let idx = (h as usize) % self.nbits;
+                    let pos = idx / 8;
+                    let offset = idx % 8;
+                    bits[pos] |= 1 << offset;
+                    h = h.wrapping_add(delta);
+                }
+            }
+
+            for (pos, byte) in bits[..nbytes].iter_mut().enumerate() {
+                let mask = *byte;
+                if mask != 0 {
+                    self.filter[pos].fetch_or(mask, std::sync::atomic::Ordering::Release);
+                    *byte = 0;
+                }
+            }
+        });
+    }
+
     /// Check if the bloom filter may contain this hash.
     /// Uses `load(Acquire)` — safe to call concurrently with `push_hash`.
     /// Acquire/Release ensures that if a reader sees any bit set by `push_hash`,

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -612,6 +612,8 @@ impl Wal {
         // Reserve header space (filled later).
         let mut cursor = DirectBufCursor::new(&mut buf, V4_BATCH_HEADER_SIZE);
 
+        #[cfg(feature = "bench")]
+        let entries_start = Instant::now();
         for (entry, (kl, vl)) in data.iter().zip(validated.iter()) {
             let key = entry.key();
             let value = entry.value();
@@ -623,21 +625,32 @@ impl Wal {
             cursor.write_u16_be(*vl);
             cursor.write(value);
         }
+        #[cfg(feature = "bench")]
+        let entries_ns = entries_start.elapsed().as_nanos() as u64;
 
+        #[cfg(feature = "bench")]
+        let crc_header_start = Instant::now();
         let pos = cursor.position();
         let crc = crc32fast::hash(buf.initialized_slice(V4_BATCH_HEADER_SIZE, pos));
         buf.write_u64_be_at(0, commit_ts);
         buf.write_u32_be_at(8, entry_count);
         buf.write_u32_be_at(12, crc);
         buf.write_u32_be_at(16, entries_size as u32);
+        #[cfg(feature = "bench")]
+        let crc_header_ns = crc_header_start.elapsed().as_nanos() as u64;
 
         // Zero-pad to 4KB alignment (O_DIRECT requirement).
+        #[cfg(feature = "bench")]
+        let finish_start = Instant::now();
         let aligned_len = DirectBuf::align_up(pos);
         buf.zero_range(pos, aligned_len);
         buf.set_len(aligned_len);
         #[cfg(feature = "bench")]
+        let finish_ns = finish_start.elapsed().as_nanos() as u64;
+        #[cfg(feature = "bench")]
         if let Some(profile) = profile {
             profile.record_wal_encode_ns(encode_start.elapsed().as_nanos() as u64);
+            profile.record_wal_encode_parts_ns(entries_ns, crc_header_ns, finish_ns);
         }
 
         #[cfg(feature = "bench")]


### PR DESCRIPTION
## Summary

- add bench-only write-path profile splits for batch build, MVCC WAL-only work, WAL encode substeps, and memtable publish substeps
- add a focused `wal_batch_delete` write-perf workload that excludes prepopulation from profile counters
- keep the rejected batch bloom update experiment reverted while preserving the profiling checkpoints

## Verification

- [x] cargo make check
- [x] focused `write-perf --profile` runs for `wal_batch` and `wal_batch_delete`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a concurrent batched-delete workload to the write performance benchmark suite.
  - The workload is also available through the existing `wal_batch_delete` benchmark name.

- **Improvements**
  - Expanded write-performance reports with more detailed timing breakdowns for WAL processing and memtable updates (including finer-grained WAL and publish sub-phases).
  - Added profiling coverage for batch preparation and MVCC-related write phases.
  - Improved benchmark profile reset and measurement collection for clearer comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->