### PR TITLE
feat: add compaction setsum verifier

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUST_TOOLCHAIN: nightly-2026-05-28
+  RUST_TOOLCHAIN: nightly-2026-08-20
 
 name: Check
 jobs:

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  RUST_TOOLCHAIN: nightly-2026-05-28
+  RUST_TOOLCHAIN: nightly-2026-08-20
 
 name: Safety
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           components: llvm-tools-preview
       - name: cargo install cargo-llvm-cov
-        uses: taiki-e/install-action@29ee91bbad05696171dd917a8c7a3838049b93d5 # cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --version 0.8.7 --locked
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUST_TOOLCHAIN: nightly-2026-05-28
+  RUST_TOOLCHAIN: nightly-2026-08-20
 
 name: Test
 jobs:
@@ -42,6 +42,10 @@ jobs:
         uses: taiki-e/install-action@nextest
       - name: cargo nextest --locked (unit)
         run: cargo nextest run --locked --workspace --all-features --lib -E 'not test(/integration/)'
+      - name: compaction setsum verifier smoke
+        env:
+          TOYKV_COMPACTION_SETSUM: "1"
+        run: cargo test --locked --package kv-engine --all-features --lib tests::compaction::test_task1_full_compaction -- --exact
 
   integration:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ A toy LSM-tree-based key-value storage engine written in Rust. This is an educat
 ## Technology Stack
 
 - **Language**: Rust (Edition 2024)
