### PR TITLE
fix: shrink steady-state smoke preset

### DIFF
--- a/kv-engine/src/bin/write-perf.rs
+++ b/kv-engine/src/bin/write-perf.rs
@@ -256,7 +256,7 @@ impl HarnessConfig {
                 ("large", 2_000_000, 500_000, 10, 1_000_000, 1024, 4, 0, 10)
             }
             (Suite::SteadyState, Preset::Smoke) => {
-                ("smoke", 10_000, 10_000, 30, 10_000, 400, 4, 0, 30)
+                ("smoke", 10_000, 10_000, 1, 10_000, 400, 1, 0, 1)
             }
             (Suite::SteadyState, Preset::Default) => (
                 "default", 1_000_000, 100_000, 180, 1_000_000, 400, 16, 60, 180,
@@ -5940,9 +5940,9 @@ mod tests {
         assert_eq!(cfg.preset_name, "smoke");
         assert_eq!(cfg.num, 10_000);
         assert_eq!(cfg.value_size, 400);
-        assert_eq!(cfg.clients, 4);
+        assert_eq!(cfg.clients, 1);
         assert_eq!(cfg.warmup_secs, 0);
-        assert_eq!(cfg.measurement_secs, 30);
+        assert_eq!(cfg.measurement_secs, 1);
     }
 
     #[test]

--- a/rfcs/018-steady-state-benchmark-suite.md
+++ b/rfcs/018-steady-state-benchmark-suite.md
@@ -219,7 +219,7 @@ The suite should expose named scale presets while keeping benchmark semantics
 constant:
 
 ```text
-smoke:          10,000 records, 4 clients, 0s warmup, 30s measurement
+smoke:          10,000 records, 1 client, 0s warmup, 1s measurement
 local default:  1,000,000 records, 16 clients, 60s warmup, 180s measurement
 benchmark host: configurable records, 64 clients, 300s warmup, 900s measurement
 ```


### PR DESCRIPTION
## Summary

- Shrink the RFC 018 steady-state smoke preset to 1 client and a 1-second measurement window.
- Keep default and large steady-state presets unchanged for real benchmark-host runs.
- Update RFC 018 preset documentation to match the executable smoke defaults.

## Why

The previous smoke preset used 4 clients for 30 seconds. On constrained local hosts this can create enough WAL/io_uring pressure to fail with "failed to create io_uring ring: Cannot allocate memory". The smoke preset should be a quick local correctness gate; longer runs remain covered by the default and large presets.

## Verification

- cargo test --package kv-engine --bin write-perf
- cargo clippy --package kv-engine --bin write-perf -- -D warnings
- git diff --check
- cargo run --release --bin write-perf -- --suite steady-state --preset smoke --prepare-golden --golden-path /tmp/toykv-steady-state-golden --path /tmp/toykv-steady-state-prepare --settle-timeout-secs 30 --output json
- cargo run --release --bin write-perf -- --suite steady-state --preset smoke --bench balanced_zipfian --golden-path /tmp/toykv-steady-state-golden --clone-golden --path /tmp/toykv-steady-state-runs --latency-sample-every 100 --settle-timeout-secs 30 --output json

Smoke balanced_zipfian result: validation.errors=0, completed_operations=333930, observed_operation_mix=get=0.500018,put=0.499982.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the steady-state smoke benchmark preset to run with one client over a one-second measurement period.
  * Reduced the smoke preset’s warmup period to zero seconds and adjusted the test value size to 400 bytes.
  * Updated benchmark defaults validation to reflect the new configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->