### PR TITLE
perf: optimize large write batches

### DIFF
--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -4874,7 +4874,7 @@ impl LsmStorageInner {
         memtable: &MemTable,
         publish_data: crate::mvcc::DeferredBatchPublish,
     ) -> Result<()> {
-        if Self::use_owned_batch_publish(publish_data.len()) {
+        if Self::use_owned_batch_publish(publish_data.len()) || !publish_data.has_borrowed_refs() {
             if publish_data.is_delete_only() {
                 return memtable.publish_raw_delete_batch_owned(publish_data.into_entries());
             }

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -5133,6 +5133,13 @@ impl LsmStorageInner {
             );
         }
 
+        if Self::write_batch_keys_are_strictly_increasing(batch) {
+            return (
+                Self::build_point_batch_entries(batch, None, shared_value_bytes),
+                None,
+            );
+        }
+
         let mut seen = AHashSet::with_capacity(batch.len());
         let mut data = Vec::with_capacity(batch.len());
         for record in batch {
@@ -5171,6 +5178,16 @@ impl LsmStorageInner {
             );
         }
 
+        if Self::write_batch_keys_are_strictly_increasing(batch) {
+            return (
+                batch
+                    .iter()
+                    .map(|record| bytes::Bytes::copy_from_slice(Self::write_batch_key(record)))
+                    .collect(),
+                None,
+            );
+        }
+
         let mut seen = AHashSet::with_capacity(batch.len());
         let mut data = Vec::with_capacity(batch.len());
         for record in batch {
@@ -5196,6 +5213,24 @@ impl LsmStorageInner {
         }
 
         (data, None)
+    }
+
+    fn write_batch_keys_are_strictly_increasing<T: AsRef<[u8]>>(
+        batch: &[WriteBatchRecord<T>],
+    ) -> bool {
+        let mut records = batch.iter();
+        let Some(first) = records.next() else {
+            return true;
+        };
+        let mut previous = Self::write_batch_key(first);
+        for record in records {
+            let key = Self::write_batch_key(record);
+            if previous >= key {
+                return false;
+            }
+            previous = key;
+        }
+        true
     }
 
     fn use_delete_only_key_batch(serializable: bool, delete_only: bool, entries: usize) -> bool {

--- a/kv-engine/src/mem_table.rs
+++ b/kv-engine/src/mem_table.rs
@@ -1105,6 +1105,16 @@ impl MemTable {
         self.write_wal_batch(data)
     }
 
+    pub(crate) fn write_wal_owned_batch_only(
+        &self,
+        data: &[(Bytes, Bytes)],
+    ) -> Result<Option<u64>> {
+        if data.is_empty() {
+            return Ok(None);
+        }
+        self.write_wal_owned_batch(data)
+    }
+
     fn write_wal_batch(&self, data: &[(KeySlice, &[u8])]) -> Result<Option<u64>> {
         if data.is_empty() {
             return Ok(None);
@@ -1131,6 +1141,42 @@ impl MemTable {
         )?;
         #[cfg(not(feature = "bench"))]
         let ticket = wal.put_key_batch(data, commit_ts)?;
+        self.last_ticket
+            .fetch_max(ticket + 1, std::sync::atomic::Ordering::Release);
+        #[cfg(feature = "bench")]
+        self.write_profile.load().wal_write_ns.fetch_add(
+            t.elapsed().as_nanos() as u64,
+            std::sync::atomic::Ordering::Relaxed,
+        );
+
+        Ok(Some(ticket))
+    }
+
+    fn write_wal_owned_batch(&self, data: &[(Bytes, Bytes)]) -> Result<Option<u64>> {
+        if data.is_empty() {
+            return Ok(None);
+        }
+        let Some(wal) = &self.wal else {
+            return Ok(None);
+        };
+        let commit_ts = data
+            .first()
+            .and_then(|(k, _)| crate::key::extract_ts(k.as_ref()))
+            .unwrap_or(0);
+        debug_assert!(
+            data.iter()
+                .all(|(k, _)| { crate::key::extract_ts(k.as_ref()).unwrap_or(0) == commit_ts }),
+            "write_wal_owned_batch: entries have mismatched commit_ts (first={commit_ts})",
+        );
+        #[cfg(feature = "bench")]
+        let t = Instant::now();
+        #[cfg(feature = "bench")]
+        let ticket = crate::profile_scope!(
+            "wal.put_batch",
+            wal.put_owned_batch_profiled(data, commit_ts, &self.write_profile.load())
+        )?;
+        #[cfg(not(feature = "bench"))]
+        let ticket = wal.put_owned_batch(data, commit_ts)?;
         self.last_ticket
             .fetch_max(ticket + 1, std::sync::atomic::Ordering::Release);
         #[cfg(feature = "bench")]

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -55,6 +55,14 @@ impl DeferredBatchPublish {
         .build()
     }
 
+    pub(crate) fn from_entries_without_refs(entries: Vec<(Bytes, Bytes)>) -> Self {
+        DeferredBatchPublishBuilder {
+            entries,
+            refs_builder: |_| Vec::new(),
+        }
+        .build()
+    }
+
     pub(crate) fn is_empty(&self) -> bool {
         self.borrow_entries().is_empty()
     }
@@ -67,6 +75,10 @@ impl DeferredBatchPublish {
         self.borrow_entries()
             .iter()
             .all(|(_, value)| value.as_ref() == TOMBSTONE_VALUE)
+    }
+
+    pub(crate) fn has_borrowed_refs(&self) -> bool {
+        self.with_refs(|refs| !refs.is_empty()) || self.borrow_entries().is_empty()
     }
 
     pub(crate) fn with_borrowed_refs<R>(&self, f: impl FnOnce(&[(KeySlice<'_>, &[u8])]) -> R) -> R {
@@ -350,9 +362,18 @@ impl LsmMvccInner {
                 }
             })
             .collect();
-        let publish_data = DeferredBatchPublish::from_entries(publish_data);
         // Write to WAL buffer only — do NOT publish to skiplist yet.
-        let ticket = publish_data.with_refs(|refs| memtable.write_wal_batch_only(refs))?;
+        let (publish_data, ticket) = if shared_publish_bytes {
+            let ticket = memtable.write_wal_owned_batch_only(&publish_data)?;
+            (
+                DeferredBatchPublish::from_entries_without_refs(publish_data),
+                ticket,
+            )
+        } else {
+            let publish_data = DeferredBatchPublish::from_entries(publish_data);
+            let ticket = publish_data.with_refs(|refs| memtable.write_wal_batch_only(refs))?;
+            (publish_data, ticket)
+        };
         // Do NOT advance current_ts here — see write_wal_only comment.
 
         Ok((commit_ts, publish_data, ticket))

--- a/kv-engine/src/tests/lsm_storage_extra.rs
+++ b/kv-engine/src/tests/lsm_storage_extra.rs
@@ -522,6 +522,23 @@ fn test_write_batch_dedup_non_serializable() {
 }
 
 #[test]
+fn test_large_write_batch_dedup_to_small_publish_set() {
+    let dir = tempdir().unwrap();
+    let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();
+
+    let mut batch = Vec::with_capacity(600);
+    for i in 0..600 {
+        batch.push(WriteBatchRecord::Put(
+            b"k1".to_vec(),
+            format!("v{i}").into_bytes(),
+        ));
+    }
+    engine.write_batch(&batch).unwrap();
+
+    assert_eq!(engine.get(b"k1").unwrap(), Some(Bytes::from("v599")));
+}
+
+#[test]
 fn test_trigger_gc_no_vlog() {
     let dir = tempdir().unwrap();
     let engine = KvEngine::open(&dir, LsmStorageOptions::default_for_test()).unwrap();

--- a/kv-engine/src/wal.rs
+++ b/kv-engine/src/wal.rs
@@ -252,6 +252,16 @@ impl WalPointEntry for (KeySlice<'_>, &[u8]) {
     }
 }
 
+impl WalPointEntry for (bytes::Bytes, bytes::Bytes) {
+    fn key(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+
+    fn value(&self) -> &[u8] {
+        self.1.as_ref()
+    }
+}
+
 /// Shared completion state for the ticket-based group commit barrier.
 ///
 /// Multiple threads call `submit_and_commit()` concurrently. Each thread
@@ -1387,6 +1397,25 @@ impl Wal {
     pub(crate) fn put_key_batch_profiled(
         &self,
         data: &[(KeySlice<'_>, &[u8])],
+        commit_ts: u64,
+        profile: &crate::mem_table::WriteProfile,
+    ) -> Result<u64> {
+        self.put_batch_entries_inner(data, commit_ts, Some(profile))
+    }
+
+    #[cfg(not(feature = "bench"))]
+    pub(crate) fn put_owned_batch(
+        &self,
+        data: &[(bytes::Bytes, bytes::Bytes)],
+        commit_ts: u64,
+    ) -> Result<u64> {
+        self.put_batch_entries_inner(data, commit_ts, None)
+    }
+
+    #[cfg(feature = "bench")]
+    pub(crate) fn put_owned_batch_profiled(
+        &self,
+        data: &[(bytes::Bytes, bytes::Bytes)],
         commit_ts: u64,
         profile: &crate::mem_table::WriteProfile,
     ) -> Result<u64> {


### PR DESCRIPTION
## Summary

- Skip write-batch dedup work when input keys are already strictly increasing.
- Encode large point-batch WAL records from the owned publish data instead of building a second borrowed refs vector first.
- Keep delete-only batches on the existing faster specialized path.
- Add regression coverage for large batches that dedup down to a small publish set.

## Validation

- cargo fmt --all
- cargo check --package kv-engine --features bench
- cargo test --package kv-engine write_batch
- External crud-bench toykv sync run: batch_create_1000 1821.88 OPS, batch_update_1000 1813.59 OPS, batch_delete_1000 5482.29 OPS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved handling of large write batches, including repeated writes to the same key.
  * Reduced unnecessary allocation and copying during batch processing.
  * Optimized write-ahead logging for owned key-value data.

* **Bug Fixes**
  * Ensured deferred batch publication correctly handles batches without borrowed data.
  * Preserved final values and correct deduplication in large write operations.

* **Tests**
  * Added regression coverage for 600-operation batches with repeated key updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->