### PR TITLE
perf: streamline large delete batches

### DIFF
--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -5195,6 +5195,10 @@ impl LsmStorageInner {
         (data, None)
     }
 
+    fn use_delete_only_key_batch(serializable: bool, delete_only: bool, entries: usize) -> bool {
+        !serializable && delete_only && entries >= DELETE_ONLY_KEY_BATCH_MIN_ENTRIES
+    }
+
     fn push_non_mvcc_batch_entry<T: AsRef<[u8]>>(
         data: &mut Vec<(bytes::Bytes, bytes::Bytes)>,
         record: &WriteBatchRecord<T>,
@@ -6173,10 +6177,11 @@ impl LsmStorageInner {
                 let shared_publish_bytes = Self::use_owned_batch_publish(batch.len());
                 #[cfg(feature = "bench")]
                 let build_start = std::time::Instant::now();
-                let (commit_ts, data, ticket) = if !self.options.serializable
-                    && delete_only
-                    && batch.len() >= DELETE_ONLY_KEY_BATCH_MIN_ENTRIES
-                {
+                let (commit_ts, data, ticket) = if Self::use_delete_only_key_batch(
+                    self.options.serializable,
+                    delete_only,
+                    batch.len(),
+                ) {
                     let (keys, _) = Self::build_unique_delete_batch_keys_or_dedup(batch);
                     #[cfg(feature = "bench")]
                     self.write_profile
@@ -6931,6 +6936,103 @@ impl LsmStorageInner {
             Bound::Included(k) => Bound::Included(k.to_vec()),
             Bound::Excluded(k) => Bound::Excluded(k.to_vec()),
             Bound::Unbounded => Bound::Unbounded,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use tempfile::tempdir;
+
+    use super::{
+        DELETE_ONLY_KEY_BATCH_MIN_ENTRIES, KvEngine, LsmStorageInner, LsmStorageOptions,
+        WriteBatchRecord,
+    };
+
+    fn delete_records(count: usize) -> Vec<WriteBatchRecord<Vec<u8>>> {
+        (0..count)
+            .map(|idx| WriteBatchRecord::Del(format!("k{idx:04}").into_bytes()))
+            .collect()
+    }
+
+    fn put_records(count: usize) -> Vec<WriteBatchRecord<Vec<u8>>> {
+        (0..count)
+            .map(|idx| WriteBatchRecord::Put(format!("k{idx:04}").into_bytes(), b"value".to_vec()))
+            .collect()
+    }
+
+    #[test]
+    fn delete_only_key_batch_route_respects_boundary() {
+        assert!(!LsmStorageInner::use_delete_only_key_batch(
+            false,
+            true,
+            DELETE_ONLY_KEY_BATCH_MIN_ENTRIES - 1,
+        ));
+        assert!(LsmStorageInner::use_delete_only_key_batch(
+            false,
+            true,
+            DELETE_ONLY_KEY_BATCH_MIN_ENTRIES,
+        ));
+        assert!(!LsmStorageInner::use_delete_only_key_batch(
+            true,
+            true,
+            DELETE_ONLY_KEY_BATCH_MIN_ENTRIES,
+        ));
+        assert!(!LsmStorageInner::use_delete_only_key_batch(
+            false,
+            false,
+            DELETE_ONLY_KEY_BATCH_MIN_ENTRIES,
+        ));
+    }
+
+    #[test]
+    fn delete_only_key_batch_dedup_preserves_last_ops() {
+        let batch = vec![
+            WriteBatchRecord::Del(b"a".to_vec()),
+            WriteBatchRecord::Del(b"b".to_vec()),
+            WriteBatchRecord::Del(b"a".to_vec()),
+        ];
+
+        let (keys, dedup_indices) =
+            LsmStorageInner::build_unique_delete_batch_keys_or_dedup(&batch);
+
+        assert_eq!(
+            keys,
+            vec![Bytes::from_static(b"b"), Bytes::from_static(b"a")]
+        );
+        assert_eq!(dedup_indices, Some(vec![1, 2]));
+    }
+
+    #[test]
+    fn large_delete_only_write_batch_deletes_unique_keys() {
+        let dir = tempdir().unwrap();
+        let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+        let count = DELETE_ONLY_KEY_BATCH_MIN_ENTRIES;
+
+        engine.write_batch(&put_records(count)).unwrap();
+        engine.write_batch(&delete_records(count)).unwrap();
+
+        for idx in 0..count {
+            assert_eq!(engine.get(format!("k{idx:04}").as_bytes()).unwrap(), None);
+        }
+    }
+
+    #[test]
+    fn serializable_large_delete_only_write_batch_uses_regular_path() {
+        let dir = tempdir().unwrap();
+        let options = LsmStorageOptions {
+            serializable: true,
+            ..LsmStorageOptions::default_for_test()
+        };
+        let engine = KvEngine::open(&dir, options).unwrap();
+        let count = DELETE_ONLY_KEY_BATCH_MIN_ENTRIES;
+
+        engine.write_batch(&put_records(count)).unwrap();
+        engine.write_batch(&delete_records(count)).unwrap();
+
+        for idx in [0, count / 2, count - 1] {
+            assert_eq!(engine.get(format!("k{idx:04}").as_bytes()).unwrap(), None);
         }
     }
 }

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -154,6 +154,8 @@ pub enum WriteBatchRecord<T: AsRef<[u8]>> {
 
 type PointBatchEntry = (bytes::Bytes, bytes::Bytes, crate::mvcc::BatchEntryKind);
 type PointBatchBuild = (Vec<PointBatchEntry>, Option<Vec<usize>>);
+type DeleteBatchBuild = (Vec<bytes::Bytes>, Option<Vec<usize>>);
+const DELETE_ONLY_KEY_BATCH_MIN_ENTRIES: usize = 512;
 
 impl LsmStorageState {
     fn create(options: &LsmStorageOptions, vlog_enabled: bool) -> Self {
@@ -4934,19 +4936,24 @@ impl LsmStorageInner {
 
     fn validate_and_classify_write_batch<T: AsRef<[u8]>>(
         batch: &[WriteBatchRecord<T>],
-    ) -> Result<bool> {
+    ) -> Result<(bool, bool)> {
         let mut has_point = false;
         let mut has_range = false;
+        let mut delete_only = true;
         for record in batch {
             match record {
-                WriteBatchRecord::Put(key, _)
-                | WriteBatchRecord::PutWithTtl(key, _, _)
-                | WriteBatchRecord::Del(key) => {
+                WriteBatchRecord::Put(key, _) | WriteBatchRecord::PutWithTtl(key, _, _) => {
+                    has_point = true;
+                    delete_only = false;
+                    Self::validate_key_size(key.as_ref())?;
+                }
+                WriteBatchRecord::Del(key) => {
                     has_point = true;
                     Self::validate_key_size(key.as_ref())?;
                 }
                 WriteBatchRecord::DelRange(_, _) => {
                     has_range = true;
+                    delete_only = false;
                 }
             }
         }
@@ -4955,7 +4962,7 @@ impl LsmStorageInner {
             "mixed point/range batches are not supported in the MVP"
         );
 
-        Ok(has_range)
+        Ok((has_range, has_point && delete_only))
     }
 
     fn dedup_write_batch_indices<T: AsRef<[u8]>>(
@@ -5143,6 +5150,46 @@ impl LsmStorageInner {
                 return (dedup_data, Some(dedup_indices));
             }
             Self::push_point_batch_entry(&mut data, record, shared_value_bytes);
+        }
+
+        (data, None)
+    }
+
+    fn build_unique_delete_batch_keys_or_dedup<T: AsRef<[u8]>>(
+        batch: &[WriteBatchRecord<T>],
+    ) -> DeleteBatchBuild {
+        if batch.len() <= 1 {
+            return (
+                batch
+                    .iter()
+                    .map(|record| bytes::Bytes::copy_from_slice(Self::write_batch_key(record)))
+                    .collect(),
+                None,
+            );
+        }
+
+        let mut seen = AHashSet::with_capacity(batch.len());
+        let mut data = Vec::with_capacity(batch.len());
+        for record in batch {
+            let key = Self::write_batch_key(record);
+            if !seen.insert(key) {
+                seen.clear();
+                let mut dedup_data = Vec::with_capacity(batch.len());
+                let mut dedup_indices = Vec::with_capacity(batch.len());
+                for (idx, record) in batch.iter().enumerate().rev() {
+                    let key = Self::write_batch_key(record);
+                    if seen.insert(key) {
+                        dedup_data.push(bytes::Bytes::copy_from_slice(key));
+                        dedup_indices.push(idx);
+                    }
+                }
+
+                dedup_data.reverse();
+                dedup_indices.reverse();
+
+                return (dedup_data, Some(dedup_indices));
+            }
+            data.push(bytes::Bytes::copy_from_slice(key));
         }
 
         (data, None)
@@ -6088,7 +6135,7 @@ impl LsmStorageInner {
     /// commit timestamp.
     #[allow(clippy::type_complexity)]
     pub fn write_batch<T: AsRef<[u8]>>(&self, batch: &[WriteBatchRecord<T>]) -> Result<()> {
-        let has_range = Self::validate_and_classify_write_batch(batch)?;
+        let (has_range, delete_only) = Self::validate_and_classify_write_batch(batch)?;
         #[cfg(feature = "bench")]
         self.maybe_start_write_batch_profile_window();
 
@@ -6126,28 +6173,52 @@ impl LsmStorageInner {
                 let shared_publish_bytes = Self::use_owned_batch_publish(batch.len());
                 #[cfg(feature = "bench")]
                 let build_start = std::time::Instant::now();
-                let (entries, dedup_indices) =
-                    Self::build_unique_point_batch_entries_or_dedup(batch, shared_publish_bytes);
-                #[cfg(feature = "bench")]
-                self.write_profile
-                    .record_batch_build_ns(build_start.elapsed().as_nanos() as u64);
-                // WAL-only: do NOT publish to skiplist yet.
-                #[cfg(feature = "bench")]
-                let wal_only_start = std::time::Instant::now();
-                let (commit_ts, data, ticket) =
-                    mvcc.write_batch_wal_only(&entries, &state.memtable, shared_publish_bytes)?;
-                #[cfg(feature = "bench")]
-                self.write_profile
-                    .record_mvcc_wal_only_ns(wal_only_start.elapsed().as_nanos() as u64);
+                let (commit_ts, data, ticket) = if !self.options.serializable
+                    && delete_only
+                    && batch.len() >= DELETE_ONLY_KEY_BATCH_MIN_ENTRIES
+                {
+                    let (keys, _) = Self::build_unique_delete_batch_keys_or_dedup(batch);
+                    #[cfg(feature = "bench")]
+                    self.write_profile
+                        .record_batch_build_ns(build_start.elapsed().as_nanos() as u64);
+                    #[cfg(feature = "bench")]
+                    let wal_only_start = std::time::Instant::now();
+                    let result = mvcc.write_delete_batch_wal_only(
+                        &keys,
+                        &state.memtable,
+                        shared_publish_bytes,
+                    )?;
+                    #[cfg(feature = "bench")]
+                    self.write_profile
+                        .record_mvcc_wal_only_ns(wal_only_start.elapsed().as_nanos() as u64);
+                    result
+                } else {
+                    let (entries, dedup_indices) = Self::build_unique_point_batch_entries_or_dedup(
+                        batch,
+                        shared_publish_bytes,
+                    );
+                    #[cfg(feature = "bench")]
+                    self.write_profile
+                        .record_batch_build_ns(build_start.elapsed().as_nanos() as u64);
+                    // WAL-only: do NOT publish to skiplist yet.
+                    #[cfg(feature = "bench")]
+                    let wal_only_start = std::time::Instant::now();
+                    let result =
+                        mvcc.write_batch_wal_only(&entries, &state.memtable, shared_publish_bytes)?;
+                    #[cfg(feature = "bench")]
+                    self.write_profile
+                        .record_mvcc_wal_only_ns(wal_only_start.elapsed().as_nanos() as u64);
+                    // Defer record_committed_txn until after commit_wal_ticket succeeds
+                    // so that failed WAL syncs don't poison serializable validation.
+                    if self.options.serializable && result.0 > 0 {
+                        txn_info = Some((
+                            result.0,
+                            Self::build_serializable_write_set(batch, dedup_indices.as_deref()),
+                        ));
+                    }
+                    result
+                };
                 mvcc_commit_ts = commit_ts;
-                // Defer record_committed_txn until after commit_wal_ticket succeeds
-                // so that failed WAL syncs don't poison serializable validation.
-                if self.options.serializable && commit_ts > 0 {
-                    txn_info = Some((
-                        commit_ts,
-                        Self::build_serializable_write_set(batch, dedup_indices.as_deref()),
-                    ));
-                }
                 (state.memtable.clone(), data, ticket)
             } else {
                 // Non-MVCC path: write raw user keys to WAL only.

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -352,6 +352,32 @@ impl LsmMvccInner {
         Ok((commit_ts, publish_data, ticket))
     }
 
+    pub(crate) fn write_delete_batch_wal_only(
+        &self,
+        keys: &[bytes::Bytes],
+        memtable: &MemTable,
+        shared_publish_bytes: bool,
+    ) -> Result<(u64, DeferredBatchPublish, Option<u64>), anyhow::Error> {
+        if keys.is_empty() {
+            return Ok((0, DeferredBatchPublish::from_entries(Vec::new()), None));
+        }
+        let _write_guard = self.write_lock.lock();
+        let commit_ts = self.current_ts.load(Ordering::Acquire) + 1;
+        let publish_data: Vec<(Bytes, Bytes)> = keys
+            .iter()
+            .map(|key| {
+                (
+                    Self::encode_internal_key_bytes(key, commit_ts, shared_publish_bytes),
+                    Bytes::from_static(TOMBSTONE_VALUE),
+                )
+            })
+            .collect();
+        let publish_data = DeferredBatchPublish::from_entries(publish_data);
+        let ticket = publish_data.with_refs(|refs| memtable.write_wal_batch_only(refs))?;
+
+        Ok((commit_ts, publish_data, ticket))
+    }
+
     /// Get a read timestamp (the latest committed ts).
     /// This does NOT add a reader to the watermark — use `new_read_guard()` instead.
     #[allow(dead_code)]

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -352,6 +352,18 @@ impl LsmMvccInner {
         Ok((commit_ts, publish_data, ticket))
     }
 
+    /// Write a delete-only point batch to the WAL buffer only — no skiplist
+    /// insert, no sync.
+    ///
+    /// This is specialized for large public `write_batch` deletes: callers pass
+    /// only raw user keys, avoiding per-entry empty value buffers and kind
+    /// tuples before MVCC assigns one commit timestamp to the whole batch.
+    ///
+    /// Returns `(commit_ts, publish_data, wal_ticket)`. The caller must
+    /// subsequently call `memtable.commit_wal_ticket(ticket)`, then publish
+    /// `publish_data`, then advance `current_ts`, in that order. Do NOT advance
+    /// `current_ts` here: readers must not observe the timestamp before WAL
+    /// sync succeeds and the tombstones are visible in the skiplist.
     pub(crate) fn write_delete_batch_wal_only(
         &self,
         keys: &[bytes::Bytes],

--- a/todo.md
+++ b/todo.md
@@ -521,6 +521,11 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   3,262,991 OPS). The external CRUD sync probe was mixed and raised memory to ~1.1 GiB; `batch_delete_1000` improved
   to 5,073.75 OPS, but `batch_update_100` regressed to 6,122.49 OPS and `batch_update_1000` to 1,697.31 OPS. Do not
   retain oversized buffers in the shared pool without a more selective policy.
+  Follow-up: large delete-only MVCC batches now use a key-only staging path before WAL encoding, avoiding construction
+  of empty value buffers and per-entry kind tuples for the common `batch_delete_1000` CRUD shape while leaving smaller
+  delete batches and serializable writes on the existing path. Same-window external CRUD sync comparison moved
+  `batch_delete_1000` 4,680.46 -> 4,930.22 OPS; unrelated create/update rows were noisy and are not the target signal
+  for this delete-only route.
   Rejected follow-up: replacing `DeferredBatchPublish`'s always-built borrowed-ref cache with on-demand refs plus a
   WAL encode path over owned `Bytes` entries did not produce a stable external CRUD win. The all-owned WAL variant
   improved `batch_create_100` (7,480.56 -> 8,263.38 OPS), `batch_update_100` (6,988.44 -> 7,633.13 OPS), and

--- a/todo.md
+++ b/todo.md
@@ -521,6 +521,29 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   3,262,991 OPS). The external CRUD sync probe was mixed and raised memory to ~1.1 GiB; `batch_delete_1000` improved
   to 5,073.75 OPS, but `batch_update_100` regressed to 6,122.49 OPS and `batch_update_1000` to 1,697.31 OPS. Do not
   retain oversized buffers in the shared pool without a more selective policy.
+  Rejected follow-up: replacing `DeferredBatchPublish`'s always-built borrowed-ref cache with on-demand refs plus a
+  WAL encode path over owned `Bytes` entries did not produce a stable external CRUD win. The all-owned WAL variant
+  improved `batch_create_100` (7,480.56 -> 8,263.38 OPS), `batch_update_100` (6,988.44 -> 7,633.13 OPS), and
+  `batch_update_1000` (1,684.61 -> 1,806.74 OPS), but regressed `batch_create_1000` (1,805.39 -> 1,744.04 OPS) and
+  `batch_delete_1000` (4,929.18 -> 4,615.44 OPS). A value-carrying large-batch-only variant avoided the first
+  `batch_create_100` outlier on rerun and moved `batch_create_1000` to 1,815.19 OPS once, but confirmation collapsed
+  `batch_create_1000` to 1,396.24 OPS and left `batch_delete_1000` at 5,088.48 OPS. Do not retry this ref-cache-only
+  staging shape; the next WAL format attempt needs to remove encoded payload duplication, not merely change how refs
+  are passed into the existing encoder. A conservative prepared-DirectBuf prototype that kept publish `Bytes`
+  ownership but filled the WAL payload while building MVCC publish entries also failed the same-session focused gate:
+  `batch_create_after_crud_phase` fell 1,901,083 -> 1,573,896 OPS while update was only flat and delete stayed flat.
+  The WAL encode work disappeared from `wal_write`, but the copy cost moved into MVCC staging and hurt the measured
+  create path. Do not keep a prepared-WAL path unless it actually removes a copy/owned payload, not just moves it.
+  A direct public `write_batch` MVCC staging prototype also regressed badly (`batch_create_after_crud_phase` 1,901,083
+  -> 875,738 OPS, `batch_update_after_crud_phase` 1,907,356 -> 535,094 OPS, `batch_delete_after_crud_phase` 3,121,189
+  -> 2,674,529 OPS). It skipped the temporary user-key `Bytes`, but had to build commit-ts-bearing internal keys under
+  `mvcc.write_lock`, serializing work that previously ran in parallel before timestamp assignment. Do not move
+  large-batch entry construction under `write_lock`; a direct-staging design needs a separate timestamp reservation
+  mechanism or another way to keep pre-WAL preparation parallel. Narrowing the pre-encoded staging path to delete-only
+  batches and folding delete-only detection into validation looked good in the focused gate
+  (`batch_delete_after_crud_phase` 3,121,189 -> 3,665,831 OPS while create/update held), but failed the real external
+  CRUD gate: same-session `main` beat the candidate on every batch write row, including `batch_delete_1000` 4,680.46
+  -> 2,119.97 OPS. Do not keep this pre-encoded delete-only staging path.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add a large delete-only MVCC batch path that stages only keys before WAL encoding.
- Keep small delete batches and serializable writes on the existing general write-batch path.
- Record rejected WAL staging probes and the kept delete-batch benchmark signal in todo.md.

## Benchmark

External CRUD sync same-window comparison against main:

- batch_delete_1000: 4,680.46 -> 4,930.22 OPS

The route is gated to delete-only batches with at least 512 entries, so smaller batch deletes and non-delete batch writes keep the existing path.

## Verification

- cargo make check
- cargo test --package kv-engine --lib tests::wal
- cargo run --release --features 'rocksdb fjall toykv toykv/bench' --bin crud-bench -- -d toykv -s 100000 -c 4 -t 4 --sync --skip-indexes --skip-scans --color never

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large batches containing only delete operations.
  * Duplicate keys in delete batches now honor the final operation.
  * Delete-only batches use more efficient MVCC and WAL processing while preserving expected results.
  * Serializable batches continue to use the appropriate deletion path for consistent behavior.
  * Empty delete batches complete without unnecessary processing.

* **Documentation**
  * Added documentation covering delete-batch processing improvements and performance considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->