### PR TITLE
chore: add CRUD write profiling diagnostics

### DIFF
--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -1468,9 +1468,15 @@ fn effective_wal_batch_size(num_keys: usize, writer_threads: usize, requested: u
 }
 
 #[derive(Clone, Copy)]
-enum BatchWritePhase {
-    Put { start_key: usize },
-    Delete { start_key: usize },
+enum BatchWriteOp {
+    Put,
+    Delete,
+}
+
+#[derive(Clone, Copy)]
+struct BatchWritePhase {
+    op: BatchWriteOp,
+    start_key: usize,
 }
 
 fn build_crud_bench_toykv_options(cfg: &HarnessConfig) -> LsmStorageOptions {
@@ -1517,7 +1523,10 @@ fn run_crud_phase_batch_writes(cfg: &HarnessConfig) -> Result<Vec<BenchMeasureme
             options: &options,
             value: &value,
             batch_size,
-            phase: BatchWritePhase::Put { start_key: cfg.num },
+            phase: BatchWritePhase {
+                op: BatchWriteOp::Put,
+                start_key: cfg.num,
+            },
         })?,
         run_crud_phase_batch_write_measurement(CrudPhaseMeasurement {
             cfg,
@@ -1527,7 +1536,10 @@ fn run_crud_phase_batch_writes(cfg: &HarnessConfig) -> Result<Vec<BenchMeasureme
             options: &options,
             value: &value,
             batch_size,
-            phase: BatchWritePhase::Put { start_key: cfg.num },
+            phase: BatchWritePhase {
+                op: BatchWriteOp::Put,
+                start_key: cfg.num,
+            },
         })?,
         run_crud_phase_batch_write_measurement(CrudPhaseMeasurement {
             cfg,
@@ -1537,7 +1549,10 @@ fn run_crud_phase_batch_writes(cfg: &HarnessConfig) -> Result<Vec<BenchMeasureme
             options: &options,
             value: &value,
             batch_size,
-            phase: BatchWritePhase::Delete { start_key: cfg.num },
+            phase: BatchWritePhase {
+                op: BatchWriteOp::Delete,
+                start_key: cfg.num,
+            },
         })?,
     ];
 
@@ -1581,6 +1596,7 @@ fn run_crud_bench_batch_create_100(cfg: &HarnessConfig) -> Result<Vec<BenchMeasu
         CRUD_BENCH_BATCH_ITERATIONS,
         cfg.threads,
         CRUD_BENCH_BATCH_SIZE,
