### PR TITLE
perf: route large delete batches through owned WAL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,6 +776,7 @@ dependencies = [
  "parking_lot",
  "rand",
  "rustyline",
+ "scc",
  "serde",
  "serde_json",
  "static_assertions",
@@ -1326,6 +1327,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
+name = "saa"
+version = "5.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5acb362a0e75c2a963532fa7fabf13dff81626dc494df16488d30befcbea0"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,10 +1342,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "3.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8af0b99483d1c3e59471d4f0cb58b244169436a8979c889a91a3f697075ea01"
+dependencies = [
+ "saa",
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "4.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1836bad8bdc9c6d665b63202da3d9c6d60ed1e597cae63620e21ebf89a3595a9"
+dependencies = [
+ "saa",
+]
 
 [[package]]
 name = "seize"

--- a/kv-engine/Cargo.toml
+++ b/kv-engine/Cargo.toml
@@ -52,6 +52,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
+scc = "3.8.6"
 static_assertions = "1"
 tempfile = "3"
 

--- a/kv-engine/benches/memtable_bench.rs
+++ b/kv-engine/benches/memtable_bench.rs
@@ -4,10 +4,17 @@
 //! 1. New approach: stack-buffer encoding + `Bound<&[u8]>` range (zero heap alloc)
 //! 2. Old approach: `Bytes::from(encode_internal_key(...))` range (heap alloc per seek)
 
+use std::sync::Arc;
+use std::time::Instant;
+
 use bytes::Bytes;
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use crossbeam_skiplist::SkipMap;
 use kv_engine::key;
 use kv_engine::mem_table::MemTable;
+use scc::{Guard, TreeIndex};
+
+const PUBLISH_BATCH_ENTRIES: usize = 100_000;
 
 fn bench_memtable_lookup(c: &mut Criterion) {
     let mut group = c.benchmark_group("memtable_seek");
@@ -54,6 +61,99 @@ fn bench_memtable_lookup(c: &mut Criterion) {
                     let user_key = &keys[idx % keys.len()];
                     idx += 1;
                     black_box(seek_bytes_alloc(&memtable, user_key, u64::MAX));
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_ordered_map_publish(c: &mut Criterion) {
+    let mut group = c.benchmark_group("memtable_ordered_map_publish");
+
+    for key_size in [4, 16] {
+        let entries = make_publish_entries(key_size, PUBLISH_BATCH_ENTRIES);
+
+        group.bench_with_input(
+            BenchmarkId::new("crossbeam_skipmap_insert", key_size),
+            &entries,
+            |b, entries| {
+                b.iter_custom(|iters| {
+                    let start = Instant::now();
+                    for _ in 0..iters {
+                        let map: SkipMap<Bytes, Bytes> = SkipMap::new();
+                        for (key, value) in entries {
+                            map.insert(key.clone(), value.clone());
+                        }
+                        black_box(map.len());
+                    }
+                    start.elapsed()
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("scc_treeindex_upsert", key_size),
+            &entries,
+            |b, entries| {
+                b.iter_custom(|iters| {
+                    let start = Instant::now();
+                    for _ in 0..iters {
+                        let map: TreeIndex<Bytes, Bytes> = TreeIndex::new();
+                        for (key, value) in entries {
+                            map.upsert_sync(key.clone(), value.clone());
+                        }
+                        black_box(map.len());
+                    }
+                    start.elapsed()
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_ordered_map_iter(c: &mut Criterion) {
+    let mut group = c.benchmark_group("memtable_ordered_map_iter");
+
+    for key_size in [4, 16] {
+        let entries = make_publish_entries(key_size, PUBLISH_BATCH_ENTRIES);
+
+        let skipmap: Arc<SkipMap<Bytes, Bytes>> = Arc::new(SkipMap::new());
+        for (key, value) in &entries {
+            skipmap.insert(key.clone(), value.clone());
+        }
+        group.bench_with_input(
+            BenchmarkId::new("crossbeam_skipmap_iter", key_size),
+            &skipmap,
+            |b, map| {
+                b.iter(|| {
+                    let mut total = 0usize;
+                    for entry in map.iter() {
+                        total += entry.key().len() + entry.value().len();
+                    }
+                    black_box(total);
+                });
+            },
+        );
+
+        let treeindex: Arc<TreeIndex<Bytes, Bytes>> = Arc::new(TreeIndex::new());
+        for (key, value) in &entries {
+            treeindex.upsert_sync(key.clone(), value.clone());
+        }
+        group.bench_with_input(
+            BenchmarkId::new("scc_treeindex_iter", key_size),
+            &treeindex,
+            |b, map| {
+                b.iter(|| {
+                    let guard = Guard::new();
+                    let mut total = 0usize;
+                    for (key, value) in map.iter(&guard) {
+                        total += key.len() + value.len();
+                    }
+                    black_box(total);
                 });
             },
         );
@@ -120,5 +220,20 @@ fn make_key(size: usize, idx: usize) -> Vec<u8> {
     key
 }
 
-criterion_group!(benches, bench_memtable_lookup);
+fn make_publish_entries(key_size: usize, entries: usize) -> Vec<(Bytes, Bytes)> {
+    (0..entries)
+        .map(|i| {
+            let key = key::encode_internal_key(&make_key(key_size, i), i as u64 + 1);
+            let value = Bytes::from_static(&[kv_engine::vlog::KvKind::Tombstone as u8]);
+            (Bytes::from(key), value)
+        })
+        .collect()
+}
+
+criterion_group!(
+    benches,
+    bench_memtable_lookup,
+    bench_ordered_map_publish,
+    bench_ordered_map_iter
+);
 criterion_main!(benches);

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -152,8 +152,8 @@ pub enum WriteBatchRecord<T: AsRef<[u8]>> {
     DelRange(T, T),
 }
 
-type PointBatchEntry = (bytes::Bytes, bytes::Bytes, crate::mvcc::BatchEntryKind);
-type PointBatchBuild = (Vec<PointBatchEntry>, Option<Vec<usize>>);
+type PointBatchEntry<'a> = (&'a [u8], bytes::Bytes, crate::mvcc::BatchEntryKind);
+type PointBatchBuild<'a> = (Vec<PointBatchEntry<'a>>, Option<Vec<usize>>);
 type DeleteBatchBuild = (Vec<bytes::Bytes>, Option<Vec<usize>>);
 const DELETE_ONLY_KEY_BATCH_MIN_ENTRIES: usize = 512;
 
@@ -4898,8 +4898,12 @@ impl LsmStorageInner {
         let (commit_ts, memtable, publish_data, ticket) = {
             let _read_guard = self.active_memtable_lock.read();
             let state = self.state.load();
+            let borrowed_entries: Vec<_> = entries
+                .iter()
+                .map(|(key, value, kind)| (key.as_ref(), value.clone(), *kind))
+                .collect();
             let (commit_ts, data, ticket) = mvcc.write_batch_wal_only(
-                entries,
+                &borrowed_entries,
                 &state.memtable,
                 Self::use_owned_batch_publish(entries.len()),
             )?;
@@ -5058,15 +5062,15 @@ impl LsmStorageInner {
         self.try_freeze_memtable()
     }
 
-    fn push_point_batch_entry<T: AsRef<[u8]>>(
-        data: &mut Vec<PointBatchEntry>,
-        record: &WriteBatchRecord<T>,
+    fn push_point_batch_entry<'a, T: AsRef<[u8]>>(
+        data: &mut Vec<PointBatchEntry<'a>>,
+        record: &'a WriteBatchRecord<T>,
         shared_value_bytes: bool,
     ) {
         match record {
             WriteBatchRecord::Put(key, value) => {
                 data.push((
-                    bytes::Bytes::copy_from_slice(key.as_ref()),
+                    key.as_ref(),
                     bytes::Bytes::from(Self::encode_kind_value_for_batch(
                         KvKind::Inline,
                         value.as_ref(),
@@ -5085,14 +5089,14 @@ impl LsmStorageInner {
                     shared_value_bytes,
                 );
                 data.push((
-                    bytes::Bytes::copy_from_slice(key.as_ref()),
+                    key.as_ref(),
                     bytes::Bytes::from(p),
                     crate::mvcc::BatchEntryKind::PutPrefixed,
                 ));
             }
             WriteBatchRecord::Del(key) => {
                 data.push((
-                    bytes::Bytes::copy_from_slice(key.as_ref()),
+                    key.as_ref(),
                     bytes::Bytes::new(),
                     crate::mvcc::BatchEntryKind::Delete,
                 ));
@@ -5101,11 +5105,11 @@ impl LsmStorageInner {
         }
     }
 
-    fn build_point_batch_entries<T: AsRef<[u8]>>(
-        batch: &[WriteBatchRecord<T>],
+    fn build_point_batch_entries<'a, T: AsRef<[u8]>>(
+        batch: &'a [WriteBatchRecord<T>],
         dedup_indices: Option<&[usize]>,
         shared_value_bytes: bool,
-    ) -> Vec<PointBatchEntry> {
+    ) -> Vec<PointBatchEntry<'a>> {
         let mut data = Vec::with_capacity(dedup_indices.map_or(batch.len(), <[usize]>::len));
         match dedup_indices {
             Some(indices) => {
@@ -5125,7 +5129,7 @@ impl LsmStorageInner {
     fn build_unique_point_batch_entries_or_dedup<T: AsRef<[u8]>>(
         batch: &[WriteBatchRecord<T>],
         shared_value_bytes: bool,
-    ) -> PointBatchBuild {
+    ) -> PointBatchBuild<'_> {
         if batch.len() <= 1 {
             return (
                 Self::build_point_batch_entries(batch, None, shared_value_bytes),
@@ -5328,8 +5332,12 @@ impl LsmStorageInner {
             // L5: Use load() (borrow) instead of load_full() (Arc clone)
             // to avoid an unnecessary atomic increment.
             let guard = self.state.load();
+            let borrowed_entries: Vec<_> = entries
+                .iter()
+                .map(|(key, value, kind)| (key.as_ref(), value.clone(), *kind))
+                .collect();
             let (commit_ts, data, ticket) = mvcc.write_batch_wal_only(
-                entries,
+                &borrowed_entries,
                 &guard.memtable,
                 Self::use_owned_batch_publish(entries.len()),
             )?;

--- a/kv-engine/src/lsm_storage.rs
+++ b/kv-engine/src/lsm_storage.rs
@@ -152,8 +152,8 @@ pub enum WriteBatchRecord<T: AsRef<[u8]>> {
     DelRange(T, T),
 }
 
-type PointBatchEntry<'a> = (&'a [u8], bytes::Bytes, crate::mvcc::BatchEntryKind);
-type PointBatchBuild<'a> = (Vec<PointBatchEntry<'a>>, Option<Vec<usize>>);
+type PointBatchEntry = (bytes::Bytes, bytes::Bytes, crate::mvcc::BatchEntryKind);
+type PointBatchBuild = (Vec<PointBatchEntry>, Option<Vec<usize>>);
 type DeleteBatchBuild = (Vec<bytes::Bytes>, Option<Vec<usize>>);
 const DELETE_ONLY_KEY_BATCH_MIN_ENTRIES: usize = 512;
 
@@ -4898,12 +4898,8 @@ impl LsmStorageInner {
         let (commit_ts, memtable, publish_data, ticket) = {
             let _read_guard = self.active_memtable_lock.read();
             let state = self.state.load();
-            let borrowed_entries: Vec<_> = entries
-                .iter()
-                .map(|(key, value, kind)| (key.as_ref(), value.clone(), *kind))
-                .collect();
             let (commit_ts, data, ticket) = mvcc.write_batch_wal_only(
-                &borrowed_entries,
+                entries,
                 &state.memtable,
                 Self::use_owned_batch_publish(entries.len()),
             )?;
@@ -5062,15 +5058,15 @@ impl LsmStorageInner {
         self.try_freeze_memtable()
     }
 
-    fn push_point_batch_entry<'a, T: AsRef<[u8]>>(
-        data: &mut Vec<PointBatchEntry<'a>>,
-        record: &'a WriteBatchRecord<T>,
+    fn push_point_batch_entry<T: AsRef<[u8]>>(
+        data: &mut Vec<PointBatchEntry>,
+        record: &WriteBatchRecord<T>,
         shared_value_bytes: bool,
     ) {
         match record {
             WriteBatchRecord::Put(key, value) => {
                 data.push((
-                    key.as_ref(),
+                    bytes::Bytes::copy_from_slice(key.as_ref()),
                     bytes::Bytes::from(Self::encode_kind_value_for_batch(
                         KvKind::Inline,
                         value.as_ref(),
@@ -5089,14 +5085,14 @@ impl LsmStorageInner {
                     shared_value_bytes,
                 );
                 data.push((
-                    key.as_ref(),
+                    bytes::Bytes::copy_from_slice(key.as_ref()),
                     bytes::Bytes::from(p),
                     crate::mvcc::BatchEntryKind::PutPrefixed,
                 ));
             }
             WriteBatchRecord::Del(key) => {
                 data.push((
-                    key.as_ref(),
+                    bytes::Bytes::copy_from_slice(key.as_ref()),
                     bytes::Bytes::new(),
                     crate::mvcc::BatchEntryKind::Delete,
                 ));
@@ -5105,11 +5101,11 @@ impl LsmStorageInner {
         }
     }
 
-    fn build_point_batch_entries<'a, T: AsRef<[u8]>>(
-        batch: &'a [WriteBatchRecord<T>],
+    fn build_point_batch_entries<T: AsRef<[u8]>>(
+        batch: &[WriteBatchRecord<T>],
         dedup_indices: Option<&[usize]>,
         shared_value_bytes: bool,
-    ) -> Vec<PointBatchEntry<'a>> {
+    ) -> Vec<PointBatchEntry> {
         let mut data = Vec::with_capacity(dedup_indices.map_or(batch.len(), <[usize]>::len));
         match dedup_indices {
             Some(indices) => {
@@ -5129,7 +5125,7 @@ impl LsmStorageInner {
     fn build_unique_point_batch_entries_or_dedup<T: AsRef<[u8]>>(
         batch: &[WriteBatchRecord<T>],
         shared_value_bytes: bool,
-    ) -> PointBatchBuild<'_> {
+    ) -> PointBatchBuild {
         if batch.len() <= 1 {
             return (
                 Self::build_point_batch_entries(batch, None, shared_value_bytes),
@@ -5332,12 +5328,8 @@ impl LsmStorageInner {
             // L5: Use load() (borrow) instead of load_full() (Arc clone)
             // to avoid an unnecessary atomic increment.
             let guard = self.state.load();
-            let borrowed_entries: Vec<_> = entries
-                .iter()
-                .map(|(key, value, kind)| (key.as_ref(), value.clone(), *kind))
-                .collect();
             let (commit_ts, data, ticket) = mvcc.write_batch_wal_only(
-                &borrowed_entries,
+                entries,
                 &guard.memtable,
                 Self::use_owned_batch_publish(entries.len()),
             )?;

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -330,7 +330,7 @@ impl LsmMvccInner {
     #[allow(clippy::type_complexity)]
     pub(crate) fn write_batch_wal_only(
         &self,
-        entries: &[(bytes::Bytes, bytes::Bytes, BatchEntryKind)],
+        entries: &[(&[u8], bytes::Bytes, BatchEntryKind)],
         memtable: &MemTable,
         shared_publish_bytes: bool,
     ) -> Result<(u64, DeferredBatchPublish, Option<u64>), anyhow::Error> {

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -330,7 +330,7 @@ impl LsmMvccInner {
     #[allow(clippy::type_complexity)]
     pub(crate) fn write_batch_wal_only(
         &self,
-        entries: &[(&[u8], bytes::Bytes, BatchEntryKind)],
+        entries: &[(bytes::Bytes, bytes::Bytes, BatchEntryKind)],
         memtable: &MemTable,
         shared_publish_bytes: bool,
     ) -> Result<(u64, DeferredBatchPublish, Option<u64>), anyhow::Error> {

--- a/kv-engine/src/mvcc.rs
+++ b/kv-engine/src/mvcc.rs
@@ -411,8 +411,17 @@ impl LsmMvccInner {
                 )
             })
             .collect();
-        let publish_data = DeferredBatchPublish::from_entries(publish_data);
-        let ticket = publish_data.with_refs(|refs| memtable.write_wal_batch_only(refs))?;
+        let (publish_data, ticket) = if shared_publish_bytes {
+            let ticket = memtable.write_wal_owned_batch_only(&publish_data)?;
+            (
+                DeferredBatchPublish::from_entries_without_refs(publish_data),
+                ticket,
+            )
+        } else {
+            let publish_data = DeferredBatchPublish::from_entries(publish_data);
+            let ticket = publish_data.with_refs(|refs| memtable.write_wal_batch_only(refs))?;
+            (publish_data, ticket)
+        };
 
         Ok((commit_ts, publish_data, ticket))
     }

--- a/todo.md
+++ b/todo.md
@@ -496,6 +496,11 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   `batch_delete_100` 11,854.17 -> 2,931.01 OPS, `batch_create_1000` 1,656.03 -> 700.37 OPS,
   `batch_update_1000` 1,658.15 -> 833.46 OPS, and `batch_delete_1000` 5,163.59 -> 1,926.97 OPS. The profile showed
   both `publish_skipmap_ms` and `follower_wait_ms` exploding, so sorted-order manipulation is not a viable local fix.
+  Rejected follow-up before external CRUD: serializing large owned memtable publish batches behind a per-memtable mutex
+  reduced focused create publish cost, but removed useful parallelism for update/delete. Same-session
+  `crud_phase_batch` moved `batch_create_after_crud_phase` 1,748,290 -> 1,827,055 OPS, but regressed
+  `batch_update_after_crud_phase` 1,948,903 -> 1,711,812 OPS and collapsed `batch_delete_after_crud_phase`
+  3,120,418 -> 779,426 OPS. Do not serialize SkipMap publish without a delete-specific design.
   Final PR-head sync/no-sync comparison artifacts:
   `result-toykv_pr174_final_sync_100k.csv` and `result-toykv_pr174_final_nosync_100k.csv`. Same command shape
   (`--samples 100000 --clients 4 --threads 4 --skip-indexes --skip-scans`) shows durable batch writes remain below

--- a/todo.md
+++ b/todo.md
@@ -278,7 +278,12 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   OPS). Carrying precomputed user-key bloom hashes through deferred publish also regressed sync `batch_create_1000`
   (1,182.16 OPS) and `batch_delete_1000` (3,932.22 OPS). Borrowing user keys through MVCC WAL staging also regressed the
   current kept sync patch (`batch_create_1000` 1,636.52 OPS versus 1,678.16 OPS, and `batch_delete_100` 11,023.76 OPS
-  versus 13,477.38 OPS). Replacing hash-based uniqueness with a strictly-ordered-key fast path also regressed
+  versus 13,477.38 OPS). The narrower retry that only borrowed public `WriteBatchRecord` keys until MVCC built owned
+  internal keys looked good in focused `crud_phase_batch`, but the external same-window CRUD sync gate rejected it:
+  `toykv_borrow_point_keys_control_sync_100k` versus `toykv_borrow_point_keys_candidate_sync_100k` moved
+  `batch_create_1000` flat at 1,732.50 -> 1,736.67 OPS, regressed `batch_update_1000` 1,631.92 -> 1,262.48 OPS, and
+  regressed `batch_delete_1000` 5,316.40 -> 3,996.11 OPS, so it was reverted in `0f1cc87`. Replacing hash-based
+  uniqueness with a strictly-ordered-key fast path also regressed
   `batch_create_1000` to 1,648.14 OPS and `batch_delete_1000` to 4,793.31 OPS. Replacing MVCC publish-data iterator
   construction with an explicit preallocated loop improved `batch_delete_1000` but regressed `batch_create_1000` to
   1,029.54 OPS, so it was reverted. Replacing `DeferredBatchPublish` refs-builder collection with an explicit

--- a/todo.md
+++ b/todo.md
@@ -232,6 +232,13 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   `batch_delete_1000` 4,828.19 → 4,983.64 OPS. Current no-sync comparison before these publish slices:
   `batch_create_1000` 1,678.16 / 2,660.18 OPS (63.1%), and `batch_delete_1000` 5,414.47 / 7,408.65 OPS (73.1%).
   The next remaining gap is still durable `batch_create_1000`.
+  Structural follow-up: prototype alternate ordered concurrent memtable backends before doing more publish-loop
+  micro-edits. Current profiles show `SkipMap` insertion dominates large delete publish and is still a major part of
+  create/update publish. Candidate crates to benchmark first: `scc::TreeIndex` (concurrent B+ tree with range
+  iteration), `concurrent_map` (sled-derived lock-free B+ tree), `skl` (skiplist crate aimed at LSM/MVCC memtables),
+  and `arctic-map` (lock-free adaptive radix tree with ordered range scans). Keep the existing `crossbeam_skiplist`
+  backend as the control, require point get + range scan + flush correctness, and judge candidates on same-window
+  `crud-bench` sync `batch_create_1000`, `batch_update_1000`, and `batch_delete_1000`.
   Rejected follow-ups: consuming the prepared entry vector in MVCC WAL staging regressed `batch_delete_1000`, and fusing
   point key validation into entry construction was too noisy/regressive in rerun (`batch_create_1000` fell to 1,099.95
   OPS). Carrying precomputed user-key bloom hashes through deferred publish also regressed sync `batch_create_1000`

--- a/todo.md
+++ b/todo.md
@@ -239,6 +239,11 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   and `arctic-map` (lock-free adaptive radix tree with ordered range scans). Keep the existing `crossbeam_skiplist`
   backend as the control, require point get + range scan + flush correctness, and judge candidates on same-window
   `crud-bench` sync `batch_create_1000`, `batch_update_1000`, and `batch_delete_1000`.
+  First production-swap prototype rejected: moving the memtable point map to `scc::TreeIndex` with a vector-backed scan
+  snapshot passed focused correctness checks, and the ordered microbench had looked promising, but the external sync
+  CRUD gate regressed large create/update versus the kept branch (`batch_create_1000` 1,344.90 OPS,
+  `batch_update_1000` 1,634.01 OPS, `batch_delete_1000` 5,392.91 OPS). Keep the benchmark-only evidence, but do not
+  retry this shape without a non-cloning range iterator and same-window CRUD control.
   Rejected follow-ups: consuming the prepared entry vector in MVCC WAL staging regressed `batch_delete_1000`, and fusing
   point key validation into entry construction was too noisy/regressive in rerun (`batch_create_1000` fell to 1,099.95
   OPS). Carrying precomputed user-key bloom hashes through deferred publish also regressed sync `batch_create_1000`

--- a/todo.md
+++ b/todo.md
@@ -501,6 +501,14 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   `crud_phase_batch` moved `batch_create_after_crud_phase` 1,748,290 -> 1,827,055 OPS, but regressed
   `batch_update_after_crud_phase` 1,948,903 -> 1,711,812 OPS and collapsed `batch_delete_after_crud_phase`
   3,120,418 -> 779,426 OPS. Do not serialize SkipMap publish without a delete-specific design.
+  Next direction after the backend/prototype sweep: stop local staging, key-shape, and serialization micro-edits until a
+  larger design changes the durable batch shape. External profile-window artifact
+  `result-toykv_profile_windows_current_after_backend_sweep` shows large create/update dominated by WAL group
+  wait/submit plus SkipMap publish, while large delete is mostly SkipMap-publish bound. The next useful PR should either
+  design a WAL/publish representation that avoids building publish data and then re-encoding equivalent WAL payload
+  bytes without moving that work under `write_lock`, or design a delete-specific tombstone publication/index path that
+  avoids one SkipMap insertion per tombstone. Gate any candidate directly with external `crud-bench` profile windows
+  before accepting it.
   Final PR-head sync/no-sync comparison artifacts:
   `result-toykv_pr174_final_sync_100k.csv` and `result-toykv_pr174_final_nosync_100k.csv`. Same command shape
   (`--samples 100000 --clients 4 --threads 4 --skip-indexes --skip-scans`) shows durable batch writes remain below

--- a/todo.md
+++ b/todo.md
@@ -273,6 +273,13 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   benchmark a serialized B+ tree rather than the intended lock-free publish path, and an unsafe `Sync` wrapper would
   bypass the crate's reclamation contract. Do not prototype this backend unless the design first gives each accessing
   thread its own cloned handle without weakening `MemTable`'s sharing model.
+  Follow-up kept: public MVCC point-batch staging now borrows the user key from `WriteBatchRecord` until MVCC assigns
+  the commit timestamp and builds the owned internal key for WAL/publish. This removes an early user-key `Bytes` copy
+  from create/update staging without changing the WAL sync then memtable publish ordering. Same-window focused
+  `crud_phase_batch` A/B (`--num 100000 --threads 4 --value-size 1024 --wal-batch-size 1000 --profile`) moved
+  `batch_create_after_crud_phase` 1,543,028 -> 1,741,342 OPS, `batch_update_after_crud_phase` 1,796,584 -> 1,993,471
+  OPS, and `batch_delete_after_crud_phase` 3,689,102 -> 3,846,375 OPS. Focused correctness passed (`write_batch` 23/23,
+  `txn` 40/40, and `wal` 82/82 outside sandbox; the in-sandbox WAL filter only failed on io_uring permission).
   Rejected follow-ups: consuming the prepared entry vector in MVCC WAL staging regressed `batch_delete_1000`, and fusing
   point key validation into entry construction was too noisy/regressive in rerun (`batch_create_1000` fell to 1,099.95
   OPS). Carrying precomputed user-key bloom hashes through deferred publish also regressed sync `batch_create_1000`

--- a/todo.md
+++ b/todo.md
@@ -473,6 +473,12 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   `batch_update_100` 5,724.03 -> 7,467.48 OPS, but `batch_create_1000` fell 1,656.03 -> 1,538.30 OPS and
   `batch_delete_1000` was slightly lower at 5,163.59 -> 5,056.26 OPS. The ToyKV-internal `batch_build` bucket did not
   improve for large create, so caller key-Vec allocation is not the right next durable-batch target.
+  Rejected follow-up before external CRUD: adding a native-endian `u32` monotonic-key uniqueness proof for ToyKV's
+  external adapter shape avoided the hash-set dedup pass for `u32::to_ne_bytes()` batch keys while preserving duplicate
+  fallback, but the focused current-head `crud_phase_batch` profile regressed create/update
+  (`batch_create_after_crud_phase` 1,748,290 -> 1,706,555 OPS, `batch_update_after_crud_phase` 1,948,903 ->
+  1,732,647 OPS) and only helped delete versus that one baseline. Do not add more key-shape uniqueness fast paths
+  without an external profile showing `batch_build` as the limiting bucket.
   Follow-up profiling split approximate-size accounting out of memtable publish map time. Review cleanup narrowed the
   accounting bucket to the batch-level relaxed `approximate_size.fetch_add`, leaving per-entry length accumulation
   untimed so the profile does not mostly measure `Instant::now()` overhead. Do not optimize approximate-size bookkeeping

--- a/todo.md
+++ b/todo.md
@@ -257,8 +257,15 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   memcomparable user-key padding deliberately includes `0x00`, and the inverted timestamp suffix can contain any byte.
   That makes `NonNull` invalid and makes `Terminated<N>` invalid without an order-preserving escaping/termination layer
   or a custom unsafe `Key` proof. A safe `arctic-map` attempt should first design and benchmark that key adapter;
-  otherwise the benchmark would measure a different key space or rely on unsound unchecked construction. Next immediate
-  candidate after TreeIndex: read `skl` API/safety before attempting a production swap.
+  otherwise the benchmark would measure a different key space or rely on unsound unchecked construction.
+  `skl` API/safety and production-swap prototype rejected: the crate is arena-backed and has built-in MVCC, but ToyKV's
+  memtable already encodes MVCC in the internal key, so the plausible swap used `generic::unique::sync::SkipMap<[u8],
+  [u8]>`. That shape compiled and passed focused correctness (`memtable` 86/86 outside sandbox, `write_batch` 23/23,
+  and `scan` 116/116 outside sandbox), but the practical gate failed: a 64 MiB heap arena exhausted during the 100k x
+  1 KiB focused CRUD profile, and raising the arena to 256 MiB made the same `crud_phase_batch` profile fail to produce
+  rows after roughly two minutes before it was killed. Do not keep the `skl` production swap unless there is first a
+  bounded/dynamic arena design and a profile proving scan/insert does not stall the publish workload. Next structural
+  candidate: inspect `concurrent_map`.
   Rejected follow-ups: consuming the prepared entry vector in MVCC WAL staging regressed `batch_delete_1000`, and fusing
   point key validation into entry construction was too noisy/regressive in rerun (`batch_create_1000` fell to 1,099.95
   OPS). Carrying precomputed user-key bloom hashes through deferred publish also regressed sync `batch_create_1000`

--- a/todo.md
+++ b/todo.md
@@ -266,6 +266,13 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   rows after roughly two minutes before it was killed. Do not keep the `skl` production swap unless there is first a
   bounded/dynamic arena design and a profile proving scan/insert does not stall the publish workload. Next structural
   candidate: inspect `concurrent_map`.
+  `concurrent-map` API rejected before production swap: the crate provides a lock-free linearizable B+ tree and returns
+  owned `(K, V)` pairs from range iteration, but its `ConcurrentMap` handle is explicitly `Send` and not `Sync` because
+  each cloned handle owns local EBR state. ToyKV shares `MemTable` through `Arc` across write/read/flush paths, so
+  replacing the point map with a single `ConcurrentMap` handle would make `MemTable` not `Sync`. A mutex wrapper would
+  benchmark a serialized B+ tree rather than the intended lock-free publish path, and an unsafe `Sync` wrapper would
+  bypass the crate's reclamation contract. Do not prototype this backend unless the design first gives each accessing
+  thread its own cloned handle without weakening `MemTable`'s sharing model.
   Rejected follow-ups: consuming the prepared entry vector in MVCC WAL staging regressed `batch_delete_1000`, and fusing
   point key validation into entry construction was too noisy/regressive in rerun (`batch_create_1000` fell to 1,099.95
   OPS). Carrying precomputed user-key bloom hashes through deferred publish also regressed sync `batch_create_1000`

--- a/todo.md
+++ b/todo.md
@@ -273,13 +273,6 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   benchmark a serialized B+ tree rather than the intended lock-free publish path, and an unsafe `Sync` wrapper would
   bypass the crate's reclamation contract. Do not prototype this backend unless the design first gives each accessing
   thread its own cloned handle without weakening `MemTable`'s sharing model.
-  Follow-up kept: public MVCC point-batch staging now borrows the user key from `WriteBatchRecord` until MVCC assigns
-  the commit timestamp and builds the owned internal key for WAL/publish. This removes an early user-key `Bytes` copy
-  from create/update staging without changing the WAL sync then memtable publish ordering. Same-window focused
-  `crud_phase_batch` A/B (`--num 100000 --threads 4 --value-size 1024 --wal-batch-size 1000 --profile`) moved
-  `batch_create_after_crud_phase` 1,543,028 -> 1,741,342 OPS, `batch_update_after_crud_phase` 1,796,584 -> 1,993,471
-  OPS, and `batch_delete_after_crud_phase` 3,689,102 -> 3,846,375 OPS. Focused correctness passed (`write_batch` 23/23,
-  `txn` 40/40, and `wal` 82/82 outside sandbox; the in-sandbox WAL filter only failed on io_uring permission).
   Rejected follow-ups: consuming the prepared entry vector in MVCC WAL staging regressed `batch_delete_1000`, and fusing
   point key validation into entry construction was too noisy/regressive in rerun (`batch_create_1000` fell to 1,099.95
   OPS). Carrying precomputed user-key bloom hashes through deferred publish also regressed sync `batch_create_1000`

--- a/todo.md
+++ b/todo.md
@@ -244,6 +244,21 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   CRUD gate regressed large create/update versus the kept branch (`batch_create_1000` 1,344.90 OPS,
   `batch_update_1000` 1,634.01 OPS, `batch_delete_1000` 5,392.91 OPS). Keep the benchmark-only evidence, but do not
   retry this shape without a non-cloning range iterator and same-window CRUD control.
+  Second `scc::TreeIndex` production-swap prototype also rejected: replacing the full-range scan clone with a `Send`
+  cursor iterator avoided storing `scc::Guard` across async boundaries and passed `cargo test --package kv-engine
+  memtable` outside sandbox, but external sync CRUD exposed a large point-read regression (`batch_read_1000` collapsed
+  to 17.16 OPS) even though publish-heavy rows looked decent (`batch_create_1000` 1,736.51 OPS,
+  `batch_update_1000` 1,826.38 OPS, `batch_delete_1000` 5,756.76 OPS). Treat TreeIndex as rejected for the production
+  memtable unless the lookup path can avoid per-read guarded B-tree range seeks. Next structural candidate:
+  `arctic-map`.
+  `arctic-map` API read: defer the production memtable prototype until there is a dedicated key adapter. Its
+  `ConcurrentMap` gives lock-free writes, wait-free point reads, and ordered scans, but dynamic byte keys must satisfy
+  the crate's prefix-property wrappers (`NonNull` or `Terminated<N>`). ToyKV internal keys are arbitrary bytes:
+  memcomparable user-key padding deliberately includes `0x00`, and the inverted timestamp suffix can contain any byte.
+  That makes `NonNull` invalid and makes `Terminated<N>` invalid without an order-preserving escaping/termination layer
+  or a custom unsafe `Key` proof. A safe `arctic-map` attempt should first design and benchmark that key adapter;
+  otherwise the benchmark would measure a different key space or rely on unsound unchecked construction. Next immediate
+  candidate after TreeIndex: read `skl` API/safety before attempting a production swap.
   Rejected follow-ups: consuming the prepared entry vector in MVCC WAL staging regressed `batch_delete_1000`, and fusing
   point key validation into entry construction was too noisy/regressive in rerun (`batch_create_1000` fell to 1,099.95
   OPS). Carrying precomputed user-key bloom hashes through deferred publish also regressed sync `batch_create_1000`

--- a/todo.md
+++ b/todo.md
@@ -259,7 +259,11 @@ See `docs/bench-report-crud-bench-fjall.md` for benchmark details.
   OPS), so it was reverted. Removing the WAL point-batch validated length vector was also rejected: same-window
   outside-sandbox sync A/B on 2026-07-15 moved `batch_create_1000` 1,682.54 → 1,682.08 OPS, but regressed
   `batch_update_1000` 1,724.53 → 1,162.76 OPS and `batch_delete_1000` 5,716.15 → 4,862.19 OPS. Replacing WAL
-  submission chunk-range collection with a direct index loop was also rejected: same-window sync A/B moved
+  point-batch validation's first length-check pass with validation only in the existing encoded-length collection was
+  also rejected: focused `crud_phase_batch` control stayed faster than the candidate on create/update/delete
+  (`batch_create` 1,901,929 vs 1,771,400 OPS, `batch_update` 1,842,048 vs 1,680,386 OPS, `batch_delete` 4,050,344 vs
+  3,434,640 OPS), while the external CRUD control window was too noisy to use. Replacing WAL submission chunk-range
+  collection with a direct index loop was also rejected: same-window sync A/B moved
   `batch_create_1000` 1,074.83 → 1,565.98 OPS in a noisy baseline window, but regressed `batch_update_1000`
   1,587.33 → 1,563.96 OPS and `batch_delete_1000` 5,078.36 → 4,752.27 OPS. Increasing WAL fallocate granularity
   from 1 MiB to 16 MiB was a hard reject: same-window sync A/B moved `batch_create_1000` 1,726.79 → 983.89 OPS,


### PR DESCRIPTION
## Summary

- Route large delete-only MVCC batches through the owned WAL/publish path.
- Add benchmark-only ordered memtable backend coverage and record why the tested production backend swaps were rejected.
- Record rejected WAL/publish micro-prototypes and the next durable-batch direction in `todo.md`.

## Notes

The latest TODO entry points away from more local staging/key-shape/serialization tweaks. External profile-window artifact `result-toykv_profile_windows_current_after_backend_sweep` showed large create/update dominated by WAL group wait/submit plus SkipMap publish, while large delete remained mostly SkipMap-publish bound.

## Verification

- `cargo fmt --all`
- `cargo check --package kv-engine --features bench`
- `cargo test --package kv-engine write_batch`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved an internal write path for configurations using shared publishing, supporting more efficient batch handling.
  * Added performance benchmarks covering entry publication and iteration across different key sizes.
* **Documentation**
  * Updated performance investigation notes with benchmark findings, profiling results, and areas for future optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->