-- **Toolchain**: Nightly (`nightly-2026-05-28`), managed via `rust-toolchain` file
+- **Toolchain**: Nightly (`nightly-2026-08-20`), managed via `rust-toolchain` file
 - **Build Tool**: Cargo + cargo-make (`Makefile.toml`)
 - **Test Runner**: cargo-nextest
 - **Coverage**: cargo-llvm-cov

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,8 +175,6 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "cfg_aliases"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chunked_transfer"
@@ -287,6 +294,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,6 +407,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +428,16 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -529,6 +565,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -749,6 +795,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "kv-engine"
 version = "0.1.0"
 dependencies = [
@@ -780,6 +835,7 @@ dependencies = [
  "scc",
  "serde",
  "serde_json",
+ "setsum",
  "static_assertions",
  "tempfile",
  "tokio",
@@ -1415,6 +1471,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "setsum"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0122e6b6da18bf35920eaa52ce8f66528f255a3bf7a72311fc1c6e079234b6a8"
+dependencies = [
+ "sha3",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,6 +1618,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+exclude = ["vendor/cfg_aliases"]
 members = ["kv-engine"]
 resolver = "3"
 
@@ -15,5 +16,8 @@ repository = "https://github.com/ben1009/toy-kv-engine"
 anyhow = "1"
 bytes = "1"
 
+# Local patch for nix 0.31.3's build-time cfg_aliases use on nightly-2026-08-20
+# until upstream cfg_aliases is bumped past the trailing-semicolon macro issue
+# tracked by rust-lang/rust#79813.
 [patch.crates-io]
 cfg_aliases = { path = "vendor/cfg_aliases" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,5 @@ repository = "https://github.com/ben1009/toy-kv-engine"
 anyhow = "1"
 bytes = "1"
 
+[patch.crates-io]
+cfg_aliases = { path = "vendor/cfg_aliases" }

--- a/README.md
+++ b/README.md
@@ -226,6 +226,9 @@ cargo make test-chaos
 # Coverage report
 cargo make test-cov
 
+# Optional compaction accounting verifier
+TOYKV_COMPACTION_SETSUM=1 cargo test --package kv-engine --features compaction-setsum tests::compaction
+
 # Example Criterion benchmarks
 cargo bench --package kv-engine --bench wal_bench
 cargo bench --package kv-engine --bench vlog_benchmarks
@@ -237,6 +240,39 @@ scenario-driven performance checks.
 `cargo make check` runs the normal local gate and does not include the dedicated
 chaos harness. Run `cargo make test-chaos` when validating crash recovery,
 failpoint injection, and cross-process persistence behavior.
+
+### Compaction Setsum Verifier
+
+The `compaction-setsum` feature adds an optional invariant checker around the
+compaction rewrite path. When `TOYKV_COMPACTION_SETSUM` is set to any value
+except `0`, compaction records a commutative `setsum` digest of every input
+point entry, every output point entry, and every entry that compaction is allowed
+to drop. The verifier fails the compaction if:
+
+```text
+input != output + allowed_drops
+```
+
+This catches accounting bugs where compaction silently loses, duplicates, or
+rewrites an entry outside the normal MVCC, TTL, range-tombstone, or compaction
+filter drop rules. Keep it off for ordinary benchmarks because it hashes every
+compacted point entry.
+
+Useful targeted runs:
+
+```bash
+# Run the CI smoke check
+TOYKV_COMPACTION_SETSUM=1 cargo test --locked --package kv-engine \
+  --features compaction-setsum --lib \
+  tests::compaction::test_task1_full_compaction -- --exact
+
+# Run all in-crate compaction tests with the verifier enabled
+TOYKV_COMPACTION_SETSUM=1 cargo test --locked --package kv-engine \
+  --features compaction-setsum --lib tests::compaction
+
+# `--all-features` also enables the verifier code; the env var still controls runtime use
+TOYKV_COMPACTION_SETSUM=1 cargo nextest run --workspace --all-features --lib
+```
 
 ## Performance Notes
 

--- a/kv-engine/Cargo.toml
+++ b/kv-engine/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/bin/write-perf.rs"
 [features]
 bench = []
 chaos-testing = ["fail/failpoints"]
+compaction-setsum = ["dep:setsum"]
 hotpath-profile = ["dep:hotpath", "hotpath/hotpath", "hotpath/threads"]
 
 [dependencies]
@@ -49,6 +50,7 @@ rand_chacha = "0.3.1"
 rustyline = "18.0.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
+setsum = { version = "0.9", optional = true }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
 
 [dev-dependencies]

--- a/kv-engine/README.md
+++ b/kv-engine/README.md
@@ -28,7 +28,12 @@ cargo make check
 
 # Chaos harness tests
 cargo make test-chaos
+
+# Optional compaction accounting verifier
+TOYKV_COMPACTION_SETSUM=1 cargo test --locked --package kv-engine \
+  --features compaction-setsum --lib tests::compaction
 ```
 
 See the repository [README](../README.md) for the top-level feature list, RFC
-index, and benchmark notes.
+index, benchmark notes, and details on when to use the `compaction-setsum`
+verifier.

--- a/kv-engine/src/compact.rs
+++ b/kv-engine/src/compact.rs
@@ -62,6 +62,71 @@ struct CompactionEntryDecision<'a> {
     is_tombstone: bool,
 }
 
+#[cfg(feature = "compaction-setsum")]
+#[derive(Clone, Debug, Default)]
+struct CompactionSetsumVerifier {
+    input: setsum::Setsum,
+    output: setsum::Setsum,
+    allowed_drops: setsum::Setsum,
+    input_entries: u64,
+    output_entries: u64,
+    allowed_drop_entries: u64,
+}
+
+#[cfg(feature = "compaction-setsum")]
+impl CompactionSetsumVerifier {
+    fn enabled() -> bool {
+        static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        *ENABLED.get_or_init(|| {
+            std::env::var_os("TOYKV_COMPACTION_SETSUM").is_some_and(|value| value != "0")
+        })
+    }
+
+    fn add_input(&mut self, key: KeySlice<'_>, value: &[u8]) {
+        Self::insert_entry(&mut self.input, key, value);
+        self.input_entries += 1;
+    }
+
+    fn add_allowed_drop(&mut self, key: KeySlice<'_>, value: &[u8]) {
+        Self::insert_entry(&mut self.allowed_drops, key, value);
+        self.allowed_drop_entries += 1;
+    }
+
+    fn add_output(&mut self, key: KeySlice<'_>, value: &[u8]) {
+        Self::insert_entry(&mut self.output, key, value);
+        self.output_entries += 1;
+    }
+
+    fn verify(&self) -> Result<()> {
+        let accounted = self.output + self.allowed_drops;
+        anyhow::ensure!(
+            self.input == accounted,
+            "compaction setsum mismatch: input={} output={} allowed_drops={} \
+             input_entries={} output_entries={} allowed_drop_entries={}",
+            self.input.hexdigest(),
+            self.output.hexdigest(),
+            self.allowed_drops.hexdigest(),
+            self.input_entries,
+            self.output_entries,
+            self.allowed_drop_entries
+        );
+
+        Ok(())
+    }
+
+    fn insert_entry(sum: &mut setsum::Setsum, key: KeySlice<'_>, value: &[u8]) {
+        let key_len = key.raw_ref().len().to_be_bytes();
+        let value_len = value.len().to_be_bytes();
+        sum.insert_vectored(&[
+            b"toykv.compaction.point.v1",
+            &key_len,
+            key.raw_ref(),
+            &value_len,
+            value,
+        ]);
+    }
+}
+
 struct ReservedSsts<'a> {
     inner: &'a LsmStorageInner,
     ids: Vec<usize>,
@@ -1186,6 +1251,9 @@ impl LsmStorageInner {
         let mut ret = vec![];
         let mut all_vlog_ids: Vec<u32> = vec![];
         let mut builder = self.new_compaction_builder(should_backfill);
+        #[cfg(feature = "compaction-setsum")]
+        let mut setsum_verifier =
+            CompactionSetsumVerifier::enabled().then(CompactionSetsumVerifier::default);
 
         // Snapshot the watermark once before the loop. When no active readers
         // exist, watermark() returns latest_commit_ts so everything below it
@@ -1284,6 +1352,10 @@ impl LsmStorageInner {
             decoded_user_key.clear();
             key.decode_user_key_into(&mut decoded_user_key);
             let user_key: &[u8] = &decoded_user_key;
+            #[cfg(feature = "compaction-setsum")]
+            if let Some(verifier) = setsum_verifier.as_mut() {
+                verifier.add_input(key, raw);
+            }
 
             let should_keep = self.should_keep_compaction_entry(
                 CompactionEntryDecision {
@@ -1327,9 +1399,19 @@ impl LsmStorageInner {
                     *output_state.current_last_key = Some(user_key.to_vec());
                 }
                 builder.add_raw(iter.key(), iter.raw_value())?;
+                #[cfg(feature = "compaction-setsum")]
+                if let Some(verifier) = setsum_verifier.as_mut() {
+                    verifier.add_output(key, raw);
+                }
             } else if should_drop_for_filter {
                 let dropped_bytes = (iter.key().raw_ref().len() + iter.raw_value().len()) as u64;
                 self.record_compaction_filter_drop(dropped_bytes);
+            }
+            #[cfg(feature = "compaction-setsum")]
+            if !(should_keep && !should_drop_for_filter && !should_drop_for_ttl)
+                && let Some(verifier) = setsum_verifier.as_mut()
+            {
+                verifier.add_allowed_drop(key, raw);
             }
             iter.next()?;
         }
@@ -1346,6 +1428,10 @@ impl LsmStorageInner {
 
         all_vlog_ids.sort_unstable();
         all_vlog_ids.dedup();
+        #[cfg(feature = "compaction-setsum")]
+        if let Some(verifier) = setsum_verifier.as_ref() {
+            verifier.verify()?;
+        }
         Ok((
             ret,
             all_vlog_ids,

--- a/kv-engine/src/key.rs
+++ b/kv-engine/src/key.rs
@@ -47,12 +47,11 @@ const ENC_PAD: u8 = 0x00;
 
 /// Encode the user key portion using TiKV memcomparable encoding.
 fn encode_memcomparable_user_key_to(buf: &mut Vec<u8>, user_key: &[u8]) {
-    let mut chunks = user_key.chunks_exact(ENC_GROUP_SIZE);
-    for chunk in &mut chunks {
+    let (chunks, remainder) = user_key.as_chunks::<ENC_GROUP_SIZE>();
+    for chunk in chunks {
         buf.extend_from_slice(chunk);
         buf.push(ENC_MARKER);
     }
-    let remainder = chunks.remainder();
     // Always emit a final padded group (terminator). This ensures every encoded
     // key ends with a marker < 0xFF, which is required for correct lexicographic
     // sort order — without it, a key whose length is an exact multiple of 8
@@ -88,14 +87,13 @@ pub fn encode_internal_key_to_buf(buf: &mut Vec<u8>, user_key: &[u8], ts: u64) {
 /// Advances `pos` past the written bytes.
 #[inline]
 fn encode_memcomparable_user_key_inline(buf: &mut [u8], pos: &mut usize, user_key: &[u8]) {
-    let mut chunks = user_key.chunks_exact(ENC_GROUP_SIZE);
-    for chunk in &mut chunks {
+    let (chunks, remainder) = user_key.as_chunks::<ENC_GROUP_SIZE>();
+    for chunk in chunks {
         buf[*pos..*pos + ENC_GROUP_SIZE].copy_from_slice(chunk);
         *pos += ENC_GROUP_SIZE;
         buf[*pos] = ENC_MARKER;
         *pos += 1;
     }
-    let remainder = chunks.remainder();
     let pad_count = ENC_GROUP_SIZE - remainder.len();
     buf[*pos..*pos + remainder.len()].copy_from_slice(remainder);
     *pos += remainder.len();

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2026-05-28"
+channel = "nightly-2026-08-20"

--- a/vendor/cfg_aliases/Cargo.toml
+++ b/vendor/cfg_aliases/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "cfg_aliases"
+version = "0.2.1"
+edition = "2018"
+license = "MIT"
+description = "A tiny utility to help save you a lot of effort with long winded cfg checks."
+repository = "https://github.com/katharostech/cfg_aliases"
+
+[lib]
+path = "src/lib.rs"

--- a/vendor/cfg_aliases/Cargo.toml
+++ b/vendor/cfg_aliases/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.1"
 edition = "2018"
 license = "MIT"
 description = "A tiny utility to help save you a lot of effort with long winded cfg checks."
+publish = false
 repository = "https://github.com/katharostech/cfg_aliases"
 
 [lib]

--- a/vendor/cfg_aliases/LICENSE
+++ b/vendor/cfg_aliases/LICENSE
@@ -1,0 +1,16 @@
+MIT License
+
+Copyright (c) 2020 Katharos Technology
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/cfg_aliases/src/lib.rs
+++ b/vendor/cfg_aliases/src/lib.rs
@@ -1,0 +1,171 @@
+#![allow(clippy::needless_doctest_main)]
+
+/// Create `cfg` aliases from a build script.
+///
+/// This local patch matches `cfg_aliases` 0.2.1 for the syntax used by
+/// dependencies, but avoids expanding recursive parser arms with trailing
+/// semicolons in expression position on newer nightly Rust.
+#[macro_export]
+macro_rules! cfg_aliases {
+    (@cfg_is_set $cfgname:ident) => {{
+        let cfg_var = stringify!($cfgname).to_uppercase().replace("-", "_");
+        let result = std::env::var(format!("CARGO_CFG_{}", &cfg_var)).is_ok();
+
+        if !result && cfg_var == "DEBUG_ASSERTIONS" {
+            std::env::var("PROFILE") == Ok("debug".to_owned())
+        } else {
+            result
+        }
+    }};
+
+    (@cfg_has_feature $feature:expr) => {{
+        std::env::var(format!(
+            "CARGO_FEATURE_{}",
+            &stringify!($feature)
+                .to_uppercase()
+                .replace("-", "_")
+                .replace('"', "")
+        ))
+        .map(|x| x == "1")
+        .unwrap_or(false)
+    }};
+
+    (@cfg_contains $cfgname:ident = $cfgvalue:expr) => {{
+        std::env::var(format!(
+            "CARGO_CFG_{}",
+            &stringify!($cfgname).to_uppercase().replace("-", "_")
+        ))
+        .unwrap_or("".to_owned())
+        .split(",")
+        .find(|x| x == &$cfgvalue)
+        .is_some()
+    }};
+
+    (
+        @parser_emit
+        all
+        $({$($grouped:tt)+})+
+    ) => {
+        ($(
+            ($crate::cfg_aliases!(@parser $($grouped)+))
+        )&&+)
+    };
+
+    (
+        @parser_emit
+        any
+        $({$($grouped:tt)+})+
+    ) => {
+        ($(
+            ($crate::cfg_aliases!(@parser $($grouped)+))
+        )||+)
+    };
+
+    (
+        @parser_clause
+        $op:ident
+        [$({$($grouped:tt)+})*]
+        [, $($rest:tt)*]
+        $($current:tt)+
+    ) => {
+        $crate::cfg_aliases!(@parser_clause $op [
+            $(
+                {$($grouped)+}
+            )*
+            {$($current)+}
+        ] [
+            $($rest)*
+        ])
+    };
+
+    (
+        @parser_clause
+        $op:ident
+        [$({$($grouped:tt)+})*]
+        [$tok:tt $($rest:tt)*]
+        $($current:tt)*
+    ) => {
+        $crate::cfg_aliases!(@parser_clause $op [
+            $(
+                {$($grouped)+}
+            )*
+        ] [
+            $($rest)*
+        ] $($current)* $tok)
+    };
+
+    (
+        @parser_clause
+        $op:ident
+        [$({$($grouped:tt)+})*]
+        []
+        $($current:tt)+
+    ) => {
+        $crate::cfg_aliases!(@parser_emit $op
+            $(
+                {$($grouped)+}
+            )*
+            {$($current)+}
+        )
+    };
+
+    (
+        @parser
+        all($($tokens:tt)+)
+    ) => {
+        $crate::cfg_aliases!(@parser_clause all [] [$($tokens)+])
+    };
+
+    (
+        @parser
+        any($($tokens:tt)+)
+    ) => {
+        $crate::cfg_aliases!(@parser_clause any [] [$($tokens)+])
+    };
+
+    (
+        @parser
+        not($($tokens:tt)+)
+    ) => {
+        !($crate::cfg_aliases!(@parser $($tokens)+))
+    };
+
+    (@parser feature = $value:expr) => {
+        $crate::cfg_aliases!(@cfg_has_feature $value)
+    };
+
+    (@parser $key:ident = $value:expr) => {
+        $crate::cfg_aliases!(@cfg_contains $key = $value)
+    };
+
+    (@parser $e:ident) => {
+        __cfg_aliases_matcher__!($e)
+    };
+
+    (
+        @with_dollar[$dol:tt]
+        $( $alias:ident : { $($config:tt)* } ),* $(,)?
+    ) => {{
+        macro_rules! __cfg_aliases_matcher__ {
+            $(
+                ( $alias ) => {
+                    $crate::cfg_aliases!(@parser $($config)*)
+                };
+            )*
+            ( $dol e:ident ) => {
+                $crate::cfg_aliases!(@cfg_is_set $dol e)
+            };
+        }
+
+        $(
+            println!("cargo:rustc-check-cfg=cfg({})", stringify!($alias));
+            if $crate::cfg_aliases!(@parser $($config)*) {
+                println!("cargo:rustc-cfg={}", stringify!($alias));
+            }
+        )*
+    }};
+
+    ($($tokens:tt)*) => {
+        $crate::cfg_aliases!(@with_dollar[$] $($tokens)*)
+    };
+}


### PR DESCRIPTION
## Summary

Add an optional setsum-based verifier for compaction accounting and update the project to the latest nightly toolchain pin.

## Changes

- Add the `compaction-setsum` feature and optional `setsum` dependency.
- Track compaction input, output, and allowed drops behind `TOYKV_COMPACTION_SETSUM=1`.
- Add a CI smoke test that runs the verifier on full compaction.
- Update the Rust nightly pin to `nightly-2026-08-20` across repo docs and workflows.
- Patch `cfg_aliases` locally so `nix v0.31.3` no longer reports future-incompat warnings on the new nightly.
- Apply clippy cleanup required by the updated toolchain.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo check --locked --workspace --all-features --all-targets --future-incompat-report`
- `cargo nextest run --workspace --all-features --lib --bins --tests`
- `TOYKV_COMPACTION_SETSUM=1 cargo test --locked --package kv-engine --all-features --lib tests::compaction::test_task1_full_compaction -- --exact`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional compaction verification to detect missing or unexpected entries during data compaction.
  * Verification can be enabled with `TOYKV_COMPACTION_SETSUM`.

* **Reliability**
  * Compaction now reports an error when entry conservation checks fail.

* **Chores**
  * Updated the project’s pinned Rust nightly toolchain.
  * Added locally bundled configuration support for more consistent builds and checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->