### PR TITLE
perf: optimize count-only scan iteration

### DIFF
--- a/docs/bench-report-crud-bench-rocksdb.md
+++ b/docs/bench-report-crud-bench-rocksdb.md
@@ -340,7 +340,7 @@ Run the 2026-08-01 focused scan rerun:
 ```bash
 cd <crud-bench checkout>
 
-cargo run --release --features "rocksdb fjall toykv toykv/bench" --bin crud-bench -- \
+cargo run --release --no-default-features --features "rocksdb fjall toykv toykv/bench" --bin crud-bench -- \
   --database toykv \
   --samples 100000 \
   --clients 4 \
@@ -350,7 +350,7 @@ cargo run --release --features "rocksdb fjall toykv toykv/bench" --bin crud-benc
   --skip-batches \
   --color never
 
-cargo run --release --features "rocksdb fjall toykv toykv/bench" --bin crud-bench -- \
+cargo run --release --no-default-features --features "rocksdb fjall toykv toykv/bench" --bin crud-bench -- \
   --name rocksdb-scan-compare \
   --database rocksdb \
   --samples 100000 \
@@ -361,7 +361,7 @@ cargo run --release --features "rocksdb fjall toykv toykv/bench" --bin crud-benc
   --skip-batches \
   --color never
 
-cargo run --release --features "rocksdb fjall toykv toykv/bench" --bin crud-bench -- \
+cargo run --release --no-default-features --features "rocksdb fjall toykv toykv/bench" --bin crud-bench -- \
   --name fjall-scan-compare \
   --database fjall \
   --samples 100000 \

--- a/docs/bench-report-crud-bench-rocksdb.md
+++ b/docs/bench-report-crud-bench-rocksdb.md
@@ -5,9 +5,10 @@ This report tracks ToyKV against the embedded RocksDB backend in a sibling
 
 ## Summary
 
-Run date: 2026-07-23 latest PR #194 embedded durable rerun. Earlier durable
-RocksDB/Fjall runs are from 2026-07-13 to 2026-07-16, with focused scan and
-batch reruns from 2026-07-14 to 2026-07-15.
+Run date: 2026-07-23 latest PR #194 embedded durable rerun. Latest focused
+scan comparison rerun: 2026-08-01 after the ToyKV count-only iterator
+optimization. Earlier durable RocksDB/Fjall runs are from 2026-07-13 to
+2026-07-16, with focused scan and batch reruns from 2026-07-14 to 2026-07-15.
 
 Configuration:
 
@@ -109,10 +110,12 @@ ToyKV wins 11 of 12 rows in the latest three-way compare. RocksDB only wins
 ToyKV is ahead of RocksDB on point reads and durable batch writes, including
 large batch create/update/delete rows. The PR #170 focused scan rerun flipped
 four of the five previously RocksDB-winning scan rows. PR #173 repeated the
-remaining `select(*) limit(100)` gap and now puts ToyKV ahead on all five
-focused no-index scan watch rows. The repeated `select(*) limit(100)` row is
-646,130.69 OPS for ToyKV vs 503,709.26 OPS for RocksDB, a 28.3% ToyKV lead. The
-focused `batch_read_100` row changed substantially across the default
+remaining `select(*) limit(100)` gap and put ToyKV ahead on all five focused
+no-index scan watch rows. The 2026-08-01 scan rerun after the ToyKV count-only
+iterator optimization keeps ToyKV ahead of both RocksDB and Fjall on all
+supported focused no-index scan watch rows; `count()` is now 683.48 OPS for
+ToyKV vs 431.77 OPS for RocksDB and 105.63 OPS for Fjall. The focused
+`batch_read_100` row changed substantially across the default
 250-iteration reruns, so it was repeated with a temporary 10,000-iteration
 batch-read config. That longer timed row puts ToyKV ahead by 15.6%. ToyKV also
 still leads `batch_read_1000`.
@@ -134,6 +137,9 @@ Artifacts:
 - `result-rocksdb_batch100_iter10000_pr170_sync_100k.{csv,json,html}`
 - `result-toykv_read_rerun_pr173_sync_100k.{csv,json,html}`
 - `result-rocksdb_read_rerun_pr173_sync_100k.{csv,json,html}`
+- `result.{csv,json,html}` from the 2026-08-01 ToyKV scan confirmation run
+- `result-rocksdb-scan-compare.{csv,json,html}`
+- `result-fjall-scan-compare.{csv,json,html}`
 
 ## Durable 100k Results
 
@@ -156,23 +162,26 @@ All rows are OPS. Higher is better.
 
 ## Focused Scan Rerun
 
-These rows come from the 2026-07-15 focused PR #173 scan rerun on head
-`4bd002d`. The command used `--skip-indexes --skip-batches` to isolate the
-read-only no-index scan rows after the scan iterator fast paths landed and the
-remaining full-projection limit row was repeated. Fjall was not rerun in this
-focused pass.
+These rows come from the 2026-08-01 focused scan rerun after the ToyKV
+count-only iterator optimization. The command used
+`--sync --skip-indexes --skip-batches` to isolate the read-only no-index scan
+rows. All rows are OPS. Higher is better.
 
-| Row | ToyKV | RocksDB | Result |
-|---|---:|---:|---|
-| count() | **639.73** | 422.17 | ToyKV +51.5% |
-| select(id) limit(100) | **531,176.56** | 531,124.54 | ToyKV +0.01%, tie |
-| select(*) limit(100) | **646,130.69** | 503,709.26 | ToyKV +28.3% |
-| select(id) start(5000) limit(100) | **15,064.87** | 12,260.85 | ToyKV +22.9% |
-| select(*) start(5000) limit(100) | **14,969.44** | 12,209.65 | ToyKV +22.6% |
+| Row | ToyKV | RocksDB | Fjall | Result |
+|---|---:|---:|---:|---|
+| Read | **3,630,047.09** | 1,502,250.12 | 1,669,290.01 | ToyKV +141.6% over RocksDB |
+| count() | **683.48** | 431.77 | 105.63 | ToyKV +58.3% over RocksDB |
+| select(id) limit(100) | **553,042.81** | 494,049.35 | 105,512.11 | ToyKV +11.9% over RocksDB |
+| select(*) limit(100) | **515,849.87** | 510,486.54 | 88,287.29 | ToyKV +1.1%, near tie with RocksDB |
+| select(id) start(5000) limit(100) | **15,211.95** | 11,850.74 | 2,067.49 | ToyKV +28.4% over RocksDB |
+| select(*) start(5000) limit(100) | **15,136.67** | 11,898.40 | 2,051.96 | ToyKV +27.2% over RocksDB |
 
-The 2026-07-13 full durable run had RocksDB ahead on all five scan rows before
-the PR #170 and PR #173 scan work. Keep the full-run artifacts for historical
-comparison, but use this focused rerun as the current scan baseline.
+The count-only iterator patch moved ToyKV `count()` from 623.35 OPS before the
+change to 688.72 OPS on the first patched run and 683.48 OPS on the confirmation
+run, a roughly 9.6%-10.5% improvement. The 2026-07-13 full durable run had
+RocksDB ahead on all five scan rows before the PR #170, PR #173, and count-only
+iterator scan work. Keep the full-run artifacts for historical comparison, but
+use this focused rerun as the current scan baseline.
 
 ## Focused Batch Rerun
 
@@ -230,9 +239,12 @@ Keep the current durable batch-write path intact. ToyKV is substantially ahead
 on `batch_create_100`, `batch_update_100`, `batch_create_1000`,
 `batch_update_1000`, and `batch_delete_1000`.
 
-The focused read-path gap is closed after PR #173:
+The focused read-path gap remains closed after the 2026-08-01 scan rerun:
 
-- `select(*) limit(100)`: ToyKV +28.3% in the focused scan rerun.
+- `count()`: ToyKV +58.3% over RocksDB after the count-only iterator
+  optimization.
+- `select(*) limit(100)`: ToyKV +1.1%, effectively tied but still ahead in the
+  latest focused scan rerun.
 
 Do not start deeper full-projection scan work from the old PR #170 gap unless a
 future repeat reproduces a stable RocksDB lead. Keep `batch_read_100`,
@@ -323,13 +335,12 @@ cargo run --release --no-default-features --features fjall,rocksdb,toykv -- \
   --color never
 ```
 
