### PR TITLE
perf: streamline delete-only batch publish

### DIFF
--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -4875,6 +4875,9 @@ impl LsmStorageInner {
         publish_data: crate::mvcc::DeferredBatchPublish,
     ) -> Result<()> {
         if Self::use_owned_batch_publish(publish_data.len()) {
+            if publish_data.is_delete_only() {
+                return memtable.publish_raw_delete_batch_owned(publish_data.into_entries());
+            }
             memtable.publish_raw_batch_owned(publish_data.into_entries())
         } else {
             publish_data.with_borrowed_refs(|refs| memtable.publish_raw_batch(refs))

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -1393,6 +1393,127 @@ impl MemTable {
         Ok(())
     }
 
+    pub(crate) fn publish_raw_delete_batch_owned(
+        &self,
+        entries: Vec<(Bytes, Bytes)>,
+    ) -> Result<()> {
+        struct AbortOnPanic;
+        impl Drop for AbortOnPanic {
+            fn drop(&mut self) {
+                if std::thread::panicking() {
+                    log::error!(
+                        "panic during memtable delete publication — aborting to prevent WAL/memtable divergence"
+                    );
+                    std::process::abort();
+                }
+            }
+        }
+        let _abort_guard = AbortOnPanic;
+
+        #[cfg(feature = "bench")]
+        let t = Instant::now();
+        thread_local! {
+            static PUBLISH_USER_KEY_BUF: std::cell::RefCell<Vec<u8>> =
+                const { std::cell::RefCell::new(Vec::new()) };
+        }
+        #[cfg(feature = "bench")]
+        let entry_count = entries.len();
+        PUBLISH_USER_KEY_BUF.with(|buf| {
+            let mut buf = buf.borrow_mut();
+            let mut approximate_size_delta = 0usize;
+            #[cfg(feature = "bench")]
+            let ttl_check_ns = 0u64;
+            #[cfg(feature = "bench")]
+            let mut decode_ns = 0u64;
+            #[cfg(feature = "bench")]
+            let mut bloom_ns = 0u64;
+            #[cfg(feature = "bench")]
+            let mut map_ns = 0u64;
+            #[cfg(feature = "bench")]
+            let mut copy_ns = 0u64;
+            #[cfg(feature = "bench")]
+            let mut skipmap_ns = 0u64;
+            #[cfg(feature = "bench")]
+            let mut accounting_ns = 0u64;
+            crate::profile_scope!("memtable.publish_delete_batch", {
+                for (key, _) in entries {
+                    #[cfg(feature = "bench")]
+                    let part_start = Instant::now();
+                    buf.clear();
+                    KeySlice::from_slice(key.as_ref()).decode_user_key_into(&mut buf);
+                    #[cfg(feature = "bench")]
+                    {
+                        decode_ns += part_start.elapsed().as_nanos() as u64;
+                    }
+
+                    #[cfg(feature = "bench")]
+                    let part_start = Instant::now();
+                    self.bloom.push_hash(super::table::bloom::hash_key(&buf));
+                    #[cfg(feature = "bench")]
+                    {
+                        bloom_ns += part_start.elapsed().as_nanos() as u64;
+                    }
+
+                    let key_len = key.len();
+                    #[cfg(feature = "bench")]
+                    let part_start = Instant::now();
+                    let map_key = key;
+                    let map_value = Bytes::from_static(crate::mvcc::TOMBSTONE_VALUE);
+                    #[cfg(feature = "bench")]
+                    let copy_elapsed_ns = part_start.elapsed().as_nanos() as u64;
+                    #[cfg(feature = "bench")]
+                    {
+                        copy_ns += copy_elapsed_ns;
+                    }
+
+                    approximate_size_delta += key_len + crate::mvcc::TOMBSTONE_VALUE.len();
+
+                    #[cfg(feature = "bench")]
+                    let insert_start = Instant::now();
+                    self.map.insert(map_key, map_value);
+                    #[cfg(feature = "bench")]
+                    {
+                        let insert_elapsed_ns = insert_start.elapsed().as_nanos() as u64;
+                        skipmap_ns += insert_elapsed_ns;
+                        map_ns += copy_elapsed_ns + insert_elapsed_ns;
+                    }
+                }
+                #[cfg(feature = "bench")]
+                let part_start = Instant::now();
+                self.approximate_size
+                    .fetch_add(approximate_size_delta, std::sync::atomic::Ordering::Relaxed);
+                #[cfg(feature = "bench")]
+                {
+                    accounting_ns += part_start.elapsed().as_nanos() as u64;
+                }
+            });
+            #[cfg(feature = "bench")]
+            self.write_profile
+                .load()
+                .record_memtable_publish_parts(MemtablePublishProfileParts {
+                    ttl_check_ns,
+                    decode_ns,
+                    bloom_ns,
+                    map_ns,
+                    copy_ns,
+                    skipmap_ns,
+                    accounting_ns,
+                });
+        });
+        #[cfg(feature = "bench")]
+        {
+            let wp = self.write_profile.load();
+            wp.memtable_insert_ns.fetch_add(
+                t.elapsed().as_nanos() as u64,
+                std::sync::atomic::Ordering::Relaxed,
+            );
+            wp.op_count
+                .fetch_add(entry_count as u64, std::sync::atomic::Ordering::Relaxed);
+        }
+
+        Ok(())
+    }
+
     fn maybe_note_ttl_value(flag: &AtomicBool, value: &[u8]) {
         if value.first().is_some_and(|kind| {
             *kind == crate::vlog::KvKind::TtlInline as u8

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -63,6 +63,12 @@ impl DeferredBatchPublish {
         self.borrow_entries().len()
     }
 
+    pub(crate) fn is_delete_only(&self) -> bool {
+        self.borrow_entries()
+            .iter()
+            .all(|(_, value)| value.as_ref() == TOMBSTONE_VALUE)
+    }
+
     pub(crate) fn with_borrowed_refs<R>(&self, f: impl FnOnce(&[(KeySlice<'_>, &[u8])]) -> R) -> R {
         self.with_refs(|refs| f(refs.as_slice()))
     }


### PR DESCRIPTION
## Summary

- Add a delete-only detection helper for deferred MVCC batch publish data.
- Route large owned delete-only batches through a specialized memtable publish path.
- Reuse the static tombstone value during publish and skip TTL/value handling that cannot apply to delete-only batches.

## Benchmark

External CRUD sync benchmark, `-s 100000 -c 4 -t 4 --sync --skip-indexes --skip-scans`, A/B against clean HEAD under the same runtime:

- `batch_delete_1000`: `5150.17 -> 5422.87` OPS, about +5.3%
- `batch_create_1000`: `1649.75 -> 1670.12` OPS
- `batch_update_1000`: `1777.74 -> 1849.70` OPS

## Verification

- `cargo test --package kv-engine --lib large_delete_only`
- `cargo test --package kv-engine --lib write_batch`
- `cargo test --package kv-engine --lib wal_group_commit`
- `cargo clippy --package kv-engine --all-features --lib -- -D warnings`
- `cargo make check` outside sandbox: 755 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large delete-only operations in the storage engine.
  * Ensured deleted records are consistently published as tombstones, helping maintain data integrity and prevent inconsistencies during failures.
  * Preserved existing behavior for batches containing non-delete updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->