+        cfg.num,
         &value,
     )?;
     if cfg.profile {
@@ -1626,6 +1642,8 @@ fn crud_bench_like_payload(value_size: usize) -> Vec<u8> {
 }
 
 fn ordered_integer_key_bytes(sample_idx: usize) -> [u8; 4] {
+    // Matches the external crud-bench ToyKV adapter byte-for-byte; this is not a sortable key
+    // encoding.
     (sample_idx as u32 + 1).to_ne_bytes()
 }
 
@@ -1634,6 +1652,7 @@ fn run_crud_bench_batch_create_iterations(
     iterations: usize,
     writer_threads: usize,
     batch_size: usize,
+    start_key: usize,
     value: &[u8],
 ) -> Result<Duration> {
     let next_iteration = Arc::new(AtomicUsize::new(0));
@@ -1651,7 +1670,9 @@ fn run_crud_bench_batch_create_iterations(
                 }
                 let mut keys = Vec::with_capacity(batch_size);
                 for offset in 0..batch_size {
-                    keys.push(ordered_integer_key_bytes(iteration * batch_size + offset));
+                    keys.push(ordered_integer_key_bytes(
+                        start_key + iteration * batch_size + offset,
+                    ));
                 }
                 let batch: Vec<_> = keys
                     .iter()
@@ -1747,24 +1768,21 @@ fn run_concurrent_batch_write_phase(
             let mut next = 0usize;
             while next < thread_ops {
                 let current_batch = (thread_ops - next).min(batch_size);
-                let key_start = match phase {
-                    BatchWritePhase::Put { start_key } | BatchWritePhase::Delete { start_key } => {
-                        start_key
-                    }
-                };
                 let mut keys = Vec::with_capacity(current_batch);
                 for i in 0..current_batch {
-                    keys.push(format!("key{:08}", key_start + base_idx + next + i).into_bytes());
+                    keys.push(
+                        format!("key{:08}", phase.start_key + base_idx + next + i).into_bytes(),
+                    );
                 }
-                match phase {
-                    BatchWritePhase::Put { .. } => {
+                match phase.op {
+                    BatchWriteOp::Put => {
                         let batch: Vec<_> = keys
                             .iter()
                             .map(|key| WriteBatchRecord::Put(key.as_slice(), val.as_slice()))
                             .collect();
                         eng.write_batch(&batch).expect("write_batch failed");
                     }
-                    BatchWritePhase::Delete { .. } => {
+                    BatchWriteOp::Delete => {
                         let batch: Vec<_> = keys
                             .iter()
                             .map(|key| WriteBatchRecord::Del(key.as_slice()))

--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -6,7 +6,7 @@ use std::io::Write as _;
 use std::ops::Bound;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use wrapper::kv_engine_wrapper;
 
@@ -19,10 +19,12 @@ use kv_engine_wrapper::{
         TieredCompactionOptions,
     },
     iterators::StorageIterator,
+    key::{KeySlice, encode_internal_key},
     lsm_storage::{
         CacheAdmission, KvEngine, LsmStorageOptions, ParallelScanOptions, PrefixBloomOptions,
         WriteBatchRecord,
     },
+    mem_table::MemTable,
     vlog::ValueSeparationOptions,
 };
 use rand::prelude::*;
@@ -343,6 +345,26 @@ const WORKLOADS: &[WorkloadSpec] = &[
         run: run_wal_batch_delete_concurrent,
     },
     WorkloadSpec {
+        name: "memtable_publish_concurrent",
+        aliases: &["memtable_publish"],
+        run: run_memtable_publish_concurrent,
+    },
+    WorkloadSpec {
+        name: "memtable_publish_delete_concurrent",
+        aliases: &["memtable_publish_delete"],
+        run: run_memtable_publish_delete_concurrent,
+    },
+    WorkloadSpec {
+        name: "crud_phase_batch_writes",
+        aliases: &["crud_phase_batch"],
+        run: run_crud_phase_batch_writes,
+    },
+    WorkloadSpec {
+        name: "crud_bench_batch_create_100",
+        aliases: &["crud_batch_create_100"],
+        run: run_crud_bench_batch_create_100,
+    },
+    WorkloadSpec {
         name: "vlog_gc",
         aliases: &[],
         run: run_vlog_gc,
@@ -532,6 +554,13 @@ struct MeasurementCounters {
 
 fn print_write_profile(engine: &KvEngine, label: &str) {
     let p = engine.write_profile();
+    print_write_profile_snapshot(&p, label);
+}
+
+fn print_write_profile_snapshot(
+    p: &kv_engine_wrapper::mem_table::WriteProfileSnapshot,
+    label: &str,
+) {
     if p.op_count == 0 {
         return;
     }
@@ -553,7 +582,7 @@ fn print_write_profile(engine: &KvEngine, label: &str) {
          follower_events: calls={:>7}  parks={:>7}  retries={:>7}\n  \
          memtable:     {:>8.2} ms  ({:>5.1}%)\n  \
          publish_parts: ttl={:>7.2} ms  decode={:>7.2} ms  bloom={:>7.2} ms  map={:>7.2} ms\n  \
-         publish_map:   copy={:>7.2} ms  skipmap={:>7.2} ms\n  \
+         publish_map:   copy={:>7.2} ms  skipmap={:>7.2} ms  accounting={:>7.2} ms\n  \
          commit_groups: {:>7}  solo={:>7} ({:>5.1}%)  avg_bufs={:>5.2}  max_bufs={:>3}\n  \
          commit_bytes:  avg={:>8.0} B  max={:>8} B\n  \
         total:        {:>8.2} ms",
@@ -593,6 +622,7 @@ fn print_write_profile(engine: &KvEngine, label: &str) {
         p.memtable_publish_map_ms(),
         p.memtable_publish_copy_ms(),
         p.memtable_publish_skipmap_ms(),
+        p.memtable_publish_accounting_ms(),
         p.wal_commit_groups,
         p.wal_commit_solo_groups,
         p.wal_commit_solo_pct(),
@@ -1329,11 +1359,418 @@ fn run_wal_batch_delete_concurrent(cfg: &HarnessConfig) -> Result<Vec<BenchMeasu
     )])
 }
 
+fn run_memtable_publish_concurrent(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    run_memtable_publish_workload(cfg, "memtable_publish_concurrent", false)
+}
+
+fn run_memtable_publish_delete_concurrent(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    run_memtable_publish_workload(cfg, "memtable_publish_delete_concurrent", true)
+}
+
+fn run_memtable_publish_workload(
+    cfg: &HarnessConfig,
+    workload: &'static str,
+    delete_values: bool,
+) -> Result<Vec<BenchMeasurement>> {
+    let options = cfg.build_options(false, false);
+    let memtable = Arc::new(MemTable::create(0, false));
+    #[cfg(feature = "bench")]
+    {
+        memtable.set_write_profile(Arc::new(
+            kv_engine_wrapper::mem_table::WriteProfile::default(),
+        ));
+    }
+
+    let num_keys = cfg.num;
+    let writer_threads = cfg.threads;
+    let per_thread = num_keys / writer_threads;
+    let remainder = num_keys % writer_threads;
+    let batch_size = effective_wal_batch_size(num_keys, writer_threads, cfg.wal_batch_size);
+    let value = if delete_values {
+        vec![kv_engine_wrapper::vlog::KvKind::Tombstone as u8]
+    } else {
+        let mut value = Vec::with_capacity(1 + cfg.value_size);
+        value.push(kv_engine_wrapper::vlog::KvKind::Inline as u8);
+        value.extend(std::iter::repeat_n(b'x', cfg.value_size));
+        value
+    };
+
+    let start = Instant::now();
+    let mut handles = vec![];
+    for t in 0..writer_threads {
+        let mt = memtable.clone();
+        let val = value.clone();
+        handles.push(std::thread::spawn(move || -> Result<()> {
+            let thread_ops = per_thread + usize::from(t < remainder);
+            let start_idx = t * per_thread + remainder.min(t);
+            let mut next = 0usize;
+            while next < thread_ops {
+                let current_batch = (thread_ops - next).min(batch_size);
+                let mut keys = Vec::with_capacity(current_batch);
+                for i in 0..current_batch {
+                    let user_key = format!("key{:08}", start_idx + next + i);
+                    keys.push(encode_internal_key(user_key.as_bytes(), 1));
+                }
+                let batch: Vec<_> = keys
+                    .iter()
+                    .map(|key| (KeySlice::from_slice(key.as_slice()), val.as_slice()))
+                    .collect();
+                mt.put_raw_batch_no_wal(&batch)
+                    .expect("memtable publish failed");
+                next += current_batch;
+            }
+            Ok(())
+        }));
+    }
+    for handle in handles {
+        handle
+            .join()
+            .map_err(|_| anyhow!("writer thread panicked"))??;
+    }
+    let elapsed = start.elapsed();
+    if cfg.profile {
+        let snapshot = memtable.write_profile().snapshot();
+        print_write_profile_snapshot(&snapshot, workload);
+    }
+
+    Ok(vec![make_measurement(
+        cfg,
+        workload,
+        if delete_values {
+            format!("concurrent_delete_batch_{batch_size}")
+        } else {
+            format!("concurrent_batch_{batch_size}")
+        },
+        &options,
+        MeasurementParams {
+            num: Some(num_keys),
+            value_size: Some(cfg.value_size),
+            batch_size: Some(batch_size),
+            threads: Some(writer_threads),
+            seed: Some(cfg.seed),
+            ..MeasurementParams::default()
+        },
+        MeasurementResult {
+            measure_elapsed_ms: ms(elapsed),
+            ops: Some(num_keys as u64),
+            ops_per_sec: Some(rate(num_keys as u64, elapsed)),
+            ..MeasurementResult::default()
+        },
+        MeasurementCounters::default(),
+    )])
+}
+
 fn effective_wal_batch_size(num_keys: usize, writer_threads: usize, requested: usize) -> usize {
     let per_thread = num_keys / writer_threads;
     let remainder = num_keys % writer_threads;
     let max_thread_ops = per_thread + usize::from(remainder > 0);
     requested.min(max_thread_ops.max(1))
+}
+
+#[derive(Clone, Copy)]
+enum BatchWritePhase {
+    Put { start_key: usize },
+    Delete { start_key: usize },
+}
+
+fn build_crud_bench_toykv_options(cfg: &HarnessConfig) -> LsmStorageOptions {
+    let mut options = cfg.build_options(true, true);
+    options.block_size = 64 * 1024;
+    options.target_sst_size = 256 << 20;
+    options.compaction_options = CompactionOptions::Leveled(LeveledCompactionOptions {
+        level0_file_num_compaction_trigger: 2,
+        max_levels: 4,
+        base_level_size_mb: 128,
+        level_size_multiplier: 2,
+    });
+    if let Some(vlog) = options.value_separation.as_mut() {
+        vlog.min_value_size = 4 * 1024;
+    }
+    options
+}
+
+fn run_crud_phase_batch_writes(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    let workload = "crud_phase_batch_writes";
+    let path = prepare_path(cfg, workload)?;
+    let options = build_crud_bench_toykv_options(cfg);
+
+    let engine = KvEngine::open(&path, options.clone())?;
+    let value = vec![b'x'; cfg.value_size];
+    let batch_size = effective_wal_batch_size(cfg.num, cfg.threads, cfg.wal_batch_size);
+
+    for i in 0..cfg.num {
+        engine.put(format!("key{i:08}").as_bytes(), &value)?;
+    }
+    for i in 0..cfg.num {
+        engine.put(format!("key{i:08}").as_bytes(), &value)?;
+    }
+    for i in 0..cfg.num {
+        engine.delete(format!("key{i:08}").as_bytes())?;
+    }
+
+    let mut measurements = Vec::new();
+    measurements.push(run_crud_phase_batch_write_measurement(
+        cfg,
+        workload,
+        "batch_create_after_crud_phase",
+        &engine,
+        &options,
+        &value,
+        batch_size,
+        BatchWritePhase::Put { start_key: cfg.num },
+    )?);
+    measurements.push(run_crud_phase_batch_write_measurement(
+        cfg,
+        workload,
+        "batch_update_after_crud_phase",
+        &engine,
+        &options,
+        &value,
+        batch_size,
+        BatchWritePhase::Put { start_key: cfg.num },
+    )?);
+    measurements.push(run_crud_phase_batch_write_measurement(
+        cfg,
+        workload,
+        "batch_delete_after_crud_phase",
+        &engine,
+        &options,
+        &value,
+        batch_size,
+        BatchWritePhase::Delete { start_key: cfg.num },
+    )?);
+
+    engine.drain_flush()?;
+    engine.close()?;
+    finalize_path(cfg, &path)?;
+
+    Ok(measurements)
+}
+
+fn run_crud_bench_batch_create_100(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
+    const CRUD_BENCH_BATCH_SIZE: usize = 100;
+    const CRUD_BENCH_BATCH_ITERATIONS: usize = 250;
+
+    let workload = "crud_bench_batch_create_100";
+    let path = prepare_path(cfg, workload)?;
+    let options = build_crud_bench_toykv_options(cfg);
+    let engine = KvEngine::open(&path, options.clone())?;
+    let value = crud_bench_like_payload(cfg.value_size);
+
+    for i in 0..cfg.num {
+        let key = ordered_integer_key_bytes(i);
+        engine.put(&key, &value)?;
+    }
+    for i in 0..cfg.num {
+        let key = ordered_integer_key_bytes(i);
+        engine.put(&key, &value)?;
+    }
+    for i in 0..cfg.num {
+        let key = ordered_integer_key_bytes(i);
+        engine.delete(&key)?;
+    }
+
+    #[cfg(feature = "bench")]
+    if cfg.profile {
+        engine.reset_write_profile();
+    }
+    let baseline = collect_counters(&engine)?;
+    let elapsed = run_crud_bench_batch_create_iterations(
+        &engine,
+        CRUD_BENCH_BATCH_ITERATIONS,
+        cfg.threads,
+        CRUD_BENCH_BATCH_SIZE,
+        &value,
+    )?;
+    if cfg.profile {
+        print_write_profile(&engine, "crud_bench_batch_create_100");
+    }
+    let counters = collect_counter_delta(&baseline, &collect_counters(&engine)?);
+
+    engine.drain_flush()?;
+    engine.close()?;
+    finalize_path(cfg, &path)?;
+
+    Ok(vec![make_measurement(
+        cfg,
+        workload,
+        "batch_create_100",
+        &options,
+        MeasurementParams {
+            num: Some(CRUD_BENCH_BATCH_ITERATIONS),
+            value_size: Some(cfg.value_size),
+            batch_size: Some(CRUD_BENCH_BATCH_SIZE),
+            threads: Some(cfg.threads),
+            seed: Some(cfg.seed),
+            ..MeasurementParams::default()
+        },
+        MeasurementResult {
+            measure_elapsed_ms: ms(elapsed),
+            ops: Some((CRUD_BENCH_BATCH_ITERATIONS * CRUD_BENCH_BATCH_SIZE) as u64),
+            ops_per_sec: Some(rate(
+                (CRUD_BENCH_BATCH_ITERATIONS * CRUD_BENCH_BATCH_SIZE) as u64,
+                elapsed,
+            )),
+            ..MeasurementResult::default()
+        },
+        counters,
+    )])
+}
+
+fn crud_bench_like_payload(value_size: usize) -> Vec<u8> {
+    let mut value = Vec::with_capacity(value_size.max(1));
+    value.push(6);
+    value.extend(std::iter::repeat_n(b'x', value_size.saturating_sub(1)));
+    value
+}
+
+fn ordered_integer_key_bytes(sample_idx: usize) -> [u8; 4] {
+    (sample_idx as u32 + 1).to_ne_bytes()
+}
+
+fn run_crud_bench_batch_create_iterations(
+    engine: &Arc<KvEngine>,
+    iterations: usize,
+    writer_threads: usize,
+    batch_size: usize,
+    value: &[u8],
+) -> Result<Duration> {
+    let next_iteration = Arc::new(AtomicUsize::new(0));
+    let start = Instant::now();
+    let mut handles = vec![];
+    for _ in 0..writer_threads {
+        let eng = engine.clone();
+        let val = value.to_vec();
+        let next = next_iteration.clone();
+        handles.push(std::thread::spawn(move || {
+            loop {
+                let iteration = next.fetch_add(1, Ordering::Relaxed);
+                if iteration >= iterations {
+                    break;
+                }
+                let mut keys = Vec::with_capacity(batch_size);
+                for offset in 0..batch_size {
+                    keys.push(ordered_integer_key_bytes(iteration * batch_size + offset));
+                }
+                let batch: Vec<_> = keys
+                    .iter()
+                    .map(|key| WriteBatchRecord::Put(key.as_slice(), val.as_slice()))
+                    .collect();
+                eng.write_batch(&batch).expect("write_batch failed");
+            }
+        }));
+    }
+    for handle in handles {
+        handle
+            .join()
+            .map_err(|_| anyhow!("writer thread panicked"))?;
+    }
+
+    Ok(start.elapsed())
+}
+
+fn run_crud_phase_batch_write_measurement(
+    cfg: &HarnessConfig,
+    workload: &str,
+    measurement: &str,
+    engine: &Arc<KvEngine>,
+    options: &LsmStorageOptions,
+    value: &[u8],
+    batch_size: usize,
+    phase: BatchWritePhase,
+) -> Result<BenchMeasurement> {
+    #[cfg(feature = "bench")]
+    if cfg.profile {
+        engine.reset_write_profile();
+    }
+    let baseline = collect_counters(engine)?;
+    let elapsed =
+        run_concurrent_batch_write_phase(engine, cfg.num, cfg.threads, batch_size, value, phase)?;
+    if cfg.profile {
+        print_write_profile(engine, measurement);
+    }
+    let counters = collect_counter_delta(&baseline, &collect_counters(engine)?);
+
+    Ok(make_measurement(
+        cfg,
+        workload,
+        measurement,
+        options,
+        MeasurementParams {
+            num: Some(cfg.num),
+            value_size: Some(cfg.value_size),
+            batch_size: Some(batch_size),
+            threads: Some(cfg.threads),
+            seed: Some(cfg.seed),
+            ..MeasurementParams::default()
+        },
+        MeasurementResult {
+            measure_elapsed_ms: ms(elapsed),
+            ops: Some(cfg.num as u64),
+            ops_per_sec: Some(rate(cfg.num as u64, elapsed)),
+            ..MeasurementResult::default()
+        },
+        counters,
+    ))
+}
+
+fn run_concurrent_batch_write_phase(
+    engine: &Arc<KvEngine>,
+    num_keys: usize,
+    writer_threads: usize,
+    batch_size: usize,
+    value: &[u8],
+    phase: BatchWritePhase,
+) -> Result<Duration> {
+    let per_thread = num_keys / writer_threads;
+    let remainder = num_keys % writer_threads;
+    let start = Instant::now();
+    let mut handles = vec![];
+    for t in 0..writer_threads {
+        let eng = engine.clone();
+        let val = value.to_vec();
+        handles.push(std::thread::spawn(move || {
+            let thread_ops = per_thread + usize::from(t < remainder);
+            let base_idx = t * per_thread + remainder.min(t);
+            let mut next = 0usize;
+            while next < thread_ops {
+                let current_batch = (thread_ops - next).min(batch_size);
+                let key_start = match phase {
+                    BatchWritePhase::Put { start_key } | BatchWritePhase::Delete { start_key } => {
+                        start_key
+                    }
+                };
+                let mut keys = Vec::with_capacity(current_batch);
+                for i in 0..current_batch {
+                    keys.push(format!("key{:08}", key_start + base_idx + next + i).into_bytes());
+                }
+                match phase {
+                    BatchWritePhase::Put { .. } => {
+                        let batch: Vec<_> = keys
+                            .iter()
+                            .map(|key| WriteBatchRecord::Put(key.as_slice(), val.as_slice()))
+                            .collect();
+                        eng.write_batch(&batch).expect("write_batch failed");
+                    }
+                    BatchWritePhase::Delete { .. } => {
+                        let batch: Vec<_> = keys
+                            .iter()
+                            .map(|key| WriteBatchRecord::Del(key.as_slice()))
+                            .collect();
+                        eng.write_batch(&batch).expect("write_batch delete failed");
+                    }
+                }
+                next += current_batch;
+            }
+        }));
+    }
+    for handle in handles {
+        handle
+            .join()
+            .map_err(|_| anyhow!("writer thread panicked"))?;
+    }
+
+    Ok(start.elapsed())
 }
 
 fn run_vlog_gc(cfg: &HarnessConfig) -> Result<Vec<BenchMeasurement>> {
@@ -2654,6 +3091,41 @@ mod tests {
         let selected = select_workloads(Some("wal_batch_delete")).expect("select workload");
         let names: Vec<_> = selected.iter().map(|w| w.name).collect();
         assert_eq!(names, vec!["wal_batch_delete_concurrent"]);
+    }
+
+    #[test]
+    fn parse_memtable_publish_alias() {
+        let selected = select_workloads(Some("memtable_publish")).expect("select workload");
+        let names: Vec<_> = selected.iter().map(|w| w.name).collect();
+        assert_eq!(names, vec!["memtable_publish_concurrent"]);
+    }
+
+    #[test]
+    fn parse_memtable_publish_delete_alias() {
+        let selected = select_workloads(Some("memtable_publish_delete")).expect("select workload");
+        let names: Vec<_> = selected.iter().map(|w| w.name).collect();
+        assert_eq!(names, vec!["memtable_publish_delete_concurrent"]);
+    }
+
+    #[test]
+    fn parse_crud_phase_batch_alias() {
+        let selected = select_workloads(Some("crud_phase_batch")).expect("select workload");
+        let names: Vec<_> = selected.iter().map(|w| w.name).collect();
+        assert_eq!(names, vec!["crud_phase_batch_writes"]);
+    }
+
+    #[test]
+    fn parse_crud_batch_create_100_alias() {
+        let selected = select_workloads(Some("crud_batch_create_100")).expect("select workload");
+        let names: Vec<_> = selected.iter().map(|w| w.name).collect();
+        assert_eq!(names, vec!["crud_bench_batch_create_100"]);
+    }
+
+    #[test]
+    fn ordered_integer_key_bytes_match_crud_bench() {
+        assert_eq!(ordered_integer_key_bytes(0), 1u32.to_ne_bytes());
+        assert_eq!(ordered_integer_key_bytes(99), 100u32.to_ne_bytes());
+        assert_eq!(ordered_integer_key_bytes(100), 101u32.to_ne_bytes());
     }
 
     #[test]

--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -1508,37 +1508,38 @@ fn run_crud_phase_batch_writes(cfg: &HarnessConfig) -> Result<Vec<BenchMeasureme
         engine.delete(format!("key{i:08}").as_bytes())?;
     }
 
-    let mut measurements = Vec::new();
-    measurements.push(run_crud_phase_batch_write_measurement(
-        cfg,
-        workload,
-        "batch_create_after_crud_phase",
-        &engine,
-        &options,
-        &value,
-        batch_size,
-        BatchWritePhase::Put { start_key: cfg.num },
-    )?);
-    measurements.push(run_crud_phase_batch_write_measurement(
-        cfg,
-        workload,
-        "batch_update_after_crud_phase",
-        &engine,
-        &options,
-        &value,
-        batch_size,
-        BatchWritePhase::Put { start_key: cfg.num },
-    )?);
-    measurements.push(run_crud_phase_batch_write_measurement(
-        cfg,
-        workload,
-        "batch_delete_after_crud_phase",
-        &engine,
-        &options,
-        &value,
-        batch_size,
-        BatchWritePhase::Delete { start_key: cfg.num },
-    )?);
+    let measurements = vec![
+        run_crud_phase_batch_write_measurement(CrudPhaseMeasurement {
+            cfg,
+            workload,
+            measurement: "batch_create_after_crud_phase",
+            engine: &engine,
+            options: &options,
+            value: &value,
+            batch_size,
+            phase: BatchWritePhase::Put { start_key: cfg.num },
+        })?,
+        run_crud_phase_batch_write_measurement(CrudPhaseMeasurement {
+            cfg,
+            workload,
+            measurement: "batch_update_after_crud_phase",
+            engine: &engine,
+            options: &options,
+            value: &value,
+            batch_size,
+            phase: BatchWritePhase::Put { start_key: cfg.num },
+        })?,
+        run_crud_phase_batch_write_measurement(CrudPhaseMeasurement {
+            cfg,
+            workload,
+            measurement: "batch_delete_after_crud_phase",
+            engine: &engine,
+            options: &options,
+            value: &value,
+            batch_size,
+            phase: BatchWritePhase::Delete { start_key: cfg.num },
+        })?,
+    ];
 
     engine.drain_flush()?;
     engine.close()?;
@@ -1669,37 +1670,48 @@ fn run_crud_bench_batch_create_iterations(
     Ok(start.elapsed())
 }
 
-fn run_crud_phase_batch_write_measurement(
-    cfg: &HarnessConfig,
-    workload: &str,
-    measurement: &str,
-    engine: &Arc<KvEngine>,
-    options: &LsmStorageOptions,
-    value: &[u8],
+struct CrudPhaseMeasurement<'a> {
+    cfg: &'a HarnessConfig,
+    workload: &'a str,
+    measurement: &'a str,
+    engine: &'a Arc<KvEngine>,
+    options: &'a LsmStorageOptions,
+    value: &'a [u8],
     batch_size: usize,
     phase: BatchWritePhase,
+}
+
+fn run_crud_phase_batch_write_measurement(
+    input: CrudPhaseMeasurement<'_>,
 ) -> Result<BenchMeasurement> {
+    let cfg = input.cfg;
     #[cfg(feature = "bench")]
     if cfg.profile {
-        engine.reset_write_profile();
+        input.engine.reset_write_profile();
     }
-    let baseline = collect_counters(engine)?;
-    let elapsed =
-        run_concurrent_batch_write_phase(engine, cfg.num, cfg.threads, batch_size, value, phase)?;
+    let baseline = collect_counters(input.engine)?;
+    let elapsed = run_concurrent_batch_write_phase(
+        input.engine,
+        cfg.num,
+        cfg.threads,
+        input.batch_size,
+        input.value,
+        input.phase,
+    )?;
     if cfg.profile {
-        print_write_profile(engine, measurement);
+        print_write_profile(input.engine, input.measurement);
     }
-    let counters = collect_counter_delta(&baseline, &collect_counters(engine)?);
+    let counters = collect_counter_delta(&baseline, &collect_counters(input.engine)?);
 
     Ok(make_measurement(
         cfg,
-        workload,
-        measurement,
-        options,
+        input.workload,
+        input.measurement,
+        input.options,
         MeasurementParams {
             num: Some(cfg.num),
             value_size: Some(cfg.value_size),
-            batch_size: Some(batch_size),
+            batch_size: Some(input.batch_size),
             threads: Some(cfg.threads),
             seed: Some(cfg.seed),
             ..MeasurementParams::default()

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -6215,9 +6215,12 @@ impl LsmStorageInner {
         }
 
         let current = self.write_profile.snapshot();
-        let mut last = self.write_batch_profile_log_last.lock();
-        let delta = current.saturating_sub(*last);
-        *last = current;
+        let delta = {
+            let mut last = self.write_batch_profile_log_last.lock();
+            let delta = current.saturating_sub(*last);
+            *last = current;
+            delta
+        };
         if delta.op_count == 0 {
             return;
         }

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -6210,7 +6210,7 @@ impl LsmStorageInner {
             .write_batch_profile_log_count
             .fetch_add(1, Ordering::Relaxed)
             + 1;
-        if call % every != 0 {
+        if !call.is_multiple_of(every) {
             return;
         }
 

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -1017,6 +1017,14 @@ pub(crate) struct LsmStorageInner {
     pub(crate) background_tasks: Mutex<Option<BackgroundTaskSubmitter>>,
     /// Cumulative write-path profiling counters (persists across memtable freezes).
     pub(crate) write_profile: Arc<crate::mem_table::WriteProfile>,
+    #[cfg(feature = "bench")]
+    write_batch_profile_log_every: usize,
+    #[cfg(feature = "bench")]
+    write_batch_profile_log_count: AtomicUsize,
+    #[cfg(feature = "bench")]
+    write_batch_profile_log_started: AtomicBool,
+    #[cfg(feature = "bench")]
+    write_batch_profile_log_last: Mutex<crate::mem_table::WriteProfileSnapshot>,
     /// Lifecycle state machine for async close / admission control.
     pub(crate) lifecycle: LifecycleHandle,
     /// Bounded blocking executor for running sync ops in async context.
@@ -3317,6 +3325,19 @@ impl LsmStorageInner {
             weak_self: std::sync::OnceLock::new(),
             background_tasks: Mutex::new(None),
             write_profile: Arc::new(crate::mem_table::WriteProfile::default()),
+            #[cfg(feature = "bench")]
+            write_batch_profile_log_every: std::env::var("TOYKV_WRITE_BATCH_PROFILE_EVERY")
+                .ok()
+                .and_then(|value| value.parse().ok())
+                .unwrap_or(0),
+            #[cfg(feature = "bench")]
+            write_batch_profile_log_count: AtomicUsize::new(0),
+            #[cfg(feature = "bench")]
+            write_batch_profile_log_started: AtomicBool::new(false),
+            #[cfg(feature = "bench")]
+            write_batch_profile_log_last: Mutex::new(
+                crate::mem_table::WriteProfileSnapshot::default(),
+            ),
             lifecycle: LifecycleHandle::new(),
             blocking: BlockingExecutor::with_default(),
         };
@@ -6068,6 +6089,8 @@ impl LsmStorageInner {
     #[allow(clippy::type_complexity)]
     pub fn write_batch<T: AsRef<[u8]>>(&self, batch: &[WriteBatchRecord<T>]) -> Result<()> {
         let has_range = Self::validate_and_classify_write_batch(batch)?;
+        #[cfg(feature = "bench")]
+        self.maybe_start_write_batch_profile_window();
 
         if has_range {
             return self.range_batch_write(batch);
@@ -6157,7 +6180,79 @@ impl LsmStorageInner {
             mvcc.record_committed_txn(commit_ts, write_set, 0);
         }
         drop(_commit_guard);
-        self.try_freeze_memtable()
+        self.try_freeze_memtable()?;
+        #[cfg(feature = "bench")]
+        self.maybe_log_write_batch_profile_window();
+        Ok(())
+    }
+
+    #[cfg(feature = "bench")]
+    fn maybe_start_write_batch_profile_window(&self) {
+        if self.write_batch_profile_log_every == 0 {
+            return;
+        }
+        if self
+            .write_batch_profile_log_started
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            *self.write_batch_profile_log_last.lock() = self.write_profile.snapshot();
+        }
+    }
+
+    #[cfg(feature = "bench")]
+    fn maybe_log_write_batch_profile_window(&self) {
+        let every = self.write_batch_profile_log_every;
+        if every == 0 {
+            return;
+        }
+        let call = self
+            .write_batch_profile_log_count
+            .fetch_add(1, Ordering::Relaxed)
+            + 1;
+        if call % every != 0 {
+            return;
+        }
+
+        let current = self.write_profile.snapshot();
+        let mut last = self.write_batch_profile_log_last.lock();
+        let delta = current.saturating_sub(*last);
+        *last = current;
+        if delta.op_count == 0 {
+            return;
+        }
+
+        eprintln!(
+            "toykv_write_batch_profile window={} calls={} ops={} batch_build_ms={:.2} \
+             mvcc_wal_only_ms={:.2} wal_write_ms={:.2} wal_encode_ms={:.2} \
+             wal_sync_ms={:.2} wal_submit_ms={:.2} follower_wait_ms={:.2} \
+             follower_calls={} follower_parks={} memtable_ms={:.2} publish_copy_ms={:.2} \
+             publish_skipmap_ms={:.2} publish_accounting_ms={:.2} commit_groups={} solo_groups={} solo_pct={:.1} \
+             avg_bufs={:.2} avg_bytes={:.0} max_bufs_since_open={} max_bytes_since_open={}",
+            call / every,
+            every,
+            delta.op_count,
+            delta.batch_build_ms(),
+            delta.mvcc_wal_only_ms(),
+            delta.wal_write_ms(),
+            delta.wal_encode_ms(),
+            delta.wal_sync_ms(),
+            delta.wal_submit_ms(),
+            delta.wal_follower_wait_ms(),
+            delta.wal_follower_wait_calls,
+            delta.wal_follower_condvar_waits,
+            delta.memtable_insert_ms(),
+            delta.memtable_publish_copy_ms(),
+            delta.memtable_publish_skipmap_ms(),
+            delta.memtable_publish_accounting_ms(),
+            delta.wal_commit_groups,
+            delta.wal_commit_solo_groups,
+            delta.wal_commit_solo_pct(),
+            delta.wal_commit_avg_buffers(),
+            delta.wal_commit_avg_bytes(),
+            current.wal_commit_max_buffers,
+            current.wal_commit_max_bytes,
+        );
     }
 
     pub(crate) fn try_freeze_memtable(&self) -> Result<()> {

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -273,27 +273,31 @@ impl WriteProfile {
     }
 
     #[cfg(feature = "bench")]
-    pub(crate) fn record_memtable_publish_parts(
-        &self,
-        ttl_check_ns: u64,
-        decode_ns: u64,
-        bloom_ns: u64,
-        map_ns: u64,
-        copy_ns: u64,
-        skipmap_ns: u64,
-        accounting_ns: u64,
-    ) {
+    pub(crate) fn record_memtable_publish_parts(&self, parts: MemtablePublishProfileParts) {
         let o = std::sync::atomic::Ordering::Relaxed;
         self.memtable_publish_ttl_check_ns
-            .fetch_add(ttl_check_ns, o);
-        self.memtable_publish_decode_ns.fetch_add(decode_ns, o);
-        self.memtable_publish_bloom_ns.fetch_add(bloom_ns, o);
-        self.memtable_publish_map_ns.fetch_add(map_ns, o);
-        self.memtable_publish_copy_ns.fetch_add(copy_ns, o);
-        self.memtable_publish_skipmap_ns.fetch_add(skipmap_ns, o);
+            .fetch_add(parts.ttl_check_ns, o);
+        self.memtable_publish_decode_ns
+            .fetch_add(parts.decode_ns, o);
+        self.memtable_publish_bloom_ns.fetch_add(parts.bloom_ns, o);
+        self.memtable_publish_map_ns.fetch_add(parts.map_ns, o);
+        self.memtable_publish_copy_ns.fetch_add(parts.copy_ns, o);
+        self.memtable_publish_skipmap_ns
+            .fetch_add(parts.skipmap_ns, o);
         self.memtable_publish_accounting_ns
-            .fetch_add(accounting_ns, o);
+            .fetch_add(parts.accounting_ns, o);
     }
+}
+
+#[cfg(feature = "bench")]
+pub(crate) struct MemtablePublishProfileParts {
+    pub(crate) ttl_check_ns: u64,
+    pub(crate) decode_ns: u64,
+    pub(crate) bloom_ns: u64,
+    pub(crate) map_ns: u64,
+    pub(crate) copy_ns: u64,
+    pub(crate) skipmap_ns: u64,
+    pub(crate) accounting_ns: u64,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -1242,15 +1246,17 @@ impl MemTable {
                 }
             });
             #[cfg(feature = "bench")]
-            self.write_profile.load().record_memtable_publish_parts(
-                ttl_check_ns,
-                decode_ns,
-                bloom_ns,
-                map_ns,
-                copy_ns,
-                skipmap_ns,
-                accounting_ns,
-            );
+            self.write_profile
+                .load()
+                .record_memtable_publish_parts(MemtablePublishProfileParts {
+                    ttl_check_ns,
+                    decode_ns,
+                    bloom_ns,
+                    map_ns,
+                    copy_ns,
+                    skipmap_ns,
+                    accounting_ns,
+                });
         });
         #[cfg(feature = "bench")]
         {
@@ -1367,15 +1373,17 @@ impl MemTable {
                 }
             });
             #[cfg(feature = "bench")]
-            self.write_profile.load().record_memtable_publish_parts(
-                ttl_check_ns,
-                decode_ns,
-                bloom_ns,
-                map_ns,
-                copy_ns,
-                skipmap_ns,
-                accounting_ns,
-            );
+            self.write_profile
+                .load()
+                .record_memtable_publish_parts(MemtablePublishProfileParts {
+                    ttl_check_ns,
+                    decode_ns,
+                    bloom_ns,
+                    map_ns,
+                    copy_ns,
+                    skipmap_ns,
+                    accounting_ns,
+                });
         });
         #[cfg(feature = "bench")]
         {

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -1338,20 +1338,25 @@ impl MemTable {
                         bloom_ns += part_start.elapsed().as_nanos() as u64;
                     }
 
+                    let key_len = key.len();
+                    let value_len = value.len();
                     #[cfg(feature = "bench")]
                     let part_start = Instant::now();
-                    #[cfg(feature = "bench")]
-                    let accounting_start = Instant::now();
-                    approximate_size_delta += key.len() + value.len();
-                    #[cfg(feature = "bench")]
-                    {
-                        accounting_ns += accounting_start.elapsed().as_nanos() as u64;
-                    }
                     let map_key = key;
                     let map_value = value;
                     #[cfg(feature = "bench")]
+                    let copy_elapsed_ns = part_start.elapsed().as_nanos() as u64;
+                    #[cfg(feature = "bench")]
                     {
-                        copy_ns += part_start.elapsed().as_nanos() as u64;
+                        copy_ns += copy_elapsed_ns;
+                    }
+
+                    #[cfg(feature = "bench")]
+                    let accounting_start = Instant::now();
+                    approximate_size_delta += key_len + value_len;
+                    #[cfg(feature = "bench")]
+                    {
+                        accounting_ns += accounting_start.elapsed().as_nanos() as u64;
                     }
 
                     #[cfg(feature = "bench")]
@@ -1359,8 +1364,9 @@ impl MemTable {
                     self.map.insert(map_key, map_value);
                     #[cfg(feature = "bench")]
                     {
-                        skipmap_ns += insert_start.elapsed().as_nanos() as u64;
-                        map_ns += part_start.elapsed().as_nanos() as u64;
+                        let insert_elapsed_ns = insert_start.elapsed().as_nanos() as u64;
+                        skipmap_ns += insert_elapsed_ns;
+                        map_ns += copy_elapsed_ns + insert_elapsed_ns;
                     }
                 }
                 #[cfg(feature = "bench")]

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -1228,13 +1228,7 @@ impl MemTable {
                     // is sufficient and avoids unnecessary fence overhead (L3).
                     // Use raw_ref().len() for key data size (size_of_val on KeySlice
                     // returns the struct size, not the data length).
-                    #[cfg(feature = "bench")]
-                    let part_start = Instant::now();
                     approximate_size_delta += key.raw_ref().len() + value.len();
-                    #[cfg(feature = "bench")]
-                    {
-                        accounting_ns += part_start.elapsed().as_nanos() as u64;
-                    }
                 }
                 #[cfg(feature = "bench")]
                 let part_start = Instant::now();
@@ -1351,13 +1345,7 @@ impl MemTable {
                         copy_ns += copy_elapsed_ns;
                     }
 
-                    #[cfg(feature = "bench")]
-                    let accounting_start = Instant::now();
                     approximate_size_delta += key_len + value_len;
-                    #[cfg(feature = "bench")]
-                    {
-                        accounting_ns += accounting_start.elapsed().as_nanos() as u64;
-                    }
 
                     #[cfg(feature = "bench")]
                     let insert_start = Instant::now();

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -88,6 +88,8 @@ pub struct WriteProfile {
     pub memtable_publish_copy_ns: AtomicU64,
     /// Time inside SkipMap insertion after owned bytes are ready.
     pub memtable_publish_skipmap_ns: AtomicU64,
+    /// Time updating approximate-size accounting for published entries.
+    pub memtable_publish_accounting_ns: AtomicU64,
     /// Number of WAL commit groups that reached fdatasync.
     pub wal_commit_groups: AtomicU64,
     /// Number of WAL commit groups that only contained one pending buffer.
@@ -132,6 +134,7 @@ impl WriteProfile {
         self.memtable_publish_map_ns.store(0, o);
         self.memtable_publish_copy_ns.store(0, o);
         self.memtable_publish_skipmap_ns.store(0, o);
+        self.memtable_publish_accounting_ns.store(0, o);
         self.wal_commit_groups.store(0, o);
         self.wal_commit_solo_groups.store(0, o);
         self.wal_commit_buffers.store(0, o);
@@ -168,6 +171,7 @@ impl WriteProfile {
             memtable_publish_map_ns: self.memtable_publish_map_ns.load(o),
             memtable_publish_copy_ns: self.memtable_publish_copy_ns.load(o),
             memtable_publish_skipmap_ns: self.memtable_publish_skipmap_ns.load(o),
+            memtable_publish_accounting_ns: self.memtable_publish_accounting_ns.load(o),
             wal_commit_groups: self.wal_commit_groups.load(o),
             wal_commit_solo_groups: self.wal_commit_solo_groups.load(o),
             wal_commit_buffers: self.wal_commit_buffers.load(o),
@@ -277,6 +281,7 @@ impl WriteProfile {
         map_ns: u64,
         copy_ns: u64,
         skipmap_ns: u64,
+        accounting_ns: u64,
     ) {
         let o = std::sync::atomic::Ordering::Relaxed;
         self.memtable_publish_ttl_check_ns
@@ -286,10 +291,12 @@ impl WriteProfile {
         self.memtable_publish_map_ns.fetch_add(map_ns, o);
         self.memtable_publish_copy_ns.fetch_add(copy_ns, o);
         self.memtable_publish_skipmap_ns.fetch_add(skipmap_ns, o);
+        self.memtable_publish_accounting_ns
+            .fetch_add(accounting_ns, o);
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct WriteProfileSnapshot {
     pub batch_build_ns: u64,
     pub mvcc_wal_only_ns: u64,
@@ -315,6 +322,7 @@ pub struct WriteProfileSnapshot {
     pub memtable_publish_map_ns: u64,
     pub memtable_publish_copy_ns: u64,
     pub memtable_publish_skipmap_ns: u64,
+    pub memtable_publish_accounting_ns: u64,
     pub wal_commit_groups: u64,
     pub wal_commit_solo_groups: u64,
     pub wal_commit_buffers: u64,
@@ -325,6 +333,85 @@ pub struct WriteProfileSnapshot {
 }
 
 impl WriteProfileSnapshot {
+    pub fn saturating_sub(self, before: Self) -> Self {
+        Self {
+            batch_build_ns: self.batch_build_ns.saturating_sub(before.batch_build_ns),
+            mvcc_wal_only_ns: self
+                .mvcc_wal_only_ns
+                .saturating_sub(before.mvcc_wal_only_ns),
+            wal_write_ns: self.wal_write_ns.saturating_sub(before.wal_write_ns),
+            wal_validate_ns: self.wal_validate_ns.saturating_sub(before.wal_validate_ns),
+            wal_prepare_ns: self.wal_prepare_ns.saturating_sub(before.wal_prepare_ns),
+            wal_encode_ns: self.wal_encode_ns.saturating_sub(before.wal_encode_ns),
+            wal_encode_entries_ns: self
+                .wal_encode_entries_ns
+                .saturating_sub(before.wal_encode_entries_ns),
+            wal_encode_crc_header_ns: self
+                .wal_encode_crc_header_ns
+                .saturating_sub(before.wal_encode_crc_header_ns),
+            wal_encode_finish_ns: self
+                .wal_encode_finish_ns
+                .saturating_sub(before.wal_encode_finish_ns),
+            wal_enqueue_ns: self.wal_enqueue_ns.saturating_sub(before.wal_enqueue_ns),
+            wal_sync_ns: self.wal_sync_ns.saturating_sub(before.wal_sync_ns),
+            wal_submit_ns: self.wal_submit_ns.saturating_sub(before.wal_submit_ns),
+            wal_fdatasync_ns: self
+                .wal_fdatasync_ns
+                .saturating_sub(before.wal_fdatasync_ns),
+            wal_follower_wait_ns: self
+                .wal_follower_wait_ns
+                .saturating_sub(before.wal_follower_wait_ns),
+            wal_follower_wait_calls: self
+                .wal_follower_wait_calls
+                .saturating_sub(before.wal_follower_wait_calls),
+            wal_follower_condvar_waits: self
+                .wal_follower_condvar_waits
+                .saturating_sub(before.wal_follower_condvar_waits),
+            wal_follower_retry_loops: self
+                .wal_follower_retry_loops
+                .saturating_sub(before.wal_follower_retry_loops),
+            memtable_insert_ns: self
+                .memtable_insert_ns
+                .saturating_sub(before.memtable_insert_ns),
+            memtable_publish_ttl_check_ns: self
+                .memtable_publish_ttl_check_ns
+                .saturating_sub(before.memtable_publish_ttl_check_ns),
+            memtable_publish_decode_ns: self
+                .memtable_publish_decode_ns
+                .saturating_sub(before.memtable_publish_decode_ns),
+            memtable_publish_bloom_ns: self
+                .memtable_publish_bloom_ns
+                .saturating_sub(before.memtable_publish_bloom_ns),
+            memtable_publish_map_ns: self
+                .memtable_publish_map_ns
+                .saturating_sub(before.memtable_publish_map_ns),
+            memtable_publish_copy_ns: self
+                .memtable_publish_copy_ns
+                .saturating_sub(before.memtable_publish_copy_ns),
+            memtable_publish_skipmap_ns: self
+                .memtable_publish_skipmap_ns
+                .saturating_sub(before.memtable_publish_skipmap_ns),
+            memtable_publish_accounting_ns: self
+                .memtable_publish_accounting_ns
+                .saturating_sub(before.memtable_publish_accounting_ns),
+            wal_commit_groups: self
+                .wal_commit_groups
+                .saturating_sub(before.wal_commit_groups),
+            wal_commit_solo_groups: self
+                .wal_commit_solo_groups
+                .saturating_sub(before.wal_commit_solo_groups),
+            wal_commit_buffers: self
+                .wal_commit_buffers
+                .saturating_sub(before.wal_commit_buffers),
+            wal_commit_bytes: self
+                .wal_commit_bytes
+                .saturating_sub(before.wal_commit_bytes),
+            wal_commit_max_buffers: self.wal_commit_max_buffers,
+            wal_commit_max_bytes: self.wal_commit_max_bytes,
+            op_count: self.op_count.saturating_sub(before.op_count),
+        }
+    }
+
     pub fn batch_build_ms(&self) -> f64 {
         self.batch_build_ns as f64 / 1_000_000.0
     }
@@ -407,6 +494,10 @@ impl WriteProfileSnapshot {
 
     pub fn memtable_publish_skipmap_ms(&self) -> f64 {
         self.memtable_publish_skipmap_ns as f64 / 1_000_000.0
+    }
+
+    pub fn memtable_publish_accounting_ms(&self) -> f64 {
+        self.memtable_publish_accounting_ns as f64 / 1_000_000.0
     }
 
     pub fn total_ms(&self) -> f64 {
@@ -1082,6 +1173,8 @@ impl MemTable {
             let mut copy_ns = 0u64;
             #[cfg(feature = "bench")]
             let mut skipmap_ns = 0u64;
+            #[cfg(feature = "bench")]
+            let mut accounting_ns = 0u64;
             crate::profile_scope!("memtable.publish_batch", {
                 for (key, value) in data {
                     #[cfg(feature = "bench")]
@@ -1131,10 +1224,22 @@ impl MemTable {
                     // is sufficient and avoids unnecessary fence overhead (L3).
                     // Use raw_ref().len() for key data size (size_of_val on KeySlice
                     // returns the struct size, not the data length).
+                    #[cfg(feature = "bench")]
+                    let part_start = Instant::now();
                     approximate_size_delta += key.raw_ref().len() + value.len();
+                    #[cfg(feature = "bench")]
+                    {
+                        accounting_ns += part_start.elapsed().as_nanos() as u64;
+                    }
                 }
+                #[cfg(feature = "bench")]
+                let part_start = Instant::now();
                 self.approximate_size
                     .fetch_add(approximate_size_delta, std::sync::atomic::Ordering::Relaxed);
+                #[cfg(feature = "bench")]
+                {
+                    accounting_ns += part_start.elapsed().as_nanos() as u64;
+                }
             });
             #[cfg(feature = "bench")]
             self.write_profile.load().record_memtable_publish_parts(
@@ -1144,6 +1249,7 @@ impl MemTable {
                 map_ns,
                 copy_ns,
                 skipmap_ns,
+                accounting_ns,
             );
         });
         #[cfg(feature = "bench")]
@@ -1197,6 +1303,8 @@ impl MemTable {
             let mut copy_ns = 0u64;
             #[cfg(feature = "bench")]
             let mut skipmap_ns = 0u64;
+            #[cfg(feature = "bench")]
+            let mut accounting_ns = 0u64;
             crate::profile_scope!("memtable.publish_batch", {
                 for (key, value) in entries {
                     #[cfg(feature = "bench")]
@@ -1226,7 +1334,13 @@ impl MemTable {
 
                     #[cfg(feature = "bench")]
                     let part_start = Instant::now();
+                    #[cfg(feature = "bench")]
+                    let accounting_start = Instant::now();
                     approximate_size_delta += key.len() + value.len();
+                    #[cfg(feature = "bench")]
+                    {
+                        accounting_ns += accounting_start.elapsed().as_nanos() as u64;
+                    }
                     let map_key = key;
                     let map_value = value;
                     #[cfg(feature = "bench")]
@@ -1243,8 +1357,14 @@ impl MemTable {
                         map_ns += part_start.elapsed().as_nanos() as u64;
                     }
                 }
+                #[cfg(feature = "bench")]
+                let part_start = Instant::now();
                 self.approximate_size
                     .fetch_add(approximate_size_delta, std::sync::atomic::Ordering::Relaxed);
+                #[cfg(feature = "bench")]
+                {
+                    accounting_ns += part_start.elapsed().as_nanos() as u64;
+                }
             });
             #[cfg(feature = "bench")]
             self.write_profile.load().record_memtable_publish_parts(
@@ -1254,6 +1374,7 @@ impl MemTable {
                 map_ns,
                 copy_ns,
                 skipmap_ns,
+                accounting_ns,
             );
         });
         #[cfg(feature = "bench")]

--- a/kv-engine/src/tests/wal.rs
+++ b/kv-engine/src/tests/wal.rs
@@ -504,8 +504,13 @@ fn test_wal_profiled_group_commit_records_follower_wait_events() {
 
     let snapshot = profile.snapshot();
     assert!(snapshot.wal_commit_groups > 0);
-    assert!(snapshot.wal_follower_wait_calls > 0);
-    assert!(snapshot.wal_follower_condvar_waits > 0);
+    assert!(snapshot.wal_commit_buffers >= snapshot.wal_commit_groups);
+    assert!(snapshot.wal_commit_bytes > 0);
+    assert!(snapshot.wal_commit_max_buffers > 0);
+    assert!(snapshot.wal_commit_max_bytes > 0);
+    if snapshot.wal_follower_wait_calls > 0 {
+        assert!(snapshot.wal_follower_condvar_waits > 0);
+    }
 }
 
 #[test]

--- a/todo.md
+++ b/todo.md
@@ -369,6 +369,78 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   4,480.67 -> 7,845.61 OPS, `batch_update_100` 2,063.21 -> 8,060.23 OPS, `batch_delete_100`
   3,658.38 -> 11,376.21 OPS, `batch_create_1000` 721.23 -> 1,385.87 OPS, `batch_update_1000`
   612.92 -> 1,824.51 OPS, and `batch_delete_1000` 1,775.83 -> 5,994.75 OPS.
+  Follow-up instrumentation: `write-perf --bench crud_phase_batch --num 100000 --threads 4 --value-size 1024
+  --wal-batch-size 1000 --profile` now runs the CRUD phase shape inside the repo and reports create/update/delete
+  batch profiles after the single-row create/update/delete warmup. A same-branch rerun measured create/update at
+  1.60M/1.62M OPS with similar profile shape (`batch_build` 51-53 ms, `wal_encode` 33-34 ms, `wal_sync` 43-44 ms,
+  `memtable` 52-56 ms), while delete measured 3.75M OPS and stayed memtable-bound (`memtable` 66 ms, `wal_write`
+  1.62 ms). This confirms that further group-commit delay tuning is the wrong target for large batch rows: the
+  workload still forms almost entirely solo 1 MiB commit groups, and delete is dominated by SkipMap publication.
+  Rejected follow-ups after this instrumentation: dedicated delete publish paths, precomputed publish hashes, borrowed
+  user keys through MVCC staging, consuming prepared `Bytes` into deferred publish, and retuning solo-delay constants
+  each regressed at least one CRUD batch row. The next worthwhile production slice should be a larger write-batch/WAL
+  format change that avoids building publish data and then re-encoding equivalent WAL payload bytes, not another
+  localized loop micro-edit. A first owned-large-batch WAL attempt that skipped the unused self-referencing borrowed-ref
+  view for batches >=512 improved the in-repo CRUD-phase profile and large CRUD rows, but failed the focused sync CRUD
+  gate twice by regressing `batch_create_100`: same-window rerun control/candidate was 6,578.23 -> 3,126.48 OPS
+  (-52.5%), while `batch_create_1000` only moved 1,651.22 -> 1,678.63 OPS (+1.7%),
+  `batch_update_1000` 1,606.71 -> 1,821.36 OPS (+13.4%), and `batch_delete_1000` 4,518.24 -> 4,750.70 OPS (+5.1%).
+  That path was reverted; the next attempt needs a correctness-preserving format/API change that does not perturb
+  smaller batch scheduling.
+  Lowering the owned-publish threshold from 512 to 100 was also rejected. It removed the in-repo batch-100 publish-copy
+  bucket (`create` publish copy 57.07 ms -> 1.42 ms; `create` 1.50M -> 1.63M OPS, `update` 1.64M -> 1.75M OPS,
+  `delete` 2.30M -> 3.82M OPS), but failed the focused sync CRUD gate against the same-window control:
+  `batch_create_100` 6,578.23 -> 5,853.75 OPS (-11.0%), while `batch_update_100` and `batch_delete_100` improved.
+  Keep the threshold at 512 unless a full CRUD rerun proves the scheduling interaction has been fixed.
+  Follow-up instrumentation added `write-perf --bench crud_batch_create_100`, matching the default CRUD batch-create row
+  more closely: 250 timed batches of 100, ordered integer keys encoded with `u32::to_ne_bytes`, ToyKV adapter options,
+  and the single-row create/update/delete warmup before timing. Baseline profile measured 946,035 OPS with 226 commit
+  groups, 89.8% solo groups, 21.33 ms WAL sync, and 65.25 ms memtable publish. A temporary threshold-100 rerun still
+  improved locally to 1,020,771 OPS while eliminating publish copy (23.02 ms -> 0.43 ms), so the standalone in-repo
+  repro does not explain the external `crud-bench batch_create_100` regression. Next evidence should come from the
+  external adapter/full-run path, not more local threshold tuning.
+  Follow-up external instrumentation: with the ToyKV `bench` feature enabled,
+  `TOYKV_WRITE_BATCH_PROFILE_EVERY=250 cargo run --release --no-default-features --features 'toykv toykv/bench' --bin
+  crud-bench -- -d toykv -s 100000 -c 4 -t 4 --sync --skip-indexes --skip-scans` now emits one ToyKV write-batch
+  profile window per default CRUD batch write row. Clean current rerun (`toykv_profile_windows_current_rerun2`) measured
+  `batch_create_100` at 7,438.61 OPS with 36 commit groups for 250 batch calls, 2.8% solo groups, 353.43 ms accumulated
+  WAL sync, 322.71 ms follower wait, 49.06 ms memtable publish, and 7.14 ms publish copy. A temporary threshold-100
+  rerun (`toykv_profile_windows_threshold100`) reproduced the external failure: `batch_create_100` fell to 1,331.60 OPS,
+  while WAL sync/follower wait jumped to 2,539.31/2,369.65 ms and memtable publish rose to 112.46 ms even though publish
+  copy fell to 1.07 ms. This confirms the threshold change disrupts concurrent commit scheduling enough to swamp the
+  saved copy. Reverted; keep the env logger as the next external-gate diagnostic.
+  Rejected follow-up: gating WAL `notify_all()` on a counted condvar waiter set was neutral for `batch_create_100`
+  (7,438.61 -> 7,375.77 OPS) and helped `batch_create_1000` slightly (1,656.03 -> 1,690.74 OPS), but badly regressed
+  `batch_update_1000` (1,658.15 -> 1,086.10 OPS) and `batch_delete_1000` (5,163.59 -> 4,626.49 OPS). The profile showed
+  worse update/delete follower wait and solo-group shape, so unconditional wakeup remains the safer commit barrier.
+  Rejected follow-up: extending the large-buffer leader spin to wait for small groups below 4 buffers regressed the
+  external gate. `batch_create_100` fell 7,438.61 -> 6,022.87 OPS, `batch_create_1000` fell 1,656.03 -> 1,157.31 OPS,
+  and `batch_delete_1000` fell 5,163.59 -> 4,051.59 OPS. The candidate raised solo-group share and follower wait on
+  large create/delete, so the existing solo-only wait remains better.
+  Rejected external-adapter follow-up: changing the `crud-bench` ToyKV u32 batch adapter to store stack `[u8; 4]` keys
+  plus encoded value `Vec`s, then call `write_batch` with borrowed `WriteBatchRecord<&[u8]>`, helped small create/update
+  rows but regressed large create. Same-window profile moved `batch_create_100` 7,438.61 -> 8,059.50 OPS and
+  `batch_update_100` 5,724.03 -> 7,467.48 OPS, but `batch_create_1000` fell 1,656.03 -> 1,538.30 OPS and
+  `batch_delete_1000` was slightly lower at 5,163.59 -> 5,056.26 OPS. The ToyKV-internal `batch_build` bucket did not
+  improve for large create, so caller key-Vec allocation is not the right next durable-batch target.
+  Follow-up profiling split approximate-size accounting out of memtable publish map time. External CRUD profile
+  (`toykv_publish_accounting_profile`) showed accounting is not material: `batch_create_100` spent 0.67 ms in
+  accounting versus 43.84 ms in SkipMap insert and 308.93 ms in follower wait; `batch_create_1000` spent 4.17 ms in
+  accounting versus 218.06 ms in SkipMap insert and 530.50 ms in follower wait. Do not optimize approximate-size
+  bookkeeping further unless those ratios change; the remaining durable-batch targets are SkipMap publish cost and WAL
+  group/wait shape.
+  Rejected follow-up: hashing the decoded user key directly from the memcomparable internal-key prefix avoided
+  materializing the user key for bloom insertion, and helped the local CRUD-shaped write-perf profile, but failed the
+  external CRUD gate. `toykv_direct_bloom_hash_candidate` moved `batch_create_100` only flat (7,438.61 -> 7,437.06
+  OPS), regressed `batch_create_1000` (1,656.03 -> 1,611.07 OPS), and badly regressed `batch_update_1000`
+  (1,658.15 -> 1,349.01 OPS), despite improving `batch_delete_1000` (5,163.59 -> 5,260.20 OPS). The prior decode path
+  is safer.
+  Rejected follow-up: reversing large sorted owned publish batches before `SkipMap` insertion was intended to test
+  whether insertion order was the hidden cost, but it badly disrupted the external CRUD gate. `toykv_reverse_sorted_publish_candidate`
+  moved `batch_create_100` 7,438.61 -> 2,507.90 OPS, `batch_update_100` 5,724.03 -> 1,551.57 OPS,
+  `batch_delete_100` 11,854.17 -> 2,931.01 OPS, `batch_create_1000` 1,656.03 -> 700.37 OPS,
+  `batch_update_1000` 1,658.15 -> 833.46 OPS, and `batch_delete_1000` 5,163.59 -> 1,926.97 OPS. The profile showed
+  both `publish_skipmap_ms` and `follower_wait_ms` exploding, so sorted-order manipulation is not a viable local fix.
   Final PR-head sync/no-sync comparison artifacts:
   `result-toykv_pr174_final_sync_100k.csv` and `result-toykv_pr174_final_nosync_100k.csv`. Same command shape
   (`--samples 100000 --clients 4 --threads 4 --skip-indexes --skip-scans`) shows durable batch writes remain below

--- a/todo.md
+++ b/todo.md
@@ -423,12 +423,11 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   `batch_update_100` 5,724.03 -> 7,467.48 OPS, but `batch_create_1000` fell 1,656.03 -> 1,538.30 OPS and
   `batch_delete_1000` was slightly lower at 5,163.59 -> 5,056.26 OPS. The ToyKV-internal `batch_build` bucket did not
   improve for large create, so caller key-Vec allocation is not the right next durable-batch target.
-  Follow-up profiling split approximate-size accounting out of memtable publish map time. External CRUD profile
-  (`toykv_publish_accounting_profile`) showed accounting is not material: `batch_create_100` spent 0.67 ms in
-  accounting versus 43.84 ms in SkipMap insert and 308.93 ms in follower wait; `batch_create_1000` spent 4.17 ms in
-  accounting versus 218.06 ms in SkipMap insert and 530.50 ms in follower wait. Do not optimize approximate-size
-  bookkeeping further unless those ratios change; the remaining durable-batch targets are SkipMap publish cost and WAL
-  group/wait shape.
+  Follow-up profiling split approximate-size accounting out of memtable publish map time. Review cleanup narrowed the
+  accounting bucket to the batch-level relaxed `approximate_size.fetch_add`, leaving per-entry length accumulation
+  untimed so the profile does not mostly measure `Instant::now()` overhead. Do not optimize approximate-size bookkeeping
+  further unless this narrower bucket becomes material; the remaining durable-batch targets are SkipMap publish cost and
+  WAL group/wait shape.
   Rejected follow-up: hashing the decoded user key directly from the memcomparable internal-key prefix avoided
   materializing the user key for bloom insertion, and helped the local CRUD-shaped write-perf profile, but failed the
   external CRUD gate. `toykv_direct_bloom_hash_candidate` moved `batch_create_100` only flat (7,438.61 -> 7,437.06


### PR DESCRIPTION
## Summary

Adds bench-only diagnostics for ToyKV CRUD write batches so future optimization work can use external CRUD profile windows instead of local-only guesses.

## Changes

- Add CRUD-shaped write-perf workloads for memtable publish and CRUD batch phases.
- Add `TOYKV_WRITE_BATCH_PROFILE_EVERY` bench-feature logging for external `crud-bench` write-batch profile windows.
- Split memtable publish accounting time from copy and SkipMap insertion time.
- Record accepted/rejected benchmark evidence in `todo.md`, including approximate-size accounting, direct bloom hash, and reversed sorted publish experiments.

## Verification

- `cargo fmt --all`
- `cargo check --locked -p kv-engine --features bench --bin write-perf`
- `cargo check --locked -p kv-engine`
- `cargo test -p kv-engine parse_crud_batch_create_100_alias`
- `cargo test -p kv-engine ordered_integer_key_bytes_match_crud_bench`
- External CRUD profile runs: `toykv_publish_accounting_profile`, `toykv_direct_bloom_hash_candidate`, `toykv_reverse_sorted_publish_candidate`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added benchmark workloads for concurrent memtable publishing and batched CRUD operations.
  * Added support for selecting the new workloads by name or alias.

* **Performance**
  * Enhanced write profiling with memtable publish accounting time.
  * Added optional profiling-window metrics for write batches.

* **Documentation**
  * Updated performance investigation notes with benchmark results and evaluated optimization approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->