-Run the focused PR #173 scan rerun:
+Run the 2026-08-01 focused scan rerun:
 
 ```bash
 cd <crud-bench checkout>
 
-cargo run --release --no-default-features --features rocksdb,toykv -- \
-  --name toykv_read_rerun_pr173_sync_100k \
+cargo run --release --features "rocksdb fjall toykv toykv/bench" --bin crud-bench -- \
   --database toykv \
   --samples 100000 \
   --clients 4 \
@@ -339,9 +350,20 @@ cargo run --release --no-default-features --features rocksdb,toykv -- \
   --skip-batches \
   --color never
 
-cargo run --release --no-default-features --features rocksdb,toykv -- \
-  --name rocksdb_read_rerun_pr173_sync_100k \
+cargo run --release --features "rocksdb fjall toykv toykv/bench" --bin crud-bench -- \
+  --name rocksdb-scan-compare \
   --database rocksdb \
+  --samples 100000 \
+  --clients 4 \
+  --threads 4 \
+  --sync \
+  --skip-indexes \
+  --skip-batches \
+  --color never
+
+cargo run --release --features "rocksdb fjall toykv toykv/bench" --bin crud-bench -- \
+  --name fjall-scan-compare \
+  --database fjall \
   --samples 100000 \
   --clients 4 \
   --threads 4 \

--- a/kv-engine/src/lsm_iterator.rs
+++ b/kv-engine/src/lsm_iterator.rs
@@ -209,12 +209,39 @@ impl LsmIterator {
             .extend_from_slice(self.inner.key().encoded_user_key());
     }
 
+    fn refresh_cached_encoded_user_key(&mut self) {
+        self.encoded_user_key.clear();
+        if self.inner.is_valid() {
+            self.encoded_user_key
+                .extend_from_slice(self.inner.key().encoded_user_key());
+        }
+    }
+
     fn skip_legacy_tombstones(&mut self) -> Result<()> {
         while self.inner.is_valid()
             && crate::vlog::KvKind::is_tombstone_value(self.inner.raw_value())
         {
             self.inner.next()?;
         }
+
+        Ok(())
+    }
+
+    fn next_count_unbounded(&mut self) -> Result<()> {
+        if !TS_ENABLED || !self.upper_unbounded {
+            return self.next();
+        }
+
+        Self::skip_current_user_key_versions(&mut self.inner, &self.encoded_user_key)?;
+        Self::skip_non_visible_entries(
+            &mut self.inner,
+            self.read_ts,
+            self.range_ts_iter.as_mut(),
+            &mut self.tmp_encoded_key,
+            &mut self.tmp_decoded_key,
+            self.ttl_now_secs,
+        )?;
+        self.refresh_cached_encoded_user_key();
 
         Ok(())
     }
@@ -389,6 +416,15 @@ impl ScanIterator {
         Ok(())
     }
 
+    fn next_count_inner(&mut self) -> Result<()> {
+        if let Err(e) = self.iter.iter.next_count_unbounded() {
+            self.iter.has_errored = true;
+            return Err(e);
+        }
+
+        Ok(())
+    }
+
     #[cfg(test)]
     pub(crate) fn for_testing_mark_errored(&mut self) {
         self.iter.has_errored = true;
@@ -463,8 +499,11 @@ impl ScanIterator {
         while count < limit && self.iter.iter.is_valid() {
             count += 1;
             if count < limit {
-                self.next_inner()?;
+                self.next_count_inner()?;
             }
+        }
+        if self.iter.iter.is_valid() {
+            self.iter.iter.refresh_cached_user_keys();
         }
 
         Ok(count)

--- a/kv-engine/src/tests/iterators.rs
+++ b/kv-engine/src/tests/iterators.rs
@@ -1,4 +1,4 @@
-use std::{ops::Bound, sync::Arc};
+use std::{ops::Bound, sync::Arc, time::Duration};
 
 use bytes::Bytes;
 use tempfile::tempdir;
@@ -372,6 +372,61 @@ fn test_scan_iterator_limited_helpers() {
     assert_eq!(iter.visit_keys(2, |_| unreachable!()).unwrap(), 0);
     assert_eq!(iter.visit_values(2, |_| unreachable!()).unwrap(), 0);
     assert_eq!(iter.count_entries(2).unwrap(), 0);
+}
+
+#[test]
+fn test_scan_iterator_count_skips_point_tombstone() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+
+    storage.put(b"a", b"va").unwrap();
+    storage.put(b"b", b"vb").unwrap();
+    storage.delete(b"b").unwrap();
+    storage.put(b"c", b"vc").unwrap();
+
+    let mut iter = storage.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    assert_eq!(iter.count_entries(2).unwrap(), 2);
+    assert_eq!(iter.key(), b"c");
+    iter.next().unwrap();
+    assert!(!iter.is_valid());
+}
+
+#[test]
+fn test_scan_iterator_count_skips_range_tombstone() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+
+    storage.put(b"a", b"va").unwrap();
+    storage.put(b"b", b"vb").unwrap();
+    storage.put(b"c", b"vc").unwrap();
+    storage.delete_range_internal(b"b", b"c").unwrap();
+
+    let mut iter = storage.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    assert_eq!(iter.count_entries(2).unwrap(), 2);
+    assert_eq!(iter.key(), b"c");
+    iter.next().unwrap();
+    assert!(!iter.is_valid());
+}
+
+#[test]
+fn test_scan_iterator_count_skips_expired_ttl() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_test()).unwrap());
+
+    storage.put(b"a", b"va").unwrap();
+    storage
+        .put_with_ttl(b"b", b"vb", Duration::from_secs(0))
+        .unwrap();
+    storage.put(b"c", b"vc").unwrap();
+
+    let mut iter = storage.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    assert_eq!(iter.count_entries(2).unwrap(), 2);
+    assert_eq!(iter.key(), b"c");
+    iter.next().unwrap();
+    assert!(!iter.is_valid());
 }
 
 #[test]

--- a/todo.md
+++ b/todo.md
@@ -474,14 +474,52 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   five scan rows, while a 10,000-iteration focused batch rerun moves `batch_read_100` back ahead and keeps
   `batch_read_1000` ahead of RocksDB.
 - [x] **Repeat remaining focused read gap** — PR #173 repeated the remaining `select(*) limit(100)` gap with
-  `--sync --samples 100000 --clients 4 --threads 4 --skip-indexes --skip-batches`. ToyKV now leads RocksDB on all five
-  focused no-index scan watch rows; the repeated `select(*) limit(100)` row is 646,130.69 vs 503,709.26 OPS
-  (+28.3%). Keep the scan rows plus `batch_read_100` and `batch_read_1000` as regression watch rows.
+  `--sync --samples 100000 --clients 4 --threads 4 --skip-indexes --skip-batches`. The 2026-08-01 focused scan rerun
+  after the count-only iterator optimization keeps ToyKV ahead of RocksDB on all focused no-index scan watch rows:
+  `count()` is 683.48 vs 431.77 OPS (+58.3%) and `select(*) limit(100)` is 515,849.87 vs 510,486.54 OPS (+1.1%).
+  Keep the scan rows plus `batch_read_100` and `batch_read_1000` as regression watch rows.
+  Rejected follow-up: for non-MVCC batches with no range tombstones, forcing the direct small-batch lookup path for all
+  batch sizes avoided sorting/context setup but regressed the external CRUD sync `batch_read_1000` row
+  (6,294.15 -> 5,635.68 OPS). `batch_read_100` improved in that noisy run (30,086.96 -> 53,194.00 OPS), but the large
+  batch regression means the sorted large-batch path still helps enough to keep.
 - [x] **Ticket-based group commit** — Replace CAS-based leader election with ticket/sequence design to eliminate
   O(N) leader-election cascade. Assign monotonic ticket on `put_batch`, leader drains queue + records max ticket,
   sets `durable_sequence` atomic after I/O. Followers check `durable_sequence >= my_ticket` and return immediately
   without touching CAS. Avoids N-1 wasted empty-bufs leader elections after each real commit. Suggested by
   gemini-code-assist in PR #134 review.
+  Rejected follow-up: precomputing decoded-user-key bloom hashes for large owned MVCC publish avoided the owned
+  publish decode path, but moved work earlier and worsened the same-window focused CRUD-phase profile. Control versus
+  candidate was `batch_create_after_crud_phase` 1,794,006 -> 1,839,480 OPS (+2.5%), `batch_update_after_crud_phase`
+  2,062,548 -> 1,741,810 OPS (-15.6%), and `batch_delete_after_crud_phase` 3,667,005 -> 3,428,113 OPS (-6.5%).
+  The next concurrency-oriented write-path slice should not simply remove `write_lock`: it needs a separate timestamp
+  allocator plus a contiguous published-ts visibility frontier, otherwise readers can take a high `read_ts` while a
+  lower timestamp is still unpublished and then observe a non-repeatable snapshot when that lower timestamp appears.
+  Rejected follow-up: implementing that allocator/frontier directly with `next_ts`, a completed timestamp set, and
+  skipped timestamps on WAL/publish errors improved the focused in-repo CRUD-phase profile
+  (`batch_create_after_crud_phase` 1,794,006 -> 1,844,719 OPS, `batch_update_after_crud_phase` 2,062,548 -> 2,188,471
+  OPS, `batch_delete_after_crud_phase` 3,667,005 -> 4,915,413 OPS), but failed the external CRUD sync gate. First
+  external run was mixed (`batch_create_1000` 1,673.58 -> 1,678.56 OPS, `batch_update_1000` 1,784.42 -> 1,760.23 OPS,
+  `batch_delete_1000` 4,332.19 -> 4,146.61 OPS, `batch_delete_100` 12,419.88 -> 11,342.41 OPS), and rerun collapsed
+  batch scheduling (`batch_create_1000` 872.61 OPS, `batch_update_1000` 734.67 OPS, `batch_delete_1000` 1,989.73
+  OPS). Keep the serialized timestamp staging unless a later design can prove stable external grouping behavior.
+  Rejected follow-up before CRUD: adding a pending-arrival condvar and waiting up to 25us for a peer before draining a
+  solo >=512 KiB WAL buffer kept most focused groups solo while adding latency. Same-window focused profile moved
+  `batch_create_after_crud_phase` 1,794,006 -> 1,578,814 OPS, `batch_update_after_crud_phase` 2,062,548 -> 1,718,337
+  OPS, and `batch_delete_after_crud_phase` 3,667,005 -> 2,899,435 OPS, so time-based leader waiting is the wrong
+  scheduler direction without a stronger admission signal.
+  Rejected follow-up before CRUD: opportunistically draining late pending WAL buffers after the leader's first write
+  wave but before fdatasync improved focused create (`batch_create_after_crud_phase` 1,794,006 -> 1,968,388 OPS) and
+  formed some larger commit groups, but regressed focused update/delete (`batch_update_after_crud_phase` 2,062,548 ->
+  1,730,213 OPS, `batch_delete_after_crud_phase` 3,667,005 -> 3,288,824 OPS). The extra submit work/follower wait is
+  not a broad win while publish remains the dominant delete cost.
+  Rejected follow-up: retaining large DirectBufs in the existing WAL buffer pool confirmed churn but was not a safe
+  win. Bench-only counters showed 1 MiB create/update batches popped undersized 256 KiB buffers and allocated new
+  DirectBufs, while delete reused the small pool. Letting undersized buffers drop and retaining buffers up to 2 MiB
+  warmed the pool for later large batches, but retention-only focused results regressed update/delete
+  (`batch_update_after_crud_phase` 2,062,548 -> 1,702,466 OPS, `batch_delete_after_crud_phase` 3,667,005 ->
+  3,262,991 OPS). The external CRUD sync probe was mixed and raised memory to ~1.1 GiB; `batch_delete_1000` improved
+  to 5,073.75 OPS, but `batch_update_100` regressed to 6,122.49 OPS and `batch_update_1000` to 1,697.31 OPS. Do not
+  retain oversized buffers in the shared pool without a more selective policy.
 
 ---
 

--- a/todo.md
+++ b/todo.md
@@ -503,7 +503,8 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   batch scheduling (`batch_create_1000` 872.61 OPS, `batch_update_1000` 734.67 OPS, `batch_delete_1000` 1,989.73
   OPS). Keep the serialized timestamp staging unless a later design can prove stable external grouping behavior.
   Rejected follow-up before CRUD: adding a pending-arrival condvar and waiting up to 25us for a peer before draining a
-  solo >=512 KiB WAL buffer kept most focused groups solo while adding latency. Same-window focused profile moved
+  single WAL buffer of at least 512 KiB from a solo focused group kept most focused groups as single-buffer groups
+  while adding latency. The same-window focused profile moved
   `batch_create_after_crud_phase` 1,794,006 -> 1,578,814 OPS, `batch_update_after_crud_phase` 2,062,548 -> 1,718,337
   OPS, and `batch_delete_after_crud_phase` 3,667,005 -> 2,899,435 OPS, so time-based leader waiting is the wrong
   scheduler direction without a stronger admission signal.


### PR DESCRIPTION
## Summary

Optimize count-only unbounded MVCC scans by advancing with the encoded user-key cache and deferring decoded key refresh until the iterator remains positioned after a partial count.

## Changes

- Add a count-only scan advance path that avoids decoded `user_key` refresh on intermediate counted rows.
- Keep public iterator positioning correct after partial `count_entries()` calls.
- Add count-path tests for point tombstones, range tombstones, and expired TTL entries.
- Refresh the CRUD RocksDB/Fjall scan comparison report and `todo.md` baseline with the 2026-08-01 focused rerun.

## Benchmark

Focused CRUD scan rerun, `--sync --samples 100000 --clients 4 --threads 4 --skip-indexes --skip-batches`:

- `count()`: ToyKV 683.48 OPS, RocksDB 431.77 OPS, Fjall 105.63 OPS
- `select(id) limit(100)`: ToyKV 553,042.81 OPS, RocksDB 494,049.35 OPS, Fjall 105,512.11 OPS
- `select(*) limit(100)`: ToyKV 515,849.87 OPS, RocksDB 510,486.54 OPS, Fjall 88,287.29 OPS

The ToyKV `count()` row moved from 623.35 OPS before the patch to 688.72 / 683.48 OPS across patched runs.

## Verification

- `cargo fmt --all`
- `cargo test --package kv-engine --lib scan_iterator_count`
- `cargo test --package kv-engine --lib test_scan_iterator_limited_helpers`
- `cargo test --package kv-engine --lib iterator`
- `git diff --check`
- `cargo make check` outside sandbox: 751 tests passed, plus fmt, dep-sort, clippy, machete, and typos


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved scan and entry-count performance, particularly for workloads with multiple record versions.
  * Refreshed benchmark results show updated scan performance comparisons and current baseline measurements.

* **Bug Fixes**
  * Ensured scans correctly skip point-deleted, range-deleted, and expired records.
  * Improved iterator behavior so scans stop at the expected visible records.

* **Documentation**
  * Updated benchmark reports and performance notes with current results, scan configurations, and optimization findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->